### PR TITLE
SAK-51724 Rubrics Criterion comments not showing up in instructor view

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
@@ -301,6 +301,8 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
     });
 
     this.updateTotalPoints(false);
+
+    this.querySelectorAll("sakai-rubric-grading-comment").forEach(gc => gc.requestUpdate());
   }
 
   fineTuneRating(e) {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rubric comment editors now refresh immediately after criteria or points are updated, preventing stale or mismatched comments.
  * Keeps comments in sync with recalculated totals during grading, reducing display glitches and confusion.
  * Resolves cases where comments wouldn’t reflect the latest rubric selections until a manual refresh, ensuring a smoother and more reliable grading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->