### PR TITLE
SAK-51937 ERROR - org.sakaiproject.site.api.Site.getMember(String) is null

### DIFF
--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -67,6 +67,7 @@ import org.sakaiproject.announcement.api.AnnouncementMessageHeaderEdit;
 import org.sakaiproject.announcement.api.AnnouncementService;
 import org.sakaiproject.announcement.api.ViewableFilter;
 import org.sakaiproject.authz.api.FunctionManager;
+import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.entity.api.ContentExistsAware;
@@ -2392,7 +2393,12 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 					String messageSiteId = entityManager.newReference(msg.getReference()).getContext();
 					try {
 						Site msgSite = siteService.getSite(messageSiteId);
-						String userRole = msgSite.getMember(currentUserId).getRole().getId();
+						Member member = msgSite.getMember(currentUserId);
+						if (member == null) {
+							log.warn("User {} is not a member of site {}", currentUserId, messageSiteId);
+							return false;
+						}
+						String userRole = member.getRole().getId();
 						return selectedRoles.contains(userRole);
 					} catch (IdUnusedException idue) {
 						log.warn("No site found with id {}", messageSiteId);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevented errors when checking announcement access for users who aren’t members of a site; access is now correctly denied instead of failing.
  - Added a warning log when site membership is missing to aid troubleshooting.
  - Improves reliability of announcement visibility across sites and roles.
  - No changes to permissions or UI required; behavior is more stable and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->