### PR TITLE
SAK-51931 RSF fix datepicker input used by Evalsys

### DIFF
--- a/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-date-field-input.html
+++ b/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-date-field-input.html
@@ -23,24 +23,27 @@
 	src="/library/js/lang-datepicker/lang-datepicker.js"
 	rsf:id="scr=contribute-script"></script>
 <script type="text/javascript" rsf:id="scr=contribute-script">
-	// Simple wrapper to make it easy to call from RSF.
-	var rsfDatePicker = function(id, hidden, time) {
-		// jQuery selectors need colons escaped.
-		id = "#" + id.replace(/:/g, "\\:");
-		hidden = hidden.replace(/:/g, "\\:");
-		// Load plugin on DOM ready.
-		$(function() {
-			$(id).sakaiDateTimePicker({
-				input : id,
-				useTime : time,
-				parseFormat : 'YYYY-MM-DD HH:mm:ss',
-				val : document.getElementById(hidden) ? document.getElementById(hidden).value : "",
-				ashidden : {
-					iso8601 : hidden
-				}
+	// Simple wrapper to make it easy to call from RSF, now using the
+	// modern SakaiDateTimePicker class instead of the old jQuery plugin.
+	const rsfDatePicker = function(id, hidden, time) {
+		// Preserve raw ids for getElementById/ashidden; escape only for selector usage.
+		const rawId = id;
+		const rawHidden = hidden;
+		const selector = "#" + rawId.replace(/:/g, "\\:");
+
+		// Initialize on DOM ready without jQuery
+		document.addEventListener('DOMContentLoaded', () => {
+			const initialVal = document.getElementById(rawHidden) ? document.getElementById(rawHidden).value : "";
+			new SakaiDateTimePicker({
+				input: selector,
+				useTime: time,
+				val: initialVal,
+				ashidden: { iso8601: rawHidden }
 			});
 		});
 	};
+	// Ensure global access for the inline init script
+	window.rsfDatePicker = rsfDatePicker;
 </script>
 </head>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Rebuilt the date/time picker initialization to remove the jQuery dependency and use native browser events.
  * Improved handling of initial values for more consistent prefilled dates/times.
  * Preserved existing usage and parameters; no changes required by users.

* **Chores**
  * Exposed the date/time picker initializer as a global for broader compatibility.
  * Streamlined selector handling to better support IDs and CSS selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->