### PR TITLE
SAK-51871 Lessons importing LTI items from Import from site

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -820,7 +820,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				while(matcher.find()) {
 					String urlFirstPart = matcher.group(1);
 					Long ltiContentId = Long.valueOf(matcher.group(2));
-					log.info("Updating reference: {}", matcher.group(0));
+					log.debug("Updating reference: {}", matcher.group(0));
 					foundLtiLink = true;
 					try {
 						Map<String, Object> ltiContent = ltiService.getContentDao(ltiContentId, oldSiteId, securityService.isSuperUser());
@@ -829,10 +829,10 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 						String[] bltiId = sakaiId.split("/");
 						ltiContentId = Long.valueOf(bltiId[2]);
 					} catch (Exception e) {
-						log.warn("Unable to import LTI tool to new site: {}", e);
+						log.warn("Failed to import LTI tool [contentId: {}, fromSite: {}, toSite: {}]: {}. Tool will be skipped.", ltiContentId, oldSiteId, siteId, e.toString());
 					} finally {
 						String updatedReference = urlFirstPart + "/" + siteId + "/content:" + ltiContentId;
-						log.info("New reference: {}", updatedReference);
+						log.debug("New reference: {}", updatedReference);
 						matcher.appendReplacement(sb, Matcher.quoteReplacement(updatedReference));
 					}
 				}
@@ -840,7 +840,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				if(foundLtiLink) {
 					matcher.appendTail(sb);
 					explanation = sb.toString();
-					log.info("Updated at least one LTI reference lesson HTML");
+					log.debug("Updated at least one LTI reference lesson HTML");
 				}
 			} else if (type == SimplePageItem.PAGE) {
 				// sakaiId should be the new page ID


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51781

- Recover the code which was removed on https://github.com/sakaiproject/sakai/commit/6732b2067ed5f42df633fe85a8cd6ef4d5ae866d
- Pattern addapted to accept retrocompatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded LTI content inside text is now copied to the destination site during page merges/copies and in-text LTI links are rewritten to the new content IDs to prevent broken references. HTML is only modified when such links are detected, and updates are logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->