### PR TITLE
SAK-51701 Missing content.singleInstanceStore property on the default sakai.properties file

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -667,6 +667,10 @@
 # content.direct.upload.instructors=instructor-uploads
 # content.direct.upload.students=student-uploads
 
+# SAK-48238--SAK-51701 Support Single Instance Store in Content Hosting
+# DEFAULT: true
+# content.singleInstanceStore=false
+
 # #######################################################################
 # CLOUD-CONTENT
 # #######################################################################


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51701

Property missing on this commit: https://github.com/sakaiproject/sakai/commit/c94861b624de3f89e4ed21f60a50f5c2aef9d895