### PR TITLE
SAK-51664 Gradebook fix percentage grades showing blank in student summary

### DIFF
--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -1892,8 +1892,8 @@ public class GradingServiceImpl implements GradingService {
         if (Objects.equals(GradingConstants.GRADE_TYPE_LETTER, gradeEntryType)) {
             grade = gradeRecord.getLetterEarned();
         } else if (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradeEntryType)) {
-            final Double percentEarned = gradeRecord.getPercentEarned();
-            grade = percentEarned != null ? percentEarned.toString() : null;
+            final Double percent = calculateEquivalentPercent(gbo.getPointsPossible(), gradeRecord.getPointsEarned());
+            grade = percent != null ? percent.toString() : null;
         } else {
             final Double pointsEarned = gradeRecord.getPointsEarned();
             grade = pointsEarned != null ? pointsEarned.toString() : null;

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -98,7 +98,6 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 		final boolean showingStudentView = (boolean) data.get("showingStudentView");
 		final Integer gradeType = (Integer) data.get("gradeType");
 		final String studentUuid = (String) data.get("studentUuid");
-		
 		this.isGroupedByCategory = (boolean) data.get("isGroupedByCategory");
 		final Map<String, CategoryDefinition> categoriesMap = (Map<String, CategoryDefinition>) data.get("categoriesMap");
 		final ModalWindow assignmentStatsWindow = new ModalWindow("assignmentStatsWindow");

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -352,6 +352,8 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 
 						final WebMarkupContainer gradeScore = new WebMarkupContainer("gradeScore");
 						if (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradeType)) {
+							// For percentage gradebooks, show just the percentage (e.g., "80%")
+							// Don't show the relative weight as it's confusing to students
 							gradeScore.add(new Label("grade",
 									new StringResourceModel("label.percentage.valued")
 											.setParameters(FormatHelper.formatGrade(rawGrade))) {
@@ -361,6 +363,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 								}
 							});
 
+							// Hide the "/22" relative weight part for percentage gradebooks
 							gradeScore.add(new Label("outOf").setVisible(false));
 
 							final WebMarkupContainer sakaiRubricButton = new WebMarkupContainer("sakai-rubric-student-button");
