### PR TITLE
SAK-51765 Portal when clicking Organize Favorites perform a refresh of notifications

### DIFF
--- a/library/src/webapp/js/portal/portal.all.sites.js
+++ b/library/src/webapp/js/portal/portal.all.sites.js
@@ -286,15 +286,13 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   const organizeTab = document.getElementById('allsites-organize-favourites-tab');
-  if (organizeTab) {
-    organizeTab.addEventListener("click", e => {
-      const refreshNotification = document.getElementById('allsites-refresh-notification');
-      if (refreshNotification) {
-        const computedStyle = window.getComputedStyle(refreshNotification);
-        const displayValue = computedStyle.getPropertyValue('display');
-        if (displayValue === 'block') {
-          location.reload();
-        }
+  const refreshNotification = document.getElementById("allsites-refresh-notification");
+
+  if (organizeTab && refreshNotification) {
+    organizeTab.addEventListener("click", () => {
+      if (refreshNotification.offsetParent !== null) {
+        // Element is visible
+        location.reload();
       }
     });
   }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-51765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking the “Organize Favourites” tab now triggers an automatic page refresh when a refresh notification is visible, ensuring the view updates immediately and reflects the latest changes or notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->