### PR TITLE
SAK-51809 Scorm fix sorting and use student's surname and given name

### DIFF
--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.Strings;
 
 public class Learner implements Serializable, Comparable<Learner>
 {
@@ -46,6 +47,9 @@ public class Learner implements Serializable, Comparable<Learner>
 	@Override
 	public int compareTo(Learner learner)
 	{
-		return sortName.compareTo(learner.sortName);
+		// Replace spaces to handle sorting scenarios where surname has space
+		String prop1 = Strings.CS.replace(sortName, " ", "+");
+		String prop2 = Strings.CS.replace(learner.sortName, " ", "+");
+		return prop1.compareTo(prop2);
 	}
 }

--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
@@ -38,7 +38,8 @@ public class LearnerExperience implements Serializable
 
 	public LearnerExperience(Learner learner, long contentPackageId)
 	{
-		this.learnerName = new StringBuilder(learner.getDisplayName()).append(" (").append(learner.getDisplayId()).append(")").toString();
+		// Display learner as "Surname, Firstname (displayId)" to match other tools
+		this.learnerName = new StringBuilder(learner.getSortName()).append(" (").append(learner.getDisplayId()).append(")").toString();
 		this.learnerId = learner.getId();
 		this.contentPackageId = contentPackageId;
 		this.numberOfAttempts = 0;

--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
@@ -27,6 +27,8 @@ public class LearnerExperience implements Serializable
 
 	@Setter @Getter private String learnerName;
 	@Setter @Getter private String learnerId;
+	@Setter @Getter private String sortName;
+	@Setter @Getter private String displayId;
 	@Setter @Getter private String progress;
 	@Setter @Getter private String score;
 	@Setter @Getter private String previousLearnerIds;
@@ -41,7 +43,10 @@ public class LearnerExperience implements Serializable
 		// Display learner as "Surname, Firstname (displayId)" to match other tools
 		this.learnerName = new StringBuilder(learner.getSortName()).append(" (").append(learner.getDisplayId()).append(")").toString();
 		this.learnerId = learner.getId();
+		this.sortName = learner.getSortName();
+		this.displayId = learner.getDisplayId();
 		this.contentPackageId = contentPackageId;
 		this.numberOfAttempts = 0;
 	}
+
 }

--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.scorm.model.api.LearnerExperience;
 