@@ -386,6 +389,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 
 							gradeScore.add(sakaiRubricButton);
 						} else {
+							// For points/letter gradebooks, show grade with "out of" points
 							gradeScore.add(
 									new Label("grade", FormatHelper.convertEmptyGradeToDash(FormatHelper.formatGradeForDisplay(rawGrade))));
 							gradeScore.add(new Label("outOf",

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -98,6 +98,9 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 		final boolean showingStudentView = (boolean) data.get("showingStudentView");
 		final Integer gradeType = (Integer) data.get("gradeType");
 		final String studentUuid = (String) data.get("studentUuid");
+		
+		log.debug("GradeSummaryTablePanel: gradeType={} (PERCENTAGE={}), showingStudentView={}", 
+			gradeType, GradingConstants.GRADE_TYPE_PERCENTAGE, showingStudentView);
 		this.isGroupedByCategory = (boolean) data.get("isGroupedByCategory");
 		final Map<String, CategoryDefinition> categoriesMap = (Map<String, CategoryDefinition>) data.get("categoriesMap");
 		final ModalWindow assignmentStatsWindow = new ModalWindow("assignmentStatsWindow");
@@ -354,6 +357,8 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 						if (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradeType)) {
 							// For percentage gradebooks, show just the percentage (e.g., "80%")
 							// Don't show the relative weight as it's confusing to students
+							log.debug("PERCENTAGE PATH: gradeType={}, rawGrade={}, formattedGrade={}, assignment.getPoints()={}", 
+								gradeType, rawGrade, FormatHelper.formatGrade(rawGrade), assignment.getPoints());
 							gradeScore.add(new Label("grade",
 									new StringResourceModel("label.percentage.valued")
 											.setParameters(FormatHelper.formatGrade(rawGrade))) {
@@ -390,6 +395,8 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 							gradeScore.add(sakaiRubricButton);
 						} else {
 							// For points/letter gradebooks, show grade with "out of" points
+							log.debug("POINTS PATH: gradeType={}, rawGrade={}, assignment.getPoints()={}", 
+								gradeType, rawGrade, assignment.getPoints());
 							gradeScore.add(
 									new Label("grade", FormatHelper.convertEmptyGradeToDash(FormatHelper.formatGradeForDisplay(rawGrade))));
 							gradeScore.add(new Label("outOf",

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -99,8 +99,6 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 		final Integer gradeType = (Integer) data.get("gradeType");
 		final String studentUuid = (String) data.get("studentUuid");
 		
-		log.debug("GradeSummaryTablePanel: gradeType={} (PERCENTAGE={}), showingStudentView={}", 
-			gradeType, GradingConstants.GRADE_TYPE_PERCENTAGE, showingStudentView);
 		this.isGroupedByCategory = (boolean) data.get("isGroupedByCategory");
 		final Map<String, CategoryDefinition> categoriesMap = (Map<String, CategoryDefinition>) data.get("categoriesMap");
 		final ModalWindow assignmentStatsWindow = new ModalWindow("assignmentStatsWindow");
@@ -357,8 +355,6 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 						if (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradeType)) {
 							// For percentage gradebooks, show just the percentage (e.g., "80%")
 							// Don't show the relative weight as it's confusing to students
-							log.debug("PERCENTAGE PATH: gradeType={}, rawGrade={}, formattedGrade={}, assignment.getPoints()={}", 
-								gradeType, rawGrade, FormatHelper.formatGrade(rawGrade), assignment.getPoints());
 							gradeScore.add(new Label("grade",
 									new StringResourceModel("label.percentage.valued")
 											.setParameters(FormatHelper.formatGrade(rawGrade))) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/InstructorGradeSummaryGradesPanel.java
@@ -135,7 +135,7 @@ public class InstructorGradeSummaryGradesPanel extends BasePanel {
 		tableModel.put("isCategoryWeightEnabled", isCategoryWeightEnabled());
 		tableModel.put("isGroupedByCategory", this.isGroupedByCategory);
 		tableModel.put("showingStudentView", false);
-		tableModel.put("gradingType", gradebook.getGradeType());
+		tableModel.put("gradeType", gradebook.getGradeType());
 		tableModel.put("categoriesMap", categoriesMap);
 		tableModel.put("studentUuid", userId);
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentGradeSummaryGradesPanel.java
@@ -170,7 +170,7 @@ public class StudentGradeSummaryGradesPanel extends BasePanel {
 		tableModel.put("isCategoryWeightEnabled", isCategoryWeightEnabled());
 		tableModel.put("isGroupedByCategory", this.isGroupedByCategory);
 		tableModel.put("showingStudentView", true);
-		tableModel.put("gradingType", gradebook.getGradeType());
+		tableModel.put("gradeType", gradebook.getGradeType());
 		tableModel.put("categoriesMap", categoriesMap);
 		tableModel.put("studentUuid", userId);
 

--- a/library/src/skins/default/src/sass/print.scss
+++ b/library/src/skins/default/src/sass/print.scss
@@ -45,6 +45,8 @@ aside.offcanvas,
 .#{$namespace}toolTitleNav__button_container *,
 ##{$namespace}footerApp__chat,
 #roleSwitch,
+.Mrphs-sakai-lessonbuildertool .itemcopylink,
+.Mrphs-sakai-lessonbuildertool .navIntraTool .bottomButtons,
 .current-role,
 .portal-header-breadcrumb {
 	display: none !important;

--- a/library/src/skins/default/src/sass/print.scss
+++ b/library/src/skins/default/src/sass/print.scss
@@ -45,8 +45,6 @@ aside.offcanvas,
 .#{$namespace}toolTitleNav__button_container *,
 ##{$namespace}footerApp__chat,
 #roleSwitch,
-.Mrphs-sakai-lessonbuildertool .itemcopylink,
-.Mrphs-sakai-lessonbuildertool .navIntraTool .bottomButtons,
 .current-role,
 .portal-header-breadcrumb {
 	display: none !important;


### PR DESCRIPTION
Fixes percentage grades appearing blank (-) in student grade summary after
SAK-51562 optimization. The optimization incorrectly switched from using
calculateEquivalentPercent() to getPercentEarned() for percentage gradebooks.

Restored original percentage calculation logic in convertGradeRecordToGradeDefinition()
to properly calculate percentage from pointsEarned/pointsPossible while maintaining
the performance benefits of the bulk grade fetching optimization.

## The Bug:
  - These panels were setting "gradingType" in the data map
  - But GradeSummaryTablePanel was looking for "gradeType"
  - This caused gradeType to always be null
  - Result: Percentage logic NEVER triggered, always used points display

## The Fix:
```java
  // BEFORE (broken):
  tableModel.put("gradingType", gradebook.getGradeType());

  // AFTER (fixed):
  tableModel.put("gradeType", gradebook.getGradeType());
```

  Impact: This was the critical fix that made everything work. Without this, the percentage display logic was never being reached.