### PR TITLE
SAK-51309 Dashboard announcements widget default to Latest First

### DIFF
--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/AnnouncementsController.java
@@ -65,7 +65,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
                     try {
                         Site site = siteService.getSite(siteId);
 
-                        return announcementService.getMessages(announcementService.channelReference(siteId, SiteService.MAIN_CONTAINER), filter, true, false)
+                        return announcementService.getMessages(announcementService.channelReference(siteId, SiteService.MAIN_CONTAINER), filter, false, false)
                             .stream()
                             .map(am -> {
                                 Optional<String> optionalUrl = entityManager.getUrl(am.getReference(), Entity.UrlType.PORTAL);
@@ -79,6 +79,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
                         return Stream.<AnnouncementRestBean>empty();
                     }
                 })
+                .sorted((a1, a2) -> Long.compare(a2.getDate(), a1.getDate()))
                 .collect(Collectors.toList());
 
             return Map.of("announcements", announcements, "sites", getPinnedSiteList());
@@ -101,7 +102,7 @@ public class AnnouncementsController extends AbstractSakaiApiController {
             ToolConfiguration placement = site.getToolForCommonId(AnnouncementService.SAKAI_ANNOUNCEMENT_TOOL_ID);
             String mergedChannels = placement.getPlacementConfig().getProperty(AnnouncementService.PORTLET_CONFIG_PARM_MERGED_CHANNELS);
 
-            return Map.of("announcements", announcementService.getChannelMessages(channelRef, null, true, mergedChannels, false, false, siteId, 10)
+            return Map.of("announcements", announcementService.getChannelMessages(channelRef, null, false, mergedChannels, false, false, siteId, 10)
                 .stream()
                 .filter(announcementService::isMessageViewable)
                 .map(am -> {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-announcements/src/SakaiAnnouncements.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-announcements/src/SakaiAnnouncements.js
@@ -117,12 +117,14 @@ export class SakaiAnnouncements extends SakaiPageableElement {
         ` : nothing }
         <div id="sorting">
           <select class="w-100 mb-3" aria-label="${this._i18n.announcement_sort_label}" @change=${this._sortChanged}>
-            <option value="${EARLIEST_FIRST}">${this._i18n.earliest_first}</option>
             <option value="${LATEST_FIRST}">${this._i18n.latest_first}</option>
+            <option value="${EARLIEST_FIRST}">${this._i18n.earliest_first}</option>
             <option value="${TITLE_A_TO_Z}">${this._i18n.title_a_to_z}</option>
             <option value="${TITLE_Z_TO_A}">${this._i18n.title_z_to_a}</option>
+            ${!this.siteId || this.siteId === "home" ? html`
             <option value="${SITE_A_TO_Z}">${this._i18n.site_a_to_z}</option>
             <option value="${SITE_Z_TO_A}">${this._i18n.site_z_to_a}</option>
+            ` : nothing}
             <option value="${INSTRUCTOR_ORDER}">${this._i18n.instructor_order}</option>
           </select>
         </div>


### PR DESCRIPTION
- Change Dashboard announcements widget default sort from Earliest First to Latest First
- Hide site sorting options (Site A-Z, Site Z-A) when viewing announcements within a specific course site
- Fix API sorting: getUserAnnouncements now sorts combined results by latest first
- Fix API sorting: getSiteAnnouncements changed from ascending=true to ascending=false