### PR TITLE
SAK-51776 Assignments raw html entities display in notification

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_bulk_operation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_bulk_operation.vm
@@ -30,7 +30,7 @@
 							#if ($assignment.draft)
 								<span class="highlight">$tlang.getString("gen.dra2") </span>
 							#end
-							$formattedText.escapeHtml($assignment.Title)</td>
+							$assignment.Title</td>
 						<td headers="duedate">$!service.getUsersLocalDateTimeString($assignment.DueDate)</td>
 						##<td headers="section">$assignment.Section</td>
 						<td headers="status">

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -3,7 +3,6 @@
 <script>
 	focus_path = ["search"];
 	var linkFlag = true;
-
 	function duplicateLink(lnk) {
 		var params = ASN.params_unserialize(lnk.search.substring(1));
 		params.push({'name':'sakai_csrf_token','value':'$sakai_csrf_token'});
@@ -62,6 +61,7 @@
 		<h1>
 			$!tlang.getString('lisofass1')
 		</h1>
+
 	</div>
 
 	<div class="sakai-table-toolBar mb-3">
@@ -318,6 +318,7 @@
 				#foreach ($assignment in $assignments)
 					#set ($assignmentReference = $!service.assignmentReference($assignment.Id))
 					#set($assignmentProperties=$!assignment.getProperties())
+
 					## all allow function results
 					#set($allowUpdateAssignment=$!service.allowUpdateAssignment($assignmentReference))
 					#if (!($!allowAddAssignment && $!view.equals('lisofass1')))
@@ -338,16 +339,18 @@
 								#if (($!allowAddAssignment || $!allowUpdateAssignment || $!service.allowGradeSubmission($assignmentReference)) && $!view.equals('lisofass1'))
 									<strong>
 										## normal instructor view
+
 										#if ($assignment.Draft && $!allowUpdateAssignment )
-											<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
+											<a name="asnActionLink" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")" title="$!assignment.Title">
 										#else
-											<a name="asnActionLink" href="#toolLinkParam("$action" "doView_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
+											<a name="asnActionLink" href="#toolLinkParam("$action" "doView_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")" title="$!assignment.Title">
 										#end
 										#if ($!assignment.draft)
 											<span class="highlight">$tlang.getString("gen.dra2")</span>
 										#end
-											$formattedText.escapeHtml($!assignment.Title)
+											$!assignment.Title
 										</a>
+
 										#if ($assignmentAlertMap.containsKey($assignment.getId()))
 											<span>$assignmentAlertMap.get($assignment.getId())</span>
 										#end
@@ -369,8 +372,8 @@
 									</strong>
 									<div class="itemAction">
 										#set($prevAction=false)
-										#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' );" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi")<span class="skip"> $formattedText.escapeHtml($!assignment.Title)</span></a>#end
-										#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) |#else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' );return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")">$!tlang.getString("dupli")<span class="skip"> $formattedText.escapeHtml($!assignment.Title)</span></a>#end
+										#if ($!allowUpdateAssignment)#set($prevAction=true)<a name="asnActionLink" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' );" href="#toolLinkParam("$action" "doEdit_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")">$!tlang.getString("gen.revi")<span class="skip"> $!assignment.Title</span></a>#end
+										#if ($allowAddAssignment&&$!allowUpdateAssignment)#if($prevAction) |#else#set($prevAction=true)#end<a name="asnActionLink" onclick="duplicateLink(this);SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' );return false;" href="#toolLinkParam("$action" "doDuplicate_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")">$!tlang.getString("dupli")<span class="skip"> $!assignment.Title</span></a>#end
 										#if ($taggable && $allowAddAssignment)
 											#foreach ($provider in $providers)
 												#set ($helperInfo = false)
@@ -389,7 +392,7 @@
 										#if (!$assignment.Draft && $!service.allowGradeSubmission($assignmentReference))#if($prevAction) |#end
 										#set ($gradeScale = $assignment.TypeOfGrade.ordinal())
 										## show "view submissions" link for ungraded type of assignment
-											<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")'; }" >#if ($gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end<span class="skip"> $formattedText.escapeHtml($!assignment.getTitle())</span></a>
+											<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerInPreallocated( this, null, 'linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")'; }" >#if ($gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end<span class="skip"> $!assignment.getTitle()</span></a>
 										#end
 										<div id="linksSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)" class="allocatedSpinPlaceholder"></div>
 									</div>
@@ -407,11 +410,11 @@
 											## if not submitted or returned and still allowed to submit within the due time
 											#if ($service.canSubmit($assignment))
 												## go to view submission page when (1) submission has been returned and allow for resubmit;(2)submission has not been posted yet.
-												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
+												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$!assignment.Title">
 											#else
-												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$formattedText.escapeUrl($submissionReference)")" title="$formattedText.escapeHtml($!assignment.Title)">
+												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_grade" "submissionId=$formattedText.escapeUrl($submissionReference)")" title="$!assignment.Title">
 											#end
-											$formattedText.escapeHtml($assignment.Title)</a>
+											$assignment.Title</a>
 											#assignmentIcons($assignment)
 											#if ($rubricMap.containsKey($assignment.getId()))
 												<sakai-rubric-student-button
@@ -423,7 +426,7 @@
 												</sakai-rubric-student-button>
 											#end
 										#else
-											$formattedText.escapeHtml($assignment.Title)
+											$assignment.Title
 											#assignmentIcons($assignment)
 											#if ($rubricMap.containsKey($assignment.getId()))
 												<sakai-rubric-student-button
@@ -436,8 +439,8 @@
 											#end
 											#if ($!allowSubmit)
 												<div class="itemAction">
-													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)&submitterIdInstructor=instructor")" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'subAsStudentSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' );" title="$formattedText.escapeHtml($!assignment.Title)">
-														$tlang.getString("subasstudent")<span class="skip">: $formattedText.escapeHtml($assignment.Title)</span>
+													<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)&submitterIdInstructor=instructor")" onclick="SPNR.insertSpinnerInPreallocated( this, null, 'subAsStudentSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)' );" title="$!assignment.Title">
+														$tlang.getString("subasstudent")<span class="skip">: $assignment.Title</span>
 													</a>
 													<div id="subAsStudentSpinnerPlaceholder_$formattedText.escapeUrl($assignmentReference)" class="allocatedSpinPlaceholder"></div>
 												</div>
