### PR TITLE
SAK-51646 Library active tab should be same background color as active navigation

### DIFF
--- a/library/src/skins/default/src/sass/themes/_light.scss
+++ b/library/src/skins/default/src/sass/themes/_light.scss
@@ -209,8 +209,8 @@
     --tool-tab-hover-text-color: var(--sakai-text-color-3);
     --tool-tab-hover-background-color: var(--sakai-passive-color-2);
     --tool-tab-hover-highlight-color: var(--sakai-active-color-2);
-    --tool-tab-active-text-color: var(--sakai-text-color-3);
-    --tool-tab-active-background-color: var(--sakai-background-color-1);
+    --tool-tab-active-text-color: var(--sakai-text-color-inverted);
+    --tool-tab-active-background-color: var(--sakai-primary-color-1);
     --tool-tab-active-highlight-color:var(--sakai-active-color-3);
 
     --top-header-background: var(--sakai-background-color-1);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51646

![image](https://github.com/user-attachments/assets/64a9506e-e66c-40c8-9303-0802fe4210ca)

![image](https://github.com/user-attachments/assets/6783db02-226d-4d25-b14b-d9dc389207cb)

On Dark

![image](https://github.com/user-attachments/assets/2dc48a49-04bb-4729-be8e-d7d123705bcb)