### PR TITLE
SAK-51861 Assignments: Instructor’s Assignment list is missing Rubric icon when Hide Rubric from Student is set

### DIFF
--- a/library/src/skins/default/src/sass/base/_icons.scss
+++ b/library/src/skins/default/src/sass/base/_icons.scss
@@ -73,7 +73,6 @@ $fa-font-path: "./fonts";
     sakai-resetpass : bi-person,
     sakai-resources : bi-folder,
     sakai-rubrics : bi-table,
-    sakai-rubrics-hidden : bi-x-square,
     sakai-rwiki : bi-pencil-square,
     sakai-samigo : bi-check2-square,
     sakai-schedule : bi-calendar,

--- a/library/src/skins/default/src/sass/base/_icons.scss
+++ b/library/src/skins/default/src/sass/base/_icons.scss
@@ -73,6 +73,7 @@ $fa-font-path: "./fonts";
     sakai-resetpass : bi-person,
     sakai-resources : bi-folder,
     sakai-rubrics : bi-table,
+    sakai-rubrics-hidden : bi-x-square,
     sakai-rwiki : bi-pencil-square,
     sakai-samigo : bi-check2-square,
     sakai-schedule : bi-calendar,

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
@@ -14,7 +14,6 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     evaluatedItemOwnerId: { attribute: "evaluated-item-owner-id", type: String },
     forcePreview: { attribute: "force-preview", type: Boolean },
     instructor: { type: Boolean },
-    icon: { type: String },
   };
 
   constructor() {
@@ -22,7 +21,6 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     super();
 
     this.forcePreview = false;
-    this.icon = "si si-sakai-rubrics";
   }
 
   set siteId(value) {
@@ -50,7 +48,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
 
     return html`
       <a @click=${this.showRubric} href="javascript:;" title="${this._i18n.preview_rubric}">
-        <span class="${this.icon}"></span>
+        <span class="si si-sakai-rubrics"></span>
       </a>
     `;
   }
@@ -60,16 +58,11 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     this.apiGetAssociation()
       .then(association => {
 
-        if (association) {
-          if (this.instructor || !association.parameters.hideStudentPreview) {
-            this._rubricId = association.rubricId;
-            if (this.instructor && association.parameters.hideStudentPreview) {
-              this.icon = "si si-sakai-rubrics-hidden";
-            }
-          }
+        if (association && (this.instructor || !association.parameters.hideStudentPreview)) {
+          this._rubricId = association.rubricId;
         }
       })
-      .catch(error => console.error(error));
+    .catch(error => console.error(error));
   }
 
   showRubric() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
@@ -14,6 +14,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     evaluatedItemOwnerId: { attribute: "evaluated-item-owner-id", type: String },
     forcePreview: { attribute: "force-preview", type: Boolean },
     instructor: { type: Boolean },
+    icon: { type: String },
   };
 
   constructor() {
@@ -21,6 +22,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     super();
 
     this.forcePreview = false;
+    this.icon = "si si-sakai-rubrics";
   }
 
   set siteId(value) {
@@ -48,7 +50,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
 
     return html`
       <a @click=${this.showRubric} href="javascript:;" title="${this._i18n.preview_rubric}">
-        <span class="si si-sakai-rubrics"></span>
+        <span class="${this.icon}"></span>
       </a>
     `;
   }
@@ -58,11 +60,16 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     this.apiGetAssociation()
       .then(association => {
 
-        if (association && !association.parameters.hideStudentPreview) {
-          this._rubricId = association.rubricId;
+        if (association) {
+          if (this.instructor || !association.parameters.hideStudentPreview) {
+            this._rubricId = association.rubricId;
+            if (this.instructor && association.parameters.hideStudentPreview) {
+              this.icon = "si si-sakai-rubrics-hidden";
+            }
+          }
         }
       })
-    .catch(error => console.error(error));
+      .catch(error => console.error(error));
   }
 
   showRubric() {


### PR DESCRIPTION
SAK-51861 Assignments: Instructor’s Assignment list is missing Rubric icon when Hide Rubric from Student is set

https://sakaiproject.atlassian.net/browse/SAK-51861


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Instructors can now always preview associated rubrics, even when student preview is hidden, ensuring visibility for teaching staff.
  * Students remain unable to view rubric previews when “hide student preview” is enabled, maintaining the intended restriction.
  * Aligns rubric preview behavior across roles to reduce inconsistencies and confusion in the interface.
  * Improves reliability of the rubric preview button in courses where student previews are intentionally disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->