### PR TITLE
SAK-51948 RSF date picker detects ISO8601 strings with a time part and a trailing timezone offset

### DIFF
--- a/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-date-field-input.html
+++ b/rsf/sakai-rsf-web/templates/src/webapp/content/templates/sakai-date-field-input.html
@@ -33,7 +33,20 @@
 
 		// Initialize on DOM ready without jQuery
 		document.addEventListener('DOMContentLoaded', () => {
-			const initialVal = document.getElementById(rawHidden) ? document.getElementById(rawHidden).value : "";
+			let initialVal = document.getElementById(rawHidden) ? document.getElementById(rawHidden).value : "";
+			if (initialVal) {
+				// Check for ISO format with timezone. Could be more compact but ampersands don't work in RSF templates AFAIK.
+				const hasT = initialVal.indexOf('T') !== -1;
+				const hasPlus = (initialVal.lastIndexOf('+') == initialVal.length -3);
+				const hasMinus = (initialVal.lastIndexOf('-') == initialVal.length -3);
+
+				if (hasT) {
+					if (hasPlus || hasMinus) {
+						initialVal = initialVal + ':00';
+					}
+				}
+			}
+
 			new SakaiDateTimePicker({
 				input: selector,
 				useTime: time,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timezone-aware normalization for ISO8601-like inputs to avoid mis-parsing offsets.
  * Appends missing seconds (":00") when needed for compatibility with the date-time picker.
  * Skips normalization for empty values to prevent accidental mutation.
  * Passes normalized value and ISO8601 flag into the date-time picker for consistent initialization.
  * Reduces errors and improves displayed date/time consistency across inputs and locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->