### PR TITLE
SAK-51667 Portal fix portal.max.recent.sites property not being enforced

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -65,7 +65,7 @@
 
 # Configure the maximum sites to show in the recent sites section of the site navigation
 # DEFAULT: 3
-# portal.max.recent.sites
+portal.max.recent.sites=3
 
 # SAK-29457
 # Enable/disable the cookie policy warning

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -960,10 +960,14 @@ public class PortalServiceImpl implements PortalService, Observer
 
 		List<String> current = getRecentSites(userId);
 
-		if (current.size() == 3) {
-			// Oldest is last
-			String last = current.toArray(new String[] {})[current.size() - 1];
+		int maxRecentSites = serverConfigurationService.getInt("portal.max.recent.sites", 3);
+		// Clean up excess sites if user has more than the limit
+		while (current.size() >= maxRecentSites && !current.isEmpty()) {
+			// Remove oldest entry (last in the list)
+			String last = current.get(current.size() - 1);
 			recentSiteRepository.deleteByUserIdAndSiteId(userId, last);
+			// Refresh the list after deletion
+			current = getRecentSites(userId);
 		}
 
 		RecentSite recentSite = new RecentSite();

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalTestConfiguration.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalTestConfiguration.java
@@ -20,6 +20,7 @@ import javax.annotation.Resource;
 import static org.mockito.Mockito.*;
 
 import org.sakaiproject.alias.api.AliasService;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.springframework.orm.hibernate.AdditionalHibernateMappings;
 import org.sakaiproject.test.SakaiTestConfiguration;
@@ -68,5 +69,12 @@ public class PortalTestConfiguration extends SakaiTestConfiguration {
     @Bean(name = "org.sakaiproject.thread_local.api.ThreadLocalManager")
     public ThreadLocalManager threadLocalManager() {
         return mock(ThreadLocalManager.class);
+    }
+
+    @Bean(name = "org.sakaiproject.component.api.ServerConfigurationService")
+    public ServerConfigurationService serverConfigurationService() {
+        ServerConfigurationService mock = mock(ServerConfigurationService.class);
+        when(mock.getInt("portal.max.recent.sites", 3)).thenReturn(3);
+        return mock;
     }
 }


### PR DESCRIPTION
The portal.max.recent.sites property was defined in default.sakai.properties but completely ignored by PortalServiceImpl.addRecentSite(), causing users to accumulate 50+ recent sites instead of the intended limit.

Changes:
- PortalServiceImpl.java: Read portal.max.recent.sites property instead of hardcoded limit
- Enhanced cleanup loop to handle users with existing 50+ recent sites
- default.sakai.properties: Uncomment portal.max.recent.sites=3 to activate property
- PortalTestConfiguration.java: Mock ServerConfigurationService for tests
