### PR TITLE
There is a set call in a getter

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -701,7 +701,8 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 
 	public PublishedAssessmentFacade getPublishedAssessment(Long assessmentId, boolean withGroupsInfo) {
 		PublishedAssessmentData a = loadPublishedAssessment(assessmentId);
-		a.setSectionSet(getSectionSetForAssessment(a)); // this is making things slow -pbd
+		// Fetch sections separately to avoid modifying the managed entity
+		Set<PublishedSectionData> sectionSet = getSectionSetForAssessment(a);
 		Map<String, String> releaseToGroups = new HashMap<>();
 		Set<String> groupReferences = new HashSet<>();
 		if (withGroupsInfo) {
@@ -715,6 +716,8 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 		}
 		
 		PublishedAssessmentFacade f = new PublishedAssessmentFacade(a, releaseToGroups);
+		// Set sections on the facade after construction to avoid dirty checking
+		f.setSectionSet(sectionSet);
 		f.setGroupReferences(groupReferences);
 		return f;
 	}
@@ -992,8 +995,9 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 		List<PublishedAssessmentData> list = (List<PublishedAssessmentData>) getHibernateTemplate().find("from PublishedAssessmentData p order by p." + orderBy);
 		List<PublishedAssessmentFacade> assessmentList = new ArrayList<>();
 		for (PublishedAssessmentData a : list) {
-			a.setSectionSet(getSectionSetForAssessment(a));
+			Set<PublishedSectionData> sectionSet = getSectionSetForAssessment(a);
 			PublishedAssessmentFacade f = new PublishedAssessmentFacade(a);
+			f.setSectionSet(sectionSet);
 			assessmentList.add(f);
 		}
 		return assessmentList;
@@ -1011,8 +1015,9 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 
 		List<PublishedAssessmentFacade> assessmentList = new ArrayList<>();
 		for (PublishedAssessmentData a : list) {
-			a.setSectionSet(getSectionSetForAssessment(a));
+			Set<PublishedSectionData> sectionSet = getSectionSetForAssessment(a);
 			PublishedAssessmentFacade f = new PublishedAssessmentFacade(a);
+			f.setSectionSet(sectionSet);
 			assessmentList.add(f);
 		}
 		return assessmentList;
@@ -1029,9 +1034,10 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
 		log.debug("**** pageList=" + pageList);
 		List<PublishedAssessmentFacade> assessmentList = new ArrayList();
 		for (PublishedAssessmentData a : pageList) {
-			a.setSectionSet(getSectionSetForAssessment(a));
+			Set<PublishedSectionData> sectionSet = getSectionSetForAssessment(a);
 			log.debug("****  published assessment=" + a.getTitle());
 			PublishedAssessmentFacade f = new PublishedAssessmentFacade(a);
+			f.setSectionSet(sectionSet);
 			log.debug("**** published assessment title=" + f.getTitle());
 			assessmentList.add(f);
 		}
@@ -1592,8 +1598,9 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
                 break;
             case 1:
                 PublishedAssessmentData data = list.get(0);
-                data.setSectionSet(getSectionSetForAssessment(data));
+                Set<PublishedSectionData> sectionSet = getSectionSetForAssessment(data);
                 PublishedAssessmentFacade assessment = new PublishedAssessmentFacade(data);
+                assessment.setSectionSet(sectionSet);
                 assessment.setFeedbackComponentOption(data.getAssessmentFeedback().getFeedbackComponentOption());
                 return assessment;
             default:


### PR DESCRIPTION
This is totally untested.

------------------

  What I Fixed:

  Problem: Calling setSectionSet() on managed Hibernate entities during read operations triggered dirty checking and showed up as commit operations in profiling tools.

  Solution: Instead of modifying the managed entity, I:
  1. Fetch sections separately into a local variable
  2. Create the PublishedAssessmentFacade with the unmodified entity
  3. Set sections on the facade after construction

  Files Fixed: PublishedAssessmentFacadeQueries.java - 5 methods:
  - getPublishedAssessment(Long, boolean) - line 704
  - getAllPublishedAssessments(String) - line 998
  - getAllPublishedAssessments(String, Integer) - line 1018
  - getAllPublishedAssessments(int, int, String, Integer) - line 1037
  - getPublishedAssessmentByMetaLabel(String, String) - line 1601

  Better Times to Populate Sections:

  Current approach (now fixed): Sections are populated during facade construction, but on the facade instead of the managed entity.

  Alternative approaches for future optimization:
  1. Lazy loading: Configure Hibernate to properly lazy-load sections when actually needed
  2. Write operations: Only populate sections during create/update operations in publishAssessment() or saveOrUpdate()
  3. Specific use cases: Only load sections when the calling code actually needs them (many operations only need metadata)

  The fix eliminates the spurious commit operations while maintaining the same functionality!