### PR TITLE
SAK-51863 Tags add validation when creating/editing a tag to check for inappropriate content

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1024,11 +1024,11 @@
 # valid options are listed below:
 # - none - errors are completely ignored and not even stored at all 
 # - logged - errors are output in the logs only 
-# - return - errors are returned to the tool (legacy behavior) 
+# - return - this is now removed as the caller can decide if they want the messages from scanning
 # - notify - user notified about errors using a non-blocking JS popup 
 # - display - errors are displayed to the user using the new and fancy JS popup 
 # Default: notify
-#content.cleaner.errors.handling=return
+#content.cleaner.errors.handling=display
 
 # Force the logging of errors despite the handling setting 
 # (useful for debugging but can get very noisy)

--- a/kernel/api/src/main/java/org/sakaiproject/util/api/FormattedText.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/api/FormattedText.java
@@ -58,45 +58,13 @@ public interface FormattedText {
         NONE
     }
 
-
-    /**
-     * Scans content using OWASP AntiSamy to detect security policy violations.
-     * <p>
-     * This method performs security scanning of HTML content to identify potentially
-     * malicious elements, scripts, or other content that violates the configured
-     * security policies. The scan is performed using OWASP AntiSamy with either
-     * high or low security policy enforcement.
-     * </p>
-     * <p>
-     * Note: if scanning cannot be performed due to initialization failures,
-     * policy errors, or unexpected exceptions, the method returns {@code false}.
-     * </p>
-     *
-     * @param content the HTML content to scan for security violations;
-     *                null, empty, or whitespace-only content is considered safe
-     * @param level the security level to apply during scanning:
-     *              {@link Level#HIGH} for strict policy enforcement,
-     *              {@link Level#LOW} for relaxed policy enforcement,
-     *              or {@code null} to default to {@link Level#HIGH}
-     *
-     * @return {@code true} if the content contains security policy violations,
-     *         scanner initialization failed, or scanning encountered errors;
-     *         {@code false} if the content passed security validation or is blank
-     *
-     * @see Level#HIGH
-     * @see Level#LOW
-     * @see org.owasp.validator.html.AntiSamy
-     * @see org.owasp.validator.html.CleanResults
-     */
-    boolean containsSecurityViolations(String content, Level level);
-
     /**
      * This is maintained for backwards compatibility
      * @see #processFormattedText(String, StringBuilder)
      * @deprecated since Nov 2007, use {@link #processFormattedText(String, StringBuilder)} instead
      */
     @Deprecated
-    public String processFormattedText(final String strFromBrowser, StringBuffer errorMessages);
+    public String processFormattedText(final String strFromBrowser, StringBuffer messages);
 
     /**
      * Processes and validates user-entered HTML received from the web browser (from the WYSIWYG editor). Validates that the user input follows the Sakai formatted text specification; disallows dangerous stuff such as &lt;SCRIPT&gt; JavaScript tags.
@@ -106,11 +74,11 @@ public interface FormattedText {
      * 
      * @param strFromBrowser
      *        The formatted text as sent from the web browser (from the WYSIWYG editor)
-     * @param errorMessages
-     *        User-readable error messages will be returned here.
+     * @param messages
+     *        If supplied, user-readable scanning results will be returned in this parameter; otherwise results are discarded.
      * @return The validated processed formatted text, ready for use by the system.
      */
-    public String processFormattedText(final String strFromBrowser, StringBuilder errorMessages);
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages);
 
     /**
      * Processes and validates user-entered HTML received from the web browser (from the WYSIWYG editor). Validates that the user input follows the Sakai formatted text specification; disallows dangerous stuff such as &lt;SCRIPT&gt; JavaScript tags.
@@ -120,14 +88,14 @@ public interface FormattedText {
      * 
      * @param strFromBrowser
      *        The formatted text as sent from the web browser (from the WYSIWYG editor)
-     * @param errorMessages
-     *        User-readable error messages will be returned here.
+     * @param messages
+     *        If supplied, user-readable scanning results will be returned in this parameter; otherwise results are discarded.
      * @param level
      *        The security level used for the scan (HIGH level will be more aggressive about what is allowed while NONE will allow anything),
      *        null or DEFAULT will use whatever security level the system is configured for
      * @return The validated processed formatted text, ready for use by the system.
      */
