### PR TITLE
SAK-51664 Gradebook Fix percentage display precision to 2 decimal places

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -356,7 +356,8 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 							// Don't show the relative weight as it's confusing to students
 							gradeScore.add(new Label("grade",
 									new StringResourceModel("label.percentage.valued")
-											.setParameters(FormatHelper.formatGrade(rawGrade))) {
+											.setParameters(StringUtils.isNotBlank(rawGrade) ? 
+												FormatHelper.formatDoubleToDecimal(Double.valueOf(rawGrade)) : "")) {
 								@Override
 								public boolean isVisible() {
 									return StringUtils.isNotBlank(rawGrade);


### PR DESCRIPTION
Fixed percentage grades showing excessive decimals (e.g., 81.818181%) by using FormatHelper.formatDoubleToDecimal() which rounds to 2 decimal places and removes trailing zeros.