### PR TITLE
SAK-51759 Assignments Not Displayed After Exiting Add Assignment Page

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -6197,8 +6197,6 @@ public class AssignmentAction extends PagedResourceActionII {
         state.removeAttribute(SEARCH_ASSIGNMENTS);
     }
 
-
-
     /**
      * Filter the assignments list by AssignmentFilter
      */


### PR DESCRIPTION
The doSearch_clear method was missing that is called by the doView method. It clears the state variables. All search and filter state is properly reset, allowing the full list of assignments to be displayed.