-    public String processFormattedText(final String strFromBrowser, StringBuilder errorMessages, Level level);
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages, Level level);
 
     /**
      * Processes and validates user-entered HTML received from the web browser (from the WYSIWYG editor). Validates that the user input follows the Sakai formatted text specification; disallows dangerous stuff such as &lt;SCRIPT&gt; JavaScript tags.
@@ -135,12 +103,12 @@ public interface FormattedText {
      * 
      * @param strFromBrowser
      *        The formatted text as sent from the web browser (from the WYSIWYG editor)
-     * @param errorMessages
-     *        User-readable error messages will be returned here.
+     * @param messages
+     *        If supplied, user-readable scanning results will be returned in this parameter; otherwise results are discarded.
      * @param useLegacySakaiCleaner if true the old html cleaner is used, if false the new OWASP antisamy cleaner is used
      * @return The validated processed formatted text, ready for use by the system.
      */
-    public String processFormattedText(final String strFromBrowser, StringBuilder errorMessages, boolean useLegacySakaiCleaner);
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages, boolean useLegacySakaiCleaner);
 
     /**
      * Process an HTML document that has been edited using the formatted text widget. The document can contain any valid HTML; it will NOT be checked to eliminate things like image tags, script tags, etc, because it is its own document.
@@ -158,15 +126,15 @@ public interface FormattedText {
      * 
      * @param strFromBrowser
      *        The formatted text as sent from the web browser (from the WYSIWYG editor)
-     * @param errorMessages
-     *        User-readable error messages will be returned here.
+     * @param messages
+     *        If supplied, user-readable scanning results will be returned in this parameter; otherwise results are discarded.
      * @param checkForEvilTags
      *        If true, check for tags and attributes that shouldn't be in formatted text
      * @param replaceWhitespaceTags
      *        If true, clean up line breaks to be like "&lt;br /&gt;".
      * @return The validated processed HTML formatted text, ready for use by the system.
      */
-    public String processFormattedText(final String strFromBrowser, StringBuilder errorMessages, boolean checkForEvilTags,
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages, boolean checkForEvilTags,
             boolean replaceWhitespaceTags);
 
     /**
@@ -175,8 +143,8 @@ public interface FormattedText {
      * 
      * @param strFromBrowser
      *        The formatted text as sent from the web browser (from the WYSIWYG editor)
-     * @param errorMessages
-     *        User-readable error messages will be returned here.
+     * @param messages
+     *        If supplied, user-readable scanning results will be returned in this parameter; otherwise results are discarded.
      * @param level
      *        The security level used for the scan (HIGH level will be more aggressive about what is allowed while NONE will allow anything),
      *        null or DEFAULT will use whatever security level the system is configured for
@@ -187,7 +155,7 @@ public interface FormattedText {
      * @param useLegacySakaiCleaner if true the old html cleaner is used, if false the new OWASP antisamy cleaner is used
      * @return The validated processed HTML formatted text, ready for use by the system.
      */
