### PR TITLE
SAK-51889 Lessons draft announcements showing in embedded widget

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -24,7 +24,6 @@ package org.sakaiproject.announcement.entityprovider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -55,7 +54,6 @@ import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityPermissionException;
 import org.sakaiproject.entity.api.Reference;
-import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entitybroker.EntityReference;
 import org.sakaiproject.entitybroker.EntityView;
 import org.sakaiproject.entitybroker.entityprovider.EntityProvider;
@@ -246,6 +244,7 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 					}
 				}
 			} catch (PermissionException | IdUnusedException | NullPointerException ex) {
+				log.warn("Falling back to public messages for channel {} due to {}: {}", channel, ex.getClass().getSimpleName(), ex.getMessage(), ex);
 				//user may not have access to view the channel but get all public messages in this channel
 				AnnouncementChannel announcementChannel = (AnnouncementChannel) announcementService.getChannelPublic(channel);
 				if (announcementChannel != null) {

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementWrapper.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementWrapper.java
@@ -91,7 +91,7 @@ public class AnnouncementWrapper implements AnnouncementMessage
 
 		// This message is editable only if the site matches.
 		String originChannel = message.getOriginChannel();
-		this.editable = originChannel != null && originChannel.equals(hostingChannel.getReference());
+		this.editable = hostingChannel != null && java.util.Objects.equals(originChannel, hostingChannel.getReference());
 
 		Site site = null;
 

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementWrapper.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementWrapper.java
@@ -90,7 +90,8 @@ public class AnnouncementWrapper implements AnnouncementMessage
 		this.announcementMessage = message;
 
 		// This message is editable only if the site matches.
-		this.editable = message.getOriginChannel().equals(hostingChannel.getReference());
+		String originChannel = message.getOriginChannel();
+		this.editable = originChannel != null && originChannel.equals(hostingChannel.getReference());
 
 		Site site = null;
 


### PR DESCRIPTION
This commit fixes two related bugs in the Lessons embedded announcements component:

1. **Draft announcements visible to instructors**: Draft announcements were showing in the Lessons embedded widget without draft labels, confusing instructors who might think the announcements were published.

2. **NullPointerException in announcement sorting**: A NPE was occurring when sorting announcements due to null originChannel values.

## Root Cause Analysis

The issues stem from SAK-49604 (ca2134e1831) which simplified channel handling in the announcement sorting logic but introduced a regression:

**Before SAK-49604:**
- Each message had its originChannel properly set from its actual channel
- Draft filtering worked correctly

**After SAK-49604:**
- All messages used defaultChannel, leaving originChannel = null
- NPE occurred in AnnouncementWrapper constructor when calling getOriginChannel().equals()
- NPE masked the fact that ViewableFilter wasn't filtering drafts properly for instructors

## The Fixes

### Fix 1: Explicit Draft Filtering (AnnouncementEntityProviderImpl.java)
- Added explicit draft checks in both main and fallback code paths
- Main path: Filter drafts after ViewableFilter since instructors can normally see their own drafts
- Fallback path: Added missing draft check that was only in main path

### Fix 2: Null Safety (AnnouncementWrapper.java)
- Added null check for originChannel before calling .equals()
- Prevents NPE when originChannel is not set (common for non-merged announcements)

## Impact
- Draft announcements no longer appear in Lessons embedded widget
- NPE in announcement sorting is prevented
- Instructors won't see confusing draft announcements in Lessons
- Normal Announcement tool functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Draft announcements no longer appear in lists; only published, viewable items within the valid time window are shown, including in public views.
  - Prevented occasional errors when determining if an announcement is editable when origin or hosting details are missing, ensuring consistent edit controls.
- Stability
  - Improved reliability of announcement listing and editing behavior without changing existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->