### PR TITLE
SAK-51959 Samigo add Reset Selection to MC questions

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2618,6 +2618,7 @@ public class DeliveryBean implements Serializable {
             }
 
             if (item.getItemData().getTypeId().longValue() == TypeIfc.MULTIPLE_CHOICE.longValue() ||
+                    item.getItemData().getTypeId().longValue() == TypeIfc.MULTIPLE_CORRECT.longValue() ||
                     item.getItemData().getTypeId().longValue() == TypeIfc.MULTIPLE_CORRECT_SINGLE_SELECTION.longValue() ||
                     item.getItemData().getTypeId().longValue() == TypeIfc.MULTIPLE_CHOICE_SURVEY.longValue() ||
                     item.getItemData().getTypeId().longValue() == TypeIfc.MATRIX_CHOICES_SURVEY.longValue()) {

--- a/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMultipleChoiceMultipleCorrect.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/item/deliverMultipleChoiceMultipleCorrect.jsp
@@ -67,6 +67,13 @@ should be included in file importing DeliveryMessages
     </t:column>
   </t:dataTable>
 
+  <h:commandLink id="cmdclean" value="#{deliveryMessages.reset_selection}" action="#{delivery.cleanRadioButton}" onclick="saveTime(); serializeImagePoints();"
+	rendered="#{(delivery.actionString=='previewAssessment' || delivery.actionString=='previewAssessmentPublished'
+                || delivery.actionString=='takeAssessment'
+                || delivery.actionString=='takeAssessmentViaUrl')}">
+	<f:param name="radioId" value="#{question.itemData.itemId}" />
+  </h:commandLink>
+
 <f:verbatim><br /></f:verbatim>
 <h:panelGroup rendered="#{(delivery.actionString=='previewAssessment'
                 || delivery.actionString=='takeAssessment' 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Clear selection” option for Multiple Choice (Multiple Correct) questions during preview and taking assessments, allowing users to reset their selections easily.

- Bug Fixes
  - Clearing selections now correctly resets the answer state for Multiple Correct items, ensuring they are marked unanswered and removing any previously recorded selections.
  - Improves consistency of selection clearing across matrix and non-matrix variants of multi-select questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->