-    public String processFormattedText(final String strFromBrowser, StringBuilder errorMessages, Level level, boolean checkForEvilTags,
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages, Level level, boolean checkForEvilTags,
             boolean replaceWhitespaceTags, boolean useLegacySakaiCleaner);
 
     /**

--- a/kernel/api/src/main/java/org/sakaiproject/util/api/FormattedText.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/api/FormattedText.java
@@ -58,6 +58,38 @@ public interface FormattedText {
         NONE
     }
 
+
+    /**
+     * Scans content using OWASP AntiSamy to detect security policy violations.
+     * <p>
+     * This method performs security scanning of HTML content to identify potentially
+     * malicious elements, scripts, or other content that violates the configured
+     * security policies. The scan is performed using OWASP AntiSamy with either
+     * high or low security policy enforcement.
+     * </p>
+     * <p>
+     * Note: if scanning cannot be performed due to initialization failures,
+     * policy errors, or unexpected exceptions, the method returns {@code false}.
+     * </p>
+     *
+     * @param content the HTML content to scan for security violations;
+     *                null, empty, or whitespace-only content is considered safe
+     * @param level the security level to apply during scanning:
+     *              {@link Level#HIGH} for strict policy enforcement,
+     *              {@link Level#LOW} for relaxed policy enforcement,
+     *              or {@code null} to default to {@link Level#HIGH}
+     *
+     * @return {@code true} if the content contains security policy violations,
+     *         scanner initialization failed, or scanning encountered errors;
+     *         {@code false} if the content passed security validation or is blank
+     *
+     * @see Level#HIGH
+     * @see Level#LOW
+     * @see org.owasp.validator.html.AntiSamy
+     * @see org.owasp.validator.html.CleanResults
+     */
+    boolean containsSecurityViolations(String content, Level level);
+
     /**
      * This is maintained for backwards compatibility
      * @see #processFormattedText(String, StringBuilder)

--- a/kernel/api/src/main/java/org/sakaiproject/util/api/MockFormattedText.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/api/MockFormattedText.java
@@ -37,27 +37,22 @@ import org.w3c.dom.Element;
 public class MockFormattedText implements FormattedText {
     private static final String WARNING = "Using MOCK FormattedText: all values just pass through and are not processed: FOR TESTING ONLY (if this is live there is a big problem)";
 
-    @Override
-    public boolean containsSecurityViolations(String content, Level level) {
-        return false;
-    }
-
-    public String processFormattedText(String strFromBrowser, StringBuffer errorMessages) {
+    public String processFormattedText(String strFromBrowser, StringBuffer messages) {
         log.warn(WARNING);
         return strFromBrowser;
     }
 
-    public String processFormattedText(String strFromBrowser, StringBuilder errorMessages) {
+    public String processFormattedText(String strFromBrowser, StringBuilder messages) {
         log.warn(WARNING);
         return strFromBrowser;
     }
 
-    public String processFormattedText(String strFromBrowser, StringBuilder errorMessages, Level level) {
+    public String processFormattedText(String strFromBrowser, StringBuilder messages, Level level) {
         log.warn(WARNING);
         return strFromBrowser;
     }
 
-    public String processFormattedText(String strFromBrowser, StringBuilder errorMessages, boolean useLegacySakaiCleaner) {
+    public String processFormattedText(String strFromBrowser, StringBuilder messages, boolean useLegacySakaiCleaner) {
         log.warn(WARNING);
         return strFromBrowser;
     }
@@ -67,14 +62,14 @@ public class MockFormattedText implements FormattedText {
         return strFromBrowser;
     }
 
-    public String processFormattedText(String strFromBrowser, StringBuilder errorMessages, boolean checkForEvilTags,
-            boolean replaceWhitespaceTags) {
+    public String processFormattedText(String strFromBrowser, StringBuilder messages, boolean checkForEvilTags,
+                                       boolean replaceWhitespaceTags) {
         log.warn(WARNING);
         return strFromBrowser;
     }
 
-    public String processFormattedText(String strFromBrowser, StringBuilder errorMessages, Level level, boolean checkForEvilTags,
-            boolean replaceWhitespaceTags, boolean useLegacySakaiCleaner) {
+    public String processFormattedText(String strFromBrowser, StringBuilder messages, Level level, boolean checkForEvilTags,
+                                       boolean replaceWhitespaceTags, boolean useLegacySakaiCleaner) {
         log.warn(WARNING);
         return strFromBrowser;
     }

--- a/kernel/api/src/main/java/org/sakaiproject/util/api/MockFormattedText.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/api/MockFormattedText.java
@@ -37,6 +37,11 @@ import org.w3c.dom.Element;
 public class MockFormattedText implements FormattedText {
     private static final String WARNING = "Using MOCK FormattedText: all values just pass through and are not processed: FOR TESTING ONLY (if this is live there is a big problem)";
 
+    @Override
+    public boolean containsSecurityViolations(String content, Level level) {
+        return false;
+    }
+
     public String processFormattedText(String strFromBrowser, StringBuffer errorMessages) {
         log.warn(WARNING);
         return strFromBrowser;

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -381,41 +381,29 @@ public class FormattedTextImpl implements FormattedText
     private Pattern M_patternHrefRel = Pattern.compile("\\srel\\s*=\\s*(\".*?\"|'.*?')",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
-    /* (non-Javadoc)
-     * @see org.sakaiproject.utils.impl.FormattedText#processFormattedText(java.lang.String, java.lang.StringBuffer)
-     */
     public String processFormattedText(final String strFromBrowser, StringBuffer messages) {
-        StringBuilder sb = new StringBuilder(messages.toString());
+        StringBuilder sb = new StringBuilder();
         String fixed = processFormattedText(strFromBrowser, sb);
-        messages.setLength(0);
-        messages.append(sb.toString());
+        if (messages != null) {
+            messages.setLength(0);
+            messages.append(sb);
+        }
         return fixed;
     }
 
