### PR TITLE
SAK-51899 Gradebook sorter buttons should show a drag cursor to indicate they can be reordered

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
+++ b/library/src/skins/default/src/sass/modules/tool/gradebook/gradebook-sorter.css
@@ -13,6 +13,10 @@
   position: relative;
 }
 
+#gradebookSorter .gb-sorter-sortable button {
+  cursor: move;
+  text-align: left;
+}
 
 #gradebookSorter .gb-sorter-sortable .si-grip-horizontal:before {
   margin-right: 5px;


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Gradebook sorter buttons now show a drag cursor to indicate they can be reordered.
  - Button text within the sorter is left-aligned for improved readability and visual consistency.
  - Small visual refinements improve usability and clarity without changing functionality or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->