@@ -463,7 +466,7 @@
 										## SAK-21525 END
 										#if($allowSubmit)
 											<strong>
-												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
+												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$!assignment.Title">$assignment.Title</a>
 												#assignmentIcons($assignment)
 											</strong>
 											#set($submissionId="undefined")
@@ -515,7 +518,7 @@
 												</div>
 											#end
 										#else
-											<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_as_student" "assignmentId=$assignmentReference")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
+											<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_assignment_as_student" "assignmentId=$assignmentReference")" title="$!assignment.Title">$assignment.Title</a>
 										#end
 									#end
 									#set ($deleted = false)
@@ -640,7 +643,7 @@
 									#set($totalNumber = $!service.countSubmissions($assignmentReference, null))
 									<div class="spinnerBesideContainer">
 										<a name="asnActionLink" href="javascript:void(0)" onclick="if(ASN.allowClick(this)){ SPNR.insertSpinnerAfter( this, null, null ); window.location='#toolLinkParam("$action" "doGrade_assignment" "assignmentId=$formattedText.escapeUrl($assignmentReference)")'; }" >
-											<span class="skip"> #if ($gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end : $formattedText.escapeHtml($!assignment.Title). </span> <span class="skip">$!tlang.getString("gen.subm2"): </span>$!totalNumber/<span class="skip">$!tlang.getString("ungra"): </span>$!ungradedNumber
+											<span class="skip"> #if ($gradeScale != 1)$!tlang.getString("gen.assign.gra")#else$!tlang.getString("viewsubmissions")#end : $!assignment.Title. </span> <span class="skip">$!tlang.getString("gen.subm2"): </span>$!totalNumber/<span class="skip">$!tlang.getString("ungra"): </span>$!ungradedNumber
 										</a>
 									</div>
 								#end
@@ -684,7 +687,7 @@
 							#if ($!allowRemoveAssignment && $!view.equals('lisofass1'))
 								<td headers="remove" class="screenOnly">
 										<input type="checkbox" name="selectedAssignments" value="$assignmentReference" id="check_$assignmentCount" onclick="ASN.checkEnableRemove();" />
-										<label for="check_$assignmentCount" class="skip">$tlang.getString("gen.remove"): $formattedText.escapeHtml($!assignment.Title)</label>
+										<label for="check_$assignmentCount" class="skip">$tlang.getString("gen.remove"): $!assignment.Title</label>
 								</td>
 							#end
 						</tr>
@@ -696,7 +699,7 @@
 							<tr>
 								<!-- title col -->
 								<td class="peer-header">
-									<strong title="$formattedText.escapeHtml($!assignment.Title)"><span class="fa fa-caret-square-o-right" aria-hidden="true"></span> $formattedText.escapeHtml($assignment.Title)</strong>
+									<strong title="$!assignment.Title"><span class="fa fa-caret-square-o-right" aria-hidden="true"></span> $assignment.Title</strong>
 									#if ($assignment.IsGroup)
 										$tlang.getFormattedMessage("peerAssessmentName", $tlang.getString("peerAssessmentGroups"))
 									#else


### PR DESCRIPTION
Removed the double HTML encoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Assignment titles now display with preserved formatting across instructor lists and bulk operations, improving visual fidelity.
  * Titles appear consistently in link text and tooltips (edit, view, grade, submission, duplicate, peer-assessment, and student view links), ensuring uniform presentation wherever titles are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->