### PR TITLE
SAK-51705 Kernel singleInstanceStore should also count soft deleted files

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -1992,7 +1992,7 @@ public class DbContentService extends BaseContentService
 											references - deletedReferences, deletedReferences, filePath);
 									}
 								} catch ( IdUnusedException e ) {
-									log.warn("Unexpected error {}", e.getMessage());
+									log.warn("missing id during countQuery,  {}", e.toString());
 								}
 
 								if ( references > 1 ) {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -1740,7 +1740,6 @@ public class DbContentService extends BaseContentService
            }
        }
 
-       /** return deleted resource for the given  id */ 
        public void removeDeletedResource(ContentResourceEdit edit)
        {
            // delete the body
@@ -1757,7 +1756,31 @@ public class DbContentService extends BaseContentService
                    // if we have been configured to use an external file system
                    if (bodyPath != null)
                    {
-                       delResourceBodyFilesystem(bodyPathDeleted, edit);
+                       // Count references in both main table and deleted table for singleInstanceStore
+                       String filePath = ((BaseResourceEdit) edit).m_filePath;
+                       String statement = contentServiceSql.getCountFilePath(resourceTableName);
+                       int references = -1;
+                       try {
+                           references = countQuery(statement, filePath);
+                           
+                           // Also count references in deleted table if it exists
+                           if (references <= 1 &&resourceDeleteTableName != null) {
+                               String deleteStatement = contentServiceSql.getCountFilePath(resourceDeleteTableName);
+                               int deletedReferences = countQuery(deleteStatement, filePath);
+                               references += deletedReferences;
+                               log.debug("Found {} references in main table and {} in deleted table for file: {}", 
+                                   references - deletedReferences, deletedReferences, filePath);
+                           }
+                       } catch ( IdUnusedException e ) {
+                           log.warn("Unexpected error {}", e.getMessage());
+                       }
+
+                       if ( references > 1 ) {
+                           log.debug("Retaining file blob for deleted resource_id={} because {} total reference(s)", edit.getId(), references);
+                       } else {
+                           log.debug("Removing deleted resource ({}) content: {} file:{}", edit.getId(), bodyPathDeleted, filePath);
+                           delResourceBodyFilesystem(bodyPathDeleted, edit);
+                       }
                    }
 
                    // otherwise use the database
@@ -1942,24 +1965,34 @@ public class DbContentService extends BaseContentService
 					   // if we have been configured to use an external file system
 					   if (removeContent) {
 							String filePath = ((BaseResourceEdit) edit).m_filePath;
-							log.debug("Removing resource ("+edit.getId()+") content: "+bodyPath+" file:"+filePath);
+							log.debug("Removing resource ({}) content: {} file:{}", edit.getId(), bodyPath, filePath);
 
+							// Count references in both main table and deleted table for singleInstanceStore
 							String statement = contentServiceSql.getCountFilePath(resourceTableName);
 							int references = -1;
 							try {
 								references = countQuery(statement, filePath);
+
+								// Also count references in deleted table if it exists
+								if (references <= 1 && resourceDeleteTableName != null) {
+									String deleteStatement = contentServiceSql.getCountFilePath(resourceDeleteTableName);
+									int deletedReferences = countQuery(deleteStatement, filePath);
+									references += deletedReferences;
+									log.debug("Found {} references in main table and {} in deleted table for file: {}", 
+										references - deletedReferences, deletedReferences, filePath);
+								}
 							} catch ( IdUnusedException e ) {
 								log.warn("Unexpected error {}", e.getMessage());
 							}
 
 							if ( references > 1 ) {
-								log.debug("Retaining file blob for resource_id={} because {} reference(s)", edit.getId(), references);
+								log.debug("Retaining file blob for resource_id={} because {} total reference(s)", edit.getId(), references);
 							} else {
-								log.debug("Removing resource ("+edit.getId()+") content: "+bodyPath+" file:"+filePath);
+								log.debug("Removing resource ({}) content: {} file:{}", edit.getId(), bodyPath, filePath);
 								delResourceBodyFilesystem(bodyPath, edit);
 							}
 					   } else {
-							log.debug("Removing original resource reference ("+edit.getId()+") without removing the actual content: "+bodyPath);
+							log.debug("Removing original resource reference ({}) without removing the actual content: {}", edit.getId(), bodyPath);
 					   }
 				   }
 				   else
@@ -1967,9 +2000,9 @@ public class DbContentService extends BaseContentService
 					   // otherwise use the database
 					   if (removeContent) {
 						   delResourceBodyDb(edit, resourceBodyTableName);
-						   log.debug("Removing resource ("+edit.getId()+") DB content");
+						   log.debug("Removing resource ({}) DB content", edit.getId());
 					   } else {
-						   log.debug("Removing original resource reference ("+edit.getId()+") without removing the actual DB content");
+						   log.debug("Removing original resource reference ({}) without removing the actual DB content", edit.getId());
 					   }
 				   }
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DbContentService.java
@@ -1772,7 +1772,7 @@ public class DbContentService extends BaseContentService
                                    references - deletedReferences, deletedReferences, filePath);
                            }
                        } catch ( IdUnusedException e ) {
-                           log.warn("Unexpected error {}", e.getMessage());
+                           log.warn("missing id during countQuery,  {}", e.toString());
                        }
 
                        if ( references > 1 ) {


### PR DESCRIPTION


- Fixed removeResource to count references in both main and deleted tables before deleting physical files
- Fixed removeDeletedResource to add missing reference counting for shared files
- Optimized to only check deleted table when main table has ≤1 references
