### PR TITLE
SAK-51905 Messages ensure icons display more reliably across browsers and themes

### DIFF
--- a/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsg.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/privateMsg/pvtMsg.jsp
@@ -268,14 +268,14 @@
 		  </h:column>
 		  <h:column>
 				<f:facet name="header">
-					<span class="bi bi-paperclip" aria-hidden="true"></span>
+					<h:outputText value="" styleClass="bi bi-paperclip" escape="false" />
 					<h:outputText value="#{msgs.msg_has_attach}" styleClass="sr-only" />
 				</f:facet>
 				<h:outputText value="" styleClass="bi bi-paperclip" escape="false" rendered="#{rcvdItems.msg.hasAttachments}" />
 			</h:column>
 			<h:column>
 				<f:facet name="header">
-		        	<span class="bi bi-reply-fill" aria-hidden="true"></span>
+					<h:outputText value="" styleClass="bi bi-reply-fill" escape="false" />
 					<h:outputText value="#{msgs.pvt_msgs_replied}" styleClass="sr-only" />
 				</f:facet>
 				<h:outputText value="" styleClass="bi bi-reply-fill" escape="false" rendered="#{rcvdItems.replied}" />


### PR DESCRIPTION
SAK-51905 Messages: fixing some header icons

https://sakaiproject.atlassian.net/browse/SAK-51905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated header icons in Private Messages to use consistent components across threaded and non-threaded views.
  - Improved visual consistency and alignment of attachment and reply indicators in message lists.
  - Ensured icons display more reliably across browsers and themes.
  - No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->