### PR TITLE
SAK-51936 Kernel broaden mime-magic ignore to js, html, htm, css, txt

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -645,8 +645,8 @@
 
 # KNL-1306 - Support to ignore content from certain types and extensions
 # If this file extension is in the list, the content from the file will not be used to aide in detection of the type
-# DEFAULT: js
-# content.mimeMagic.ignorecontent.extensions=js,html,txt
+# DEFAULT: js,html,htm,css,txt
+# content.mimeMagic.ignorecontent.extensions=js,html,htm,css,txt,xhtml,xml
 
 # If the mime type is in the list returned, it will be redetected without content which may produce a different result
 # DEFAULT: none
@@ -5754,4 +5754,3 @@
 # on a production system.  If there is no PNP base URL, this value has no effect.
 # lti.pnp.use_email=false
 # DEFAULT: false
-

--- a/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
+++ b/kernel/component-manager/src/main/bundle/org/sakaiproject/config/kernel.properties
@@ -264,8 +264,9 @@ memory.org.sakaiproject.user.api.UserDirectoryService=maxElementsInMemory=100000
 # memory.org.sakaiproject.user.api.UserDirectoryService.callCache *ALL DEFAULTS*
 # memory.org.sakaiproject.user.impl.BasePreferencesService.preferences *ALL DEFAULTS*
 
-#KNL-1306 default
-content.mimeMagic.ignorecontent.extensions=js
+# KNL-1306 default; broaden to cover common web text assets
+# These are reliably identified by filename and often mis-classified by magic
+content.mimeMagic.ignorecontent.extensions=js,html,htm,css,txt
 
 # KNL-1234 Enable MathJax on content in resources
 portal.mathjax.src.path=https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=default,Safe

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/test/ContentHostingServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/test/ContentHostingServiceTest.java
@@ -409,4 +409,73 @@ public class ContentHostingServiceTest extends SakaiKernelTestBase {
         return;
     }
 
+    // Verify that an .html file containing XHTML markers is normalized to text/html when
+    // extension-based magic detection is ignored for common web text assets.
+    @Test
+    public void testMimeDetectionHtmlWithXhtmlMarkersNormalized() throws Exception {
+        // Ensure mime magic is enabled but ignored for html-like extensions
+        ServerConfigurationService serv = getService(ServerConfigurationService.class);
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.useMimeMagic","true",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.count","5",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.1","js",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.2","html",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.3","htm",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.4","css",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.5","txt",ServerConfigurationService.UNKNOWN));
+
+        ContentHostingService ch = getService(ContentHostingService.class);
+        SessionManager sm = getService(SessionManager.class);
+        Session session = sm.getCurrentSession();
+        session.setUserEid("admin");
+        session.setUserId("admin");
+
+        final String fileName = "xhtmlish.html"; // has XHTML doctype/namespace but .html extension
+        final String CHSfileName = "/" + fileName;
+
+        InputStream stream = this.getClass().getResourceAsStream("/test-documents/" + fileName);
+        Assert.assertNotNull(stream);
+
+        ResourcePropertiesEdit props = ch.newResourceProperties();
+        props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, fileName);
+        ch.addResource(CHSfileName, "", stream, props, 0);
+
+        ContentResource cr = ch.getResource(CHSfileName);
+        Assert.assertEquals("text/html", cr.getContentType());
+        stream.close();
+    }
+
+    // Verify that a real .xhtml file retains application/xhtml+xml
+    @Test
+    public void testMimeDetectionXhtmlStaysXhtml() throws Exception {
+        // Enable mime magic and ignore only common web-text extensions; .xhtml is not ignored
+        ServerConfigurationService serv = getService(ServerConfigurationService.class);
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.useMimeMagic","true",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.count","5",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.1","js",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.2","html",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.3","htm",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.4","css",ServerConfigurationService.UNKNOWN));
+        serv.registerConfigItem(BasicConfigItem.makeConfigItem("content.mimeMagic.ignorecontent.extensions.5","txt",ServerConfigurationService.UNKNOWN));
+
+        ContentHostingService ch = getService(ContentHostingService.class);
+        SessionManager sm = getService(SessionManager.class);
+        Session session = sm.getCurrentSession();
+        session.setUserEid("admin");
+        session.setUserId("admin");
+
+        final String fileName = "truexhtml.xhtml";
+        final String CHSfileName = "/" + fileName;
+
+        InputStream stream = this.getClass().getResourceAsStream("/test-documents/" + fileName);
+        Assert.assertNotNull(stream);
+
+        ResourcePropertiesEdit props = ch.newResourceProperties();
+        props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, fileName);
+        ch.addResource(CHSfileName, "", stream, props, 0);
+
+        ContentResource cr = ch.getResource(CHSfileName);
+        Assert.assertEquals("application/xhtml+xml", cr.getContentType());
+        stream.close();
+    }
+
 }

--- a/kernel/kernel-impl/src/test/resources/test-documents/truexhtml.xhtml
+++ b/kernel/kernel-impl/src/test/resources/test-documents/truexhtml.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <title>Real XHTML</title>
+    <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+  </head>
+  <body>
+    <p>This is a minimal XHTML document for testing.</p>
+  </body>
+</html>
+

--- a/kernel/kernel-impl/src/test/resources/test-documents/xhtmlish.html
+++ b/kernel/kernel-impl/src/test/resources/test-documents/xhtmlish.html
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>XHTML-ish HTML file</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    <h1>Should be treated as text/html</h1>
+    <p>This file includes XHTML markers but has a .html extension.</p>
+  </body>
+</html>
+


### PR DESCRIPTION
- normalize HTML vs XHTML detection; add focused tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved file type detection for common web files (HTML, HTM, CSS, JS, TXT) to reduce misclassification when uploading or managing content.
  - XHTML files (.xhtml) are now more reliably recognized as application/xhtml+xml when appropriate, improving accuracy for standards-compliant documents.
  - Overall MIME handling is more consistent and case-insensitive, leading to fewer unexpected content-type changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->