### PR TITLE
SAK-51680 DateManager updating a draft discussion fails silently

### DIFF
--- a/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -1431,8 +1431,8 @@ public class DateManagerServiceImpl implements DateManagerService {
                                 String entityType = (String)jsonForum.get(DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME);
                                 DateManagerUpdate update;
                                 // Check if this is a forum (including draft forums) by checking if entityType starts with the forum type
-                                String forumType = resourceLoader.getString("itemtype.forum");
-                                if(entityType != null && entityType.startsWith(forumType)) {
+                                final String forumType = StringUtils.defaultString(resourceLoader.getString("itemtype.forum"));
+                                if (StringUtils.startsWith(StringUtils.trimToEmpty(entityType), forumType)) {
                                         BaseForum forum = forumManager.getForumById(true, forumId);
                                         if (forum == null) {
                                                 errors.add(new DateManagerError("forum", resourceLoader.getFormattedMessage("error.item.not.found", resourceLoader.getString("tool.forums.item.name")), "forums", toolTitle, idx));
@@ -1491,7 +1491,7 @@ public class DateManagerServiceImpl implements DateManagerService {
                                                 forum.setCloseDate(closeDateTemp);
                                         }
                                 }
-                                forumManager.saveDiscussionForum(forum, forum.getDraft());
+                                forumManager.saveDiscussionForum(forum, Boolean.TRUE.equals(forum.getDraft()));
                         } else {
                                 DiscussionTopic topic = (DiscussionTopic) update.object;
                                 if(topic.getAvailabilityRestricted()) {


### PR DESCRIPTION
Fix two issues with DateManager forum updates:

1. Preserve internationalization by using startsWith() instead of equals() for forum type checking. This allows proper handling of draft forums where extraInfo is "Forums Draft" instead of just "Forums".

2. Preserve draft status when saving forums by passing forum.getDraft() to saveDiscussionForum() to prevent draft forums from becoming published.

This fixes the OptimisticLockException that occurred when the system incorrectly tried to update topics instead of forums for draft forum items.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Draft forums are now correctly recognized during validations and updates, even when item type includes draft indicators.
  * Draft status is preserved when saving forums, ensuring consistent behavior between drafts and published items.
  * Safer handling of missing or null item types to avoid errors when deciding forum vs topic.
  * Existing error messages and flows retained while improving draft identification reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->