### PR TITLE
SAK-51608 Samigo exports should use the XLSX format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ scormplayer/scorm-tool/contentPackages
 .aider*
 
 **/.claude/settings.local.json
+.mcp.json

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/util/TotalScoresExportBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/util/TotalScoresExportBean.java
@@ -38,12 +38,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.poi.hssf.usermodel.HSSFCell;
-import org.apache.poi.hssf.usermodel.HSSFCellStyle;
-import org.apache.poi.hssf.usermodel.HSSFFont;
-import org.apache.poi.hssf.usermodel.HSSFRow;
-import org.apache.poi.hssf.usermodel.HSSFSheet;
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import org.sakaiproject.tool.assessment.ui.bean.evaluation.AgentResults;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
@@ -89,7 +89,8 @@ public class TotalScoresExportBean implements Serializable {
 		DateFormat df = new SimpleDateFormat(dateFormat);
 		StringBuilder fileName = new StringBuilder(ContextUtil.getLocalizedString(EVALUATION_MESSAGES_BUNDLE, "assessment"));
 		if(StringUtils.trimToNull(assessmentName) != null) {
-			assessmentName = assessmentName.replaceAll("\\s", "_"); // replace whitespace with '_'
+			// Sanitize filename: replace problematic characters with underscore
+			assessmentName = assessmentName.replaceAll("[\\s<>&;\"'\\\\/:*?|]", "_");
 			fileName.append("-");
 			fileName.append(assessmentName);
 		}
@@ -99,8 +100,8 @@ public class TotalScoresExportBean implements Serializable {
 	}
 
 	private void writeDataToResponse(List<String> headerList, List dataList, String fileName, HttpServletResponse response) {
-		response.setContentType("application/vnd.ms-excel");
-		response.setHeader("Content-disposition", "attachment; filename=" + fileName + ".xls");
+		response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+		response.setHeader("Content-disposition", "attachment; filename=" + fileName + ".xlsx");
 		OutputStream out = null;
 		try {
 			out = response.getOutputStream();
@@ -117,17 +118,17 @@ public class TotalScoresExportBean implements Serializable {
 		}
 	}
 
-	private HSSFWorkbook getAsWorkbook(List<String> headerList, List dataList) {
-		HSSFWorkbook wb = new HSSFWorkbook();
-		HSSFCellStyle boldStyle = wb.createCellStyle();
-		HSSFFont font = wb.createFont();
+	private XSSFWorkbook getAsWorkbook(List<String> headerList, List dataList) {
+		XSSFWorkbook wb = new XSSFWorkbook();
+		XSSFCellStyle boldStyle = wb.createCellStyle();
+		XSSFFont font = wb.createFont();
 		font.setBold(true);
 		boldStyle.setFont(font);
 
-		HSSFSheet sheet = wb.createSheet();
+		XSSFSheet sheet = wb.createSheet();
 
 		//The first list in the list contains column headers.
-		HSSFRow headerRow = sheet.createRow((short)0);
+		XSSFRow headerRow = sheet.createRow((short)0);
 
 		for (short i = 0; i < headerList.size(); i++) {
 			createCell(headerRow, i, boldStyle).setCellValue(headerList.get(i).toString());
@@ -136,10 +137,10 @@ public class TotalScoresExportBean implements Serializable {
 		Iterator dataIter = dataList.iterator();
 		while (dataIter.hasNext()) {
 			AgentResults agent = (AgentResults) dataIter.next();
-			HSSFRow row = sheet.createRow(rowPos++);
+			XSSFRow row = sheet.createRow(rowPos++);
 
 			//Añadimos la informacion en las celdas
-			HSSFCell cell = createCell(row, (short)0, null);
+			XSSFCell cell = createCell(row, (short)0, null);
 			cell.setCellValue(agent.getLastName() + ", " + agent.getFirstName());
 
 			cell = createCell(row, (short)1, null);
@@ -174,8 +175,8 @@ public class TotalScoresExportBean implements Serializable {
 		return wb;
 	}
 
-	private HSSFCell createCell(HSSFRow row, short column, HSSFCellStyle cellStyle) {
-		HSSFCell cell = row.createCell(column);
+	private XSSFCell createCell(XSSFRow row, short column, XSSFCellStyle cellStyle) {
+		XSSFCell cell = row.createCell(column);
 
 		if (cellStyle != null) {
 			cell.setCellStyle(cellStyle);


### PR DESCRIPTION
  1. Modern Standard

  - XLSX is the current standard - Excel has used XLSX as the default format since 2007 (18+ years ago)
  - XLS is legacy - The old binary format is from Excel 97-2003 and is increasingly unsupported
  - Future-proofing - Modern spreadsheet applications expect XLSX

  2. Better Compatibility

  - Cross-platform support - XLSX works better with LibreOffice, Google Sheets, Numbers, and other non-Microsoft tools
  - Mobile compatibility - Better support on tablets and phones
  - Cloud integration - Modern cloud services (Google Drive, OneDrive, etc.) handle XLSX better

  3. Technical Advantages

  - No artificial limits - The old code only used XLSX for 255+ columns, but XLSX is better for ANY number of columns
  - Better compression - XLSX files are typically smaller due to XML compression
  - Unicode support - Better handling of international characters and special symbols
  - Metadata support - XLSX supports richer document properties

  4. User Experience Improvements

  - Filename sanitization - Fixes the garbled character issue (&lt^^x3B^ → clean underscores)
  - Consistent behavior - No more "sometimes XLS, sometimes XLSX" confusion
  - Professional appearance - XLSX is what users expect in 2025