### PR TITLE
SAK-49834 Portal role switch hidden tools shouldn't display in Overview

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchHandler.java
@@ -146,7 +146,7 @@ public class RoleSwitchHandler extends BasePortalHandler
 
 				if (isToolHidden) {
 					if (!homePageIsHidden(activeSite)) {
-						url = portalUrl + "/site/" + parts[2] + "/tool/" + activeSite.getPages().get(0).getId() + "/";
+						url = portalUrl + "/site/" + parts[2] + "/";
 					} else {
 						url = portalUrl;
 					}
@@ -176,7 +176,10 @@ public class RoleSwitchHandler extends BasePortalHandler
 	}
 
 	private boolean homePageIsHidden(Site activeSite) {
-		return (activeSite.getPages().size()>=1 && activeSite.getPages().get(0).isHomePage() && toolManager.isHidden(activeSite.getPages().get(0).getTools().get(0)));
+		return (!activeSite.getPages().isEmpty() &&
+				activeSite.getPages().get(0).isHomePage() &&
+				!activeSite.getPages().get(0).getTools().isEmpty() &&
+				toolManager.isHidden(activeSite.getPages().get(0).getTools().get(0)));
 	}
 
 }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
@@ -88,7 +88,7 @@ public class RoleSwitchOutHandler extends BasePortalHandler
 
 				//my personal site
 				String userUrlId="~"+session.getUserId();
-				if (activeSite.getPages().size()>=1 && activeSite.getId().equals(userUrlId)) {
+				if (!activeSite.getPages().isEmpty() && activeSite.getId().equals(userUrlId)) {
 					roleExitUrl = ServerConfigurationService.getPortalUrl();
 				}
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
@@ -86,6 +86,12 @@ public class RoleSwitchOutHandler extends BasePortalHandler
 						.peek(tool -> log.debug("Resetting state for site: " + activeSite.getId() + " tool: " + tool.getId()))
 						.forEach(tool -> session.getToolSession(tool.getId()).clearAttributes()); // reset each tool
 
+				//my personal site
+				String userUrlId="~"+session.getUserId();
+				if (activeSite.getPages().size()>=1 && activeSite.getId().equals(userUrlId)) {
+					roleExitUrl = ServerConfigurationService.getPortalUrl();
+				}
+
 				portalService.setResetState("true"); // flag the portal to reset
 				
 				// Post an event


### PR DESCRIPTION
SAK-49834 View Site As: Hidden tool elements display in Overview

https://sakaiproject.atlassian.net/browse/SAK-49834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents redirects to hidden tools when switching roles; users are redirected to the site home’s first visible tool or the portal home if needed.
  * Ensures exiting role-switch from a personal site returns users to the portal home for a consistent landing.

* **Chores**
  * Improved redirect decision logic and logging to make navigation more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->