### PR TITLE
SAK-51535 Gradebook course grade export use raw entered grade instead of formatted display

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -482,7 +482,7 @@ public class ExportPanel extends BasePanel {
 					}
 					if (isCustomExport && this.includeGradeOverride) {
 						if (courseGrade.getEnteredGrade() != null) {
-							line.add(FormatHelper.formatGradeForDisplay(courseGrade.getEnteredGrade()));
+							line.add(courseGrade.getEnteredGrade());
 						} else {
 							line.add(null);
 						}


### PR DESCRIPTION
The fix aligns Grade Override export with how Course Grade export works:
 - Course Grade: Uses `courseGrade.getMappedGrade()` directly (letter grade, no formatting)
 - Grade Override: Now uses `courseGrade.getEnteredGrade()` directly (letter grade, no formatting)
 - Calculated Grade: Still uses `FormatHelper.formatGradeForDisplay(courseGrade.getCalculatedGrade())` (numeric percentage, needs formatting)
 
This change will:
✅ Eliminate the server log warnings
✅ Export Grade Override values correctly as letter grades
✅ Maintain consistency with Course Grade handling
✅ Keep the same user-visible behavior (letter grades in exports)