### PR TITLE
SAK-51813 Sitestats when exporting pdf filenames should show characters with '(' and apostrophes

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/ReportDataPage.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/pages/ReportDataPage.java
@@ -20,8 +20,6 @@ package org.sakaiproject.sitestats.tool.wicket.pages;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -618,9 +616,7 @@ public class ReportDataPage extends BasePage {
 		RequestCycle.get().scheduleRequestHandlerAfterCurrent(new EmptyRequestHandler());
 		WebResponse response = (WebResponse) getResponse();
 		response.setContentType("application/vnd.ms-excel");
-		fileName = fileName + ".xls";
-		// Filename has to be encoded because the siteId can contain non utf-8 chars.
-		response.setAttachmentHeader(this.encodeFileName(fileName));
+		response.setAttachmentHeader(fileName + ".xls");
 		response.setHeader("Cache-Control", "max-age=0");
 		response.setContentLength(hssfWorkbookBytes.length);
 		OutputStream out = null;
@@ -646,9 +642,7 @@ public class ReportDataPage extends BasePage {
 		RequestCycle.get().scheduleRequestHandlerAfterCurrent(new EmptyRequestHandler());
 		WebResponse response = (WebResponse) getResponse();
 		response.setContentType("text/comma-separated-values");
-		fileName = fileName + ".csv";
-		// Filename has to be encoded because the siteId can contain non utf-8 chars.
-		response.setAttachmentHeader(this.encodeFileName(fileName));
+		response.setAttachmentHeader(fileName + ".csv");
 		response.setHeader("Cache-Control", "max-age=0");
 		response.setContentLength(csvString.length());
 		OutputStream out = null;
@@ -674,9 +668,7 @@ public class ReportDataPage extends BasePage {
 		RequestCycle.get().scheduleRequestHandlerAfterCurrent(new EmptyRequestHandler());
 		WebResponse response = (WebResponse) getResponse();
 		response.setContentType("application/pdf");
-		fileName = fileName + ".pdf";
-		// Filename has to be encoded because the siteId can contain non utf-8 chars.
-		response.setAttachmentHeader(this.encodeFileName(fileName));
+		response.setAttachmentHeader(fileName + ".pdf");
 		response.setHeader("Cache-Control", "max-age=0");
 		response.setContentLength(pdf.length);
 		OutputStream out = null;
@@ -767,14 +759,6 @@ public class ReportDataPage extends BasePage {
 	
 	public String getReportUserSelection() {
 		return Locator.getFacade().getReportManager().getReportFormattedParams().getReportUserSelection(report);
-	}
-
-	private String encodeFileName(String fileName) {
-		try {
-			return URLEncoder.encode(fileName, StandardCharsets.UTF_8.displayName()); 
-		} catch (Exception ex) {
-			return fileName;
-		}
 	}
 
 }


### PR DESCRIPTION
SAK-51813 Sitestats - Export PDF names don't show characters with '(' and apostrophes

https://sakaiproject.atlassian.net/browse/SAK-51813


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported report downloads (XLS/CSV/PDF) now display clean, human-readable filenames in browser dialogs instead of URL-encoded names (e.g., no more “%20”).
  * Export content and data remain unchanged.

* **Chores**
  * Simplified attachment header construction and removed unused encoding logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->