-    /* (non-Javadoc)
-     * @see org.sakaiproject.utils.impl.FormattedText#processFormattedText(java.lang.String, java.lang.StringBuilder)
-     */
-    public String processFormattedText(final String strFromBrowser, StringBuilder messages)
-    {
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages) {
         boolean checkForEvilTags = true;
         boolean replaceWhitespaceTags = true;
         return processFormattedText(strFromBrowser, messages, null, checkForEvilTags, replaceWhitespaceTags, false);
     }
 
-    /* (non-Javadoc)
-     * @see org.sakaiproject.util.api.FormattedText#processFormattedText(java.lang.String, java.lang.StringBuilder, org.sakaiproject.util.api.FormattedText.Level)
-     */
     public String processFormattedText(String strFromBrowser, StringBuilder messages, Level level) {
         boolean checkForEvilTags = true;
         boolean replaceWhitespaceTags = true;
         return processFormattedText(strFromBrowser, messages, level, checkForEvilTags, replaceWhitespaceTags, false);
     }
 
-    /* (non-Javadoc)
-     * @see org.sakaiproject.utils.impl.FormattedText#processFormattedText(java.lang.String, java.lang.StringBuilder, boolean)
-     */
-    public String processFormattedText(final String strFromBrowser,
-                                       StringBuilder messages, boolean useLegacySakaiCleaner) {
+    public String processFormattedText(final String strFromBrowser, StringBuilder messages, boolean useLegacySakaiCleaner) {
         boolean checkForEvilTags = true;
         boolean replaceWhitespaceTags = true;
         return processFormattedText(strFromBrowser, messages, null, checkForEvilTags,

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -1449,6 +1449,23 @@ public class FormattedTextImpl implements FormattedText
         return makeShortText(text, cutMethod, maxLength, separator);
     }
 
+    @Override
+    public boolean containsSecurityViolations(String content, Level level) {
+        if (content == null || content.isEmpty()) return false;
+
+        Level scanLevel = (level != null) ? level : Level.HIGH;
+        AntiSamy scanner = scanLevel == Level.LOW ? antiSamyLow : antiSamyHigh;
+        try {
+            CleanResults results = scanner.scan(content);
+            boolean hasViolations = results.getNumberOfErrors() > 0;
+            log.debug("AntiSamy found {} violations in content: {}", results.getNumberOfErrors(), StringUtils.truncate(content, 128));
+            return hasViolations;
+        } catch (Exception e) {
+            log.warn("Could not scan content {}, {}", StringUtils.truncate(content, 128), e.toString());
+        }
+        return false;
+    }
+
     /**
      * TESTING ONLY
      * SAK-23567 Gets an array with 2 int values {left,right}

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -98,7 +98,7 @@ public class FormattedTextTest {
         };
 
         // add in the config so we can test it
-        basicConfigurationService.registerConfigItem(BasicConfigItem.makeDefaultedConfigItem("content.cleaner.errors.handling", "return", "FormattedTextTest"));
+        basicConfigurationService.registerConfigItem(BasicConfigItem.makeDefaultedConfigItem("content.cleaner.errors.handling", "none", "FormattedTextTest"));
         basicConfigurationService.registerConfigItem(BasicConfigItem.makeDefaultedConfigItem("content.cleaner.referrer-policy", "noopener", "FormattedTextTest"));
         serverConfigurationService = basicConfigurationService;
 
@@ -1561,63 +1561,4 @@ public class FormattedTextTest {
         }
     }
 
-    @Test
-    public void testContainsSecurityViolations() {
-        // Test null input - should return false
-        boolean result = formattedText.containsSecurityViolations(null, Level.HIGH);
-        Assert.assertFalse("Null content should not contain violations", result);
-        
-        // Test empty input - should return false
-        result = formattedText.containsSecurityViolations("", Level.HIGH);
-        Assert.assertFalse("Empty content should not contain violations", result);
-        
-        // Test whitespace-only input - should return false
-        result = formattedText.containsSecurityViolations("   \n\t   ", Level.HIGH);
-        Assert.assertFalse("Whitespace-only content should not contain violations", result);
-        
-        // Test safe HTML content - should return false
-        result = formattedText.containsSecurityViolations("<p>This is safe content</p>", Level.HIGH);
-        Assert.assertFalse("Safe HTML content should not contain violations", result);
-        
-        // Test plain text - should return false
-        result = formattedText.containsSecurityViolations("This is plain text with no HTML", Level.HIGH);
-        Assert.assertFalse("Plain text should not contain violations", result);
-        
-        // Test potentially dangerous script tag - should return true
-        result = formattedText.containsSecurityViolations("<script>alert('xss')</script>", Level.HIGH);
-        Assert.assertTrue("Script tags should be detected as violations", result);
-        
-        // Test JavaScript in onclick attribute - should return true
-        result = formattedText.containsSecurityViolations("<div onclick=\"alert('xss')\">Click me</div>", Level.HIGH);
-        Assert.assertTrue("JavaScript in event handlers should be detected as violations", result);
-        
-        // Test iframe tag - should return true
-        result = formattedText.containsSecurityViolations("<iframe src=\"http://evil.com\"></iframe>", Level.HIGH);
-        Assert.assertTrue("Iframe tags should be detected as violations", result);
-        
-        // Test object/embed tags - should return true
-        result = formattedText.containsSecurityViolations("<object data=\"evil.swf\"></object>", Level.HIGH);
-        Assert.assertTrue("Object tags should be detected as violations", result);
-        
-        // Test with null level (should default to HIGH)
-        result = formattedText.containsSecurityViolations("<script>alert('test')</script>", null);
-        Assert.assertTrue("Null level should default to HIGH and detect violations", result);
-
-        // Test complex mixed content
-        String mixedContent = "<div><p>Safe content</p><script>alert('unsafe')</script></div>";
-        result = formattedText.containsSecurityViolations(mixedContent, Level.HIGH);
-        Assert.assertTrue("Mixed content with violations should be detected", result);
-        
-        // Test content with JavaScript protocol
-        result = formattedText.containsSecurityViolations("<a href=\"javascript:alert('xss')\">Link</a>", Level.HIGH);
-        Assert.assertTrue("JavaScript protocol should be detected as violation", result);
-        
-        // Test form elements that might be restricted
-        result = formattedText.containsSecurityViolations("<form><input type=\"text\"></form>", Level.HIGH);
-        // Note: Whether forms are violations depends on AntiSamy policy
-        
-        // Test with DEFAULT level
-        result = formattedText.containsSecurityViolations("<script>alert('test')</script>", Level.DEFAULT);
-        Assert.assertTrue("DEFAULT level should detect script violations", result);
-    }
 }

--- a/tags/tags-api/api/src/java/org/sakaiproject/tags/api/i18n/tagservice.properties
+++ b/tags/tags-api/api/src/java/org/sakaiproject/tags/api/i18n/tagservice.properties
@@ -55,7 +55,7 @@ user_collection=This is your collection of tags, used in the Private Messages to
 no_tags_in_collection=No tags are available in this collection
 
 tag_label_required=The tag label is required
-tag_label_too_long=The input for field tag label is to long
-description_too_long=The input for field description is to long
-external_id_too_long=The input for field external id is to long
-contains_xss=The input contains content that violates the systems security policy
+tag_label_too_long=The input for field tag label is too long
+description_too_long=The input for field description is too long
+external_id_too_long=The input for field external id is too long
+contains_xss=The input contains content that violates the system security policy

--- a/tags/tags-api/api/src/java/org/sakaiproject/tags/api/i18n/tagservice.properties
+++ b/tags/tags-api/api/src/java/org/sakaiproject/tags/api/i18n/tagservice.properties
@@ -53,3 +53,9 @@ uuid_missing=The requested record could not be found
 site_collection=This is the collection of the site with id {0}, with tags used in the Assignments tool.
 user_collection=This is your collection of tags, used in the Private Messages tool.
 no_tags_in_collection=No tags are available in this collection
+
+tag_label_required=The tag label is required
+tag_label_too_long=The input for field tag label is to long
+description_too_long=The input for field description is to long
+external_id_too_long=The input for field external id is to long
+contains_xss=The input contains content that violates the systems security policy

--- a/tags/tags-tool/tool/pom.xml
+++ b/tags/tags-tool/tool/pom.xml
@@ -48,13 +48,18 @@
       <artifactId>json-simple</artifactId>
       <version>${json.simple.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.sakaiproject.tags</groupId>
       <artifactId>tags-api</artifactId>
     </dependency>
-
-
+      <dependency>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-web</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-beans</artifactId>
+      </dependency>
   </dependencies>
 
 

--- a/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/forms/TagForm.java
+++ b/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/forms/TagForm.java
@@ -190,11 +190,15 @@ public class TagForm extends BaseForm {
         }
 
         // XSS validation checks
-        if (formattedText.containsSecurityViolations(tagLabel, null)) {
+        StringBuilder tagMessages = new StringBuilder();
+        formattedText.processFormattedText(tagLabel, tagMessages);
+        if (!tagMessages.isEmpty()) {
             errors.addError("tagLabel", "contains_xss");
         }
 
-        if (formattedText.containsSecurityViolations(description, null)) {
+        StringBuilder descriptionMessages = new StringBuilder();
+        formattedText.processFormattedText(description, descriptionMessages);
+        if (!descriptionMessages.isEmpty()) {
             errors.addError("description", "contains_xss");
         }
 

--- a/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/forms/TagForm.java
+++ b/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/forms/TagForm.java
@@ -33,6 +33,9 @@ import org.sakaiproject.tags.api.Errors;
 import org.sakaiproject.tags.api.MissingUuidException;
 import org.sakaiproject.tags.api.Tag;
 import org.sakaiproject.tags.tool.handlers.CrudHandler;
+import org.sakaiproject.util.api.FormattedText;
+
+import java.util.Optional;
 
 /**
  * Maps to and from the tag HTML form and a tag data object.
@@ -165,14 +168,41 @@ public class TagForm extends BaseForm {
                 externalHierarchyCode, externalType, data, collectionName);
     }
 
-    public Errors validate(CrudHandler.CrudMode mode) {
+    public Errors validate(FormattedText formattedText, CrudHandler.CrudMode mode) {
         Errors errors = new Errors();
 
+        // Validate required fields
+        if (tagLabel == null || tagLabel.trim().isEmpty()) {
+            errors.addError("tagLabel", "tag_label_required");
+        }
+
+        // Validate field lengths
+        if (tagLabel != null && tagLabel.length() > 255) {
+            errors.addError("tagLabel", "tag_label_too_long");
+        }
+
+        if (description != null && description.length() > 1000) {
+            errors.addError("description", "description_too_long");
+        }
+
+        if (externalId != null && externalId.length() > 255) {
+            errors.addError("externalId", "external_id_too_long");
+        }
+
+        // XSS validation checks
+        if (formattedText.containsSecurityViolations(tagLabel, null)) {
+            errors.addError("tagLabel", "contains_xss");
+        }
+
+        if (formattedText.containsSecurityViolations(description, null)) {
+            errors.addError("description", "contains_xss");
+        }
+
+        // Merge with model-level validation errors
         Errors modelErrors = toTag().validate();
 
         return errors.merge(modelErrors);
     }
-
 
     public Tag toTag() {
         return new Tag(uuid, tagCollectionId, tagLabel, description, createdBy,

--- a/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/handlers/TagsHandler.java
+++ b/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/handlers/TagsHandler.java
@@ -95,7 +95,7 @@ public class TagsHandler extends CrudHandler {
                 // Don't let the portal buffering hijack our response.
                 // Include enough content to count as having returned a
                 // body.
-                response.getWriter().write(tag.get().getTagLabel());
+                response.getWriter().write(formattedText.escapeHtml(tag.get().getTagLabel()));
             }else{
 
                 response.getWriter().write("     ");

--- a/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/handlers/TagsHandler.java
+++ b/tags/tags-tool/tool/src/java/org/sakaiproject/tags/tool/handlers/TagsHandler.java
@@ -37,6 +37,7 @@ import org.sakaiproject.tags.api.TagCollection;
 import org.sakaiproject.tags.api.TagService;
 import org.sakaiproject.tags.api.Tag;
 import org.sakaiproject.tags.tool.forms.TagForm;
+import org.sakaiproject.util.api.FormattedText;
 
 /**
  * A handler for creating and updating tags in the Tags Service administration tool.
@@ -46,9 +47,11 @@ public class TagsHandler extends CrudHandler {
 
     private static final int TAGSERVICE_URL_TAGSINTAGCOLLECTION_PREFIX_LENGTH = 20;
     private final TagService tagService;
+    private final FormattedText formattedText;
 
-    public TagsHandler(TagService tagService) {
+    public TagsHandler(TagService tagService, FormattedText formattedText) {
         this.tagService = tagService;
+        this.formattedText = formattedText;
     }
 
     @Override
@@ -138,7 +141,7 @@ public class TagsHandler extends CrudHandler {
         String uuid = extractId(request);
         TagForm tagForm = TagForm.fromRequest(uuid, request);
 
-        this.addErrors(tagForm.validate(mode));
+        this.addErrors(tagForm.validate(formattedText, mode));
 
         if (hasErrors()) {
             showEditForm(tagForm, context, mode);

--- a/tags/tags-tool/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/tags/tags-tool/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -3,12 +3,4 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <bean id="org.sakaiproject.tags.tool.TagServiceServlet" class="org.sakaiproject.tags.tool.TagServiceServlet">
-        <property name="serverConfigurationService"><ref bean="org.sakaiproject.component.api.ServerConfigurationService" /></property>
-        <property name="sessionManager"><ref bean="org.sakaiproject.tool.api.SessionManager" /></property>
-        <property name="toolManager"><ref bean="org.sakaiproject.tool.api.ToolManager" /></property>
-        <property name="securityService"><ref bean="org.sakaiproject.authz.api.SecurityService"/></property>
-        <property name="timeService"><ref bean="org.sakaiproject.time.api.TimeService" /></property>
-    </bean>
-
 </beans>

--- a/tags/tags-tool/tool/src/webapp/WEB-INF/web.xml
+++ b/tags/tags-tool/tool/src/webapp/WEB-INF/web.xml
@@ -32,5 +32,7 @@
     <listener>
         <listener-class>org.sakaiproject.util.ToolListener</listener-class>
     </listener>
-
+    <listener>
+        <listener-class>org.sakaiproject.util.SakaiContextLoaderListener</listener-class>
+    </listener>
 </web-app>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Server-side XSS/security checks integrated into tag creation/edit flows.
  - Preview now escapes tag labels for safer display.

- Improvements
  - Tag label made required; limits enforced for label (≤255), description (≤1000), external ID (≤255).
  - New user-facing validation messages for required/too-long/XSS cases.
  - Content-cleaner default changed to display errors by default.

- Bug Fixes
  - Blocked saving tags containing potentially malicious content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->