### PR TITLE
SAK-51786 Assignments Keep Gradebook category selection in assignment drafts

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -9213,23 +9213,29 @@ public class AssignmentAction extends PagedResourceActionII {
 
                 // Store category information in assignment properties for drafts
                 // so it can be restored when editing the assignment later
-                if (!post && GRADEBOOK_INTEGRATION_ADD.equals(addtoGradebook)) {
-                    if (isGradebookGroupEnabled) {
-                        String categoriesString = (String) state.getAttribute(NEW_ASSIGNMENT_CATEGORY);
-                        if (categoriesString != null && !categoriesString.isEmpty() && !"-1".equals(categoriesString)) {
-                            aProperties.put(NEW_ASSIGNMENT_CATEGORY, categoriesString);
-                        }
-                        else {
-                            aProperties.remove(NEW_ASSIGNMENT_CATEGORY);
+                if (!post) {
+                    // On draft saves, only persist category when adding to gradebook; otherwise remove to prevent stale state
+                    if (GRADEBOOK_INTEGRATION_ADD.equals(addtoGradebook)) {
+                        if (isGradebookGroupEnabled) {
+                            String categoriesString = (String) state.getAttribute(NEW_ASSIGNMENT_CATEGORY);
+                            if (categoriesString != null && !(categoriesString = categoriesString.trim()).isEmpty() && !"-1".equals(categoriesString)) {
+                                aProperties.put(NEW_ASSIGNMENT_CATEGORY, categoriesString);
+                            }
+                            else {
+                                aProperties.remove(NEW_ASSIGNMENT_CATEGORY);
+                            }
+                        } else {
+                            Object categoryObj = state.getAttribute(NEW_ASSIGNMENT_CATEGORY);
+                            String categoryStr = (categoryObj != null) ? categoryObj.toString().trim() : null;
+                            if (categoryStr != null && !categoryStr.isEmpty() && !"-1".equals(categoryStr)) {
+                                aProperties.put(NEW_ASSIGNMENT_CATEGORY, categoryStr);
+                            }
+                            else {
+                                aProperties.remove(NEW_ASSIGNMENT_CATEGORY);
+                            }
                         }
                     } else {
-                        Object categoryObj = state.getAttribute(NEW_ASSIGNMENT_CATEGORY);
-                        if (categoryObj != null && !"-1".equals(categoryObj.toString())) {
-                            aProperties.put(NEW_ASSIGNMENT_CATEGORY, categoryObj.toString());
-                        }
-                        else {
-                            aProperties.remove(NEW_ASSIGNMENT_CATEGORY);
-                        }
+                        aProperties.remove(NEW_ASSIGNMENT_CATEGORY);
                     }
                 } else if (post) {
                     // Remove category from properties when publishing, as it will be managed by gradebook
@@ -10738,11 +10744,11 @@ public class AssignmentAction extends PagedResourceActionII {
                 state.setAttribute(NEW_ASSIGNMENT_SECTION, a.getSection());
 
                 state.setAttribute(NEW_ASSIGNMENT_SUBMISSION_TYPE, a.getTypeOfSubmission().ordinal());
-                
-                // Load current category from gradebook
+
+                // Load current category from assignment properties (drafts); published items default to "no category"
                 String siteId = a.getContext();
                 loadCurrentAssignmentCategory(state, a, siteId);
-                
+
                 state.setAttribute(NEW_ASSIGNMENT_GRADE_TYPE, a.getTypeOfGrade().ordinal());
                 if (a.getTypeOfGrade() == Assignment.GradeType.SCORE_GRADE_TYPE) {
                     state.setAttribute(NEW_ASSIGNMENT_GRADE_POINTS, a.getMaxGradePoint().toString());
@@ -13440,16 +13446,18 @@ public class AssignmentAction extends PagedResourceActionII {
         try {
             Map<String, String> properties = assignment.getProperties();
             String storedCategory = properties.get(NEW_ASSIGNMENT_CATEGORY);
+            if (storedCategory != null) storedCategory = storedCategory.trim();
 
             if (storedCategory != null && !storedCategory.isEmpty()) {
                 if (isGradebookGroupEnabled) {
                     state.setAttribute(NEW_ASSIGNMENT_CATEGORY, storedCategory);
                 } else {
+                    String normalized = storedCategory.trim();
                     try {
-                        Long categoryId = Long.parseLong(storedCategory);
-                        state.setAttribute(NEW_ASSIGNMENT_CATEGORY, categoryId);
+                        Long.parseLong(normalized);
+                        state.setAttribute(NEW_ASSIGNMENT_CATEGORY, normalized);
                     } catch (NumberFormatException e) {
-                        state.setAttribute(NEW_ASSIGNMENT_CATEGORY, -1L);
+                        state.setAttribute(NEW_ASSIGNMENT_CATEGORY, "-1");
                     }
                 }
             }
@@ -13459,7 +13467,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 state.setAttribute(NEW_ASSIGNMENT_CATEGORY, -1L);
             }
         } catch (Exception e) {
-            log.warn("Error loading category for assignment: " + assignment.getId(), e);
+            log.warn("Error loading category for assignment {} in site {}", assignment.getId(), siteId, e);
             if (isGradebookGroupEnabled) {
                 state.setAttribute(NEW_ASSIGNMENT_CATEGORY, "-1");
             } else {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves the selected assignment category when saving drafts, restoring it correctly on return.
  * Ensures consistent category handling whether gradebook grouping is enabled or not.
  * Clears temporary draft category data upon publishing to avoid inconsistencies.

* **Improvements**
  * More reliable category initialization when editing assignments, reducing fallback cases.
  * Safer handling of invalid or missing category data with sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->