### PR TITLE
SAK-51704 Announcements created on a site are not displayed in 'Home > Announcements' if using filter

### DIFF
--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -245,7 +245,6 @@
 								</th>									
 							#end
 						</tr>
-						#if ($!view == "view.all")
 						#set ($rowCount=0)
 						#foreach ($ann_item in $showMessagesList)
 							#set ($rowCount =$rowCount + 1)
@@ -337,7 +336,6 @@
 					</div>
 					<input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
 				</form>
-			#end
 		#else
 			</div> ##end navPanel						
 			<div class="instruction clear">


### PR DESCRIPTION
SAK-51704 Announcements created on a site are not displayed in 'Home > Announcements' if using filter

https://sakaiproject.atlassian.net/browse/SAK-51704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announcements now appear across all views, providing consistent visibility throughout the app.
  * Users no longer need to switch to a specific view to see announcements, reducing missed messages and improving awareness.
  * Rendering has been streamlined for a more predictable announcement experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->