### PR TITLE
SAK-51663 Rubrics remove cancel button from edit modal

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricEdit.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricEdit.js
@@ -75,9 +75,6 @@ export class SakaiRubricEdit extends RubricsElement {
               <button class="btn btn-primary" type="button" @click=${this._saveEdit} data-rubric-id="${this.rubric.id}">
                 ${this._i18n.save}
               </button>
-              <button class="btn btn-secondary" id="rubric-cancel-${this.rubric.id}" type="button" data-bs-dismiss="modal" @click=${this._cancelEdit}>
-                ${this._i18n.cancel}
-              </button>
             </div>
           </div>
         </div>
@@ -93,9 +90,4 @@ export class SakaiRubricEdit extends RubricsElement {
     bootstrap.Modal.getInstance(this.querySelector("div.modal")).hide();
   }
 
-  _cancelEdit() {
-
-    //Reset input values, in case they were changed
-    this.querySelector("input[type='text']").value = this.rubric.title;
-  }
 }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-edit.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-edit.test.js
@@ -92,7 +92,7 @@ describe("sakai-rubric-edit tests", () => {
     expect(el.querySelector("div.modal").classList.contains("show")).to.be.false;
   });
 
-  it ("tests that a new rubric pops up the modal and that you can cancel the edit", async () => {
+  it ("tests that a new rubric pops up the modal", async () => {
 
     data.rubric1.new = true;
 
@@ -112,15 +112,6 @@ describe("sakai-rubric-edit tests", () => {
     await oneEvent(el, "shown.bs.modal");
 
     expect(titleField).to.exist;
-    titleField.value = "cheeses";
-
-    const cancelButton = el.querySelector("button.btn-secondary");
-    expect(cancelButton).to.exist;
-    cancelButton.click();
-
-    await oneEvent(el, "hidden.bs.modal");
-
-    expect(titleField.value).to.equal(data.rubric1.title);
   });
 });
 


### PR DESCRIPTION
Just get rid of the cancel button as Cancel doesn't work as people expect it to