@@ -59,7 +60,33 @@ public class LearnerExperienceComparator implements Comparator<LearnerExperience
         {
             case Learner:
             {
-                return le1.getLearnerName().compareTo( le2.getLearnerName() );
+                // Use proper sorting logic similar to UserSortNameComparator
+                String sortName1 = le1.getSortName();
+                String sortName2 = le2.getSortName();
+                
+                if (sortName1 != null && sortName2 != null) {
+                    // Replace spaces to handle sorting scenarios where surname has space
+                    String prop1 = StringUtils.replace(sortName1, " ", "+");
+                    String prop2 = StringUtils.replace(sortName2, " ", "+");
+                    
+                    // Primary comparison on sort name
+                    int result = prop1.compareToIgnoreCase(prop2);
+                    if (result == 0) {
+                        // Secondary comparison on displayId if sort names are identical (matches UserSortNameComparator behavior)
+                        String displayId1 = le1.getDisplayId();
+                        String displayId2 = le2.getDisplayId();
+                        if (displayId1 != null && displayId2 != null) {
+                            result = displayId1.compareToIgnoreCase(displayId2);
+                        } else {
+                            // Fall back to learner name if displayIds are not available
+                            result = le1.getLearnerName().compareToIgnoreCase(le2.getLearnerName());
+                        }
+                    }
+                    return result;
+                }
+                
+                // Fall back to learner name comparison if sort names are not available
+                return le1.getLearnerName().compareToIgnoreCase(le2.getLearnerName());
             }
             case AttemptDate:
             {

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.java
@@ -34,6 +34,6 @@ public class LearnerDetailsPanel extends Panel
 	private void initPanel(Learner object)
 	{
 		add(new Label("id", object.getDisplayId()));
-		add(new Label("name", object.getDisplayName()));
+		add(new Label("name", object.getSortName()));
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
@@ -84,7 +84,7 @@ public class InteractionResultsPage extends BaseResultsPage
 
 			IModel breadcrumbModel = new StringResourceModel("uberuberparent.breadcrumb", this, new Model(contentPackage));
 			addBreadcrumb(breadcrumbModel, ResultsListPage.class, uberuberparentParams, true);	
-			addBreadcrumb(new Model(learner.getDisplayName()), LearnerResultsPage.class, parentParams, true);
+			addBreadcrumb(new Model(learner.getSortName()), LearnerResultsPage.class, parentParams, true);
 			addBreadcrumb(new Model(interaction.getActivityTitle()), ScoResultsPage.class, pageParams, true);
 			addBreadcrumb(new Model(interaction.getInteractionId()), InteractionResultsPage.class, pageParams, false);
 

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
@@ -101,7 +101,7 @@ public class LearnerResultsPage extends BaseResultsPage
 					addBreadcrumb(breadcrumbModel, PackageListPage.class, uberparentParams, true);
 				}
 			}
-			addBreadcrumb(new Model(learner.getDisplayName()), LearnerResultsPage.class, parentParams, false);
+			addBreadcrumb(new Model(learner.getSortName()), LearnerResultsPage.class, parentParams, false);
 
 			List<ActivitySummary> summaries = resultService.getActivitySummaries(contentPackage.getContentPackageId(), learner.getId(), attemptNumber);
 			SummaryProvider dataProvider = new SummaryProvider(summaries);

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -146,6 +146,8 @@ public class ResultsListPage extends ConsoleBasePage
 			addBreadcrumb(new Model(contentPackage.getTitle()), ResultsListPage.class, new PageParameters(), false);
 
 			SakaiDataTable table = new SakaiDataTable("resultsTable", getColumns(), dataProvider, true);
+			// Default to 200 learners per page
+			table.setItemsPerPage(200);
 			add(table);
 
 			add(new ContentPackageDetailPanel("details", contentPackage));

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -121,7 +121,7 @@ public class ResultsListPage extends ConsoleBasePage
 				}
 				catch( IOException ex )
 				{
-					log.error( "Could not generate results export: {}", ex );
+					log.error( "Could not generate results export", ex );
 				}
 
 				return tempFile;
@@ -402,11 +402,11 @@ public class ResultsListPage extends ConsoleBasePage
 			// Sort using the comparator in the direction requested
 			if( sortAsc )
 			{
-				Collections.sort( learnerExperiences, comp );
+				learnerExperiences.sort(comp);
 			}
 			else
 			{
-				Collections.sort( learnerExperiences, Collections.reverseOrder( comp ) );
+				learnerExperiences.sort(Collections.reverseOrder(comp));
 			}
 
 			// Return sub list of sorted collection

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.java
@@ -97,7 +97,7 @@ public class ScoResultsPage extends BaseResultsPage
 
 			IModel breadcrumbModel = new StringResourceModel("uberparent.breadcrumb", this, new Model(contentPackage));
 			addBreadcrumb(breadcrumbModel, ResultsListPage.class, uberparentParams, true);	
-			addBreadcrumb(new Model(learner.getDisplayName()), LearnerResultsPage.class, parentParams, true);
+			addBreadcrumb(new Model(learner.getSortName()), LearnerResultsPage.class, parentParams, true);
 
 			ActivityReport report = resultService.getActivityReport(contentPackage.getContentPackageId(), learner.getId(), attemptNumber, scoId);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Results list now defaults to 200 learners per page.
  - Learner display standardized to “Surname, Firstname (ID)” across reports and breadcrumbs.
- Bug Fixes
  - More consistent learner sorting using sort names with improved handling of spaces and multi-part surnames, with ID-based tie-breaking.
- Chores
  - Improved error logging for results export to include stack traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->