### PR TITLE
SAK-51920 Assignments preserve anonymous grading checkbox after past-due alert

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -3334,12 +3334,16 @@ public class AssignmentAction extends PagedResourceActionII {
 
         Integer scaleFactor;
         Boolean anonGrading;
+        // Preserve the user's selection from state if present (e.g., when the form
+        // is re-rendered after validation alerts like past-due warning). Otherwise
+        // fall back to the assignment's stored value (when editing) or default.
+        Boolean anonFromState = (Boolean) state.getAttribute(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING);
         if (a != null) {
             scaleFactor = a.getScaleFactor() != null ? a.getScaleFactor() : assignmentService.getScaleFactor();
-            anonGrading = assignmentService.assignmentUsesAnonymousGrading(a);
+            anonGrading = anonFromState != null ? anonFromState : assignmentService.assignmentUsesAnonymousGrading(a);
         } else {
             scaleFactor = assignmentService.getScaleFactor();
-            anonGrading = (Boolean) state.getAttribute(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING);
+            anonGrading = anonFromState;
         }
 
         Assignment.GradeType gradeType = Assignment.GradeType.values()[(Integer) state.getAttribute(NEW_ASSIGNMENT_GRADE_TYPE)];


### PR DESCRIPTION

**Problem**: When an instructor edits an assignment after its due date, the form shows an alert about the due date being in the past. After the alert, the form re-renders and the checkbox for anonymous grading is unexpectedly cleared, forcing the instructor to re-check it before saving.

**Root cause**: In setAssignmentFormContext(...), the value used for  was always taken from the persisted assignment (assignmentService.assignmentUsesAnonymousGrading(a)) when editing an existing assignment. This overwrote the user’s in-progress selection captured in SessionState (NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING) after validation, such as the past-due alert. As a result, the checkbox state did not persist across the validation round-trip.

**Fix**: Prefer the user’s in-progress selection from SessionState when it exists; otherwise fall back to the persisted value (or default when creating). Specifically: compute anonFromState = (Boolean) state.getAttribute(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING) and set anonGrading = anonFromState != null ? anonFromState : assignmentService.assignmentUsesAnonymousGrading(a) when editing; for new assignments, use anonFromState. The rest of the context remains unchanged.

**Why this is correct**: The checkbox posts to NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING and we already store that into SessionState in setNewAssignmentParameters(...). When the form re-renders due to validation (e.g., past-due), the UI should reflect the user’s latest choice, not the previously persisted assignment value. This mirrors how other form fields are preserved via state on validation errors.

**Files changed**: assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java — revised anonGrading computation inside setAssignmentFormContext(...) to use state-first fallback-to-persisted logic.

**Scope and risk**: Localized to context-value selection for the anonymous grading checkbox in the instructor new/edit assignment view. No changes to templates or services. Default behavior on first load is unchanged (still shows the persisted value when there’s no in-progress state). Low risk: purely affects in-form state retention during validation.

**Manual test plan**:

1) Edit an assignment whose due date is in the past. Check ‘Hide submitters’ identities…’. Click Post. Observe the alert about due date in the past. Scroll back down and verify the checkbox remains checked. Click Post again to save.

2) Edit an assignment whose due date is in the future (no alert). Toggle anonymous grading and Post—value should save as expected.

3) Create a new assignment and trigger a different validation error (e.g., inconsistent open/close times). Ensure the checkbox state persists after the page re-renders.

4) Re-open the edit form to confirm the persisted value is reflected on initial load (no in-progress state).

Notes: Velocity templates already bind to ; no template updates required. Verified other contexts read-only consume this value and are unaffected (grading lists, submissions, preview).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The Anonymous Grading setting is now preserved when creating or editing an assignment if the form is re-displayed after validation alerts. This prevents the option from resetting unexpectedly and ensures your selection remains intact, reducing rework and improving consistency during form corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->