### PR TITLE
SAK-51869 Portal Configure the position of new pinned sites in sakai.properties

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -67,6 +67,10 @@
 # DEFAULT: 3
 # portal.max.recent.sites=5
 
+# Place new pinned sites at the top of the pinned sites list
+# DEFAULT: false
+# portal.new.pinned.sites.top=true
+
 # SAK-29457
 # Enable/disable the cookie policy warning
 # DEFAULT: false

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -935,18 +935,15 @@ public class PortalServiceImpl implements PortalService, Observer
 	public List<String> getPinnedSites(String userId) {
 		if (StringUtils.isBlank(userId)) return Collections.emptyList();
 
-		if(!serverConfigurationService.getBoolean("portal.new.pinned.sites.top", false)) {
-			return pinnedSiteRepository.findByUserIdOrderByPosition(userId).stream()
-					.map(PinnedSite::getSiteId)
-					.collect(Collectors.toUnmodifiableList());
-		} else {
-			List<String> pinnedSites = pinnedSiteRepository.findByUserIdOrderByPosition(userId).stream()
-					.map(PinnedSite::getSiteId)
-					.collect(Collectors.toList());
-
-			Collections.reverse(pinnedSites);
-			return Collections.unmodifiableList(pinnedSites);
+		List<String> pinned = pinnedSiteRepository
+				.findByUserIdAndHasBeenUnpinnedOrderByPosition(userId, false)
+				.stream()
+				.map(PinnedSite::getSiteId)
+				.collect(Collectors.toList());
+		if (serverConfigurationService.getBoolean("portal.new.pinned.sites.top", false)) {
+			Collections.reverse(pinned);
 		}
+		return Collections.unmodifiableList(pinned);
 	}
 
 	@Override

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -223,6 +223,7 @@ public class PortalServiceTests extends SakaiTests {
 
         when(serverConfigurationService.getBoolean("portal.new.pinned.sites.top", false)).thenReturn(false);
 
+        siteIds.clear();
         siteIds.add(site1Id);
         siteIds.add(site2Id);
         siteIds.add(site3Id);

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.event.api.Event;
 import org.sakaiproject.exception.IdUnusedException;
@@ -66,6 +67,7 @@ public class PortalServiceTests extends SakaiTests {
     @Autowired private PreferencesService preferencesService;
     @Autowired private SecurityService securityService;
     @Autowired private SessionManager sessionManager;
+    @Autowired private ServerConfigurationService serverConfigurationService;
 
     private static boolean isWindowsOS = false;
     @BeforeClass
@@ -199,6 +201,8 @@ public class PortalServiceTests extends SakaiTests {
         String site3Id = "site3";
         String site4Id = "site4";
 
+        when(serverConfigurationService.getBoolean("portal.new.pinned.sites.top", false)).thenReturn(true);
+
         List<String> siteIds = new ArrayList<>();
         siteIds.add(site1Id);
         siteIds.add(site2Id);
@@ -212,6 +216,25 @@ public class PortalServiceTests extends SakaiTests {
         Assert.assertEquals(site3Id, pinnedSites.get(0));
         Assert.assertEquals(site2Id, pinnedSites.get(1));
         Assert.assertEquals(site1Id, pinnedSites.get(2));
+
+        portalService.removePinnedSite(user1, site1Id);
+        portalService.removePinnedSite(user1, site2Id);
+        portalService.removePinnedSite(user1, site3Id);
+
+        when(serverConfigurationService.getBoolean("portal.new.pinned.sites.top", false)).thenReturn(false);
+
+        siteIds.add(site1Id);
+        siteIds.add(site2Id);
+        siteIds.add(site3Id);
+
+        portalService.savePinnedSites(user1, siteIds);
+
+        pinnedSites = portalService.getPinnedSites(user1);
+        Assert.assertEquals(3, pinnedSites.size());
+
+        Assert.assertEquals(site1Id, pinnedSites.get(0));
+        Assert.assertEquals(site2Id, pinnedSites.get(1));
+        Assert.assertEquals(site3Id, pinnedSites.get(2));
 
         portalService.removePinnedSite(user1, site2Id);
         pinnedSites = portalService.getPinnedSites(user1);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an admin-configurable option to place newly pinned sites at the top of the pinned list (default remains unchanged). Pinned-site ordering now respects this setting when saving and viewing pinned sites.

- Documentation
  - Added a commented example in the default configuration showing the new pinned-site ordering option and its default.

- Tests
  - Updated tests to cover both ordering behaviors controlled by the new configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->