### PR TITLE
SAK-51712 Lessons importing a selected lesson imports all lessons

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -54,6 +54,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -625,8 +626,19 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			int count = 0;
 			if (hasSelection) {
 				Set<Long> topLevelSelectedPages = findTopLevelSelectedPages(selectedPageIds, siteId);
+				// Filter out top-level selections that are orphans (not exported as pages)
+				List<Long> orderedTopLevelPages = new ArrayList<>();
+				for (Long id : topLevelSelectedPages) {
+					if (orphanFinder.isOrphan(id)) {
+						selectionSkipped++;
+						continue;
+					}
+					orderedTopLevelPages.add(id);
+				}
+				// Ensure deterministic ordering of placements
+				Collections.sort(orderedTopLevelPages);
 
-				for (Long topLevelPageId : topLevelSelectedPages) {
+				for (Long topLevelPageId : orderedTopLevelPages) {
 					SimplePage topLevelPage = simplePageToolDao.getPage(topLevelPageId);
 					if (topLevelPage != null) {
 						element = doc.createElement(LESSONBUILDER);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51712

With the changes: if certain Lessons (1) or subpages of a Lessons (2) are selected:
(1) The selected Lessons is imported with all its content and subpages.
(2) The selected subpage is imported as a new Lessons along with its own subpages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selective export of Lessons: choose specific pages to archive or transfer; all descendant pages are automatically included.
  * When a selection is provided, only the selected top-level pages (with their descendants) are exported; full-site export remains the default when no selection is given.
  * Transfer/Copy accepts a list of page IDs to move only selected content between sites.
* **Improvements**
  * Export logging now reports skipped orphaned and non-selected pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->