### PR TITLE
SAK-51808 Portal pinned sites are in reverse order

### DIFF
--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -897,13 +897,16 @@ public class PortalServiceImpl implements PortalService, Observer
 	public void reorderPinnedSites(String userId, List<String> siteIds) {
 		if (StringUtils.isBlank(userId)) return;
 
+		List<String> reversedSiteIds = new ArrayList<>(siteIds);
+		Collections.reverse(reversedSiteIds);
+
 		pinnedSiteRepository.deleteByUserId(userId);
 
-		for (int i = 0; i < siteIds.size(); i++) {
+		for (int i = 0; i < reversedSiteIds.size(); i++) {
 
 			PinnedSite pin = new PinnedSite();
 			pin.setUserId(userId);
-			pin.setSiteId(siteIds.get(i));
+			pin.setSiteId(reversedSiteIds.get(i));
 			pin.setPosition(i);
 			pinnedSiteRepository.save(pin);
 		}
@@ -919,9 +922,12 @@ public class PortalServiceImpl implements PortalService, Observer
 	public List<String> getPinnedSites(String userId) {
 		if (StringUtils.isBlank(userId)) return Collections.emptyList();
 
-		return pinnedSiteRepository.findByUserIdOrderByPosition(userId).stream()
+		List<String> pinnedSites = pinnedSiteRepository.findByUserIdOrderByPosition(userId).stream()
 				.map(PinnedSite::getSiteId)
-				.collect(Collectors.toUnmodifiableList());
+				.collect(Collectors.toList());
+
+		Collections.reverse(pinnedSites);
+		return Collections.unmodifiableList(pinnedSites);
 	}
 
 	@Override

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -209,9 +209,9 @@ public class PortalServiceTests extends SakaiTests {
         List<String> pinnedSites = portalService.getPinnedSites(user1);
         Assert.assertEquals(3, pinnedSites.size());
 
-        Assert.assertEquals(site1Id, pinnedSites.get(0));
+        Assert.assertEquals(site3Id, pinnedSites.get(0));
         Assert.assertEquals(site2Id, pinnedSites.get(1));
-        Assert.assertEquals(site3Id, pinnedSites.get(2));
+        Assert.assertEquals(site1Id, pinnedSites.get(2));
 
         portalService.removePinnedSite(user1, site2Id);
         pinnedSites = portalService.getPinnedSites(user1);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted pinned sites ordering: the displayed order is now reversed compared to before, ensuring the visual sequence matches how users arrange their pins.
  * Reordering pins now persists in the expected visual order across sessions.

* **Tests**
  * Updated tests to reflect the corrected pinned sites ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->