### PR TITLE
SAK-51960 Fix anonymous grading regression in submission navigation dropdown

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/SubmissionNavBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/SubmissionNavBean.java
@@ -64,7 +64,14 @@ public class SubmissionNavBean extends SpringBeanAutowiringSupport implements Se
     }
 
 
-    public void populate(List<AgentResults> agentResultsList, String currentGradingId, boolean displaySubmissionDate) {
+    /**
+     * Populate the navigation bean with submission data
+     * @param agentResultsList list of agent results
+     * @param currentGradingId current grading ID
+     * @param displaySubmissionDate whether to display submission date
+     * @param isAnonymous whether anonymous grading is enabled
+     */
+    public void populate(List<AgentResults> agentResultsList, String currentGradingId, boolean displaySubmissionDate, boolean isAnonymous) {
 
         this.displaySubmissionDate = displaySubmissionDate;
         this.currentGradingId = currentGradingId;
@@ -95,15 +102,31 @@ public class SubmissionNavBean extends SpringBeanAutowiringSupport implements Se
 
         submissionsSelection = agentResultsMap.values().stream()
                 .map(agent -> {
-                    String displayName = agent.getLastName() + ", " + agent.getFirstName()
-                        + " (" + agent.getAgentDisplayId()  + ")";
-                    String optionLabel = displaySubmissionDate
+                    String displayName;
+                    if (isAnonymous) {
+                        // For anonymous grading, show only the numeric assessment grading ID
+                        displayName = agent.getAssessmentGradingId().toString();
+                    } else {
+                        // For non-anonymous grading, show student name and ID as before
+                        displayName = agent.getLastName() + ", " + agent.getFirstName()
+                            + " (" + agent.getAgentDisplayId()  + ")";
+                    }
+                    String optionLabel = displaySubmissionDate && !isAnonymous
                             ? displayName + " - " + userTimeService.dateTimeFormat(agent.getSubmittedDate().toInstant(),
                                     FormatStyle.MEDIUM, FormatStyle.SHORT)
                             : displayName;
                     return new SelectItem(agent.getAssessmentGradingId(), optionLabel);
                 })
                 .toArray(size -> new SelectItem[size]);
+    }
+
+    /**
+     * Backward compatibility method - defaults to non-anonymous grading
+     * @deprecated Use populate(List, String, boolean, boolean) instead
+     */
+    @Deprecated
+    public void populate(List<AgentResults> agentResultsList, String currentGradingId, boolean displaySubmissionDate) {
+        populate(agentResultsList, currentGradingId, displaySubmissionDate, false);
     }
 
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/SubmissionNavListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/SubmissionNavListener.java
@@ -56,7 +56,8 @@ public class SubmissionNavListener implements ValueChangeListener  {
 
         List<AgentResults> agents = new ArrayList<>(totalScoresBean.getAllAgents());
         boolean displaySubmissionDate = StringUtils.equals(TotalScoresBean.ALL_SUBMISSIONS, totalScoresBean.getAllSubmissions());
-        submissionNavBean.populate(agents, gradingId, displaySubmissionDate);
+        boolean isAnonymous = Boolean.parseBoolean(totalScoresBean.getAnonymous());
+        submissionNavBean.populate(agents, gradingId, displaySubmissionDate, isAnonymous);
 
         deliveryBean.setNextAssessmentGradingId(Long.valueOf(gradingId));
 


### PR DESCRIPTION
Anonymous grading was broken in the submission navigation dropdown introduced in S2U-15 (commit 033ca645e7b). The SubmissionNavBean always displayed student names regardless of anonymous grading setting, exposing student identities.

Changes:
- Add isAnonymous parameter to SubmissionNavBean.populate()
- Show numeric ID only for anonymous grading instead of student names
- Pass anonymous flag from TotalScoresBean in SubmissionNavListener
- Add backward compatibility method for existing callers

Fixes regression of original SAK-36952 fix from 2012.