### PR TITLE
SAK-51822 LTI incorrect type when launching LTI tool causes ClassCastException

### DIFF
--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -712,7 +712,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			return "lti_error";
 		}
 
-		Long launchType = LTIUtil.toLongNull( (Integer) tool.get(LTIService.LTI13) );
+		Long launchType = LTIUtil.toLongNull(tool.get(LTIService.LTI13));
 		context.put("launchType", launchType);
 		context.put("isAdmin", ltiService.isAdmin(getSiteId(state)) ? Boolean.TRUE : Boolean.FALSE);
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading LTI tool settings by handling the LTI 1.3 launch flag more robustly. This prevents rare errors or crashes caused by differing numeric formats or missing values, ensuring smoother display and configuration of LTI tools across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->