### PR TITLE
SAK-51695 Grader fix submission history order

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/submission.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/submission.js
@@ -9,7 +9,7 @@ class Submission {
 
       if (init.properties) {
         // Extract log entries and sort them chronologically by their numeric suffix
-        const logEntries = Object.keys(init.properties)
+        this.submissionLog = Object.keys(init.properties)
           .filter(p => p.startsWith("log"))
           .map(p => ({
             key: p,
@@ -18,8 +18,6 @@ class Submission {
           }))
           .sort((a, b) => a.index - b.index) // Sort by numeric index to maintain chronological order
           .map(entry => entry.value);
-
-        this.submissionLog = logEntries;
       } else {
         this.submissionLog = init.submissionLog || [];
       }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/submission.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-grader/src/submission.js
@@ -8,8 +8,18 @@ class Submission {
       this.id = init.id;
 
       if (init.properties) {
-        this.submissionLog = Object.keys(init.properties).filter(p => p.startsWith("log"))
-          .map(p => init.properties[p]);
+        // Extract log entries and sort them chronologically by their numeric suffix
+        const logEntries = Object.keys(init.properties)
+          .filter(p => p.startsWith("log"))
+          .map(p => ({
+            key: p,
+            index: parseInt(p.substring(3)), // Extract numeric part after "log"
+            value: init.properties[p]
+          }))
+          .sort((a, b) => a.index - b.index) // Sort by numeric index to maintain chronological order
+          .map(entry => entry.value);
+
+        this.submissionLog = logEntries;
       } else {
         this.submissionLog = init.submissionLog || [];
       }


### PR DESCRIPTION
The classic grader stores submission log entries with numbered keys (log0, log1, log2, etc.) and uses a TreeMap to maintain chronological order. However, the SakaiGrader was simply extracting these entries using Object.keys() without respecting the numeric ordering, causing drafts and submissions to appear in incorrect order.