### PR TITLE
SAK-51931 Library make datepicker more robust to useTime options

### DIFF
--- a/library/src/webapp/js/lang-datepicker/lang-datepicker.js
+++ b/library/src/webapp/js/lang-datepicker/lang-datepicker.js
@@ -183,23 +183,34 @@ const defaults = {
   }
   
   class SakaiDateTimePicker {
-	constructor(options) {
-	  this.options = { ...defaults, ...options };
-	  this.options.useTime = Boolean(this.options.useTime === 1 || this.options.useTime === true);
-	  
-	  // Handle both selector strings and DOM elements
-	  this.element = typeof this.options.input === 'string' 
-		? document.querySelector(this.options.input)
-		: this.options.input;
-	  
-	  if (!this.element) {
-		console.error("Input element not found:", this.options.input);
-		return;
-	  }
-	  
-	  this.init();
-	}
-  
+    constructor(options) {
+      this.options = { ...defaults, ...options };
+
+      // Normalize useTime to a boolean, accepting 1/0, '1'/'0', true/false, 'true'/'false'
+      const normalizeBoolean = (v) => {
+        if (typeof v === 'boolean') return v;
+        if (typeof v === 'number') return v === 1;
+        if (typeof v === 'string') {
+          const s = v.trim().toLowerCase();
+          return s === '1' || s === 'true' || s === 'yes' || s === 'on';
+        }
+        return Boolean(v);
+      };
+      this.options.useTime = normalizeBoolean(this.options.useTime);
+
+      // Handle both selector strings and DOM elements
+      this.element = typeof this.options.input === 'string' 
+          ? document.querySelector(this.options.input)
+          : this.options.input;
+
+      if (!this.element) {
+        console.error("Input element not found:", this.options.input);
+        return;
+      }
+
+      this.init();
+    }
+
 	init() {
 	  // Process initial date value
 	  const initialDate = this.getInitialDate();


### PR DESCRIPTION
  - Implemented robust useTime parsing in library/src/webapp/js/lang-datepicker/lang-datepicker.js.
  - Now accepts 1/0, '1'/'0', true/false, 'true'/'false', plus common truthy strings ('yes', 'on').
  - No changes needed to the evolver or template; existing "1"/"0" from SakaiFieldDateInputEvolver work.

  What Changed

  - In SakaiDateTimePicker constructor, replaced strict checks (=== 1 || === true) with a small normalizer:
      - Booleans → unchanged
      - Numbers → 1 is true, others false - Strings → true for '1'/'true'/'yes'/'on' (case-insensitive)

  Why

  - UIInitBlock currently passes "1"/"0" as strings from SakaiFieldDateInputEvolver.
  - Prior code only treated numeric 1 or boolean true as true, so string "1" was ignored.
  - Normalization makes the widget resilient regardless of what RSF emits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date/time picker now correctly recognizes various truthy values for the time option (e.g., 1/0, numeric, and common string forms like "true", "yes", "on"), preventing unexpected disabling of time.
  * No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->