### PR TITLE
SAK-51680 - DateManager, Discussions: Draft Discussion update silent fail

### DIFF
--- a/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -136,6 +136,7 @@ public class DateManagerServiceImpl implements DateManagerService {
 	private final DateTimeFormatter inputDateTimeFormatter;
 	private final DateTimeFormatter outputDateFormatter;
 	private final DateTimeFormatter outputDatePickerFormat;
+	private static final String TYPE_FORUMS = "forums";
 
 	public DateManagerServiceImpl() {
 		inputDateFormatter = new DateTimeFormatterBuilder()
@@ -1398,7 +1399,8 @@ public class DateManagerServiceImpl implements DateManagerService {
 
                                 String entityType = (String)jsonForum.get(DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME);
                                 DateManagerUpdate update;
-                                if(resourceLoader.getString("itemtype.forum").equals(entityType)) {
+								String normalizedType = (entityType == null) ? "unknown" : entityType.toLowerCase();						
+								if (normalizedType.startsWith(TYPE_FORUMS)) {
                                         BaseForum forum = forumManager.getForumById(true, forumId);
                                         if (forum == null) {
                                                 errors.add(new DateManagerError("forum", resourceLoader.getFormattedMessage("error.item.not.found", resourceLoader.getString("tool.forums.item.name")), "forums", toolTitle, idx));
@@ -1457,7 +1459,7 @@ public class DateManagerServiceImpl implements DateManagerService {
                                                 forum.setCloseDate(closeDateTemp);
                                         }
                                 }
-                                forumManager.saveDiscussionForum(forum);
+								forumManager.saveDiscussionForum(forum, forum.getDraft());
                         } else {
                                 DiscussionTopic topic = (DiscussionTopic) update.object;
                                 if(topic.getAvailabilityRestricted()) {


### PR DESCRIPTION
1). If updating dates on Draft Forum the code can errantly fall thru to the section processing topics because the the forum if statement expects Forum and not Draft Forum.

Once the code falls through, a lookup, getTopicById, using the Forum ID can return an unrelated Topic. 

If the topic MFR_TOPIC_T.TOPIC_DTYPE = ‘PT’ there will be a Class Cast thrown.
If the topic MFR_TOPIC_T.TOPIC_DTYPE = ‘DT’ that unrelated topic will have its dates updated.

The original Forum’s dates will not be updated.
This is fixed by adjusting the if/else branch in validateForums

2) Once issue number one if fixed, testing will show that saving dates on the draft forum in DateManager will cause the forum to change from draft to non-draft.  This issue if fixed by ensuring the draft status is passed through via:  forumManager.saveDiscussionForum(forum, forum.getDraft());