### PR TITLE
SAK-51617 Discussions add warning when topic is unavailable because forum is draft

### DIFF
--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages.properties
@@ -126,6 +126,7 @@ cdfm_newflagresponses=New messages
 cdfm_yes=Yes
 cdfm_no=No
 cdfm_draft=DRAFT
+cdfm_forum_draft_topic_unavailable=This topic is unavailable to students because its forum is in draft status
 cdfm_discussions=Discussions
 cdfm_new_forum=New Forum
 cdfm_new_topic=New Topic

--- a/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es.properties
+++ b/msgcntr/messageforums-api/src/bundle/org/sakaiproject/api/app/messagecenter/bundle/Messages_es.properties
@@ -126,6 +126,7 @@ cdfm_newflagresponses=Nuevos mensajes
 cdfm_yes=S\u00ed
 cdfm_no=No
 cdfm_draft=BORRADOR
+cdfm_forum_draft_topic_unavailable=Este tema no está disponible para los estudiantes porque su foro está en estado de borrador
 cdfm_discussions=Foros
 cdfm_new_forum=Nuevo foro
 cdfm_new_topic=Nuevo tema

--- a/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
+++ b/msgcntr/messageforums-app/src/webapp/css/msgcntr.css
@@ -650,3 +650,18 @@ img.authorImage {
 .openDateSpan {
 	display: block;
 }
+
+/* Draft forum topic styling - topics in draft forums appear unavailable to students */
+.draft-forum-topic {
+	color: #666;
+	opacity: 0.6;
+}
+
+.draft-forum-topic a {
+	color: #666 !important;
+	text-decoration: none;
+}
+
+.draft-forum-topic a:hover {
+	color: #333 !important;
+}

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/includes/dfAreaInclude.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/includes/dfAreaInclude.jsp
@@ -237,8 +237,15 @@ $(document).ready(function() {
                     <h:panelGrid columns="1" width="100%" styleClass="specialLink topicBloc" cellpadding="0" cellspacing="0">
                 <h:panelGroup>
                             
-                            <h:outputText styleClass="bi bi-folder topicIcon" style="margin-right:.5em" rendered="#{topic.unreadNoMessages == 0}" escape="false" />
-                            <h:outputText styleClass="bi bi-folder-fill topicIcon" style="margin-right:.5em" rendered="#{topic.unreadNoMessages > 0}" escape="false" />
+                            <%-- Show warning icon for topics in draft forums instead of regular folder icon --%>
+                            <h:panelGroup rendered="#{forum.forum.draft == 'true'}">
+                                <span class="bi bi-exclamation-triangle topicIcon text-warning" style="margin-right:.5em" aria-hidden="true"></span>
+                                <span class="sr-only"><h:outputText value="#{msgs.cdfm_forum_draft_topic_unavailable}" escape="false" /></span>
+                            </h:panelGroup>
+                            <h:panelGroup rendered="#{forum.forum.draft != 'true'}">
+                                <h:outputText styleClass="bi bi-folder topicIcon" style="margin-right:.5em" rendered="#{topic.unreadNoMessages == 0}" escape="false" />
+                                <h:outputText styleClass="bi bi-folder-fill topicIcon" style="margin-right:.5em" rendered="#{topic.unreadNoMessages > 0}" escape="false" />
+                            </h:panelGroup>
                             <h:outputText styleClass="highlight title draftTopic" id="draft" value="#{msgs.cdfm_draft}" rendered="#{topic.topic.draft == 'true'}"/>
                             <h:outputText id="draft_space" value="  - " rendered="#{topic.topic.draft == 'true'}" styleClass="title"/>
                             <h:panelGroup rendered="#{topic.availability == 'false'}" style="margin-right:.5em">
@@ -258,29 +265,36 @@ $(document).ready(function() {
                                     entity-id="<h:outputText value="#{topic.gradeAssign}" />">
                                 </sakai-rubric-student-preview-button>
                             </h:panelGroup>
-                            <h:commandLink action="#{ForumTool.processActionDisplayTopic}" id="topic_title" title=" #{topic.topic.title}" styleClass="title">
+                            <h:commandLink action="#{ForumTool.processActionDisplayTopic}" id="topic_title" title=" #{topic.topic.title}" styleClass="#{forum.forum.draft == 'true' ? 'title draft-forum-topic' : 'title'}">
                                 <f:param value="#{topic.topic.id}" name="topicId"/>
                                 <f:param value="#{forum.forum.id}" name="forumId"/>
                                 <h:outputText value="#{topic.topic.title}"/>
                             </h:commandLink>
+                            
+                            <%-- Indicator for topics in draft forums --%>
+                            <h:panelGroup rendered="#{forum.forum.draft == 'true'}" styleClass="draft-forum-topic text-muted">
+                                <span style="font-style: italic; font-size: 0.9em; margin-left: 0.5em;">
+                                    <h:outputText value="#{msgs.cdfm_forum_draft_topic_unavailable}" />
+                                </span>
+                            </h:panelGroup>
              
                <%-- // display  singular ('unread message') if unread message is  1 --%> 
                <h:outputText styleClass="childrenNew" id="topic_msg_count55" value="  #{topic.unreadNoMessages} #{msgs.cdfm_lowercase_unread_msg}" 
-                             rendered="#{topic.isRead && topic.unreadNoMessages >= 1}"/>   
+                             rendered="#{topic.isRead && topic.unreadNoMessages >= 1 && forum.forum.draft != 'true'}"/>   
                        
                <%-- // display  plural ('unread messages') with different style sheet if unread message is 0 --%>  
                <h:outputText styleClass="childrenNewZero" id="topic_msg_count57" value="   #{topic.unreadNoMessages} #{msgs.cdfm_lowercase_unread_msg}" 
-                             rendered="#{topic.isRead && topic.unreadNoMessages == 0}"/> 
+                             rendered="#{topic.isRead && topic.unreadNoMessages == 0 && forum.forum.draft != 'true'}"/> 
                
                <%-- // display singular ('message') if total message is 1--%>                   
                <h:outputText styleClass="textPanelFooter" id="topic_msg_count58" value="#{msgs.cdfm_of} #{topic.totalNoMessages} #{msgs.cdfm_lowercase_msg}"
-                             rendered="#{topic.isRead && topic.totalNoMessages == 1}"/>
+                             rendered="#{topic.isRead && topic.totalNoMessages == 1 && forum.forum.draft != 'true'}"/>
                                      
                <%-- // display singular ('message') if total message is 0 or more than 1--%>                   
                <h:outputText styleClass="textPanelFooter" id="topic_msg_count59" value="#{msgs.cdfm_of} #{topic.totalNoMessages} #{msgs.cdfm_lowercase_msgs}"
-                             rendered="#{topic.isRead && (topic.totalNoMessages > 1 || topic.totalNoMessages == 0)}"/>
+                             rendered="#{topic.isRead && (topic.totalNoMessages > 1 || topic.totalNoMessages == 0) && forum.forum.draft != 'true'}"/>
                                 
-               <h:outputText id="topic_moderated" value=" #{msgs.cdfm_forum_moderated_flag}" styleClass="textPanelFooter" rendered="#{topic.moderated == 'true' && topic.isRead}" />
+               <h:outputText id="topic_moderated" value=" #{msgs.cdfm_forum_moderated_flag}" styleClass="textPanelFooter" rendered="#{topic.moderated == 'true' && topic.isRead && forum.forum.draft != 'true'}" />
 
                             <%--//desNote: links to act on this topic --%>
                             <h:outputText value=" "  styleClass="actionLinks"/>
@@ -327,7 +341,7 @@ $(document).ready(function() {
                             </ul>
 
                             <%--the topic details --%>
-                            <h:outputText id="topic_desc" value="#{topic.topic.shortDescription}" styleClass="shortDescription" />
+                            <h:outputText id="topic_desc" value="#{topic.topic.shortDescription}" styleClass="#{forum.forum.draft == 'true' ? 'shortDescription draft-forum-topic' : 'shortDescription'}" />
                             <f:subview id="longDescTopic" rendered="#{!empty topic.attachList || (topic.topic.extendedDescription != '' &&  topic.topic.extendedDescription != null && topic.topic.extendedDescription != '<br/>')}">
 
                             <h:panelGroup>


### PR DESCRIPTION
## Summary of Changes

Problem Addressed: Instructors with draft forums didn't realize that topics appeared normal to them but were unavailable to students.

### Solution Implemented:

  1. Visual Icon Change (dfAreaInclude.jsp:241-248):
    - Topics in draft forums now show a warning triangle icon instead of the regular folder icon
    - Includes accessibility text for screen readers
  2. Topic Styling (dfAreaInclude.jsp:268,337):
    - Topic titles and descriptions in draft forums get draft-forum-topic CSS class
    - Content appears greyed out and muted
  3. Explicit Warning Message (dfAreaInclude.jsp:275-279):
    - Added clear text: "This topic is unavailable to students because its forum is in draft status"
    - Only visible to instructors who can see draft forums
  4. Hidden Message Counts (dfAreaInclude.jsp:283-297):
    - Unread/total message counts are hidden for topics in draft forums
    - Prevents confusion about engagement metrics for unavailable content
  5. CSS Styling (msgcntr.css:655-667):
    - Greyed out appearance with reduced opacity
    - Consistent styling for links and hover states
  6. Internationalization (Messages.properties:129, Messages_es.properties:129):
    - Added new message key in English and Spanish
    - Following Sakai's internationalization practices