### PR TITLE
SAK-51970 LTI adopt TransferBean style objects

### DIFF
--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -224,6 +224,10 @@ public interface LTIService extends LTISubstitutionsFilter {
     int LTI_TOOL_NEWPAGE_CONTENT = 2;
     String LTI_PROTECT = "protect";
     String LTI_DEBUG = "debug";
+    // choices=off,on,content
+    int LTI_TOOL_DEBUG_OFF = 0;
+    int LTI_TOOL_DEBUG_ON = 1;
+    int LTI_TOOL_DEBUG_CONTENT = 2;
     String LTI_CUSTOM = "custom";
     String LTI_ROLEMAP = "rolemap";
     String LTI_SPLASH = "splash";
@@ -368,16 +372,36 @@ public interface LTIService extends LTISubstitutionsFilter {
 
     Map<String, Object> getTool(Long key, String siteId);
 
+    org.sakaiproject.lti.beans.LtiToolBean getToolBean(Long key, String siteId);
+
     Map<String, Object> getToolDao(Long key, String siteId);
 
     Map<String, Object> getToolDao(Long key, String siteId, boolean isAdminRole);
 
+    /**
+     * Get a tool as a POJO, bypassing security checks (DAO method).
+     * 
+     * @param key The tool key
+     * @param siteId The site ID
+     * @param isAdminRole Whether to bypass security checks
+     * @return LtiToolBean instance or null if not found
+     */
+    org.sakaiproject.lti.beans.LtiToolBean getToolDaoAsPojo(Long key, String siteId, boolean isAdminRole);
 
     Object updateTool(Long key, Properties newProps, String siteId);
 
     Object updateTool(Long key, Map<String, Object> newProps, String siteId);
 
     Object updateToolDao(Long key, Map<String, Object> newProps, String siteId);
+
+    /**
+     * Update a tool with a tool bean
+     * @param key the tool key
+     * @param tool the tool bean
+     * @param siteId the site id
+     * @return the result
+     */
+    Object updateToolDao(Long key, org.sakaiproject.lti.beans.LtiToolBean tool, String siteId);
 
     Object updateToolDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
 
@@ -398,9 +422,15 @@ public interface LTIService extends LTISubstitutionsFilter {
     // Tool Retrieval
     List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId);
 
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId);
+
     List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId, boolean includeStealthed);
 
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed);
+
     List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable);
+
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable);
 
     /**
      * Gets a list of the launchable tools in the site
@@ -439,6 +469,8 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId
      */
     List<Map<String, Object>> getToolsImportItem(String siteId);
+
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolsImportItemBeans(String siteId);
 
     /**
      * Get a list of tools that can return content for the editor
@@ -482,6 +514,8 @@ public interface LTIService extends LTISubstitutionsFilter {
 
     Map<String, Object> getContent(Long key, String siteId);
 
+    org.sakaiproject.lti.beans.LtiContentBean getContentBean(Long key, String siteId);
+
     Map<String, Object> getContentDao(Long key);
 
     Map<String, Object> getContentDao(Long key, String siteId);
@@ -505,6 +539,8 @@ public interface LTIService extends LTISubstitutionsFilter {
     Object updateContentDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole);
 
     List<Map<String, Object>> getContents(String search, String order, int first, int last, String siteId);
+
+    List<org.sakaiproject.lti.beans.LtiContentBean> getContentBeans(String search, String order, int first, int last, String siteId);
 
     /**
      * This finds a set of LTI Contents objects.
@@ -655,4 +691,133 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @return The text with updated LTI launch URLs
      */
     String fixLtiLaunchUrls(String text, String toContext, MergeConfig mcx);
+
+    // POJO overload methods - return strongly typed objects instead of Map<String, Object>
+    
+    /**
+     * Get a single LTI tool as a POJO
+     * @param key The tool ID
+     * @param siteId The site ID
+     * @return LtiTool POJO or null if not found
+     */
+    org.sakaiproject.lti.beans.LtiToolBean getToolAsPojo(Long key, String siteId);
+
+    /**
+     * Get a list of LTI tools as POJOs
+     * @param search Search criteria
+     * @param order Sort order
+     * @param first First result index
+     * @param last Last result index
+     * @param siteId The site ID
+     * @return List of LtiTool POJOs
+     */
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsPojos(String search, String order, int first, int last, String siteId);
+
+    /**
+     * Get a list of LTI tools as POJOs with stealthed option
+     * @param search Search criteria
+     * @param order Sort order
+     * @param first First result index
+     * @param last Last result index
+     * @param siteId The site ID
+     * @param includeStealthed Whether to include stealthed tools
+     * @return List of LtiTool POJOs
+     */
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsPojos(String search, String order, int first, int last, String siteId, boolean includeStealthed);
+
+    /**
+     * Get a list of launchable LTI tools as POJOs
+     * @param siteId The site ID
+     * @return List of LtiTool POJOs
+     */
+    List<org.sakaiproject.lti.beans.LtiToolBean> getToolsLaunchAsPojos(String siteId);
+
+    /**
+     * Get a single LTI content item as a POJO
+     * @param key The content ID
+     * @param siteId The site ID
+     * @return LtiContent POJO or null if not found
+     */
+    org.sakaiproject.lti.beans.LtiContentBean getContentAsPojo(Long key, String siteId);
+
+    /**
+     * Get a list of LTI content items as POJOs
+     * @param search Search criteria
+     * @param order Sort order
+     * @param first First result index
+     * @param last Last result index
+     * @param siteId The site ID
+     * @return List of LtiContent POJOs
+     */
+    List<org.sakaiproject.lti.beans.LtiContentBean> getContentsAsPojos(String search, String order, int first, int last, String siteId);
+
+    /**
+     * Get a single LTI tool site as a POJO
+     * @param key The tool site ID
+     * @param siteId The site ID
+     * @return LtiToolSite POJO or null if not found
+     */
+    org.sakaiproject.lti.beans.LtiToolSiteBean getToolSiteAsPojo(Long key, String siteId);
+
+    /**
+     * Get a list of LTI tool sites as POJOs
+     * @param toolId The tool ID
+     * @param siteId The site ID
+     * @return List of LtiToolSite POJOs
+     */
+    List<org.sakaiproject.lti.beans.LtiToolSiteBean> getToolSitesByToolIdAsPojos(String toolId, String siteId);
+
+    /**
+     * Get a single LTI memberships job as a POJO
+     * @param siteId The site ID
+     * @return LtiMembershipsJob POJO or null if not found
+     */
+    org.sakaiproject.lti.beans.LtiMembershipsJobBean getMembershipsJobAsPojo(String siteId);
+
+    /**
+     * Get all LTI memberships jobs as POJOs
+     * @return List of LtiMembershipsJob POJOs
+     */
+    List<org.sakaiproject.lti.beans.LtiMembershipsJobBean> getMembershipsJobsAsPojos();
+
+    /**
+     * Insert a new LTI tool using POJO
+     * @param toolBean The tool data as POJO
+     * @param siteId The site ID
+     * @return The ID of the inserted tool
+     */
+    Object insertTool(org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId);
+
+    /**
+     * Insert a new LTI content using POJO
+     * @param contentBean The content data as POJO
+     * @param siteId The site ID
+     * @return The ID of the inserted content
+     */
+    Object insertContent(org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId);
+
+    /**
+     * Update an existing LTI tool using POJO
+     * @param key The tool ID
+     * @param toolBean The tool data as POJO
+     * @param siteId The site ID
+     * @return The result of the update operation
+     */
+    Object updateTool(Long key, org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId);
+
+    /**
+     * Update an existing LTI content using POJO
+     * @param key The content ID
+     * @param contentBean The content data as POJO
+     * @param siteId The site ID
+     * @return The result of the update operation
+     */
+    Object updateContent(Long key, org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId);
+
+    /**
+     * Get the launch URL for a content item using POJO
+     * @param contentBean The content data as POJO
+     * @return The launch URL
+     */
+    String getContentLaunch(org.sakaiproject.lti.beans.LtiContentBean contentBean);
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LTIBaseBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LTIBaseBean.java
@@ -24,8 +24,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Base class providing common type conversion utilities for LTI POJOs.
@@ -35,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * Implementation assistance provided by Claude AI for comprehensive type conversion
  * and robust database number handling across SQLite, Oracle, and MySQL systems.
  */
+@Slf4j
 public abstract class LTIBaseBean {
 
     /**
@@ -254,9 +254,8 @@ public abstract class LTIBaseBean {
 
         // Validate the three-state value
         if (intValue != null && (intValue < 0 || intValue > 2)) {
-            Logger logger = LoggerFactory.getLogger(LTIBaseBean.class);
-            logger.warn("Invalid three-state value for {}: {} (expected 0, 1, 2, or null). Treating as null (off).",
-                       fieldName, value);
+            log.warn("Invalid three-state value for {}: {} (expected 0, 1, 2, or null). Treating as null (off).",
+                     fieldName, value);
             return null;
         }
 
@@ -276,9 +275,8 @@ public abstract class LTIBaseBean {
         if (value != null) {
             // Validate the three-state value
             if (value < 0 || value > 2) {
-                Logger logger = LoggerFactory.getLogger(LTIBaseBean.class);
-                logger.warn("Invalid three-state value for {}: {} (expected 0, 1, 2, or null). Treating as null (off).",
-                           fieldName, value);
+                log.warn("Invalid three-state value for {}: {} (expected 0, 1, 2, or null). Treating as null (off).",
+                         fieldName, value);
                 return; // Don't put invalid values in the map
             }
             map.put(key, value);

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LTIBaseBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LTIBaseBean.java
@@ -1,0 +1,314 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class providing common type conversion utilities for LTI POJOs.
+ * These methods handle the robust conversion of Object types from database results
+ * to strongly-typed POJO fields, similar to the LTIUtil conversion methods.
+ *
+ * Implementation assistance provided by Claude AI for comprehensive type conversion
+ * and robust database number handling across SQLite, Oracle, and MySQL systems.
+ */
+public abstract class LTIBaseBean {
+
+    /**
+     * Safely converts a map value to a String.
+     *
+     * @param map The map containing the value
+     * @param key The key to look up
+     * @return The string value, or null if not found or null
+     */
+    protected static String getStringValue(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Safely converts a map value to a Long, handling all database number types.
+     * This method is as robust as LTIUtil.toLong() and handles:
+     * - String representations of numbers (including decimals)
+     * - All Number types (Integer, Long, Double, Float, Short, Byte, BigDecimal, etc.)
+     * - Decimal truncation (like LTIUtil)
+     * - Invalid strings return null
+     *
+     * @param map The map containing the value
+     * @param key The key to look up
+     * @return The Long value, or null if not found, null, or invalid
+     */
+    protected static Long getLongValue(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        // Handle String types (including database string representations)
+        if (value instanceof String) {
+            String str = (String) value;
+            if (str.length() == 0) {
+                return null;
+            }
+            try {
+                // Handle decimal strings by truncating (like LTIUtil)
+                if (str.contains(".")) {
+                    // Convert to double first, then to long (truncates decimal)
+                    return Long.valueOf((long) Double.parseDouble(str));
+                }
+                return Long.valueOf(str);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        // Handle all Number types (Integer, Long, Double, Float, Short, Byte, BigDecimal, etc.)
+        if (value instanceof Number) {
+            return Long.valueOf(((Number) value).longValue());
+        }
+
+        // Fallback: try toString() conversion
+        try {
+            String str = value.toString();
+            if (str.contains(".")) {
+                return Long.valueOf((long) Double.parseDouble(str));
+            }
+            return Long.parseLong(str);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Safely converts a map value to an Integer, handling all database number types.
+     * This method is as robust as LTIUtil.toInteger() and handles:
+     * - String representations of numbers (including decimals)
+     * - All Number types (Integer, Long, Double, Float, Short, Byte, BigDecimal, etc.)
+     * - Decimal truncation (like LTIUtil)
+     * - Invalid strings return null
+     *
+     * @param map The map containing the value
+     * @param key The key to look up
+     * @return The Integer value, or null if not found, null, or invalid
+     */
+    protected static Integer getIntegerValue(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        // Handle String types (including database string representations)
+        if (value instanceof String) {
+            String str = (String) value;
+            if (str.length() == 0) {
+                return null;
+            }
+            try {
+                // Handle decimal strings by truncating (like LTIUtil)
+                if (str.contains(".")) {
+                    // Convert to double first, then to int (truncates decimal)
+                    return Integer.valueOf((int) Double.parseDouble(str));
+                }
+                return Integer.valueOf(str);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        // Handle all Number types (Integer, Long, Double, Float, Short, Byte, BigDecimal, etc.)
+        if (value instanceof Number) {
+            return Integer.valueOf(((Number) value).intValue());
+        }
+
+        // Fallback: try toString() conversion
+        try {
+            String str = value.toString();
+            if (str.contains(".")) {
+                return Integer.valueOf((int) Double.parseDouble(str));
+            }
+            return Integer.parseInt(str);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Safely converts a map value to a Boolean, handling common boolean representations.
+     *
+     * @param map The map containing the value
+     * @param key The key to look up
+     * @return The Boolean value, or null if not found or null
+     */
+    protected static Boolean getBooleanValue(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        // Handle common boolean representations
+        String str = value.toString().toLowerCase();
+        return "true".equals(str) || "1".equals(str) || "yes".equals(str) || "on".equals(str);
+    }
+
+    /**
+     * Safely converts a map value to a Date, handling various timestamp representations.
+     *
+     * @param map The map containing the value
+     * @param key The key to look up
+     * @return The Date value, or null if not found or null
+     */
+    protected static Date getDateValue(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Date) {
+            return (Date) value;
+        }
+        if (value instanceof Calendar) {
+            return ((Calendar) value).getTime();
+        }
+        if (value instanceof Long) {
+            return new Date((Long) value);
+        }
+        // Try to parse as timestamp
+        try {
+            long timestamp = Long.parseLong(value.toString());
+            return new Date(timestamp);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Safely converts a map value to a three-state Integer (0=off, 1=on, 2=content, null=off).
+     * Validates that the value is in the valid set and logs warnings for invalid values.
+     *
+     * @param map The map containing the value
+     * @param key The key to look up
+     * @param fieldName The name of the field for logging purposes (e.g., "newpage", "debug")
+     * @return The Integer value (0, 1, 2, or null), with null treated as 0
+     */
+    protected static Integer getThreeStateValue(Map<String, Object> map, String key, String fieldName) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null; // null is valid and represents "off" (0)
+        }
+
+        Integer intValue = null;
+
+        // Convert to Integer using existing logic
+        if (value instanceof String) {
+            String str = (String) value;
+            if (str.length() == 0) {
+                return null;
+            }
+            try {
+                if (str.contains(".")) {
+                    intValue = Integer.valueOf((int) Double.parseDouble(str));
+                } else {
+                    intValue = Integer.valueOf(str);
+                }
+            } catch (NumberFormatException e) {
+                // Invalid string - will be caught by validation below
+            }
+        } else if (value instanceof Number) {
+            intValue = Integer.valueOf(((Number) value).intValue());
+        } else {
+            try {
+                String str = value.toString();
+                if (str.contains(".")) {
+                    intValue = Integer.valueOf((int) Double.parseDouble(str));
+                } else {
+                    intValue = Integer.parseInt(str);
+                }
+            } catch (NumberFormatException e) {
+                // Invalid conversion - will be caught by validation below
+            }
+        }
+
+        // Validate the three-state value
+        if (intValue != null && (intValue < 0 || intValue > 2)) {
+            Logger logger = LoggerFactory.getLogger(LTIBaseBean.class);
+            logger.warn("Invalid three-state value for {}: {} (expected 0, 1, 2, or null). Treating as null (off).",
+                       fieldName, value);
+            return null;
+        }
+
+        return intValue;
+    }
+
+    /**
+     * Helper method to safely put a three-state value in a map with validation.
+     * Validates that the value is in the valid set (0, 1, 2, or null) and logs warnings for invalid values.
+     *
+     * @param map The map to put the value in
+     * @param key The key
+     * @param value The three-state Integer value (0, 1, 2, or null)
+     * @param fieldName The name of the field for logging purposes (e.g., "newpage", "debug")
+     */
+    protected static void putThreeStateIfNotNull(Map<String, Object> map, String key, Integer value, String fieldName) {
+        if (value != null) {
+            // Validate the three-state value
+            if (value < 0 || value > 2) {
+                Logger logger = LoggerFactory.getLogger(LTIBaseBean.class);
+                logger.warn("Invalid three-state value for {}: {} (expected 0, 1, 2, or null). Treating as null (off).",
+                           fieldName, value);
+                return; // Don't put invalid values in the map
+            }
+            map.put(key, value);
+        }
+    }
+
+    /**
+     * Helper method to safely put a value in a map only if it's not null.
+     *
+     * @param map The map to put the value in
+     * @param key The key
+     * @param value The value (only added if not null)
+     */
+    protected static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
+    /**
+     * Helper method to safely put a Boolean value in a map as an Integer.
+     * Converts Boolean values to Integer: true → 1, false → 0, null → null
+     *
+     * @param map The map to put the value in
+     * @param key The key
+     * @param value The Boolean value to convert and add (only added if not null)
+     */
+    protected static void putBooleanAsInteger(Map<String, Object> map, String key, Boolean value) {
+        if (value != null) {
+            map.put(key, value ? Integer.valueOf(1) : Integer.valueOf(0));
+        }
+    }
+}

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiContentBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiContentBean.java
@@ -1,0 +1,174 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.sakaiproject.lti.api.LTIService;
+
+/**
+ * Transfer object for LTI Content items.
+ * Based on the CONTENT_MODEL from LTIService.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper=false)
+@ToString(exclude = {"placementsecret", "oldplacementsecret"})
+public class LtiContentBean extends LTIBaseBean {
+
+    // Core fields from CONTENT_MODEL
+    public Long id;                    // CONTENT_MODEL: "id:key:archive=true"
+    public Long toolId;                // CONTENT_MODEL: "tool_id:integer:hidden=true"
+    public String siteId;              // CONTENT_MODEL: "SITE_ID:text:label=bl_content_site_id:required=true:maxlength=99:role=admin"
+    public String title;               // CONTENT_MODEL: "title:text:label=bl_title:required=true:maxlength=1024:archive=true"
+    public String description;         // CONTENT_MODEL: "description:textarea:label=bl_description:maxlength=4096:archive=true"
+    public Integer frameheight;        // CONTENT_MODEL: "frameheight:integer:label=bl_frameheight:archive=true"
+    public Boolean newpage;            // CONTENT_MODEL: "newpage:checkbox:label=bl_newpage:archive=true"
+    public Boolean protect;            // CONTENT_MODEL: "protect:checkbox:label=bl_protect:role=admin"
+    public Boolean debug;              // CONTENT_MODEL: "debug:checkbox:label=bl_debug"
+    // LTI fields from CONTENT_MODEL
+    public String custom;              // CONTENT_MODEL: "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384:archive=true"
+    public String launch;              // CONTENT_MODEL: "launch:url:label=bl_launch:hidden=true:maxlength=1024:archive=true"
+    public String xmlimport;           // CONTENT_MODEL: "xmlimport:text:hidden=true:maxlength=1M"
+    public String settings;            // CONTENT_MODEL: "settings:text:hidden=true:maxlength=1M"
+    public String contentitem;         // CONTENT_MODEL: "contentitem:text:label=bl_contentitem:rows=5:cols=25:maxlength=1M:hidden=true:archive=true"
+    public String placement;           // CONTENT_MODEL: "placement:text:hidden=true:maxlength=256"
+    public String placementsecret;     // CONTENT_MODEL: "placementsecret:text:hidden=true:maxlength=512"
+    public String oldplacementsecret;  // CONTENT_MODEL: "oldplacementsecret:text:hidden=true:maxlength=512"
+    // Timestamps from CONTENT_MODEL
+    public Date createdAt;             // CONTENT_MODEL: "created_at:autodate"
+    public Date updatedAt;             // CONTENT_MODEL: "updated_at:autodate"
+
+    // Extra fields that can be populated from joins (CONTENT_EXTRA_FIELDS)
+    public String siteTitle;           // CONTENT_EXTRA_FIELDS: "SITE_TITLE:text:table=SAKAI_SITE:realname=TITLE"
+    public String siteContactName;     // CONTENT_EXTRA_FIELDS: "SITE_CONTACT_NAME:text:table=ssp1:realname=VALUE"
+    public String siteContactEmail;    // CONTENT_EXTRA_FIELDS: "SITE_CONTACT_EMAIL:text:table=ssp2:realname=VALUE"
+    public String attribution;         // CONTENT_EXTRA_FIELDS: "ATTRIBUTION:text:table=ssp3:realname=VALUE"
+    public String url;                 // CONTENT_EXTRA_FIELDS: "URL:text:table=ssp4:realname=VALUE"
+    public String searchUrl;           // CONTENT_EXTRA_FIELDS: "searchURL:text:table=ssp5:realname=VALUE"
+
+    /**
+     * Creates an LtiContentBean instance from a Map<String, Object>.
+     * 
+     * @param map The map containing LTI content data
+     * @return LtiContentBean instance populated from the map
+     */
+    public static LtiContentBean of(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+        
+        LtiContentBean content = new LtiContentBean();
+        
+        // Core fields
+        content.setId(getLongValue(map, LTIService.LTI_ID));
+        content.setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
+        content.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
+        content.setTitle(getStringValue(map, LTIService.LTI_TITLE));
+        content.setDescription(getStringValue(map, LTIService.LTI_DESCRIPTION));
+        content.setFrameheight(getIntegerValue(map, LTIService.LTI_FRAMEHEIGHT));
+        content.setNewpage(getBooleanValue(map, LTIService.LTI_NEWPAGE));
+        content.setProtect(getBooleanValue(map, LTIService.LTI_PROTECT));
+        content.setDebug(getBooleanValue(map, LTIService.LTI_DEBUG));
+        
+        // LTI fields
+        content.setCustom(getStringValue(map, LTIService.LTI_CUSTOM));
+        content.setLaunch(getStringValue(map, LTIService.LTI_LAUNCH));
+        content.setXmlimport(getStringValue(map, LTIService.LTI_XMLIMPORT));
+        content.setSettings(getStringValue(map, LTIService.LTI_SETTINGS));
+        content.setContentitem(getStringValue(map, "contentitem"));
+        content.setPlacement(getStringValue(map, "placement"));
+        content.setPlacementsecret(getStringValue(map, LTIService.LTI_PLACEMENTSECRET));
+        content.setOldplacementsecret(getStringValue(map, LTIService.LTI_OLDPLACEMENTSECRET));
+        
+        
+        // Timestamps
+        content.setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
+        content.setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
+        
+        // Extra fields from joins
+        content.setSiteTitle(getStringValue(map, "SITE_TITLE"));
+        content.setSiteContactName(getStringValue(map, "SITE_CONTACT_NAME"));
+        content.setSiteContactEmail(getStringValue(map, "SITE_CONTACT_EMAIL"));
+        content.setAttribution(getStringValue(map, "ATTRIBUTION"));
+        content.setUrl(getStringValue(map, "URL"));
+        content.setSearchUrl(getStringValue(map, "searchURL"));
+        
+        return content;
+    }
+
+    /**
+     * Converts this LtiContentBean instance to a Map<String, Object>.
+     * 
+     * @return Map representation of this LtiContentBean
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new HashMap<>();
+        
+        // Core fields
+        putIfNotNull(map, LTIService.LTI_ID, id);
+        putIfNotNull(map, LTIService.LTI_TOOL_ID, toolId);
+        putIfNotNull(map, LTIService.LTI_SITE_ID, siteId);
+        putIfNotNull(map, LTIService.LTI_TITLE, title);
+        putIfNotNull(map, LTIService.LTI_DESCRIPTION, description);
+        putIfNotNull(map, LTIService.LTI_FRAMEHEIGHT, frameheight);
+        putBooleanAsInteger(map, LTIService.LTI_NEWPAGE, newpage);
+        putBooleanAsInteger(map, LTIService.LTI_PROTECT, protect);
+        putBooleanAsInteger(map, LTIService.LTI_DEBUG, debug);
+        
+        // LTI fields
+        putIfNotNull(map, LTIService.LTI_CUSTOM, custom);
+        putIfNotNull(map, LTIService.LTI_LAUNCH, launch);
+        putIfNotNull(map, LTIService.LTI_XMLIMPORT, xmlimport);
+        putIfNotNull(map, LTIService.LTI_SETTINGS, settings);
+        putIfNotNull(map, "contentitem", contentitem);
+        putIfNotNull(map, "placement", placement);
+        putIfNotNull(map, LTIService.LTI_PLACEMENTSECRET, placementsecret);
+        putIfNotNull(map, LTIService.LTI_OLDPLACEMENTSECRET, oldplacementsecret);
+        
+        
+        // Timestamps
+        putIfNotNull(map, LTIService.LTI_CREATED_AT, createdAt);
+        putIfNotNull(map, LTIService.LTI_UPDATED_AT, updatedAt);
+        
+        // Extra fields from joins
+        putIfNotNull(map, "SITE_TITLE", siteTitle);
+        putIfNotNull(map, "SITE_CONTACT_NAME", siteContactName);
+        putIfNotNull(map, "SITE_CONTACT_EMAIL", siteContactEmail);
+        putIfNotNull(map, "ATTRIBUTION", attribution);
+        putIfNotNull(map, "URL", url);
+        putIfNotNull(map, "searchURL", searchUrl);
+        
+        return map;
+    }
+
+}

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiMembershipsJobBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiMembershipsJobBean.java
@@ -1,0 +1,93 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import org.sakaiproject.lti.api.LTIService;
+
+/**
+ * Transfer object for LTI Memberships Jobs.
+ * Based on the MEMBERSHIPS_JOBS_MODEL from LTIService.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper=false)
+@ToString
+public class LtiMembershipsJobBean extends LTIBaseBean {
+
+    // Fields from MEMBERSHIPS_JOBS_MODEL
+    public String siteId;              // MEMBERSHIPS_JOBS_MODEL: "SITE_ID:text:maxlength=99:required=true"
+    public String membershipsId;       // MEMBERSHIPS_JOBS_MODEL: "memberships_id:text:maxlength=256:required=true"
+    public String membershipsUrl;      // MEMBERSHIPS_JOBS_MODEL: "memberships_url:text:maxlength=4000:required=true"
+    public String consumerkey;         // MEMBERSHIPS_JOBS_MODEL: "consumerkey:text:label=bl_consumerkey:maxlength=1024"
+    public String ltiVersion;          // MEMBERSHIPS_JOBS_MODEL: "lti_version:text:maxlength=32:required=true"
+
+    /**
+     * Creates an LtiMembershipsJobBean instance from a Map<String, Object>.
+     * 
+     * @param map The map containing LTI memberships job data
+     * @return LtiMembershipsJobBean instance populated from the map
+     */
+    public static LtiMembershipsJobBean of(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+        
+        LtiMembershipsJobBean job = new LtiMembershipsJobBean();
+        
+        job.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
+        job.setMembershipsId(getStringValue(map, "memberships_id"));
+        job.setMembershipsUrl(getStringValue(map, "memberships_url"));
+        job.setConsumerkey(getStringValue(map, LTIService.LTI_CONSUMERKEY));
+        job.setLtiVersion(getStringValue(map, "lti_version"));
+        
+        return job;
+    }
+
+    /**
+     * Converts this LtiMembershipsJobBean instance to a Map<String, Object>.
+     * 
+     * @return Map representation of this LtiMembershipsJobBean
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new HashMap<>();
+        
+        putIfNotNull(map, LTIService.LTI_SITE_ID, siteId);
+        putIfNotNull(map, "memberships_id", membershipsId);
+        putIfNotNull(map, "memberships_url", membershipsUrl);
+        putIfNotNull(map, LTIService.LTI_CONSUMERKEY, consumerkey);
+        putIfNotNull(map, "lti_version", ltiVersion);
+        
+        return map;
+    }
+
+}

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolBean.java
@@ -1,0 +1,285 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.sakaiproject.lti.api.LTIService;
+
+/**
+ * Transfer object for LTI Tools.
+ * Based on the TOOL_MODEL from LTIService.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper=false)
+@ToString(exclude = {"secret", "lti13AutoToken"})
+public class LtiToolBean extends LTIBaseBean {
+
+    // Core fields from TOOL_MODEL
+    public Long id;                    // TOOL_MODEL: "id:key:archive=true"
+    public String siteId;              // TOOL_MODEL: "SITE_ID:text:maxlength=99:role=admin"
+    public String title;               // TOOL_MODEL: "title:text:label=bl_title:required=true:maxlength=1024:archive=true"
+    public String description;         // TOOL_MODEL: "description:textarea:label=bl_description:maxlength=4096:archive=true"
+    public String status;              // TOOL_MODEL: "status:radio:label=bl_status:choices=enable,disable"
+    public String visible;             // TOOL_MODEL: "visible:radio:label=bl_visible:choices=visible,stealth:role=admin"
+    public Long deploymentId;          // TOOL_MODEL: "deployment_id:integer:hidden=true:archive=true"
+    public String launch;              // TOOL_MODEL: "launch:url:label=bl_launch:maxlength=1024:required=true:archive=true"
+    public Integer newpage;            // TOOL_MODEL: "newpage:radio:label=bl_newpage:choices=off,on,content:archive=true"
+    public Integer frameheight;        // TOOL_MODEL: "frameheight:integer:label=bl_frameheight:archive=true"
+    public String faIcon;              // TOOL_MODEL: "fa_icon:text:label=bl_fa_icon:maxlength=1024:archive=true"
+    
+    // Message Types (pl_ prefix for backwards compatibility) from TOOL_MODEL
+    public Boolean plLaunch;           // TOOL_MODEL: "pl_launch:checkbox:label=bl_pl_launch:archive=true"
+    public Boolean plLinkselection;    // TOOL_MODEL: "pl_linkselection:checkbox:label=bl_pl_linkselection:archive=true"
+    public Boolean plContextlaunch;    // TOOL_MODEL: "pl_contextlaunch:checkbox:label=bl_pl_contextlaunch:hidden=true"
+    
+    // Placements from TOOL_MODEL
+    public Boolean plLessonsselection;     // TOOL_MODEL: "pl_lessonsselection:checkbox:label=bl_pl_lessonsselection:archive=true"
+    public Boolean plContenteditor;        // TOOL_MODEL: "pl_contenteditor:checkbox:label=bl_pl_contenteditor:archive=true"
+    public Boolean plAssessmentselection;  // TOOL_MODEL: "pl_assessmentselection:checkbox:label=bl_pl_assessmentselection:archive=true"
+    public Boolean plCoursenav;            // TOOL_MODEL: "pl_coursenav:checkbox:label=bl_pl_coursenav:archive=true"
+    public Boolean plImportitem;           // TOOL_MODEL: "pl_importitem:checkbox:label=bl_pl_importitem:role=admin:archive=true"
+    public Boolean plFileitem;             // TOOL_MODEL: "pl_fileitem:checkbox:label=bl_pl_fileitem:role=admin:hidden=true:archive=true"
+    
+    // Privacy from TOOL_MODEL
+    public Boolean sendname;           // TOOL_MODEL: "sendname:checkbox:label=bl_sendname:archive=true"
+    public Boolean sendemailaddr;      // TOOL_MODEL: "sendemailaddr:checkbox:label=bl_sendemailaddr:archive=true"
+    public Boolean plPrivacy;          // TOOL_MODEL: "pl_privacy:checkbox:label=bl_pl_privacy:role=admin"
+    
+    // Services from TOOL_MODEL
+    public Boolean allowoutcomes;      // TOOL_MODEL: "allowoutcomes:checkbox:label=bl_allowoutcomes:archive=true"
+    public Boolean allowlineitems;     // TOOL_MODEL: "allowlineitems:checkbox:label=bl_allowlineitems:archive=true"
+    public Boolean allowroster;        // TOOL_MODEL: "allowroster:checkbox:label=bl_allowroster:archive=true"
+    
+    // Configuration fields from TOOL_MODEL
+    public Integer debug;              // TOOL_MODEL: "debug:radio:label=bl_debug:choices=off,on,content"
+    public String siteinfoconfig;      // TOOL_MODEL: "siteinfoconfig:radio:label=bl_siteinfoconfig:advanced:choices=bypass,config"
+    public String splash;              // TOOL_MODEL: "splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384"
+    public String custom;              // TOOL_MODEL: "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384:archive=true"
+    public String rolemap;             // TOOL_MODEL: "rolemap:textarea:label=bl_rolemap:rows=5:cols=25:maxlength=16384:role=admin:archive=true"
+    public Integer lti13;              // TOOL_MODEL: "lti13:radio:label=bl_lti13:choices=off,on,both:role=admin:archive=true"
+    
+    // LTI 1.3 security values from the tool from TOOL_MODEL
+    public String lti13ToolKeyset;     // TOOL_MODEL: "lti13_tool_keyset:text:label=bl_lti13_tool_keyset:maxlength=1024:role=admin"
+    public String lti13OidcEndpoint;   // TOOL_MODEL: "lti13_oidc_endpoint:text:label=bl_lti13_oidc_endpoint:maxlength=1024:role=admin"
+    public String lti13OidcRedirect;   // TOOL_MODEL: "lti13_oidc_redirect:text:label=bl_lti13_oidc_redirect:maxlength=1024:role=admin"
+    
+    // LTI 1.3 security values from the LMS from TOOL_MODEL
+    public String lti13LmsIssuer;      // TOOL_MODEL: "lti13_lms_issuer:text:label=bl_lti13_lms_issuer:readonly=true:persist=false:maxlength=1024:role=admin"
+    public String lti13ClientId;       // TOOL_MODEL: "lti13_client_id:text:label=bl_lti13_client_id:readonly=true:maxlength=1024:role=admin"
+    public String lti13LmsDeploymentId; // TOOL_MODEL: "lti13_lms_deployment_id:text:label=bl_lti13_lms_deployment_id:readonly=true:maxlength=1024:role=admin"
+    public String lti13LmsKeyset;      // TOOL_MODEL: "lti13_lms_keyset:text:label=bl_lti13_lms_keyset:readonly=true:persist=false:maxlength=1024:role=admin"
+    public String lti13LmsEndpoint;    // TOOL_MODEL: "lti13_lms_endpoint:text:label=bl_lti13_lms_endpoint:readonly=true:persist=false:maxlength=1024:role=admin"
+    public String lti13LmsToken;       // TOOL_MODEL: "lti13_lms_token:text:label=bl_lti13_lms_token:readonly=true:persist=false:maxlength=1024:role=admin"
+    
+    // LTI 1.1 security arrangement from TOOL_MODEL
+    public String consumerkey;         // TOOL_MODEL: "consumerkey:text:label=bl_consumerkey:maxlength=1024"
+    public String secret;              // TOOL_MODEL: "secret:text:label=bl_secret:maxlength=1024"
+    public String xmlimport;           // TOOL_MODEL: "xmlimport:textarea:hidden=true:maxlength=1M"
+    public String lti13AutoToken;      // TOOL_MODEL: "lti13_auto_token:text:hidden=true:maxlength=1024"
+    public Integer lti13AutoState;     // TOOL_MODEL: "lti13_auto_state:integer:hidden=true"
+    public String lti13AutoRegistration; // TOOL_MODEL: "lti13_auto_registration:textarea:hidden=true:maxlength=1M"
+    public String sakaiToolChecksum;   // TOOL_MODEL: "sakai_tool_checksum:text:maxlength=99:hidden=true:persist=false:archive=true"
+    
+    // Timestamps from TOOL_MODEL
+    public Date createdAt;             // TOOL_MODEL: "created_at:autodate"
+    public Date updatedAt;             // TOOL_MODEL: "updated_at:autodate"
+
+    /**
+     * Creates an LtiToolBean instance from a Map<String, Object>.
+     * 
+     * @param map The map containing LTI tool data
+     * @return LtiToolBean instance populated from the map
+     */
+    public static LtiToolBean of(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+        
+        LtiToolBean tool = new LtiToolBean();
+        
+        // Core fields
+        tool.setId(getLongValue(map, LTIService.LTI_ID));
+        tool.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
+        tool.setTitle(getStringValue(map, LTIService.LTI_TITLE));
+        tool.setDescription(getStringValue(map, LTIService.LTI_DESCRIPTION));
+        tool.setStatus(getStringValue(map, LTIService.LTI_STATUS));
+        tool.setVisible(getStringValue(map, LTIService.LTI_VISIBLE));
+        tool.setDeploymentId(getLongValue(map, "deployment_id"));
+        tool.setLaunch(getStringValue(map, LTIService.LTI_LAUNCH));
+        tool.setNewpage(getThreeStateValue(map, "newpage", "newpage"));
+        tool.setFrameheight(getIntegerValue(map, LTIService.LTI_FRAMEHEIGHT));
+        tool.setFaIcon(getStringValue(map, LTIService.LTI_FA_ICON));
+        
+        // Message Types (pl_ prefix for backwards compatibility)
+        tool.setPlLaunch(getBooleanValue(map, "pl_launch"));
+        tool.setPlLinkselection(getBooleanValue(map, "pl_linkselection"));
+        tool.setPlContextlaunch(getBooleanValue(map, "pl_contextlaunch"));
+        
+        // Placements
+        tool.setPlLessonsselection(getBooleanValue(map, "pl_lessonsselection"));
+        tool.setPlContenteditor(getBooleanValue(map, "pl_contenteditor"));
+        tool.setPlAssessmentselection(getBooleanValue(map, "pl_assessmentselection"));
+        tool.setPlCoursenav(getBooleanValue(map, "pl_coursenav"));
+        tool.setPlImportitem(getBooleanValue(map, "pl_importitem"));
+        tool.setPlFileitem(getBooleanValue(map, "pl_fileitem"));
+        
+        // Privacy
+        tool.setSendname(getBooleanValue(map, LTIService.LTI_SENDNAME));
+        tool.setSendemailaddr(getBooleanValue(map, LTIService.LTI_SENDEMAILADDR));
+        tool.setPlPrivacy(getBooleanValue(map, "pl_privacy"));
+        
+        // Services
+        tool.setAllowoutcomes(getBooleanValue(map, LTIService.LTI_ALLOWOUTCOMES));
+        tool.setAllowlineitems(getBooleanValue(map, LTIService.LTI_ALLOWLINEITEMS));
+        tool.setAllowroster(getBooleanValue(map, LTIService.LTI_ALLOWROSTER));
+        
+        // Configuration
+        tool.setDebug(getThreeStateValue(map, LTIService.LTI_DEBUG, "debug"));
+        tool.setSiteinfoconfig(getStringValue(map, "siteinfoconfig"));
+        tool.setSplash(getStringValue(map, LTIService.LTI_SPLASH));
+        tool.setCustom(getStringValue(map, LTIService.LTI_CUSTOM));
+        tool.setRolemap(getStringValue(map, LTIService.LTI_ROLEMAP));
+        tool.setLti13(getIntegerValue(map, LTIService.LTI13));
+        
+        // LTI 1.3 security values from the tool
+        tool.setLti13ToolKeyset(getStringValue(map, "lti13_tool_keyset"));
+        tool.setLti13OidcEndpoint(getStringValue(map, "lti13_oidc_endpoint"));
+        tool.setLti13OidcRedirect(getStringValue(map, "lti13_oidc_redirect"));
+        
+        // LTI 1.3 security values from the LMS
+        tool.setLti13LmsIssuer(getStringValue(map, "lti13_lms_issuer"));
+        tool.setLti13ClientId(getStringValue(map, "lti13_client_id"));
+        tool.setLti13LmsDeploymentId(getStringValue(map, "lti13_lms_deployment_id"));
+        tool.setLti13LmsKeyset(getStringValue(map, "lti13_lms_keyset"));
+        tool.setLti13LmsEndpoint(getStringValue(map, "lti13_lms_endpoint"));
+        tool.setLti13LmsToken(getStringValue(map, "lti13_lms_token"));
+        
+        // LTI 1.1 security arrangement
+        tool.setConsumerkey(getStringValue(map, LTIService.LTI_CONSUMERKEY));
+        tool.setSecret(getStringValue(map, LTIService.LTI_SECRET));
+        tool.setXmlimport(getStringValue(map, LTIService.LTI_XMLIMPORT));
+        tool.setLti13AutoToken(getStringValue(map, "lti13_auto_token"));
+        tool.setLti13AutoState(getIntegerValue(map, "lti13_auto_state"));
+        tool.setLti13AutoRegistration(getStringValue(map, "lti13_auto_registration"));
+        tool.setSakaiToolChecksum(getStringValue(map, "sakai_tool_checksum"));
+        
+        // Timestamps
+        tool.setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
+        tool.setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
+        
+        return tool;
+    }
+
+    /**
+     * Converts this LtiToolBean instance to a Map<String, Object>.
+     * 
+     * @return Map representation of this LtiToolBean
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new HashMap<>();
+        
+        // Core fields
+        putIfNotNull(map, LTIService.LTI_ID, id);
+        putIfNotNull(map, LTIService.LTI_SITE_ID, siteId);
+        putIfNotNull(map, LTIService.LTI_TITLE, title);
+        putIfNotNull(map, LTIService.LTI_DESCRIPTION, description);
+        putIfNotNull(map, LTIService.LTI_STATUS, status);
+        putIfNotNull(map, LTIService.LTI_VISIBLE, visible);
+        putIfNotNull(map, "deployment_id", deploymentId);
+        putIfNotNull(map, LTIService.LTI_LAUNCH, launch);
+        putThreeStateIfNotNull(map, "newpage", newpage, "newpage");
+        putIfNotNull(map, LTIService.LTI_FRAMEHEIGHT, frameheight);
+        putIfNotNull(map, LTIService.LTI_FA_ICON, faIcon);
+        
+        // Message Types
+        putBooleanAsInteger(map, "pl_launch", plLaunch);
+        putBooleanAsInteger(map, "pl_linkselection", plLinkselection);
+        putBooleanAsInteger(map, "pl_contextlaunch", plContextlaunch);
+        
+        // Placements
+        putBooleanAsInteger(map, "pl_lessonsselection", plLessonsselection);
+        putBooleanAsInteger(map, "pl_contenteditor", plContenteditor);
+        putBooleanAsInteger(map, "pl_assessmentselection", plAssessmentselection);
+        putBooleanAsInteger(map, "pl_coursenav", plCoursenav);
+        putBooleanAsInteger(map, "pl_importitem", plImportitem);
+        putBooleanAsInteger(map, "pl_fileitem", plFileitem);
+        
+        // Privacy
+        putBooleanAsInteger(map, LTIService.LTI_SENDNAME, sendname);
+        putBooleanAsInteger(map, LTIService.LTI_SENDEMAILADDR, sendemailaddr);
+        putBooleanAsInteger(map, "pl_privacy", plPrivacy);
+        
+        // Services
+        putBooleanAsInteger(map, LTIService.LTI_ALLOWOUTCOMES, allowoutcomes);
+        putBooleanAsInteger(map, LTIService.LTI_ALLOWLINEITEMS, allowlineitems);
+        putBooleanAsInteger(map, LTIService.LTI_ALLOWROSTER, allowroster);
+        
+        // Configuration
+        putThreeStateIfNotNull(map, LTIService.LTI_DEBUG, debug, "debug");
+        putIfNotNull(map, "siteinfoconfig", siteinfoconfig);
+        putIfNotNull(map, LTIService.LTI_SPLASH, splash);
+        putIfNotNull(map, LTIService.LTI_CUSTOM, custom);
+        putIfNotNull(map, LTIService.LTI_ROLEMAP, rolemap);
+        putIfNotNull(map, LTIService.LTI13, lti13);
+        
+        // LTI 1.3 security values from the tool
+        putIfNotNull(map, "lti13_tool_keyset", lti13ToolKeyset);
+        putIfNotNull(map, "lti13_oidc_endpoint", lti13OidcEndpoint);
+        putIfNotNull(map, "lti13_oidc_redirect", lti13OidcRedirect);
+        
+        // LTI 1.3 security values from the LMS
+        putIfNotNull(map, "lti13_lms_issuer", lti13LmsIssuer);
+        putIfNotNull(map, "lti13_client_id", lti13ClientId);
+        putIfNotNull(map, "lti13_lms_deployment_id", lti13LmsDeploymentId);
+        putIfNotNull(map, "lti13_lms_keyset", lti13LmsKeyset);
+        putIfNotNull(map, "lti13_lms_endpoint", lti13LmsEndpoint);
+        putIfNotNull(map, "lti13_lms_token", lti13LmsToken);
+        
+        // LTI 1.1 security arrangement
+        putIfNotNull(map, LTIService.LTI_CONSUMERKEY, consumerkey);
+        putIfNotNull(map, LTIService.LTI_SECRET, secret);
+        putIfNotNull(map, LTIService.LTI_XMLIMPORT, xmlimport);
+        putIfNotNull(map, "lti13_auto_token", lti13AutoToken);
+        putIfNotNull(map, "lti13_auto_state", lti13AutoState);
+        putIfNotNull(map, "lti13_auto_registration", lti13AutoRegistration);
+        putIfNotNull(map, "sakai_tool_checksum", sakaiToolChecksum);
+        
+        // Timestamps
+        putIfNotNull(map, LTIService.LTI_CREATED_AT, createdAt);
+        putIfNotNull(map, LTIService.LTI_UPDATED_AT, updatedAt);
+        
+        return map;
+    }
+
+}

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
@@ -1,0 +1,93 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.sakaiproject.lti.api.LTIService;
+
+/**
+ * Transfer object for LTI Tool Sites.
+ * Based on the TOOL_SITE_MODEL from LTIService.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper=false)
+public class LtiToolSiteBean extends LTIBaseBean {
+
+    // Fields from TOOL_SITE_MODEL
+    public Long id;                    // TOOL_SITE_MODEL: "id:key"
+    public Long toolId;                // TOOL_SITE_MODEL: "tool_id:integer:hidden=true"
+    public String siteId;              // TOOL_SITE_MODEL: "SITE_ID:text:label=bl_tool_site_SITE_ID:required=true:maxlength=99:role=admin"
+    public String notes;               // TOOL_SITE_MODEL: "notes:text:label=bl_tool_site_notes:maxlength=1024"
+    public Date createdAt;             // TOOL_SITE_MODEL: "created_at:autodate"
+    public Date updatedAt;             // TOOL_SITE_MODEL: "updated_at:autodate"
+
+    /**
+     * Creates an LtiToolSiteBean instance from a Map<String, Object>.
+     * 
+     * @param map The map containing LTI tool site data
+     * @return LtiToolSiteBean instance populated from the map
+     */
+    public static LtiToolSiteBean of(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+        
+        LtiToolSiteBean toolSite = new LtiToolSiteBean();
+        
+        toolSite.setId(getLongValue(map, LTIService.LTI_ID));
+        toolSite.setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
+        toolSite.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
+        toolSite.setNotes(getStringValue(map, "notes"));
+        toolSite.setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
+        toolSite.setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
+        
+        return toolSite;
+    }
+
+    /**
+     * Converts this LtiToolSiteBean instance to a Map<String, Object>.
+     * 
+     * @return Map representation of this LtiToolSiteBean
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new HashMap<>();
+        
+        putIfNotNull(map, LTIService.LTI_ID, id);
+        putIfNotNull(map, LTIService.LTI_TOOL_ID, toolId);
+        putIfNotNull(map, LTIService.LTI_SITE_ID, siteId);
+        putIfNotNull(map, "notes", notes);
+        putIfNotNull(map, LTIService.LTI_CREATED_AT, createdAt);
+        putIfNotNull(map, LTIService.LTI_UPDATED_AT, updatedAt);
+        
+        return map;
+    }
+
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LTIServicePojoMethodsTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LTIServicePojoMethodsTest.java
@@ -1,0 +1,384 @@
+/*
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import org.sakaiproject.lti.beans.LtiToolBean;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolSiteBean;
+import org.sakaiproject.lti.beans.LtiMembershipsJobBean;
+
+/**
+ * Test that the POJO conversion methods work correctly.
+ * This is a basic test to verify the fromMap/toMap round-trip functionality.
+ */
+public class LTIServicePojoMethodsTest {
+
+    @Test
+    public void testLtiToolBeanFromMapToMap() {
+        // Create a test map with sample data
+        Map<String, Object> toolMap = new HashMap<>();
+        toolMap.put("id", 123L);
+        toolMap.put("SITE_ID", "test-site");
+        toolMap.put("title", "Test Tool");
+        toolMap.put("description", "A test tool description");
+        toolMap.put("launch", "https://example.com/launch");
+        toolMap.put("lti13", 1); // LTI13_LTI13
+        toolMap.put("consumerkey", "test-key");
+        toolMap.put("secret", "test-secret");
+        toolMap.put("sendname", true);
+        toolMap.put("sendemailaddr", false);
+
+        // Convert to POJO
+        LtiToolBean tool = LtiToolBean.of(toolMap);
+
+        // Verify the conversion
+        assertNotNull("Tool should not be null", tool);
+        assertEquals("ID should match", Long.valueOf(123L), tool.id);
+        assertEquals("Site ID should match", "test-site", tool.siteId);
+        assertEquals("Title should match", "Test Tool", tool.title);
+        assertEquals("Description should match", "A test tool description", tool.description);
+        assertEquals("Launch should match", "https://example.com/launch", tool.launch);
+        assertEquals("LTI13 should match", Integer.valueOf(1), tool.lti13);
+        assertEquals("Consumer key should match", "test-key", tool.consumerkey);
+        assertEquals("Secret should match", "test-secret", tool.secret);
+        assertTrue("Sendname should be true", tool.sendname);
+        assertFalse("Sendemailaddr should be false", tool.sendemailaddr);
+
+        // Convert back to map
+        Map<String, Object> resultMap = tool.asMap();
+
+        // Verify round-trip
+        assertNotNull("Result map should not be null", resultMap);
+        assertEquals("ID should match in round-trip", Long.valueOf(123L), resultMap.get("id"));
+        assertEquals("Site ID should match in round-trip", "test-site", resultMap.get("SITE_ID"));
+        assertEquals("Title should match in round-trip", "Test Tool", resultMap.get("title"));
+        assertEquals("Description should match in round-trip", "A test tool description", resultMap.get("description"));
+        assertEquals("Launch should match in round-trip", "https://example.com/launch", resultMap.get("launch"));
+        assertEquals("LTI13 should match in round-trip", Integer.valueOf(1), resultMap.get("lti13"));
+        assertEquals("Consumer key should match in round-trip", "test-key", resultMap.get("consumerkey"));
+        assertEquals("Secret should match in round-trip", "test-secret", resultMap.get("secret"));
+        assertEquals("Sendname should be true in round-trip", Integer.valueOf(1), resultMap.get("sendname"));
+        assertEquals("Sendemailaddr should be false in round-trip", Integer.valueOf(0), resultMap.get("sendemailaddr"));
+    }
+
+    @Test
+    public void testLtiContentBeanFromMapToMap() {
+        // Create a test map with sample data
+        Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("id", 456L);
+        contentMap.put("tool_id", 123L);
+        contentMap.put("SITE_ID", "test-site");
+        contentMap.put("title", "Test Content");
+        contentMap.put("description", "A test content description");
+        contentMap.put("frameheight", 600);
+        contentMap.put("newpage", true);
+        contentMap.put("protect", false);
+        contentMap.put("debug", true);
+
+        // Convert to POJO
+        LtiContentBean content = LtiContentBean.of(contentMap);
+
+        // Verify the conversion
+        assertNotNull("Content should not be null", content);
+        assertEquals("ID should match", Long.valueOf(456L), content.id);
+        assertEquals("Tool ID should match", Long.valueOf(123L), content.toolId);
+        assertEquals("Site ID should match", "test-site", content.siteId);
+        assertEquals("Title should match", "Test Content", content.title);
+        assertEquals("Description should match", "A test content description", content.description);
+        assertEquals("Frameheight should match", Integer.valueOf(600), content.frameheight);
+        assertTrue("Newpage should be true", content.newpage);
+        assertFalse("Protect should be false", content.protect);
+        assertTrue("Debug should be true", content.debug);
+
+        // Convert back to map
+        Map<String, Object> resultMap = content.asMap();
+
+        // Verify round-trip
+        assertNotNull("Result map should not be null", resultMap);
+        assertEquals("ID should match in round-trip", Long.valueOf(456L), resultMap.get("id"));
+        assertEquals("Tool ID should match in round-trip", Long.valueOf(123L), resultMap.get("tool_id"));
+        assertEquals("Site ID should match in round-trip", "test-site", resultMap.get("SITE_ID"));
+        assertEquals("Title should match in round-trip", "Test Content", resultMap.get("title"));
+        assertEquals("Description should match in round-trip", "A test content description", resultMap.get("description"));
+        assertEquals("Frameheight should match in round-trip", Integer.valueOf(600), resultMap.get("frameheight"));
+        assertEquals("Newpage should be true in round-trip", Integer.valueOf(1), resultMap.get("newpage"));
+        assertEquals("Protect should be false in round-trip", Integer.valueOf(0), resultMap.get("protect"));
+        assertEquals("Debug should be true in round-trip", Integer.valueOf(1), resultMap.get("debug"));
+    }
+
+    @Test
+    public void testRobustNumberConversion() {
+        // Test various number types that might come from different databases
+        Map<String, Object> testMap = new HashMap<>();
+        testMap.put("integer_as_string", "123");
+        testMap.put("integer_as_double", 123.0);
+        testMap.put("integer_as_long", 123L);
+        testMap.put("decimal_as_string", "456.789");
+        testMap.put("decimal_as_double", 456.789);
+
+        // Test LtiToolBean with robust number conversion
+        LtiToolBean tool = LtiToolBean.of(testMap);
+        assertNotNull("Tool should not be null", tool);
+
+        // Test LtiContentBean with robust number conversion
+        LtiContentBean content = LtiContentBean.of(testMap);
+        assertNotNull("Content should not be null", content);
+
+        // The robust conversion should handle all these number types gracefully
+        // without throwing exceptions
+    }
+
+    @Test
+    public void testUpdateToolDaoOverload() {
+        // Create a test tool bean
+        LtiToolBean tool = new LtiToolBean();
+        tool.id = 123L;
+        tool.title = "Test Tool";
+        tool.lti13AutoToken = "Used";
+        tool.lti13AutoState = Integer.valueOf(2);
+
+        // Create equivalent map for comparison
+        Map<String, Object> toolMap = new HashMap<>();
+        toolMap.put("id", 123L);
+        toolMap.put("title", "Test Tool");
+        toolMap.put("lti13_auto_token", "Used");
+        toolMap.put("lti13_auto_state", Integer.valueOf(2));
+
+        // Test that both asMap() calls produce equivalent results
+        Map<String, Object> toolAsMap = tool.asMap();
+        assertNotNull("Tool asMap should not be null", toolAsMap);
+
+        // Verify that the bean's asMap() method produces the expected structure
+        // (We can't easily test the full LTIService.updateToolDao method without mocking
+        // the entire Sakai environment, but we can verify the delegation works correctly)
+        assertEquals("Tool ID should match", Long.valueOf(123L), toolAsMap.get("id"));
+        assertEquals("Tool title should match", "Test Tool", toolAsMap.get("title"));
+        assertEquals("LTI13 auto token should match", "Used", toolAsMap.get("lti13_auto_token"));
+        assertEquals("LTI13 auto state should match", Integer.valueOf(2), toolAsMap.get("lti13_auto_state"));
+    }
+
+    @Test
+    public void testToStringExcludesSensitiveFields() {
+        // Test LtiToolBean - sensitive fields should be excluded from toString
+        LtiToolBean tool = new LtiToolBean();
+        tool.id = 123L;
+        tool.title = "Test Tool";
+        tool.secret = "super-secret-key";
+        tool.consumerkey = "consumer-key-123";
+        tool.lti13AutoToken = "auto-token-456";
+        tool.lti13LmsToken = "lms-token-789";
+
+        String toolToString = tool.toString();
+        assertNotNull("Tool toString should not be null", toolToString);
+        assertFalse("Tool toString should not contain secret", toolToString.contains("super-secret-key"));
+        assertTrue("Tool toString should contain consumerkey (not excluded)", toolToString.contains("consumer-key-123"));
+        assertFalse("Tool toString should not contain lti13AutoToken", toolToString.contains("auto-token-456"));
+        assertTrue("Tool toString should contain lti13LmsToken (not excluded)", toolToString.contains("lms-token-789"));
+        assertTrue("Tool toString should contain non-sensitive fields", toolToString.contains("Test Tool"));
+
+        // Test LtiContentBean - sensitive fields should be excluded from toString
+        LtiContentBean content = new LtiContentBean();
+        content.id = 456L;
+        content.title = "Test Content";
+        content.placementsecret = "placement-secret-123";
+        content.oldplacementsecret = "old-placement-secret-456";
+
+        String contentToString = content.toString();
+        assertNotNull("Content toString should not be null", contentToString);
+        assertFalse("Content toString should not contain placementsecret", contentToString.contains("placement-secret-123"));
+        assertFalse("Content toString should not contain oldplacementsecret", contentToString.contains("old-placement-secret-456"));
+        assertTrue("Content toString should contain non-sensitive fields", contentToString.contains("Test Content"));
+
+        // Test LtiMembershipsJobBean - no sensitive fields excluded from toString
+        LtiMembershipsJobBean job = new LtiMembershipsJobBean();
+        job.siteId = "test-site";
+        job.membershipsId = "memberships-123";
+        job.consumerkey = "job-consumer-key-789";
+
+        String jobToString = job.toString();
+        assertNotNull("Job toString should not be null", jobToString);
+        assertTrue("Job toString should contain consumerkey (not excluded)", jobToString.contains("job-consumer-key-789"));
+        assertTrue("Job toString should contain non-sensitive fields", jobToString.contains("test-site"));
+    }
+
+    @Test
+    public void testLtiContentBeanFromMapToMapDetailed() {
+        // Create a test map with sample data
+        Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("id", 456L);
+        contentMap.put("SITE_ID", "test-site");
+        contentMap.put("title", "Test Content");
+        contentMap.put("description", "A test content description");
+        contentMap.put("launch", "https://example.com/content/launch");
+        contentMap.put("tool_id", 123L);
+        contentMap.put("placementsecret", "test-placement-secret");
+        contentMap.put("oldplacementsecret", "old-placement-secret");
+        contentMap.put("contentitem", "test-content-item");
+        contentMap.put("settings", "test-settings");
+        contentMap.put("newpage", true);
+        contentMap.put("debug", false);
+        contentMap.put("protect", true);
+
+        // Convert to POJO
+        LtiContentBean content = LtiContentBean.of(contentMap);
+
+        // Verify the conversion
+        assertNotNull("Content should not be null", content);
+        assertEquals("ID should match", Long.valueOf(456L), content.id);
+        assertEquals("Site ID should match", "test-site", content.siteId);
+        assertEquals("Title should match", "Test Content", content.title);
+        assertEquals("Description should match", "A test content description", content.description);
+        assertEquals("Launch should match", "https://example.com/content/launch", content.launch);
+        assertEquals("Tool ID should match", Long.valueOf(123L), content.toolId);
+        assertEquals("Placement secret should match", "test-placement-secret", content.placementsecret);
+        assertEquals("Old placement secret should match", "old-placement-secret", content.oldplacementsecret);
+        assertEquals("Content item should match", "test-content-item", content.contentitem);
+        assertEquals("Settings should match", "test-settings", content.settings);
+        assertTrue("Newpage should be true", content.newpage);
+        assertFalse("Debug should be false", content.debug);
+        assertTrue("Protect should be true", content.protect);
+
+        // Convert back to map
+        Map<String, Object> resultMap = content.asMap();
+
+        // Verify round-trip
+        assertNotNull("Result map should not be null", resultMap);
+        assertEquals("ID should match in round-trip", Long.valueOf(456L), resultMap.get("id"));
+        assertEquals("Site ID should match in round-trip", "test-site", resultMap.get("SITE_ID"));
+        assertEquals("Title should match in round-trip", "Test Content", resultMap.get("title"));
+        assertEquals("Description should match in round-trip", "A test content description", resultMap.get("description"));
+        assertEquals("Launch should match in round-trip", "https://example.com/content/launch", resultMap.get("launch"));
+        assertEquals("Tool ID should match in round-trip", Long.valueOf(123L), resultMap.get("tool_id"));
+        assertEquals("Placement secret should match in round-trip", "test-placement-secret", resultMap.get("placementsecret"));
+        assertEquals("Old placement secret should match in round-trip", "old-placement-secret", resultMap.get("oldplacementsecret"));
+        assertEquals("Content item should match in round-trip", "test-content-item", resultMap.get("contentitem"));
+        assertEquals("Settings should match in round-trip", "test-settings", resultMap.get("settings"));
+        assertEquals("Newpage should match in round-trip", Integer.valueOf(1), resultMap.get("newpage"));
+        assertEquals("Debug should match in round-trip", Integer.valueOf(0), resultMap.get("debug"));
+        assertEquals("Protect should match in round-trip", Integer.valueOf(1), resultMap.get("protect"));
+    }
+
+    @Test
+    public void testLtiMembershipsJobBeanFromMapToMap() {
+        // Create a test map with sample data
+        Map<String, Object> jobMap = new HashMap<>();
+        jobMap.put("SITE_ID", "test-site");
+        jobMap.put("memberships_id", "memberships-123");
+        jobMap.put("memberships_url", "https://example.com/memberships");
+        jobMap.put("consumerkey", "test-consumer-key");
+        jobMap.put("lti_version", "1.3");
+
+        // Convert to POJO
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(jobMap);
+
+        // Verify the conversion
+        assertNotNull("Job should not be null", job);
+        assertEquals("Site ID should match", "test-site", job.siteId);
+        assertEquals("Memberships ID should match", "memberships-123", job.membershipsId);
+        assertEquals("Memberships URL should match", "https://example.com/memberships", job.membershipsUrl);
+        assertEquals("Consumer key should match", "test-consumer-key", job.consumerkey);
+        assertEquals("LTI version should match", "1.3", job.ltiVersion);
+
+        // Convert back to map
+        Map<String, Object> resultMap = job.asMap();
+
+        // Verify round-trip
+        assertNotNull("Result map should not be null", resultMap);
+        assertEquals("Site ID should match in round-trip", "test-site", resultMap.get("SITE_ID"));
+        assertEquals("Memberships ID should match in round-trip", "memberships-123", resultMap.get("memberships_id"));
+        assertEquals("Memberships URL should match in round-trip", "https://example.com/memberships", resultMap.get("memberships_url"));
+        assertEquals("Consumer key should match in round-trip", "test-consumer-key", resultMap.get("consumerkey"));
+        assertEquals("LTI version should match in round-trip", "1.3", resultMap.get("lti_version"));
+    }
+
+    @Test
+    public void testThreeStateValidation() {
+        // Test that invalid three-state values are handled gracefully with logging
+
+        // Test invalid newpage value
+        Map<String, Object> toolMap = new HashMap<>();
+        toolMap.put("id", 123L);
+        toolMap.put("title", "Test Tool");
+        toolMap.put("newpage", 5); // Invalid value > 2
+        toolMap.put("debug", -1);  // Invalid value < 0
+
+        LtiToolBean tool = LtiToolBean.of(toolMap);
+
+        // Verify that invalid values are converted to null (treated as off)
+        assertNotNull("Tool should not be null", tool);
+        assertEquals("ID should match", Long.valueOf(123L), tool.id);
+        assertEquals("Title should match", "Test Tool", tool.title);
+        assertNull("Invalid newpage should be null", tool.newpage);
+        assertNull("Invalid debug should be null", tool.debug);
+
+        // Test that asMap() also validates
+        tool.newpage = 3; // Set invalid value directly
+        tool.debug = -2;  // Set invalid value directly
+
+        Map<String, Object> resultMap = tool.asMap();
+
+        // Invalid values should not be included in the map
+        assertFalse("Invalid newpage should not be in map", resultMap.containsKey("newpage"));
+        assertFalse("Invalid debug should not be in map", resultMap.containsKey("debug"));
+
+        // Test valid values
+        tool.newpage = 1; // Valid value
+        tool.debug = 2;   // Valid value
+
+        Map<String, Object> validMap = tool.asMap();
+        assertEquals("Valid newpage should be in map", Integer.valueOf(1), validMap.get("newpage"));
+        assertEquals("Valid debug should be in map", Integer.valueOf(2), validMap.get("debug"));
+    }
+
+    @Test
+    public void testNullHandling() {
+        // Test that null maps are handled gracefully
+        LtiToolBean nullTool = LtiToolBean.of(null);
+        assertNull("Null map should result in null tool", nullTool);
+
+        LtiContentBean nullContent = LtiContentBean.of(null);
+        assertNull("Null map should result in null content", nullContent);
+
+        LtiMembershipsJobBean nullJob = LtiMembershipsJobBean.of(null);
+        assertNull("Null map should result in null job", nullJob);
+    }
+
+    @Test
+    public void testEmptyMapHandling() {
+        // Test that empty maps create objects with null fields
+        Map<String, Object> emptyMap = new HashMap<>();
+
+        LtiToolBean emptyTool = LtiToolBean.of(emptyMap);
+        assertNotNull("Empty map should create tool object", emptyTool);
+        assertNull("Empty map should result in null ID", emptyTool.id);
+        assertNull("Empty map should result in null title", emptyTool.title);
+
+        LtiContentBean emptyContent = LtiContentBean.of(emptyMap);
+        assertNotNull("Empty map should create content object", emptyContent);
+        assertNull("Empty map should result in null ID", emptyContent.id);
+        assertNull("Empty map should result in null title", emptyContent.title);
+    }
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiContentBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiContentBeanTest.java
@@ -1,0 +1,445 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sakaiproject.lti.beans.LtiContentBean;
+
+/**
+ * Unit tests for LtiContentBean POJO conversion methods.
+ */
+public class LtiContentBeanTest {
+
+    private Map<String, Object> testMap;
+    private Date testDate;
+
+    @Before
+    public void setUp() {
+        testDate = new Date();
+        testMap = new HashMap<>();
+        
+        // Core fields
+        testMap.put("id", 123L);
+        testMap.put("tool_id", 456L);
+        testMap.put("SITE_ID", "site123");
+        testMap.put("title", "Test Content Title");
+        testMap.put("description", "Test content description");
+        testMap.put("frameheight", 600);
+        testMap.put("newpage", true);
+        testMap.put("protect", false);
+        testMap.put("debug", true);
+        
+        // LTI fields
+        testMap.put("custom", "custom1=value1\ncustom2=value2");
+        testMap.put("launch", "https://example.com/launch");
+        testMap.put("xmlimport", "<xml>test</xml>");
+        testMap.put("settings", "{\"setting1\":\"value1\"}");
+        testMap.put("contentitem", "{\"lineitem\":\"data\"}");
+        testMap.put("placement", "placement123");
+        testMap.put("placementsecret", "secret123");
+        testMap.put("oldplacementsecret", "oldsecret123");
+        
+        // LTI 1.3 fields
+        
+        // Timestamps
+        testMap.put("created_at", testDate);
+        testMap.put("updated_at", testDate);
+        
+        // Extra fields from joins
+        testMap.put("SITE_TITLE", "Test Site");
+        testMap.put("SITE_CONTACT_NAME", "John Doe");
+        testMap.put("SITE_CONTACT_EMAIL", "john@example.com");
+        testMap.put("ATTRIBUTION", "Department of Testing");
+        testMap.put("URL", "https://example.com/tool");
+        testMap.put("searchURL", "https://example.com/search");
+    }
+
+    @Test
+    public void testFromMapNullInput() {
+        assertNull(LtiContentBean.of(null));
+    }
+
+    @Test
+    public void testFromMapEmptyMap() {
+        Map<String, Object> emptyMap = new HashMap<>();
+        LtiContentBean content = LtiContentBean.of(emptyMap);
+        assertNotNull(content);
+        assertNull(content.getId());
+        assertNull(content.getTitle());
+    }
+
+    @Test
+    public void testFromMapCompleteData() {
+        LtiContentBean content = LtiContentBean.of(testMap);
+        
+        assertNotNull(content);
+        
+        // Core fields
+        assertEquals(Long.valueOf(123L), content.getId());
+        assertEquals(Long.valueOf(456L), content.getToolId());
+        assertEquals("site123", content.getSiteId());
+        assertEquals("Test Content Title", content.getTitle());
+        assertEquals("Test content description", content.getDescription());
+        assertEquals(Integer.valueOf(600), content.getFrameheight());
+        assertTrue(content.getNewpage());
+        assertFalse(content.getProtect());
+        assertTrue(content.getDebug());
+        
+        // LTI fields
+        assertEquals("custom1=value1\ncustom2=value2", content.getCustom());
+        assertEquals("https://example.com/launch", content.getLaunch());
+        assertEquals("<xml>test</xml>", content.getXmlimport());
+        assertEquals("{\"setting1\":\"value1\"}", content.getSettings());
+        assertEquals("{\"lineitem\":\"data\"}", content.getContentitem());
+        assertEquals("placement123", content.getPlacement());
+        assertEquals("secret123", content.getPlacementsecret());
+        assertEquals("oldsecret123", content.getOldplacementsecret());
+        
+        // LTI 1.3 fields
+        
+        // Timestamps
+        assertEquals(testDate, content.getCreatedAt());
+        assertEquals(testDate, content.getUpdatedAt());
+        
+        // Extra fields
+        assertEquals("Test Site", content.getSiteTitle());
+        assertEquals("John Doe", content.getSiteContactName());
+        assertEquals("john@example.com", content.getSiteContactEmail());
+        assertEquals("Department of Testing", content.getAttribution());
+        assertEquals("https://example.com/tool", content.getUrl());
+        assertEquals("https://example.com/search", content.getSearchUrl());
+    }
+
+    @Test
+    public void testToMapCompleteData() {
+        LtiContentBean content = new LtiContentBean();
+        
+        // Set all fields
+        content.setId(789L);
+        content.setToolId(101112L);
+        content.setSiteId("site456");
+        content.setTitle("Test ToMap Title");
+        content.setDescription("Test toMap description");
+        content.setFrameheight(800);
+        content.setNewpage(false);
+        content.setProtect(true);
+        content.setDebug(false);
+        
+        content.setCustom("custom3=value3");
+        content.setLaunch("https://test.com/launch");
+        content.setXmlimport("<xml>test2</xml>");
+        content.setSettings("{\"setting2\":\"value2\"}");
+        content.setContentitem("{\"lineitem2\":\"data2\"}");
+        content.setPlacement("placement456");
+        content.setPlacementsecret("secret456");
+        content.setOldplacementsecret("oldsecret456");
+        
+        
+        content.setCreatedAt(testDate);
+        content.setUpdatedAt(testDate);
+        
+        content.setSiteTitle("Test Site 2");
+        content.setSiteContactName("Jane Smith");
+        content.setSiteContactEmail("jane@test.com");
+        content.setAttribution("Department of Testing 2");
+        content.setUrl("https://test.com/tool");
+        content.setSearchUrl("https://test.com/search");
+        
+        Map<String, Object> result = content.asMap();
+        
+        assertNotNull(result);
+        
+        // Core fields
+        assertEquals(789L, result.get("id"));
+        assertEquals(101112L, result.get("tool_id"));
+        assertEquals("site456", result.get("SITE_ID"));
+        assertEquals("Test ToMap Title", result.get("title"));
+        assertEquals("Test toMap description", result.get("description"));
+        assertEquals(800, result.get("frameheight"));
+        assertEquals(Integer.valueOf(0), result.get("newpage"));
+        assertEquals(Integer.valueOf(1), result.get("protect"));
+        assertEquals(Integer.valueOf(0), result.get("debug"));
+        
+        // LTI fields
+        assertEquals("custom3=value3", result.get("custom"));
+        assertEquals("https://test.com/launch", result.get("launch"));
+        assertEquals("<xml>test2</xml>", result.get("xmlimport"));
+        assertEquals("{\"setting2\":\"value2\"}", result.get("settings"));
+        assertEquals("{\"lineitem2\":\"data2\"}", result.get("contentitem"));
+        assertEquals("placement456", result.get("placement"));
+        assertEquals("secret456", result.get("placementsecret"));
+        assertEquals("oldsecret456", result.get("oldplacementsecret"));
+        
+        // LTI 1.3 fields
+        
+        // Timestamps
+        assertEquals(testDate, result.get("created_at"));
+        assertEquals(testDate, result.get("updated_at"));
+        
+        // Extra fields
+        assertEquals("Test Site 2", result.get("SITE_TITLE"));
+        assertEquals("Jane Smith", result.get("SITE_CONTACT_NAME"));
+        assertEquals("jane@test.com", result.get("SITE_CONTACT_EMAIL"));
+        assertEquals("Department of Testing 2", result.get("ATTRIBUTION"));
+        assertEquals("https://test.com/tool", result.get("URL"));
+        assertEquals("https://test.com/search", result.get("searchURL"));
+    }
+
+    @Test
+    public void testRoundTripConversion() {
+        // Convert Map to POJO
+        LtiContentBean originalContent = LtiContentBean.of(testMap);
+        assertNotNull(originalContent);
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = originalContent.asMap();
+        assertNotNull(convertedMap);
+        
+        // Verify all original values are preserved (with Boolean-to-Integer conversion)
+        for (Map.Entry<String, Object> entry : testMap.entrySet()) {
+            String key = entry.getKey();
+            Object originalValue = entry.getValue();
+            Object convertedValue = convertedMap.get(key);
+            
+            // Handle Boolean-to-Integer conversion for Boolean fields
+            if (key.equals("newpage") || key.equals("protect") || key.equals("debug")) {
+                if (originalValue instanceof Boolean) {
+                    Boolean boolValue = (Boolean) originalValue;
+                    Integer expectedValue = boolValue ? 1 : 0;
+                    assertEquals("Round-trip conversion failed for Boolean key: " + key, expectedValue, convertedValue);
+                } else {
+                    assertEquals("Round-trip conversion failed for key: " + key, originalValue, convertedValue);
+                }
+            } else {
+                assertEquals("Round-trip conversion failed for key: " + key, originalValue, convertedValue);
+            }
+        }
+        
+        // Verify no extra fields were added
+        assertEquals("Converted map has different number of fields", testMap.size(), convertedMap.size());
+    }
+
+    @Test
+    public void testRoundTripWithNullValues() {
+        Map<String, Object> mapWithNulls = new HashMap<>();
+        mapWithNulls.put("id", 999L);
+        mapWithNulls.put("title", "Title Only");
+        mapWithNulls.put("description", null);
+        mapWithNulls.put("custom", null);
+        mapWithNulls.put("frameheight", null);
+        mapWithNulls.put("newpage", null);
+        mapWithNulls.put("created_at", null);
+        
+        // Convert Map to POJO
+        LtiContentBean content = LtiContentBean.of(mapWithNulls);
+        assertNotNull(content);
+        assertEquals(Long.valueOf(999L), content.getId());
+        assertEquals("Title Only", content.getTitle());
+        assertNull(content.getDescription());
+        assertNull(content.getCustom());
+        assertNull(content.getFrameheight());
+        assertNull(content.getNewpage());
+        assertNull(content.getCreatedAt());
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = content.asMap();
+        assertNotNull(convertedMap);
+        
+        // Only non-null values should be in the converted map
+        assertEquals(Long.valueOf(999L), convertedMap.get("id"));
+        assertEquals("Title Only", convertedMap.get("title"));
+        assertFalse(convertedMap.containsKey("description"));
+        assertFalse(convertedMap.containsKey("custom"));
+        assertFalse(convertedMap.containsKey("frameheight"));
+        assertFalse(convertedMap.containsKey("newpage"));
+        assertFalse(convertedMap.containsKey("created_at"));
+    }
+
+    @Test
+    public void testTypeConversionRobustness() {
+        Map<String, Object> mapWithVariousTypes = new HashMap<>();
+        
+        // Test different number types
+        mapWithVariousTypes.put("id", 123); // Integer instead of Long
+        mapWithVariousTypes.put("tool_id", "456"); // String instead of Long
+        mapWithVariousTypes.put("frameheight", 600L); // Long instead of Integer
+        
+        // Test different boolean representations
+        mapWithVariousTypes.put("newpage", "true"); // String instead of Boolean
+        mapWithVariousTypes.put("protect", 1); // Integer instead of Boolean
+        mapWithVariousTypes.put("debug", "yes"); // String "yes" instead of Boolean
+        
+        // Test timestamp as Long
+        mapWithVariousTypes.put("created_at", testDate.getTime()); // Long timestamp
+        
+        LtiContentBean content = LtiContentBean.of(mapWithVariousTypes);
+        assertNotNull(content);
+        
+        // Verify type conversions worked
+        assertEquals(Long.valueOf(123L), content.getId());
+        assertEquals(Long.valueOf(456L), content.getToolId());
+        assertEquals(Integer.valueOf(600), content.getFrameheight());
+        assertTrue(content.getNewpage());
+        assertTrue(content.getProtect());
+        assertTrue(content.getDebug());
+        assertEquals(testDate, content.getCreatedAt());
+    }
+
+    @Test
+    public void testDatabaseNumberTypeRobustness() {
+        Map<String, Object> mapWithDatabaseTypes = new HashMap<>();
+        
+        // Test all the weird number types that come from different databases
+        mapWithDatabaseTypes.put("id", Double.valueOf(123.0)); // Double from Oracle
+        mapWithDatabaseTypes.put("tool_id", Float.valueOf(456.0f)); // Float from MySQL
+        mapWithDatabaseTypes.put("frameheight", Short.valueOf((short)800)); // Short
+        mapWithDatabaseTypes.put("created_at", testDate);
+        
+        LtiContentBean content = LtiContentBean.of(mapWithDatabaseTypes);
+        assertNotNull(content);
+        
+        // Verify all number types converted correctly
+        assertEquals("Double should convert to Long", Long.valueOf(123L), content.getId());
+        assertEquals("Float should convert to Long", Long.valueOf(456L), content.getToolId());
+        assertEquals("Short should convert to Integer", Integer.valueOf(800), content.getFrameheight());
+        assertEquals("Date should remain Date", testDate, content.getCreatedAt());
+    }
+
+    @Test
+    public void testStringNumberRobustness() {
+        Map<String, Object> mapWithStringNumbers = new HashMap<>();
+        
+        // Test string representations of numbers (common from databases)
+        mapWithStringNumbers.put("id", "123"); // String number
+        mapWithStringNumbers.put("tool_id", "-456"); // Negative string number
+        mapWithStringNumbers.put("frameheight", "0"); // Zero string
+        
+        LtiContentBean content = LtiContentBean.of(mapWithStringNumbers);
+        assertNotNull(content);
+        
+        // Verify string numbers converted correctly
+        assertEquals("String '123' should convert to Long", Long.valueOf(123L), content.getId());
+        assertEquals("String '-456' should convert to Long", Long.valueOf(-456L), content.getToolId());
+        assertEquals("String '0' should convert to Integer", Integer.valueOf(0), content.getFrameheight());
+    }
+
+    @Test
+    public void testDecimalStringHandling() {
+        Map<String, Object> mapWithDecimals = new HashMap<>();
+        
+        // Test decimal strings (should truncate like LTIUtil)
+        mapWithDecimals.put("id", "123.0"); // Decimal string with .0
+        mapWithDecimals.put("tool_id", "456.7"); // Decimal string with decimal part
+        mapWithDecimals.put("frameheight", "800.99"); // Decimal string for integer field
+        
+        LtiContentBean content = LtiContentBean.of(mapWithDecimals);
+        assertNotNull(content);
+        
+        // Verify decimal strings are truncated correctly
+        assertEquals("String '123.0' should truncate to 123", Long.valueOf(123L), content.getId());
+        assertEquals("String '456.7' should truncate to 456", Long.valueOf(456L), content.getToolId());
+        assertEquals("String '800.99' should truncate to 800", Integer.valueOf(800), content.getFrameheight());
+    }
+
+    @Test
+    public void testInvalidStringHandling() {
+        Map<String, Object> mapWithInvalidStrings = new HashMap<>();
+        
+        // Test invalid string values (should return null)
+        mapWithInvalidStrings.put("id", "invalid"); // Invalid string
+        mapWithInvalidStrings.put("tool_id", ""); // Empty string
+        mapWithInvalidStrings.put("frameheight", "not-a-number"); // Non-numeric string
+        
+        LtiContentBean content = LtiContentBean.of(mapWithInvalidStrings);
+        assertNotNull(content);
+        
+        // Verify invalid strings return null
+        assertNull("Invalid string 'invalid' should return null", content.getId());
+        assertNull("Empty string should return null", content.getToolId());
+        assertNull("Non-numeric string should return null", content.getFrameheight());
+    }
+
+    @Test
+    public void testNullAndEmptyHandling() {
+        Map<String, Object> mapWithNulls = new HashMap<>();
+        
+        // Test null values
+        mapWithNulls.put("id", null);
+        mapWithNulls.put("tool_id", null);
+        mapWithNulls.put("frameheight", null);
+        
+        LtiContentBean content = LtiContentBean.of(mapWithNulls);
+        assertNotNull(content);
+        
+        // Verify null values return null
+        assertNull("Null id should return null", content.getId());
+        assertNull("Null tool_id should return null", content.getToolId());
+        assertNull("Null frameheight should return null", content.getFrameheight());
+    }
+
+    @Test
+    public void testBigDecimalHandling() {
+        Map<String, Object> mapWithBigDecimals = new HashMap<>();
+        
+        // Test BigDecimal (common from databases)
+        java.math.BigDecimal bigDecimal123 = new java.math.BigDecimal("123.45");
+        java.math.BigDecimal bigDecimal456 = new java.math.BigDecimal("456");
+        java.math.BigDecimal bigDecimal800 = new java.math.BigDecimal("800.99");
+        
+        mapWithBigDecimals.put("id", bigDecimal123);
+        mapWithBigDecimals.put("tool_id", bigDecimal456);
+        mapWithBigDecimals.put("frameheight", bigDecimal800);
+        
+        LtiContentBean content = LtiContentBean.of(mapWithBigDecimals);
+        assertNotNull(content);
+        
+        // Verify BigDecimal conversion (should truncate decimals)
+        assertEquals("BigDecimal 123.45 should truncate to 123", Long.valueOf(123L), content.getId());
+        assertEquals("BigDecimal 456 should convert to 456", Long.valueOf(456L), content.getToolId());
+        assertEquals("BigDecimal 800.99 should truncate to 800", Integer.valueOf(800), content.getFrameheight());
+    }
+
+    @Test
+    public void testLargeNumberHandling() {
+        Map<String, Object> mapWithLargeNumbers = new HashMap<>();
+        
+        // Test large numbers that might come from databases
+        mapWithLargeNumbers.put("id", Long.MAX_VALUE); // Maximum long value
+        mapWithLargeNumbers.put("tool_id", Integer.MAX_VALUE); // Maximum integer value
+        mapWithLargeNumbers.put("frameheight", Short.MAX_VALUE); // Maximum short value
+        
+        LtiContentBean content = LtiContentBean.of(mapWithLargeNumbers);
+        assertNotNull(content);
+        
+        // Verify large numbers handled correctly
+        assertEquals("Long.MAX_VALUE should remain Long.MAX_VALUE", Long.valueOf(Long.MAX_VALUE), content.getId());
+        assertEquals("Integer.MAX_VALUE should convert to Long", Long.valueOf(Integer.MAX_VALUE), content.getToolId());
+        assertEquals("Short.MAX_VALUE should convert to Integer", Integer.valueOf(Short.MAX_VALUE), content.getFrameheight());
+    }
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiMembershipsJobBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiMembershipsJobBeanTest.java
@@ -1,0 +1,234 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sakaiproject.lti.beans.LtiMembershipsJobBean;
+
+/**
+ * Unit tests for LtiMembershipsJobBean POJO conversion methods.
+ */
+public class LtiMembershipsJobBeanTest {
+
+    private Map<String, Object> testMap;
+
+    @Before
+    public void setUp() {
+        testMap = new HashMap<>();
+        
+        testMap.put("SITE_ID", "site123");
+        testMap.put("memberships_id", "membership456");
+        testMap.put("memberships_url", "https://example.com/memberships");
+        testMap.put("consumerkey", "consumer789");
+        testMap.put("lti_version", "LTI-1p0");
+    }
+
+    @Test
+    public void testFromMapNullInput() {
+        assertNull(LtiMembershipsJobBean.of(null));
+    }
+
+    @Test
+    public void testFromMapEmptyMap() {
+        Map<String, Object> emptyMap = new HashMap<>();
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(emptyMap);
+        assertNotNull(job);
+        assertNull(job.getSiteId());
+        assertNull(job.getMembershipsId());
+        assertNull(job.getMembershipsUrl());
+        assertNull(job.getConsumerkey());
+        assertNull(job.getLtiVersion());
+    }
+
+    @Test
+    public void testFromMapCompleteData() {
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(testMap);
+        
+        assertNotNull(job);
+        assertEquals("site123", job.getSiteId());
+        assertEquals("membership456", job.getMembershipsId());
+        assertEquals("https://example.com/memberships", job.getMembershipsUrl());
+        assertEquals("consumer789", job.getConsumerkey());
+        assertEquals("LTI-1p0", job.getLtiVersion());
+    }
+
+    @Test
+    public void testToMapCompleteData() {
+        LtiMembershipsJobBean job = new LtiMembershipsJobBean();
+        
+        job.setSiteId("site456");
+        job.setMembershipsId("membership789");
+        job.setMembershipsUrl("https://test.com/memberships");
+        job.setConsumerkey("consumer123");
+        job.setLtiVersion("LTI-1p1");
+        
+        Map<String, Object> result = job.asMap();
+        
+        assertNotNull(result);
+        assertEquals("site456", result.get("SITE_ID"));
+        assertEquals("membership789", result.get("memberships_id"));
+        assertEquals("https://test.com/memberships", result.get("memberships_url"));
+        assertEquals("consumer123", result.get("consumerkey"));
+        assertEquals("LTI-1p1", result.get("lti_version"));
+    }
+
+    @Test
+    public void testRoundTripConversion() {
+        // Convert Map to POJO
+        LtiMembershipsJobBean originalJob = LtiMembershipsJobBean.of(testMap);
+        assertNotNull(originalJob);
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = originalJob.asMap();
+        assertNotNull(convertedMap);
+        
+        // Verify all original values are preserved
+        for (Map.Entry<String, Object> entry : testMap.entrySet()) {
+            String key = entry.getKey();
+            Object originalValue = entry.getValue();
+            Object convertedValue = convertedMap.get(key);
+            
+            assertEquals("Round-trip conversion failed for key: " + key, originalValue, convertedValue);
+        }
+        
+        // Verify no extra fields were added
+        assertEquals("Converted map has different number of fields", testMap.size(), convertedMap.size());
+    }
+
+    @Test
+    public void testRoundTripWithNullValues() {
+        Map<String, Object> mapWithNulls = new HashMap<>();
+        mapWithNulls.put("SITE_ID", "site999");
+        mapWithNulls.put("memberships_id", null);
+        mapWithNulls.put("memberships_url", "https://example.com/url");
+        mapWithNulls.put("consumerkey", null);
+        mapWithNulls.put("lti_version", "LTI-1p0");
+        
+        // Convert Map to POJO
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(mapWithNulls);
+        assertNotNull(job);
+        assertEquals("site999", job.getSiteId());
+        assertNull(job.getMembershipsId());
+        assertEquals("https://example.com/url", job.getMembershipsUrl());
+        assertNull(job.getConsumerkey());
+        assertEquals("LTI-1p0", job.getLtiVersion());
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = job.asMap();
+        assertNotNull(convertedMap);
+        
+        // Only non-null values should be in the converted map
+        assertEquals("site999", convertedMap.get("SITE_ID"));
+        assertFalse(convertedMap.containsKey("memberships_id"));
+        assertEquals("https://example.com/url", convertedMap.get("memberships_url"));
+        assertFalse(convertedMap.containsKey("consumerkey"));
+        assertEquals("LTI-1p0", convertedMap.get("lti_version"));
+    }
+
+    @Test
+    public void testMinimalData() {
+        Map<String, Object> minimalMap = new HashMap<>();
+        minimalMap.put("SITE_ID", "minimal-site");
+        minimalMap.put("lti_version", "LTI-1p0");
+        
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(minimalMap);
+        assertNotNull(job);
+        assertEquals("minimal-site", job.getSiteId());
+        assertNull(job.getMembershipsId());
+        assertNull(job.getMembershipsUrl());
+        assertNull(job.getConsumerkey());
+        assertEquals("LTI-1p0", job.getLtiVersion());
+        
+        Map<String, Object> result = job.asMap();
+        assertEquals("minimal-site", result.get("SITE_ID"));
+        assertEquals("LTI-1p0", result.get("lti_version"));
+        assertFalse(result.containsKey("memberships_id"));
+        assertFalse(result.containsKey("memberships_url"));
+        assertFalse(result.containsKey("consumerkey"));
+    }
+
+    @Test
+    public void testAllNullValues() {
+        Map<String, Object> allNullMap = new HashMap<>();
+        allNullMap.put("SITE_ID", null);
+        allNullMap.put("memberships_id", null);
+        allNullMap.put("memberships_url", null);
+        allNullMap.put("consumerkey", null);
+        allNullMap.put("lti_version", null);
+        
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(allNullMap);
+        assertNotNull(job);
+        assertNull(job.getSiteId());
+        assertNull(job.getMembershipsId());
+        assertNull(job.getMembershipsUrl());
+        assertNull(job.getConsumerkey());
+        assertNull(job.getLtiVersion());
+        
+        Map<String, Object> result = job.asMap();
+        assertTrue("Map should be empty when all values are null", result.isEmpty());
+    }
+
+    @Test
+    public void testLongUrls() {
+        Map<String, Object> longUrlMap = new HashMap<>();
+        longUrlMap.put("SITE_ID", "site123");
+        longUrlMap.put("memberships_url", "https://very-long-domain-name.example.com/path/to/memberships/endpoint/with/many/parameters?param1=value1&param2=value2&param3=value3");
+        longUrlMap.put("lti_version", "LTI-1p0");
+        
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(longUrlMap);
+        assertNotNull(job);
+        assertEquals("site123", job.getSiteId());
+        assertEquals("https://very-long-domain-name.example.com/path/to/memberships/endpoint/with/many/parameters?param1=value1&param2=value2&param3=value3", job.getMembershipsUrl());
+        assertEquals("LTI-1p0", job.getLtiVersion());
+        
+        Map<String, Object> result = job.asMap();
+        assertEquals("https://very-long-domain-name.example.com/path/to/memberships/endpoint/with/many/parameters?param1=value1&param2=value2&param3=value3", result.get("memberships_url"));
+    }
+
+    @Test
+    public void testSpecialCharacters() {
+        Map<String, Object> specialCharMap = new HashMap<>();
+        specialCharMap.put("SITE_ID", "site-with-special-chars_123");
+        specialCharMap.put("memberships_id", "membership@domain.com");
+        specialCharMap.put("consumerkey", "key-with-dashes_and_underscores");
+        specialCharMap.put("lti_version", "LTI-1p1/1.1");
+        
+        LtiMembershipsJobBean job = LtiMembershipsJobBean.of(specialCharMap);
+        assertNotNull(job);
+        assertEquals("site-with-special-chars_123", job.getSiteId());
+        assertEquals("membership@domain.com", job.getMembershipsId());
+        assertEquals("key-with-dashes_and_underscores", job.getConsumerkey());
+        assertEquals("LTI-1p1/1.1", job.getLtiVersion());
+        
+        Map<String, Object> result = job.asMap();
+        assertEquals("site-with-special-chars_123", result.get("SITE_ID"));
+        assertEquals("membership@domain.com", result.get("memberships_id"));
+        assertEquals("key-with-dashes_and_underscores", result.get("consumerkey"));
+        assertEquals("LTI-1p1/1.1", result.get("lti_version"));
+    }
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiToolBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiToolBeanTest.java
@@ -1,0 +1,556 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sakaiproject.lti.beans.LtiToolBean;
+
+/**
+ * Unit tests for LtiToolBean POJO conversion methods.
+ */
+public class LtiToolBeanTest {
+
+    private Map<String, Object> testMap;
+    private Date testDate;
+
+    @Before
+    public void setUp() {
+        testDate = new Date();
+        testMap = new HashMap<>();
+        
+        // Core fields
+        testMap.put("id", 123L);
+        testMap.put("SITE_ID", "site123");
+        testMap.put("title", "Test Tool Title");
+        testMap.put("description", "Test tool description");
+        testMap.put("status", "enable");
+        testMap.put("visible", "visible");
+        testMap.put("deployment_id", 789L);
+        testMap.put("launch", "https://example.com/tool/launch");
+        testMap.put("newpage", 1); // LTI_TOOL_NEWPAGE_ON
+        testMap.put("frameheight", 800);
+        testMap.put("fa_icon", "fa-tool");
+        
+        // Message Types (pl_ prefix for backwards compatibility)
+        testMap.put("pl_launch", true);
+        testMap.put("pl_linkselection", false);
+        testMap.put("pl_contextlaunch", true);
+        
+        // Placements
+        testMap.put("pl_lessonsselection", false);
+        testMap.put("pl_contenteditor", true);
+        testMap.put("pl_assessmentselection", true);
+        testMap.put("pl_coursenav", false);
+        testMap.put("pl_importitem", true);
+        testMap.put("pl_fileitem", false);
+        
+        // Privacy
+        testMap.put("sendname", true);
+        testMap.put("sendemailaddr", false);
+        testMap.put("pl_privacy", true);
+        
+        // Services
+        testMap.put("allowoutcomes", true);
+        testMap.put("allowlineitems", false);
+        testMap.put("allowroster", true);
+        
+        // Configuration
+        testMap.put("debug", 1); // LTI_TOOL_DEBUG_ON
+        testMap.put("siteinfoconfig", "config");
+        testMap.put("splash", "Welcome to the tool!");
+        testMap.put("custom", "custom1=value1\ncustom2=value2");
+        testMap.put("rolemap", "Instructor=Teacher");
+        testMap.put("lti13", 1); // LTI13_LTI13
+        
+        // LTI 1.3 security values from the tool
+        testMap.put("lti13_tool_keyset", "https://tool.com/keyset");
+        testMap.put("lti13_oidc_endpoint", "https://tool.com/oidc");
+        testMap.put("lti13_oidc_redirect", "https://tool.com/redirect");
+        
+        // LTI 1.3 security values from the LMS
+        testMap.put("lti13_lms_issuer", "https://lms.com");
+        testMap.put("lti13_client_id", "client123");
+        testMap.put("lti13_lms_deployment_id", "deployment456");
+        testMap.put("lti13_lms_keyset", "https://lms.com/keyset");
+        testMap.put("lti13_lms_endpoint", "https://lms.com/endpoint");
+        testMap.put("lti13_lms_token", "https://lms.com/token");
+        
+        // LTI 1.1 security arrangement
+        testMap.put("consumerkey", "key123");
+        testMap.put("secret", "secret456");
+        testMap.put("xmlimport", "<tool>xml</tool>");
+        testMap.put("lti13_auto_token", "token789");
+        testMap.put("lti13_auto_state", 1);
+        testMap.put("lti13_auto_registration", "{\"auto\":\"reg\"}");
+        testMap.put("sakai_tool_checksum", "checksum123");
+        
+        // Timestamps
+        testMap.put("created_at", testDate);
+        testMap.put("updated_at", testDate);
+    }
+
+    @Test
+    public void testFromMapNullInput() {
+        assertNull(LtiToolBean.of(null));
+    }
+
+    @Test
+    public void testFromMapEmptyMap() {
+        Map<String, Object> emptyMap = new HashMap<>();
+        LtiToolBean tool = LtiToolBean.of(emptyMap);
+        assertNotNull(tool);
+        assertNull(tool.getId());
+        assertNull(tool.getTitle());
+    }
+
+    @Test
+    public void testFromMapCompleteData() {
+        LtiToolBean tool = LtiToolBean.of(testMap);
+        
+        assertNotNull(tool);
+        
+        // Core fields
+        assertEquals(Long.valueOf(123L), tool.getId());
+        assertEquals("site123", tool.getSiteId());
+        assertEquals("Test Tool Title", tool.getTitle());
+        assertEquals("Test tool description", tool.getDescription());
+        assertEquals("enable", tool.getStatus());
+        assertEquals("visible", tool.getVisible());
+        assertEquals(Long.valueOf(789L), tool.getDeploymentId());
+        assertEquals("https://example.com/tool/launch", tool.getLaunch());
+        assertEquals(Integer.valueOf(1), tool.getNewpage()); // LTI_TOOL_NEWPAGE_ON
+        assertEquals(Integer.valueOf(800), tool.getFrameheight());
+        assertEquals("fa-tool", tool.getFaIcon());
+        
+        // Message Types
+        assertTrue(tool.getPlLaunch());
+        assertFalse(tool.getPlLinkselection());
+        assertTrue(tool.getPlContextlaunch());
+        
+        // Placements
+        assertFalse(tool.getPlLessonsselection());
+        assertTrue(tool.getPlContenteditor());
+        assertTrue(tool.getPlAssessmentselection());
+        assertFalse(tool.getPlCoursenav());
+        assertTrue(tool.getPlImportitem());
+        assertFalse(tool.getPlFileitem());
+        
+        // Privacy
+        assertTrue(tool.getSendname());
+        assertFalse(tool.getSendemailaddr());
+        assertTrue(tool.getPlPrivacy());
+        
+        // Services
+        assertTrue(tool.getAllowoutcomes());
+        assertFalse(tool.getAllowlineitems());
+        assertTrue(tool.getAllowroster());
+        
+        // Configuration
+        assertEquals(Integer.valueOf(1), tool.getDebug()); // LTI_TOOL_DEBUG_ON
+        assertEquals("config", tool.getSiteinfoconfig());
+        assertEquals("Welcome to the tool!", tool.getSplash());
+        assertEquals("custom1=value1\ncustom2=value2", tool.getCustom());
+        assertEquals("Instructor=Teacher", tool.getRolemap());
+        assertEquals(Integer.valueOf(1), tool.getLti13()); // LTI13_LTI13
+        
+        // LTI 1.3 security values from the tool
+        assertEquals("https://tool.com/keyset", tool.getLti13ToolKeyset());
+        assertEquals("https://tool.com/oidc", tool.getLti13OidcEndpoint());
+        assertEquals("https://tool.com/redirect", tool.getLti13OidcRedirect());
+        
+        // LTI 1.3 security values from the LMS
+        assertEquals("https://lms.com", tool.getLti13LmsIssuer());
+        assertEquals("client123", tool.getLti13ClientId());
+        assertEquals("deployment456", tool.getLti13LmsDeploymentId());
+        assertEquals("https://lms.com/keyset", tool.getLti13LmsKeyset());
+        assertEquals("https://lms.com/endpoint", tool.getLti13LmsEndpoint());
+        assertEquals("https://lms.com/token", tool.getLti13LmsToken());
+        
+        // LTI 1.1 security arrangement
+        assertEquals("key123", tool.getConsumerkey());
+        assertEquals("secret456", tool.getSecret());
+        assertEquals("<tool>xml</tool>", tool.getXmlimport());
+        assertEquals("token789", tool.getLti13AutoToken());
+        assertEquals(Integer.valueOf(1), tool.getLti13AutoState());
+        assertEquals("{\"auto\":\"reg\"}", tool.getLti13AutoRegistration());
+        assertEquals("checksum123", tool.getSakaiToolChecksum());
+        
+        // Timestamps
+        assertEquals(testDate, tool.getCreatedAt());
+        assertEquals(testDate, tool.getUpdatedAt());
+    }
+
+    @Test
+    public void testToMapCompleteData() {
+        LtiToolBean tool = new LtiToolBean();
+        
+        // Set all fields
+        tool.setId(456L);
+        tool.setSiteId("site456");
+        tool.setTitle("Test ToMap Tool");
+        tool.setDescription("Test toMap description");
+        tool.setStatus("disable");
+        tool.setVisible("stealth");
+        tool.setDeploymentId(101112L);
+        tool.setLaunch("https://test.com/launch");
+        tool.setNewpage(0); // LTI_TOOL_NEWPAGE_OFF
+        tool.setFrameheight(1000);
+        tool.setFaIcon("fa-test");
+        
+        tool.setPlLaunch(false);
+        tool.setPlLinkselection(true);
+        tool.setPlContextlaunch(false);
+        
+        tool.setPlLessonsselection(true);
+        tool.setPlContenteditor(false);
+        tool.setPlAssessmentselection(false);
+        tool.setPlCoursenav(true);
+        tool.setPlImportitem(false);
+        tool.setPlFileitem(true);
+        
+        tool.setSendname(false);
+        tool.setSendemailaddr(true);
+        tool.setPlPrivacy(false);
+        
+        tool.setAllowoutcomes(false);
+        tool.setAllowlineitems(true);
+        tool.setAllowroster(false);
+        
+        tool.setDebug(0); // LTI_TOOL_DEBUG_OFF
+        tool.setSiteinfoconfig("bypass");
+        tool.setSplash("Test splash");
+        tool.setCustom("custom4=value4");
+        tool.setRolemap("Student=Learner");
+        tool.setLti13(0); // LTI13_LTI11
+        
+        tool.setLti13ToolKeyset("https://test.com/keyset");
+        tool.setLti13OidcEndpoint("https://test.com/oidc");
+        tool.setLti13OidcRedirect("https://test.com/redirect");
+        
+        tool.setLti13LmsIssuer("https://test.com");
+        tool.setLti13ClientId("testclient");
+        tool.setLti13LmsDeploymentId("testdeployment");
+        tool.setLti13LmsKeyset("https://test.com/keyset");
+        tool.setLti13LmsEndpoint("https://test.com/endpoint");
+        tool.setLti13LmsToken("https://test.com/token");
+        
+        tool.setConsumerkey("testkey");
+        tool.setSecret("testsecret");
+        tool.setXmlimport("<test>xml</test>");
+        tool.setLti13AutoToken("testtoken");
+        tool.setLti13AutoState(2);
+        tool.setLti13AutoRegistration("{\"test\":\"reg\"}");
+        tool.setSakaiToolChecksum("testchecksum");
+        
+        tool.setCreatedAt(testDate);
+        tool.setUpdatedAt(testDate);
+        
+        Map<String, Object> result = tool.asMap();
+        
+        assertNotNull(result);
+        
+        // Core fields
+        assertEquals(456L, result.get("id"));
+        assertEquals("site456", result.get("SITE_ID"));
+        assertEquals("Test ToMap Tool", result.get("title"));
+        assertEquals("Test toMap description", result.get("description"));
+        assertEquals("disable", result.get("status"));
+        assertEquals("stealth", result.get("visible"));
+        assertEquals(101112L, result.get("deployment_id"));
+        assertEquals("https://test.com/launch", result.get("launch"));
+        assertEquals(Integer.valueOf(0), result.get("newpage")); // LTI_TOOL_NEWPAGE_OFF
+        assertEquals(1000, result.get("frameheight"));
+        assertEquals("fa-test", result.get("fa_icon"));
+        
+        // Message Types
+        assertEquals(Integer.valueOf(0), result.get("pl_launch"));
+        assertEquals(Integer.valueOf(1), result.get("pl_linkselection"));
+        assertEquals(Integer.valueOf(0), result.get("pl_contextlaunch"));
+        
+        // Placements
+        assertEquals(Integer.valueOf(1), result.get("pl_lessonsselection"));
+        assertEquals(Integer.valueOf(0), result.get("pl_contenteditor"));
+        assertEquals(Integer.valueOf(0), result.get("pl_assessmentselection"));
+        assertEquals(Integer.valueOf(1), result.get("pl_coursenav"));
+        assertEquals(Integer.valueOf(0), result.get("pl_importitem"));
+        assertEquals(Integer.valueOf(1), result.get("pl_fileitem"));
+        
+        // Privacy
+        assertEquals(Integer.valueOf(0), result.get("sendname"));
+        assertEquals(Integer.valueOf(1), result.get("sendemailaddr"));
+        assertEquals(Integer.valueOf(0), result.get("pl_privacy"));
+        
+        // Services
+        assertEquals(Integer.valueOf(0), result.get("allowoutcomes"));
+        assertEquals(Integer.valueOf(1), result.get("allowlineitems"));
+        assertEquals(Integer.valueOf(0), result.get("allowroster"));
+        
+        // Configuration
+        assertEquals(Integer.valueOf(0), result.get("debug")); // LTI_TOOL_DEBUG_OFF
+        assertEquals("bypass", result.get("siteinfoconfig"));
+        assertEquals("Test splash", result.get("splash"));
+        assertEquals("custom4=value4", result.get("custom"));
+        assertEquals("Student=Learner", result.get("rolemap"));
+        assertEquals(Integer.valueOf(0), result.get("lti13")); // LTI13_LTI11
+        
+        // LTI 1.3 security values from the tool
+        assertEquals("https://test.com/keyset", result.get("lti13_tool_keyset"));
+        assertEquals("https://test.com/oidc", result.get("lti13_oidc_endpoint"));
+        assertEquals("https://test.com/redirect", result.get("lti13_oidc_redirect"));
+        
+        // LTI 1.3 security values from the LMS
+        assertEquals("https://test.com", result.get("lti13_lms_issuer"));
+        assertEquals("testclient", result.get("lti13_client_id"));
+        assertEquals("testdeployment", result.get("lti13_lms_deployment_id"));
+        assertEquals("https://test.com/keyset", result.get("lti13_lms_keyset"));
+        assertEquals("https://test.com/endpoint", result.get("lti13_lms_endpoint"));
+        assertEquals("https://test.com/token", result.get("lti13_lms_token"));
+        
+        // LTI 1.1 security arrangement
+        assertEquals("testkey", result.get("consumerkey"));
+        assertEquals("testsecret", result.get("secret"));
+        assertEquals("<test>xml</test>", result.get("xmlimport"));
+        assertEquals("testtoken", result.get("lti13_auto_token"));
+        assertEquals(2, result.get("lti13_auto_state"));
+        assertEquals("{\"test\":\"reg\"}", result.get("lti13_auto_registration"));
+        assertEquals("testchecksum", result.get("sakai_tool_checksum"));
+        
+        // Timestamps
+        assertEquals(testDate, result.get("created_at"));
+        assertEquals(testDate, result.get("updated_at"));
+    }
+
+    @Test
+    public void testRoundTripConversion() {
+        // Convert Map to POJO
+        LtiToolBean originalTool = LtiToolBean.of(testMap);
+        assertNotNull(originalTool);
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = originalTool.asMap();
+        assertNotNull(convertedMap);
+        
+        // Verify all original values are preserved (with Boolean-to-Integer conversion)
+        for (Map.Entry<String, Object> entry : testMap.entrySet()) {
+            String key = entry.getKey();
+            Object originalValue = entry.getValue();
+            Object convertedValue = convertedMap.get(key);
+            
+            // Handle Boolean-to-Integer conversion for Boolean fields
+            if (key.equals("pl_launch") || key.equals("pl_linkselection") || key.equals("pl_contextlaunch") ||
+                key.equals("pl_lessonsselection") || key.equals("pl_contenteditor") || key.equals("pl_assessmentselection") ||
+                key.equals("pl_coursenav") || key.equals("pl_importitem") || key.equals("pl_fileitem") ||
+                key.equals("sendname") || key.equals("sendemailaddr") || key.equals("pl_privacy") ||
+                key.equals("allowoutcomes") || key.equals("allowlineitems") || key.equals("allowroster")) {
+                if (originalValue instanceof Boolean) {
+                    Boolean boolValue = (Boolean) originalValue;
+                    Integer expectedValue = boolValue ? 1 : 0;
+                    assertEquals("Round-trip conversion failed for Boolean key: " + key, expectedValue, convertedValue);
+                } else {
+                    assertEquals("Round-trip conversion failed for key: " + key, originalValue, convertedValue);
+                }
+            } else {
+                assertEquals("Round-trip conversion failed for key: " + key, originalValue, convertedValue);
+            }
+        }
+        
+        // Verify no extra fields were added
+        assertEquals("Converted map has different number of fields", testMap.size(), convertedMap.size());
+    }
+
+    @Test
+    public void testRoundTripWithNullValues() {
+        Map<String, Object> mapWithNulls = new HashMap<>();
+        mapWithNulls.put("id", 999L);
+        mapWithNulls.put("title", "Title Only");
+        mapWithNulls.put("description", null);
+        mapWithNulls.put("custom", null);
+        mapWithNulls.put("frameheight", null);
+        mapWithNulls.put("pl_launch", null);
+        mapWithNulls.put("created_at", null);
+        
+        // Convert Map to POJO
+        LtiToolBean tool = LtiToolBean.of(mapWithNulls);
+        assertNotNull(tool);
+        assertEquals(Long.valueOf(999L), tool.getId());
+        assertEquals("Title Only", tool.getTitle());
+        assertNull(tool.getDescription());
+        assertNull(tool.getCustom());
+        assertNull(tool.getFrameheight());
+        assertNull(tool.getPlLaunch());
+        assertNull(tool.getCreatedAt());
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = tool.asMap();
+        assertNotNull(convertedMap);
+        
+        // Only non-null values should be in the converted map
+        assertEquals(Long.valueOf(999L), convertedMap.get("id"));
+        assertEquals("Title Only", convertedMap.get("title"));
+        assertFalse(convertedMap.containsKey("description"));
+        assertFalse(convertedMap.containsKey("custom"));
+        assertFalse(convertedMap.containsKey("frameheight"));
+        assertFalse(convertedMap.containsKey("pl_launch"));
+        assertFalse(convertedMap.containsKey("created_at"));
+    }
+
+    @Test
+    public void testTypeConversionRobustness() {
+        Map<String, Object> mapWithVariousTypes = new HashMap<>();
+        
+        // Test different number types
+        mapWithVariousTypes.put("id", 123); // Integer instead of Long
+        mapWithVariousTypes.put("deployment_id", "456"); // String instead of Long
+        mapWithVariousTypes.put("frameheight", 600L); // Long instead of Integer
+        mapWithVariousTypes.put("lti13_auto_state", "2"); // String instead of Integer
+        
+        // Test different boolean representations
+        mapWithVariousTypes.put("pl_launch", "true"); // String instead of Boolean
+        mapWithVariousTypes.put("sendname", 1); // Integer instead of Boolean
+        mapWithVariousTypes.put("allowoutcomes", "yes"); // String "yes" instead of Boolean
+        
+        // Test timestamp as Long
+        mapWithVariousTypes.put("created_at", testDate.getTime()); // Long timestamp
+        
+        LtiToolBean tool = LtiToolBean.of(mapWithVariousTypes);
+        assertNotNull(tool);
+        
+        // Verify type conversions worked
+        assertEquals(Long.valueOf(123L), tool.getId());
+        assertEquals(Long.valueOf(456L), tool.getDeploymentId());
+        assertEquals(Integer.valueOf(600), tool.getFrameheight());
+        assertEquals(Integer.valueOf(2), tool.getLti13AutoState());
+        assertTrue(tool.getPlLaunch());
+        assertTrue(tool.getSendname());
+        assertTrue(tool.getAllowoutcomes());
+        assertEquals(testDate, tool.getCreatedAt());
+    }
+
+    @Test
+    public void testDatabaseNumberTypeRobustness() {
+        Map<String, Object> mapWithDatabaseTypes = new HashMap<>();
+        
+        // Test all the weird number types that come from different databases
+        mapWithDatabaseTypes.put("id", Double.valueOf(999.0)); // Double from Oracle
+        mapWithDatabaseTypes.put("deployment_id", Float.valueOf(888.0f)); // Float from MySQL
+        mapWithDatabaseTypes.put("frameheight", Short.valueOf((short)700)); // Short
+        mapWithDatabaseTypes.put("lti13_auto_state", Byte.valueOf((byte)2)); // Byte
+        
+        LtiToolBean tool = LtiToolBean.of(mapWithDatabaseTypes);
+        assertNotNull(tool);
+        
+        // Verify all number types converted correctly
+        assertEquals("Double should convert to Long", Long.valueOf(999L), tool.getId());
+        assertEquals("Float should convert to Long", Long.valueOf(888L), tool.getDeploymentId());
+        assertEquals("Short should convert to Integer", Integer.valueOf(700), tool.getFrameheight());
+        assertEquals("Byte should convert to Integer", Integer.valueOf(2), tool.getLti13AutoState());
+    }
+
+    @Test
+    public void testStringNumberRobustness() {
+        Map<String, Object> mapWithStringNumbers = new HashMap<>();
+        
+        // Test string representations of numbers (common from databases)
+        mapWithStringNumbers.put("id", "777"); // String number
+        mapWithStringNumbers.put("deployment_id", "-666"); // Negative string number
+        mapWithStringNumbers.put("frameheight", "0"); // Zero string
+        mapWithStringNumbers.put("lti13_auto_state", "3"); // Single digit string
+        
+        LtiToolBean tool = LtiToolBean.of(mapWithStringNumbers);
+        assertNotNull(tool);
+        
+        // Verify string numbers converted correctly
+        assertEquals("String '777' should convert to Long", Long.valueOf(777L), tool.getId());
+        assertEquals("String '-666' should convert to Long", Long.valueOf(-666L), tool.getDeploymentId());
+        assertEquals("String '0' should convert to Integer", Integer.valueOf(0), tool.getFrameheight());
+        assertEquals("String '3' should convert to Integer", Integer.valueOf(3), tool.getLti13AutoState());
+    }
+
+    @Test
+    public void testDecimalStringHandling() {
+        Map<String, Object> mapWithDecimals = new HashMap<>();
+        
+        // Test decimal strings (should truncate like LTIUtil)
+        mapWithDecimals.put("id", "555.0"); // Decimal string with .0
+        mapWithDecimals.put("deployment_id", "444.7"); // Decimal string with decimal part
+        mapWithDecimals.put("frameheight", "333.99"); // Decimal string for integer field
+        mapWithDecimals.put("lti13_auto_state", "2.5"); // Decimal string for integer field
+        
+        LtiToolBean tool = LtiToolBean.of(mapWithDecimals);
+        assertNotNull(tool);
+        
+        // Verify decimal strings are truncated correctly
+        assertEquals("String '555.0' should truncate to 555", Long.valueOf(555L), tool.getId());
+        assertEquals("String '444.7' should truncate to 444", Long.valueOf(444L), tool.getDeploymentId());
+        assertEquals("String '333.99' should truncate to 333", Integer.valueOf(333), tool.getFrameheight());
+        assertEquals("String '2.5' should truncate to 2", Integer.valueOf(2), tool.getLti13AutoState());
+    }
+
+    @Test
+    public void testInvalidStringHandling() {
+        Map<String, Object> mapWithInvalidStrings = new HashMap<>();
+        
+        // Test invalid string values (should return null)
+        mapWithInvalidStrings.put("id", "invalid"); // Invalid string
+        mapWithInvalidStrings.put("deployment_id", ""); // Empty string
+        mapWithInvalidStrings.put("frameheight", "not-a-number"); // Non-numeric string
+        mapWithInvalidStrings.put("lti13_auto_state", "abc123"); // Mixed string
+        
+        LtiToolBean tool = LtiToolBean.of(mapWithInvalidStrings);
+        assertNotNull(tool);
+        
+        // Verify invalid strings return null
+        assertNull("Invalid string 'invalid' should return null", tool.getId());
+        assertNull("Empty string should return null", tool.getDeploymentId());
+        assertNull("Non-numeric string should return null", tool.getFrameheight());
+        assertNull("Mixed string should return null", tool.getLti13AutoState());
+    }
+
+    @Test
+    public void testBigDecimalHandling() {
+        Map<String, Object> mapWithBigDecimals = new HashMap<>();
+        
+        // Test BigDecimal (common from databases)
+        java.math.BigDecimal bigDecimal111 = new java.math.BigDecimal("111.45");
+        java.math.BigDecimal bigDecimal222 = new java.math.BigDecimal("222");
+        java.math.BigDecimal bigDecimal333 = new java.math.BigDecimal("333.99");
+        
+        mapWithBigDecimals.put("id", bigDecimal111);
+        mapWithBigDecimals.put("deployment_id", bigDecimal222);
+        mapWithBigDecimals.put("frameheight", bigDecimal333);
+        
+        LtiToolBean tool = LtiToolBean.of(mapWithBigDecimals);
+        assertNotNull(tool);
+        
+        // Verify BigDecimal conversion (should truncate decimals)
+        assertEquals("BigDecimal 111.45 should truncate to 111", Long.valueOf(111L), tool.getId());
+        assertEquals("BigDecimal 222 should convert to 222", Long.valueOf(222L), tool.getDeploymentId());
+        assertEquals("BigDecimal 333.99 should truncate to 333", Integer.valueOf(333), tool.getFrameheight());
+    }
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiToolSiteBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiToolSiteBeanTest.java
@@ -1,0 +1,289 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sakaiproject.lti.beans.LtiToolSiteBean;
+
+/**
+ * Unit tests for LtiToolSiteBean POJO conversion methods.
+ */
+public class LtiToolSiteBeanTest {
+
+    private Map<String, Object> testMap;
+    private Date testDate;
+
+    @Before
+    public void setUp() {
+        testDate = new Date();
+        testMap = new HashMap<>();
+        
+        testMap.put("id", 123L);
+        testMap.put("tool_id", 456L);
+        testMap.put("SITE_ID", "site123");
+        testMap.put("notes", "Test notes for this tool site");
+        testMap.put("created_at", testDate);
+        testMap.put("updated_at", testDate);
+    }
+
+    @Test
+    public void testFromMapNullInput() {
+        assertNull(LtiToolSiteBean.of(null));
+    }
+
+    @Test
+    public void testFromMapEmptyMap() {
+        Map<String, Object> emptyMap = new HashMap<>();
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(emptyMap);
+        assertNotNull(toolSite);
+        assertNull(toolSite.getId());
+        assertNull(toolSite.getToolId());
+        assertNull(toolSite.getSiteId());
+    }
+
+    @Test
+    public void testFromMapCompleteData() {
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(testMap);
+        
+        assertNotNull(toolSite);
+        assertEquals(Long.valueOf(123L), toolSite.getId());
+        assertEquals(Long.valueOf(456L), toolSite.getToolId());
+        assertEquals("site123", toolSite.getSiteId());
+        assertEquals("Test notes for this tool site", toolSite.getNotes());
+        assertEquals(testDate, toolSite.getCreatedAt());
+        assertEquals(testDate, toolSite.getUpdatedAt());
+    }
+
+    @Test
+    public void testToMapCompleteData() {
+        LtiToolSiteBean toolSite = new LtiToolSiteBean();
+        
+        toolSite.setId(789L);
+        toolSite.setToolId(101112L);
+        toolSite.setSiteId("site456");
+        toolSite.setNotes("Test toMap notes");
+        toolSite.setCreatedAt(testDate);
+        toolSite.setUpdatedAt(testDate);
+        
+        Map<String, Object> result = toolSite.asMap();
+        
+        assertNotNull(result);
+        assertEquals(789L, result.get("id"));
+        assertEquals(101112L, result.get("tool_id"));
+        assertEquals("site456", result.get("SITE_ID"));
+        assertEquals("Test toMap notes", result.get("notes"));
+        assertEquals(testDate, result.get("created_at"));
+        assertEquals(testDate, result.get("updated_at"));
+    }
+
+    @Test
+    public void testRoundTripConversion() {
+        // Convert Map to POJO
+        LtiToolSiteBean originalToolSite = LtiToolSiteBean.of(testMap);
+        assertNotNull(originalToolSite);
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = originalToolSite.asMap();
+        assertNotNull(convertedMap);
+        
+        // Verify all original values are preserved
+        for (Map.Entry<String, Object> entry : testMap.entrySet()) {
+            String key = entry.getKey();
+            Object originalValue = entry.getValue();
+            Object convertedValue = convertedMap.get(key);
+            
+            assertEquals("Round-trip conversion failed for key: " + key, originalValue, convertedValue);
+        }
+        
+        // Verify no extra fields were added
+        assertEquals("Converted map has different number of fields", testMap.size(), convertedMap.size());
+    }
+
+    @Test
+    public void testRoundTripWithNullValues() {
+        Map<String, Object> mapWithNulls = new HashMap<>();
+        mapWithNulls.put("id", 999L);
+        mapWithNulls.put("tool_id", null);
+        mapWithNulls.put("SITE_ID", "site999");
+        mapWithNulls.put("notes", null);
+        mapWithNulls.put("created_at", null);
+        mapWithNulls.put("updated_at", testDate);
+        
+        // Convert Map to POJO
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithNulls);
+        assertNotNull(toolSite);
+        assertEquals(Long.valueOf(999L), toolSite.getId());
+        assertNull(toolSite.getToolId());
+        assertEquals("site999", toolSite.getSiteId());
+        assertNull(toolSite.getNotes());
+        assertNull(toolSite.getCreatedAt());
+        assertEquals(testDate, toolSite.getUpdatedAt());
+        
+        // Convert POJO back to Map
+        Map<String, Object> convertedMap = toolSite.asMap();
+        assertNotNull(convertedMap);
+        
+        // Only non-null values should be in the converted map
+        assertEquals(Long.valueOf(999L), convertedMap.get("id"));
+        assertFalse(convertedMap.containsKey("tool_id"));
+        assertEquals("site999", convertedMap.get("SITE_ID"));
+        assertFalse(convertedMap.containsKey("notes"));
+        assertFalse(convertedMap.containsKey("created_at"));
+        assertEquals(testDate, convertedMap.get("updated_at"));
+    }
+
+    @Test
+    public void testTypeConversionRobustness() {
+        Map<String, Object> mapWithVariousTypes = new HashMap<>();
+        
+        // Test different number types
+        mapWithVariousTypes.put("id", 123); // Integer instead of Long
+        mapWithVariousTypes.put("tool_id", "456"); // String instead of Long
+        
+        // Test timestamp as Long
+        mapWithVariousTypes.put("created_at", testDate.getTime()); // Long timestamp
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithVariousTypes);
+        assertNotNull(toolSite);
+        
+        // Verify type conversions worked
+        assertEquals(Long.valueOf(123L), toolSite.getId());
+        assertEquals(Long.valueOf(456L), toolSite.getToolId());
+        assertEquals(testDate, toolSite.getCreatedAt());
+    }
+
+    @Test
+    public void testMinimalData() {
+        Map<String, Object> minimalMap = new HashMap<>();
+        minimalMap.put("id", 1L);
+        minimalMap.put("SITE_ID", "minimal-site");
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(minimalMap);
+        assertNotNull(toolSite);
+        assertEquals(Long.valueOf(1L), toolSite.getId());
+        assertNull(toolSite.getToolId());
+        assertEquals("minimal-site", toolSite.getSiteId());
+        assertNull(toolSite.getNotes());
+        assertNull(toolSite.getCreatedAt());
+        assertNull(toolSite.getUpdatedAt());
+        
+        Map<String, Object> result = toolSite.asMap();
+        assertEquals(Long.valueOf(1L), result.get("id"));
+        assertEquals("minimal-site", result.get("SITE_ID"));
+        assertFalse(result.containsKey("tool_id"));
+        assertFalse(result.containsKey("notes"));
+        assertFalse(result.containsKey("created_at"));
+        assertFalse(result.containsKey("updated_at"));
+    }
+
+    @Test
+    public void testDatabaseNumberTypeRobustness() {
+        Map<String, Object> mapWithDatabaseTypes = new HashMap<>();
+        
+        // Test all the weird number types that come from different databases
+        mapWithDatabaseTypes.put("id", Double.valueOf(999.0)); // Double from Oracle
+        mapWithDatabaseTypes.put("tool_id", Float.valueOf(888.0f)); // Float from MySQL
+        mapWithDatabaseTypes.put("created_at", testDate);
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithDatabaseTypes);
+        assertNotNull(toolSite);
+        
+        // Verify all number types converted correctly
+        assertEquals("Double should convert to Long", Long.valueOf(999L), toolSite.getId());
+        assertEquals("Float should convert to Long", Long.valueOf(888L), toolSite.getToolId());
+        assertEquals("Date should remain Date", testDate, toolSite.getCreatedAt());
+    }
+
+    @Test
+    public void testStringNumberRobustness() {
+        Map<String, Object> mapWithStringNumbers = new HashMap<>();
+        
+        // Test string representations of numbers (common from databases)
+        mapWithStringNumbers.put("id", "777"); // String number
+        mapWithStringNumbers.put("tool_id", "-666"); // Negative string number
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithStringNumbers);
+        assertNotNull(toolSite);
+        
+        // Verify string numbers converted correctly
+        assertEquals("String '777' should convert to Long", Long.valueOf(777L), toolSite.getId());
+        assertEquals("String '-666' should convert to Long", Long.valueOf(-666L), toolSite.getToolId());
+    }
+
+    @Test
+    public void testDecimalStringHandling() {
+        Map<String, Object> mapWithDecimals = new HashMap<>();
+        
+        // Test decimal strings (should truncate like LTIUtil)
+        mapWithDecimals.put("id", "555.0"); // Decimal string with .0
+        mapWithDecimals.put("tool_id", "444.7"); // Decimal string with decimal part
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithDecimals);
+        assertNotNull(toolSite);
+        
+        // Verify decimal strings are truncated correctly
+        assertEquals("String '555.0' should truncate to 555", Long.valueOf(555L), toolSite.getId());
+        assertEquals("String '444.7' should truncate to 444", Long.valueOf(444L), toolSite.getToolId());
+    }
+
+    @Test
+    public void testInvalidStringHandling() {
+        Map<String, Object> mapWithInvalidStrings = new HashMap<>();
+        
+        // Test invalid string values (should return null)
+        mapWithInvalidStrings.put("id", "invalid"); // Invalid string
+        mapWithInvalidStrings.put("tool_id", ""); // Empty string
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithInvalidStrings);
+        assertNotNull(toolSite);
+        
+        // Verify invalid strings return null
+        assertNull("Invalid string 'invalid' should return null", toolSite.getId());
+        assertNull("Empty string should return null", toolSite.getToolId());
+    }
+
+    @Test
+    public void testBigDecimalHandling() {
+        Map<String, Object> mapWithBigDecimals = new HashMap<>();
+        
+        // Test BigDecimal (common from databases)
+        java.math.BigDecimal bigDecimal111 = new java.math.BigDecimal("111.45");
+        java.math.BigDecimal bigDecimal222 = new java.math.BigDecimal("222");
+        
+        mapWithBigDecimals.put("id", bigDecimal111);
+        mapWithBigDecimals.put("tool_id", bigDecimal222);
+        
+        LtiToolSiteBean toolSite = LtiToolSiteBean.of(mapWithBigDecimals);
+        assertNotNull(toolSite);
+        
+        // Verify BigDecimal conversion (should truncate decimals)
+        assertEquals("BigDecimal 111.45 should truncate to 111", Long.valueOf(111L), toolSite.getId());
+        assertEquals("BigDecimal 222 should convert to 222", Long.valueOf(222L), toolSite.getToolId());
+    }
+}

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2579,7 +2579,7 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				LTI13Util.return400(response, "Could not load tool associated with content");
 				return;
 			}

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -486,7 +486,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		Map<String, Object> content = loadContentCheckSignature(signed_placement, response);
+		org.sakaiproject.lti.beans.LtiContentBean content = loadContentCheckSignature(signed_placement, response);
 		if (content == null) {
 			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 			return;
@@ -498,14 +498,14 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		Long toolKey = LTIUtil.toLongKey(content.get(LTIService.LTI_TOOL_ID));
+		Long toolKey = LTIUtil.toLongKey(content.toolId);
 		if (toolKey < 0 ) {
-			log.error("Content / Tool invalid content={} tool={}", content.get(LTIService.LTI_ID), toolKey);
+			log.error("Content / Tool invalid content={} tool={}", content.id, toolKey);
 			LTI13Util.return400(response, "Content / Tool mismatch");
 			return;
 		}
 
-		Map<String, Object> tool = ltiService.getToolDao(toolKey, site.getId());
+		org.sakaiproject.lti.beans.LtiToolBean tool = ltiService.getToolDaoAsPojo(toolKey, site.getId(), true);
 		if (tool == null) {
 			log.error("Could not load tool={}", toolKey);
 			LTI13Util.return400(response, "Missing tool");
@@ -590,14 +590,14 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		// TODO: A little moar checking on the session.
-		Map<String, Object> tool = ltiService.getToolDao(tool_key, null, true);
+		org.sakaiproject.lti.beans.LtiToolBean tool = ltiService.getToolDaoAsPojo(tool_key, null, true);
 		if (tool == null) {
 			LTI13Util.return400(response, "Could not load tool");
 			log.error("Could not load tool {}", tool_key);
 			return;
 		}
 
-		String json_out = (String) tool.get(LTIService.LTI13_AUTO_REGISTRATION);
+		String json_out = tool.lti13AutoRegistration;
 		if ( json_out == null || json_out.length() < 1 ) {
 			LTI13Util.return400(response, "Could not load tool configuration");
 			log.error("Could not load tool configuration {}", tool_key);
@@ -856,7 +856,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		// Load the tool
-		Map<String, Object> tool = ltiService.getToolDao(toolKey, null, true);
+		org.sakaiproject.lti.beans.LtiToolBean tool = ltiService.getToolDaoAsPojo(toolKey, null, true);
 		if (tool == null) {
 			LTI13Util.return400(response, "Could not load tool");
 			log.error("Could not load tool {}", tool_id);
@@ -883,9 +883,6 @@ public class LTI13Servlet extends HttpServlet {
 
 		scope = scope.toLowerCase();
 
-		int allowOutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
-		int allowRoster = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWROSTER));
-		int allowLineItems = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWLINEITEMS));
 
 		SakaiAccessToken sat = new SakaiAccessToken();
 		sat.tool_id = toolKey;
@@ -897,7 +894,7 @@ public class LTI13Servlet extends HttpServlet {
 
 		// Work through requested scopes
 		if (scope.contains(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY)) {
-			if (allowLineItems != 1) {
+			if (!Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
 				log.error("Scope lineitem readonly not allowed {}", tool_id);
 				return;
@@ -907,7 +904,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		if (scope.contains(LTI13ConstantsUtil.SCOPE_LINEITEM)) {
-			if (allowLineItems != 1) {
+			if (!Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_LINEITEM);
 				log.error("Scope lineitem not allowed {}", tool_id);
 				return;
@@ -919,7 +916,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		if (scope.contains(LTI13ConstantsUtil.SCOPE_SCORE)) {
-			if (allowOutcomes != 1 || allowLineItems != 1) {
+			if (!Boolean.TRUE.equals(tool.allowoutcomes) || !Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_SCORE);
 				log.error("Scope score not allowed {}", tool_id);
 				return;
@@ -930,7 +927,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		if (scope.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY)) {
-			if (allowOutcomes != 1 || allowLineItems != 1) {
+			if (!Boolean.TRUE.equals(tool.allowoutcomes) || !Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_RESULT_READONLY);
 				log.error("Scope result readonly not allowed {}", tool_id);
 				return;
@@ -941,7 +938,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		if (scope.contains(LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES)) {
-			if (allowRoster != 1) {
+			if (!Boolean.TRUE.equals(tool.allowroster)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES);
 				log.error("Scope names and roles not allowed {}", tool_id);
 				return;
@@ -952,7 +949,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		if (scope.contains(LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY)) {
-			if (allowRoster != 1) {
+			if (!Boolean.TRUE.equals(tool.allowroster)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY);
 				log.error("Scope context group not allowed {}", tool_id);
 				return;
@@ -1039,8 +1036,8 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
-		Map<String, Object> content = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
+		org.sakaiproject.lti.beans.LtiContentBean content = null;
 		String assignment_name = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
@@ -1055,19 +1052,19 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				return;
 			}
 
-			assignment_name = (String) content.get(LTIService.LTI_TITLE);
+			assignment_name = (String) content.title;
 			if (assignment_name == null || assignment_name.length() < 1) {
-				log.error("Could not determine assignment_name title {}", content.get(LTIService.LTI_ID));
+				log.error("Could not determine assignment_name title {}", content.id);
 				LTI13Util.return400(response, "Could not determine assignment_name");
 				return;
 			}
@@ -1087,7 +1084,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");
@@ -1097,6 +1094,8 @@ public class LTI13Servlet extends HttpServlet {
 			if ( ! checkToolHasPlacements(sat.tool_id, signed_placement, response) ) return;
 
 		}
+
+		log.debug("tool={} content={} userId={}", tool, content, userId);
 
 		userId = SakaiLTIUtil.parseSubject(userId);
 		if (!checkUserInSite(site, userId)) {
@@ -1110,6 +1109,7 @@ public class LTI13Servlet extends HttpServlet {
 		// When lineitem_key is null we are the "default" lineitem associated with the content object
 		// if the content item is associated with an assignment, we talk to the assignment API,
 		// if the content item is not associated with an assignment, we talk to the gradebook API
+log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+content);
 		Object retval = SakaiLTIUtil.handleGradebookLTI13(site, sat.tool_id, content, userId, lineitem_key, scoreObj);
 		log.debug("handleGradebookLTI13 retval={}",retval);
 		if ( retval instanceof String ) {
@@ -1197,7 +1197,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		Map<String, Object> tool = ltiService.getToolDao(tool_key, null, true);
+		org.sakaiproject.lti.beans.LtiToolBean tool = ltiService.getToolDaoAsPojo(tool_key, null, true);
 		if (tool == null) {
 			log.error("Could not load tool={}", tool_key);
 			LTI13Util.return400(response, "Missing tool");
@@ -1205,7 +1205,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		// Check if the one time use token matching
-		String tool_token = (String) tool.get(LTIService.LTI13_AUTO_TOKEN);
+		String tool_token = tool.lti13AutoToken;
 		if ( tool_token == null || tool_token.length() < 1 ||
 			! tool_token.equals(registration_token) ) {
 			log.error("Bad registration_token");
@@ -1221,7 +1221,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		String client_id = (String) tool.get(LTIService.LTI13_CLIENT_ID);
+		String client_id = tool.lti13ClientId;
 
 		jso.put("client_id", client_id);
 
@@ -1236,7 +1236,7 @@ public class LTI13Servlet extends HttpServlet {
 		String json_out = null;
 		try {
 			json_out = JacksonUtil.prettyPrint(jso);
-			tool.put(LTIService.LTI13_AUTO_REGISTRATION, json_out);
+			tool.lti13AutoRegistration = json_out;
 		} catch (com.fasterxml.jackson.core.JsonProcessingException e) {
 			log.error("Could not serialize JSON={}", e.getMessage());
 			LTI13Util.return400(response, "Could not serialize JSON");
@@ -1245,8 +1245,8 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		// Store the JSON
-		tool.put(LTIService.LTI13_AUTO_TOKEN, "Used");
-		tool.put(LTIService.LTI13_AUTO_STATE, new Integer(2));
+		tool.lti13AutoToken = "Used";
+		tool.lti13AutoState = Integer.valueOf(2);
 		String siteId = null;
 		Object retval = ltiService.updateToolDao(tool_key, tool, siteId);
 
@@ -1333,11 +1333,11 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
 		if ( isSignedPlacement(signed_placement) ) {
-			Map<String, Object> content = loadContentCheckSignature(signed_placement, response);
+			org.sakaiproject.lti.beans.LtiContentBean content = loadContentCheckSignature(signed_placement, response);
 			if (content == null) {
 				LTI13Util.return400(response, "Could not load content from signed placement");
 				log.error("Could not load content from signed placement = {}", signed_placement);
@@ -1347,13 +1347,13 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				return;
 			}
 		} else { // SAK-47261 - It is just a site_id
@@ -1365,7 +1365,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");
@@ -1380,12 +1380,10 @@ public class LTI13Servlet extends HttpServlet {
 		int paging = NumberUtils.toInt(pagingstr, -1);
 		if ( paging > 0 && ( limit < 0 || limit > paging ) ) limit = paging;
 
-		int releaseName = LTIUtil.toInt(tool.get(LTIService.LTI_SENDNAME));
-		int releaseEmail = LTIUtil.toInt(tool.get(LTIService.LTI_SENDEMAILADDR));
 		// int allowOutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
 
 		/* SAK-47261 - Scope NRPS to Context, not Resource Link
-		String assignment_name = (String) content.get(LTIService.LTI_TITLE);
+		String assignment_name = (String) content.title;
 		if (assignment_name == null || assignment_name.length() < 1) {
 			assignment_name = null;
 		}
@@ -1413,7 +1411,7 @@ public class LTI13Servlet extends HttpServlet {
 
 			List<User> users = UserDirectoryService.getUsers(userIds);
 
-			String roleMapProp = (String) tool.get(LTIService.LTI_ROLEMAP);
+			String roleMapProp = tool.rolemap;
 			Map<String, String> toolRoleMap = SakaiLTIUtil.convertOutboundRoleMapPropToMap(roleMapProp);
 
 			// Hoist these out of the loop
@@ -1470,12 +1468,12 @@ public class LTI13Servlet extends HttpServlet {
 				jo.put("user_id", subject);   // TODO: Should be subject - LTI13 Quirk
 				jo.put("lis_person_sourcedid", user.getEid());
 
-				if (releaseName != 0) {
+				if (Boolean.TRUE.equals(tool.sendname)) {
 					jo.put("name", user.getDisplayName());
 					jo.put("given_name", user.getFirstName());
 					jo.put("family_name", user.getLastName());
 				}
-				if (releaseEmail != 0) {
+				if (Boolean.TRUE.equals(tool.sendemailaddr)) {
 					jo.put("email", user.getEmail());
 				}
 
@@ -1506,7 +1504,7 @@ public class LTI13Servlet extends HttpServlet {
 
 				/* SAK-47261 - Scope NRPS to Context, not Resource Link
 				if ( sat.hasScope(SakaiAccessToken.SCOPE_SCORE)  && assignment_name != null ) {
-					String placement_secret  = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+					String placement_secret  = (String) content.placementSecret;
 					String placement_id = getPlacementId(signed_placement);
 					String result_sourcedid = SakaiLTIUtil.getSourceDID(user, placement_id, placement_secret);
 					if ( result_sourcedid != null ) sakai_ext.put("lis_result_sourcedid",result_sourcedid);
@@ -1597,7 +1595,7 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
 
 		try {
 			site = SiteService.getSite(site_id);
@@ -1607,7 +1605,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		tool = ltiService.getToolDao(sat.tool_id, site.getId());
+		tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 		if (tool == null) {
 			log.error("Could not load tool={}", sat.tool_id);
 			LTI13Util.return400(response, "Missing tool");
@@ -1799,7 +1797,7 @@ public class LTI13Servlet extends HttpServlet {
 		return parts.length == 3 ? parts[1] : null;
 	}
 
-	protected static Map<String, Object> loadContentCheckSignature(String signed_placement, HttpServletResponse response) {
+	protected static org.sakaiproject.lti.beans.LtiContentBean loadContentCheckSignature(String signed_placement, HttpServletResponse response) {
 
 		String[] parts = splitSignedPlacement(signed_placement, response);
 		if (parts == null) {
@@ -1821,14 +1819,14 @@ public class LTI13Servlet extends HttpServlet {
 
 		// Note that all of the above checking requires no database access :)
 		// Now we have a valid access token and valid JSON, proceed with validating the signed_placement
-		Map<String, Object> content = ltiService.getContentDao(contentKey);
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsPojo(contentKey, context_id);
 		if (content == null) {
 			log.error("Could not load Content Item {}", contentKey);
 			LTI13Util.return400(response, "Could not load Content Item");
 			return null;
 		}
 
-		String placementSecret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+		String placementSecret = content.placementsecret;
 		if (placementSecret == null) {
 			log.error("Could not load placementsecret {}", contentKey);
 			LTI13Util.return400(response, "Could not load placementsecret");
@@ -1848,7 +1846,7 @@ public class LTI13Servlet extends HttpServlet {
 		return content;
 	}
 
-	protected Site loadSiteFromContent(Map<String, Object> content, String signed_placement, HttpServletResponse response) {
+	protected Site loadSiteFromContent(org.sakaiproject.lti.beans.LtiContentBean content, String signed_placement, HttpServletResponse response) {
 		String[] parts = splitSignedPlacement(signed_placement, response);
 		if (parts == null) {
 			return null;
@@ -1857,15 +1855,15 @@ public class LTI13Servlet extends HttpServlet {
 		String context_id = parts[1];
 
 		// Good signed_placement, lets load the site and tool
-		String siteId = (String) content.get(LTIService.LTI_SITE_ID);
+		String siteId = content.siteId;
 		if (siteId == null) {
-			log.error("Could not find site content={}", content.get(LTIService.LTI_ID));
+			log.error("Could not find site content={}", content.id);
 			LTI13Util.return400(response, "Could not find site for content");
 			return null;
 		}
 
 		if (!siteId.equals(context_id)) {
-			log.error("Found incorrect site for content={}", content.get(LTIService.LTI_ID));
+			log.error("Found incorrect site for content={}", content.id);
 			LTI13Util.return400(response, "Found incorrect site for content");
 			return null;
 		}
@@ -1899,7 +1897,7 @@ public class LTI13Servlet extends HttpServlet {
 
 	protected static boolean checkToolHasPlacements(Long toolKey, String siteId, HttpServletResponse response)
 	{
-		 List<Map<String, Object>> contents = ltiService.getContentsDao(null, null, 0, 2, siteId);
+		 List<org.sakaiproject.lti.beans.LtiContentBean> contents = ltiService.getContentsAsPojos(null, null, 0, 2, siteId);
 		if (contents.size() < 1) {
 			log.error("Tool id={} has no placements in site={}", toolKey, siteId);
 			LTI13Util.return400(response, "No placements for tool");
@@ -1908,15 +1906,15 @@ public class LTI13Servlet extends HttpServlet {
 		return true;
 	}
 
-	protected Map<String, Object> loadToolForContent(Map<String, Object> content, Site site, Long expected_tool_id, HttpServletResponse response) {
-		Long toolKey = LTIUtil.toLongKey(content.get(LTIService.LTI_TOOL_ID));
+	protected org.sakaiproject.lti.beans.LtiToolBean loadToolForContent(org.sakaiproject.lti.beans.LtiContentBean content, Site site, Long expected_tool_id, HttpServletResponse response) {
+		Long toolKey = LTIUtil.toLongKey(content.toolId);
 		if (toolKey < 0 || !toolKey.equals(expected_tool_id)) {
-			log.error("Content / Tool invalid content={} tool={}", content.get(LTIService.LTI_ID), toolKey);
+			log.error("Content / Tool invalid content={} tool={}", content.id, toolKey);
 			LTI13Util.return400(response, "Content / Tool mismatch");
 			return null;
 		}
 
-		Map<String, Object> tool = ltiService.getToolDao(toolKey, site.getId());
+		org.sakaiproject.lti.beans.LtiToolBean tool = ltiService.getToolDaoAsPojo(toolKey, site.getId(), true);
 		if (tool == null) {
 			log.error("Could not load tool={}", toolKey);
 			LTI13Util.return400(response, "Missing tool");
@@ -2022,11 +2020,11 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
 		if ( isSignedPlacement(signed_placement) ) {
-			Map<String, Object> content = loadContentCheckSignature(signed_placement, response);
+			org.sakaiproject.lti.beans.LtiContentBean content = loadContentCheckSignature(signed_placement, response);
 			if (content == null) {
 				LTI13Util.return400(response, "Could not load content from signed placement");
 				log.error("Could not load content from signed placement = {}", signed_placement);
@@ -2036,13 +2034,13 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				return;
 			}
 		} else { // SAK-47261 - It is just a site_id
@@ -2054,7 +2052,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");
@@ -2122,11 +2120,11 @@ public class LTI13Servlet extends HttpServlet {
 		if ( item == null ) return; // Error alredy handled
 
 		Site site = null;
-		Map<String, Object> tool = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
 		if ( isSignedPlacement(signed_placement) ) {
-			Map<String, Object> content = loadContentCheckSignature(signed_placement, response);
+			org.sakaiproject.lti.beans.LtiContentBean content = loadContentCheckSignature(signed_placement, response);
 			if (content == null) {
 				LTI13Util.return400(response, "Could not load content from signed placement");
 				log.error("Could not load content from signed placement = {}", signed_placement);
@@ -2136,13 +2134,13 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				return;
 			}
 		} else { // SAK-47261 - It is just a site_id
@@ -2154,7 +2152,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");
@@ -2210,8 +2208,8 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
-		Map<String, Object> content = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
+		org.sakaiproject.lti.beans.LtiContentBean content = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
 		if ( isSignedPlacement(signed_placement) ) {
@@ -2225,13 +2223,13 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				return;
 			}
 		} else { // SAK-47261 - It is just a site_id
@@ -2243,7 +2241,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");
@@ -2326,8 +2324,8 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
-		Map<String, Object> content = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
+		org.sakaiproject.lti.beans.LtiContentBean content = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
 		if ( isSignedPlacement(signed_placement) ) {
@@ -2341,13 +2339,13 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
 			tool = loadToolForContent(content, site, sat.tool_id, response);
 			if (tool == null) {
-				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.get(LTIService.LTI_ID));
+				log.error("Could not load tool={} associated with content={}", sat.tool_id, content.id);
 				return;
 			}
 		} else { // SAK-47261 - It is just a site_id
@@ -2359,7 +2357,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");
@@ -2376,7 +2374,7 @@ public class LTI13Servlet extends HttpServlet {
 		if ( lineitem_key != null ) {
 			a = LineItemUtil.getColumnByKeyDAO(context_id, sat.tool_id, lineitem_key);
 		} else if ( content != null ) {
-			String assignment_label = (String) content.get(LTIService.LTI_TITLE);
+			String assignment_label = (String) content.title;
 			a = LineItemUtil.getColumnByLabelDAO(context_id, sat.tool_id, assignment_label);
 		}
 
@@ -2498,7 +2496,7 @@ public class LTI13Servlet extends HttpServlet {
 
 				if ( actualGrade != null ) {
 					try {
-						Double dGrade = new Double(actualGrade);
+						Double dGrade = Double.valueOf(actualGrade);
 						result.resultScore = dGrade;
 					} catch(NumberFormatException e) {
 						log.error("Could not parse grade="+actualGrade);
@@ -2558,11 +2556,11 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Site site = null;
-		Map<String, Object> tool = null;
+		org.sakaiproject.lti.beans.LtiToolBean tool = null;
 
 		// SAK-47261 - Legacy URL patterns with actual signed placement
 		if ( isSignedPlacement(signed_placement) ) {
-			Map<String, Object> content = loadContentCheckSignature(signed_placement, response);
+			org.sakaiproject.lti.beans.LtiContentBean content = loadContentCheckSignature(signed_placement, response);
 			if (content == null) {
 				LTI13Util.return400(response, "Could not load content from signed placement");
 				log.error("Could not load content from signed placement = {}", signed_placement);
@@ -2572,7 +2570,7 @@ public class LTI13Servlet extends HttpServlet {
 			site = loadSiteFromContent(content, signed_placement, response);
 			if (site == null) {
 				LTI13Util.return400(response, "Could not load site associated with content");
-				log.error("Could not load site associated with content={}", content.get(LTIService.LTI_ID));
+				log.error("Could not load site associated with content={}", content.id);
 				return;
 			}
 
@@ -2591,7 +2589,7 @@ public class LTI13Servlet extends HttpServlet {
 				return;
 			}
 
-			tool = ltiService.getToolDao(sat.tool_id, site.getId());
+			tool = ltiService.getToolDaoAsPojo(sat.tool_id, site.getId(), true);
 			if (tool == null) {
 				log.error("Could not load tool={}", sat.tool_id);
 				LTI13Util.return400(response, "Missing tool");

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -1095,7 +1095,10 @@ public class LTI13Servlet extends HttpServlet {
 
 		}
 
-		log.debug("tool={} content={} userId={}", tool, content, userId);
+		log.debug("tool={} content={} userId={}",
+			tool != null ? tool.getId() : null,
+			content != null ? content.getId() : null,
+			userId);
 
 		userId = SakaiLTIUtil.parseSubject(userId);
 		if (!checkUserInSite(site, userId)) {

--- a/lti/lti-common/src/java/org/sakaiproject/lti/UrlUtility.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/UrlUtility.java
@@ -110,15 +110,4 @@ public class UrlUtility {
 			padding += "=";
 		return cleanedUrl.replaceAll("-", "+").replaceAll("_", "/") + padding;
 	}
-
-	public static void main(String[] args) {
-		String sample = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'����������Э��ҹ������ό�ĩ����ɾֳ���ÍŽ";
-		String encoded = encodeUrl(sample);
-		String decoded = decodeUrl(encoded);
-		boolean same = sample.equals(decoded);
-		log.debug("encoded={}", encoded);
-		log.debug("sample={}", sample);
-		log.debug("decoded={}", decoded);
-		log.debug("sample.equals(decoded)={}", same);
-	}
 }

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/LegacyShaUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/LegacyShaUtil.java
@@ -122,23 +122,4 @@ public class LegacyShaUtil {
 		}
 		return base;
 	}
-
-	public static void main(String[] args) {
-		final String sample1 = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅ½";
-		final String sample2 = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅ½";
-		final String sample3 = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅÅ";
-		final String sample1Hash = sha1Hash(sample1);
-		final String sample2Hash = sha1Hash(sample2);
-		final String sample3Hash = sha1Hash(sample3);
-		log.debug(sample1Hash);
-		log.debug(sample2Hash);
-		log.debug(sample3Hash);
-		assert (sample1Hash.equals(sample2Hash));
-		log.debug("{}=(sample1Hash.equals(sample2Hash))", sample1Hash.equals(sample2Hash));
-		assert (!sample3Hash.equals(sample1Hash));
-		log.debug("{}=(!sample3Hash.equals(sample1Hash))", !sample3Hash.equals(sample1Hash));
-		assert (null == byteToHex(null));
-		final boolean testNull = (null == byteToHex(null));
-		log.debug("{}=(null == byteToHex(null))", testNull);
-	}
 }

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -642,7 +642,7 @@ public class SakaiLTIUtil {
 
 	public static String getFallBackRole(String context) {
 		if (SecurityService.isSuperUser()) {
-			return LTI13ConstantsUtil.ROLE_INSTRUCTOR + "," 
+			return LTI13ConstantsUtil.ROLE_INSTRUCTOR + ","
 				+ LTI13ConstantsUtil.ROLE_CONTEXT_ADMIN + ","
 				+ LTI13ConstantsUtil.ROLE_SYSTEM_ADMIN;
 		} else if (SiteService.allowUpdateSite(context)) {
@@ -1435,6 +1435,16 @@ public class SakaiLTIUtil {
 			}
 			return publicKey;
 		}
+
+		/**
+		 * getPublicKey - Get the appropriate public key for use for an incoming request
+		 * @param tool the tool bean
+		 * @param id_token the id token
+		 * @return the public key
+		 */
+	public static Key getPublicKey(org.sakaiproject.lti.beans.LtiToolBean tool, String id_token) {
+		return getPublicKey(tool != null ? tool.asMap() : null, id_token);
+	}
 
 		/**
 		 * Create a ContentItem from the current request (may throw runtime)
@@ -2653,18 +2663,31 @@ public class SakaiLTIUtil {
 		return retval;
 	}
 
-	// When lineitem_key is null we are the "default" lineitem associated with the content object
-	// if the content item is associated with an assignment, we talk to the assignment API,
-	// if the content item is not associated with an assignment, we talk to the gradebook API
-	// If the scoreGiven is null, we are clearing out the grade value
-	// Note that scoreObj.userId is subject, not userId
+	/**
+	 * Handle gradebook LTI13 with content Map
+	 * @param site the site
+	 * @param tool_id the tool id
+	 * @param content the content Map (can be null)
+	 * @param userId the user id
+	 * @param lineitem_key the line item key
+	 * @param scoreObj the score object
+	 * @return the result
+
+	 * When lineitem_key is null we are the "default" lineitem associated with the content object.
+	 * if the content item is associated with an assignment, we talk to the assignment API,
+	 * if the content item is not associated with an assignment, we talk to the gradebook API
+     * content can be null if the lineitem_key is defined.
+	 * If the scoreGiven is null, we are clearing out the grade value.
+	 * Note that scoreObj.userId is subject, not userId (naming inconsistency in IMS specs but we have to follow here).
+	 */
 	public static Object handleGradebookLTI13(Site site,  Long tool_id, Map<String, Object> content, String userId,
 			Long lineitem_key, Score scoreObj) {
 
 		Object retval;
 		String title;
 
-		log.debug("siteid: {} tool_id: {} lineitem_key: {} userId: {} scoreObj: {}", site.getId(), tool_id, lineitem_key, userId, scoreObj);
+		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}", 
+			site.getId(), tool_id, (content == null ? "null" : content.get(LTIService.LTI_ID)), lineitem_key, userId, scoreObj);
 
 		// An empty / null score given means to delete the score
 		SakaiLineItem lineItem = new SakaiLineItem();
@@ -2675,6 +2698,10 @@ public class SakaiLTIUtil {
 		// Are we in the default lineitem for the content object?
 		// Check if this is as assignment placement and handle it if it is
 		if ( lineitem_key == null ) {
+			if (content == null ) {
+				log.error("handleGradebookLTI13 requires either content to be not null or have a lineitem_key");
+				return "handleGradebookLTI13 requires either content to be not null or have a lineitem_key";
+			}
 			pushAdvisor(); // Add security advisor to allow access to assignments
 			try {
 				org.sakaiproject.assignment.api.model.Assignment assignment = getAssignment(site, content);
@@ -2805,6 +2832,21 @@ public class SakaiLTIUtil {
 			sess.invalidate(); // Make sure to leave no traces
 		}
 		return Boolean.FALSE;
+	}
+
+	/**
+	 * Handle gradebook LTI13 with content bean
+	 * @param site the site
+	 * @param tool_id the tool id
+	 * @param content the content bean (can be null)
+	 * @param userId the user id
+	 * @param lineitem_key the line item key
+	 * @param scoreObj the score object
+	 * @return the result
+	 */
+	public static Object handleGradebookLTI13(Site site, Long tool_id, org.sakaiproject.lti.beans.LtiContentBean content, String userId, Long lineitem_key, Score scoreObj) {
+		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}", site.getId(), tool_id, (content == null ? "null" : content.id), lineitem_key, userId, scoreObj);
+		return handleGradebookLTI13(site, tool_id, (content == null ? null : content.asMap()), userId, lineitem_key, scoreObj);
 	}
 
 	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, Map<String, Object> content) {
@@ -3268,7 +3310,12 @@ public class SakaiLTIUtil {
 	/**
 	 * getLaunchCodeKey - Return the launch code key for a content item
 	 */
+	public static String getLaunchCodeKey(org.sakaiproject.lti.beans.LtiContentBean content) {
+		return getLaunchCodeKey(content != null ? content.asMap() : null);
+	}
+
 	public static String getLaunchCodeKey(Map<String, Object> content) {
+		if (content == null) return SESSION_LAUNCH_CODE + "0";
 		int id = LTIUtil.toInt(content.get(LTIService.LTI_ID));
 		return SESSION_LAUNCH_CODE + id;
 	}
@@ -3276,7 +3323,14 @@ public class SakaiLTIUtil {
 	/**
 	 * getLaunchCode - Return the launch code for a content item
 	 */
+	public static String getLaunchCode(org.sakaiproject.lti.beans.LtiContentBean content) {
+		return getLaunchCode(content != null ? content.asMap() : null);
+	}
+
 	public static String getLaunchCode(Map<String, Object> content) {
+		if (content == null) {
+			return LTI13Util.timeStampSign("0", null);
+		}
 		/*
 		long now = (new java.util.Date()).getTime();
 		int id = LTIUtil.toInt(content.get(LTIService.LTI_ID));
@@ -3483,6 +3537,28 @@ public class SakaiLTIUtil {
 		return retval;
 	}
 
+	/**
+	 * POJO overload for findBestToolMatch
+	 */
+	public static org.sakaiproject.lti.beans.LtiToolBean findBestToolMatchPojo(String launchUrl, String toolCheckSum, List<org.sakaiproject.lti.beans.LtiToolBean> tools)
+	{
+		// Guard against null tools parameter
+		if (tools == null) {
+			return null;
+		}
+		
+		// Convert POJOs to maps for the existing logic
+		List<Map<String,Object>> toolMaps = new ArrayList<>();
+		for (org.sakaiproject.lti.beans.LtiToolBean tool : tools) {
+			if (tool != null) {
+				toolMaps.add(tool.asMap());
+			}
+		}
+
+		Map<String,Object> result = findBestToolMatch(launchUrl, toolCheckSum, toolMaps);
+		return result != null ? org.sakaiproject.lti.beans.LtiToolBean.of(result) : null;
+	}
+
 	public static String getStringNull(Object value) {
 		return LTI13Util.getStringNull(value);
 	}
@@ -3649,14 +3725,20 @@ public class SakaiLTIUtil {
 	/**
 	 * Get the correct frameheight for a content / combination based on inheritance rules
 	 */
+	public static String getFrameHeight(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, String defaultValue) {
+		return getFrameHeight(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
+	}
+
 	public static String getFrameHeight(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
 		String height = defaultValue;
 
+		// Check tool first (default behavior)
 		if ( tool != null ) {
 			Long toolFrameHeight = LTIUtil.toLong(tool.get(LTIService.LTI_FRAMEHEIGHT), -1L);
-			if ( toolFrameHeight > 1 )  height = toolFrameHeight + "px";
+			if ( toolFrameHeight > 0 )  height = toolFrameHeight + "px";
 		}
 
+		// Check content second (content overrides tool if not null)
 		if (content != null) {
 			Long contentFrameHeight = LTIUtil.toLong(content.get(LTIService.LTI_FRAMEHEIGHT));
 			if ( contentFrameHeight > 0 ) height = contentFrameHeight + "px";
@@ -3668,14 +3750,27 @@ public class SakaiLTIUtil {
 	/**
 	 * Get the new page setting for a content / combination based on inheritance rules
 	 */
+	public static boolean getNewpage(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, boolean defaultValue) {
+		return getNewpage(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
+	}
+
 	public static boolean getNewpage(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
 		boolean newpage = defaultValue;
 
+		// Check content first (lower priority)
 		if (content != null ) {
-			Long contentNewpage = LTIUtil.toLongNull(content.get(LTIService.LTI_NEWPAGE));
-			if ( contentNewpage != null ) newpage = (contentNewpage != 0);
+			Object contentNewpageObj = content.get(LTIService.LTI_NEWPAGE);
+			if ( contentNewpageObj != null ) {
+				if (contentNewpageObj instanceof Boolean) {
+					newpage = (Boolean) contentNewpageObj;
+				} else {
+					Long contentNewpage = LTIUtil.toLongNull(contentNewpageObj);
+					if ( contentNewpage != null ) newpage = (contentNewpage != 0);
+				}
+			}
 		}
 
+		// Check tool second (higher priority - overrides content)
 		if ( tool != null ) {
 			Long toolNewpage = LTIUtil.toLongNull(tool.get(LTIService.LTI_NEWPAGE));
 
@@ -3686,6 +3781,43 @@ public class SakaiLTIUtil {
 			}
 		}
 		return newpage;
+	}
+
+	/**
+	 * Get the debug setting for a content / tool combination based on inheritance rules
+	 */
+	public static boolean getDebug(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, boolean defaultValue) {
+		return getDebug(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
+	}
+
+	public static boolean getDebug(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+		boolean debug = defaultValue;
+
+		// Check content first (lower priority)
+		if (content != null ) {
+			Object contentDebugObj = content.get(LTIService.LTI_DEBUG);
+			if ( contentDebugObj != null ) {
+				if (contentDebugObj instanceof Boolean) {
+					debug = (Boolean) contentDebugObj;
+				} else {
+					Long contentDebug = LTIUtil.toLongNull(contentDebugObj);
+					if ( contentDebug != null ) debug = (contentDebug != 0);
+				}
+			}
+		}
+
+		// Check tool second (higher priority - overrides content)
+		if ( tool != null ) {
+			Long toolDebug = LTIUtil.toLongNull(tool.get(LTIService.LTI_DEBUG));
+
+			if ( toolDebug != null ) {
+				// Leave this alone for LTIService.LTI_TOOL_DEBUG_CONTENT
+				if ( toolDebug == LTIService.LTI_TOOL_DEBUG_OFF ) debug = false;
+				if ( toolDebug == LTIService.LTI_TOOL_DEBUG_ON ) debug = true;
+				// toolDebug == 2 (CONTENT) - leave content value as-is
+			}
+		}
+		return debug;
 	}
 
 	/**

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -650,6 +650,16 @@ public class LineItemUtil {
 	}
 
 	/**
+	 * Gets the default lineItem for a content launch with content bean
+	 * @param site the site
+	 * @param content the content bean
+	 * @return the default line item
+	 */
+	public static SakaiLineItem getDefaultLineItem(Site site, org.sakaiproject.lti.beans.LtiContentBean content) {
+		return getDefaultLineItem(site, content.asMap());
+	}
+
+	/**
 	 * Pull a lineitem out of a Deep Link Response, construct a lineitem from a ContentItem response
 	 */
 	public static SakaiLineItem extractLineItem(String response_str) {

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -656,7 +656,7 @@ public class LineItemUtil {
 	 * @return the default line item
 	 */
 	public static SakaiLineItem getDefaultLineItem(Site site, org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getDefaultLineItem(site, content.asMap());
+		return getDefaultLineItem(site, content != null ? content.asMap() : null);
 	}
 
 	/**

--- a/lti/lti-common/src/test/org/sakaiproject/lti/UrlUtilityTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/UrlUtilityTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lti;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for UrlUtility class
+ */
+public class UrlUtilityTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void testEncodeDecodeRoundTrip() {
+        // This test covers the logic that was previously in the main() method
+        String sample = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅ½";
+        
+        String encoded = UrlUtility.encodeUrl(sample);
+        String decoded = UrlUtility.decodeUrl(encoded);
+        
+        // Test that encode/decode is a proper round-trip operation
+        assertEquals("Encode/decode should be inverse operations", sample, decoded);
+        
+        // Verify that encoding actually changes the string (not a no-op)
+        assertNotEquals("Encoding should change the string", sample, encoded);
+    }
+
+    @Test
+    public void testEncodeDecodeWithSpecialCharacters() {
+        // Test with various special characters that might cause issues
+        String[] testStrings = {
+            "simple",
+            "with spaces",
+            "with/slashes",
+            "with+plus",
+            "with=equals",
+            "with?query=param",
+            "with#fragment",
+            "with%percent",
+            "with&ampersand",
+            "with\"quotes\"",
+            "with'single'quotes",
+            "with<tags>",
+            "with[ brackets ]",
+            "with{ braces }",
+            "with| pipe |",
+            "with\\ backslash",
+            "with\n newline",
+            "with\t tab",
+            "with unicode: 中文 العربية русский",
+            "" // empty string
+        };
+        
+        for (String testString : testStrings) {
+            String encoded = UrlUtility.encodeUrl(testString);
+            String decoded = UrlUtility.decodeUrl(encoded);
+            assertEquals("Round-trip should work for: " + testString, testString, decoded);
+        }
+    }
+
+    @Test
+    public void testRawEncodeDecode() {
+        String sample = "test string";
+        
+        String encoded = UrlUtility.rawEncodeUrl(sample);
+        String decoded = UrlUtility.rawDecodeUrl(encoded);
+        
+        assertEquals("Raw encode/decode should be inverse operations", sample, decoded);
+    }
+
+    @Test
+    public void testCleanAndRepairUrl() {
+        // Test with a Base64-encoded string that naturally has padding
+        // This simulates what would happen in real usage
+        String original = "dGVzdCtzdHJpbmcvd2l0aHNsYXNoZXM="; // Base64 for "test+string/withslashes"
+        
+        String cleaned = UrlUtility.cleanUrl(original);
+        String repaired = UrlUtility.repairUrl(cleaned);
+        
+        assertEquals("Clean and repair should be inverse operations", original, repaired);
+    }
+}

--- a/lti/lti-common/src/test/org/sakaiproject/lti/beans/LTIPojoIntegrationTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/beans/LTIPojoIntegrationTest.java
@@ -1,0 +1,280 @@
+/*
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.sakaiproject.lti.beans;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.sakaiproject.lti.beans.LtiToolBean;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.util.SakaiLTIUtil;
+
+/**
+ * Integration tests for POJO usage patterns in assignments and lessonbuilder tools.
+ * These tests verify that the POJO methods work correctly in realistic usage scenarios.
+ */
+public class LTIPojoIntegrationTest {
+
+    @Test
+    public void testAssignmentsToolUsagePattern() {
+        // Simulate the assignments tool usage pattern:
+        // 1. Get content bean from LTIService
+        // 2. Access properties directly
+        // 3. Update properties and call updateContentDao
+        
+        // Create a content bean (simulating what would come from ltiService.getContentBean())
+        LtiContentBean content = new LtiContentBean();
+        content.id = 123L;
+        content.siteId = "test-site";
+        content.title = "Assignment LTI Tool";
+        content.description = "An LTI tool for assignments";
+        content.launch = "https://example.com/assignment/launch";
+        content.toolId = 456L;
+        content.placementsecret = "original-secret";
+        content.protect = false;
+        content.settings = "{\"available\":\"2023-01-01T00:00:00Z\"}";
+        
+        // Simulate assignments tool accessing properties (no more casting!)
+        String title = content.title;
+        String description = content.description;
+        Long toolId = content.toolId;
+        String placementSecret = content.placementsecret;
+        Boolean protect = content.protect;
+        String settings = content.settings;
+        
+        // Verify direct property access works
+        assertNotNull("Title should not be null", title);
+        assertEquals("Title should match", "Assignment LTI Tool", title);
+        assertNotNull("Description should not be null", description);
+        assertEquals("Description should match", "An LTI tool for assignments", description);
+        assertNotNull("Tool ID should not be null", toolId);
+        assertEquals("Tool ID should match", Long.valueOf(456L), toolId);
+        assertNotNull("Placement secret should not be null", placementSecret);
+        assertEquals("Placement secret should match", "original-secret", placementSecret);
+        assertNotNull("Protect should not be null", protect);
+        assertFalse("Protect should be false", protect);
+        assertNotNull("Settings should not be null", settings);
+        assertTrue("Settings should contain available date", settings.contains("2023-01-01"));
+        
+        // Simulate assignments tool updating properties (no more map.put()!)
+        content.placementsecret = "updated-secret";
+        content.protect = true;
+        content.settings = "{\"available\":\"2023-01-01T00:00:00Z\",\"submission\":\"2023-01-15T23:59:59Z\"}";
+        
+        // Verify updates work
+        assertEquals("Placement secret should be updated", "updated-secret", content.placementsecret);
+        assertTrue("Protect should be updated to true", content.protect);
+        assertTrue("Settings should contain submission date", content.settings.contains("2023-01-15"));
+        
+        // Simulate calling updateContentDao with the POJO
+        Map<String, Object> contentMap = content.asMap();
+        assertNotNull("asMap() should not return null", contentMap);
+        assertEquals("asMap() should preserve updated placement secret", "updated-secret", contentMap.get("placementsecret"));
+        assertEquals("asMap() should preserve updated protect", Integer.valueOf(1), contentMap.get("protect"));
+        assertTrue("asMap() should preserve updated settings", contentMap.get("settings").toString().contains("2023-01-15"));
+    }
+
+    @Test
+    public void testLessonBuilderToolUsagePattern() {
+        // Simulate the lessonbuilder tool usage pattern:
+        // 1. Get tools list from LTIService
+        // 2. Find best tool match
+        // 3. Create new content bean
+        // 4. Insert content
+        
+        // Create a list of tool beans (simulating what would come from ltiService.getToolBeans())
+        List<LtiToolBean> tools = new ArrayList<>();
+        
+        LtiToolBean tool1 = new LtiToolBean();
+        tool1.id = 100L;
+        tool1.title = "Tool A";
+        tool1.launch = "https://example.com/tool-a/launch";
+        tool1.newpage = 1; // LTI_TOOL_NEWPAGE_ON
+        tool1.frameheight = 800;
+        tools.add(tool1);
+        
+        LtiToolBean tool2 = new LtiToolBean();
+        tool2.id = 200L;
+        tool2.title = "Tool B";
+        tool2.launch = "https://example.com/tool-b/launch";
+        tool2.newpage = 0; // LTI_TOOL_NEWPAGE_OFF
+        tool2.frameheight = 600;
+        tools.add(tool2);
+        
+        // Simulate lessonbuilder finding best tool match (no more map iteration!)
+        LtiToolBean selectedTool = null;
+        String targetUrl = "https://example.com/tool-b/launch";
+        for (LtiToolBean tool : tools) {
+            if (targetUrl.equals(tool.launch)) {
+                selectedTool = tool;
+                break;
+            }
+        }
+        
+        assertNotNull("Selected tool should not be null", selectedTool);
+        assertEquals("Selected tool ID should match", Long.valueOf(200L), selectedTool.id);
+        assertEquals("Selected tool title should match", "Tool B", selectedTool.title);
+        
+        // Simulate lessonbuilder creating new content bean (no more Properties!)
+        LtiContentBean newContent = new LtiContentBean();
+        newContent.toolId = selectedTool.id;
+        newContent.title = "Lesson Content";
+        newContent.launch = "https://example.com/lesson/launch";
+        // Convert tool newpage (Integer) to content newpage (Boolean)
+        newContent.newpage = selectedTool.newpage != null && selectedTool.newpage == 1;
+        newContent.xmlimport = "test-xml-import";
+        newContent.custom = "lesson=custom";
+        
+        // Verify content creation
+        assertNotNull("New content should not be null", newContent);
+        assertEquals("Tool ID should be set", Long.valueOf(200L), newContent.toolId);
+        assertEquals("Title should be set", "Lesson Content", newContent.title);
+        assertEquals("Launch should be set", "https://example.com/lesson/launch", newContent.launch);
+        assertEquals("Newpage should inherit from tool", false, newContent.newpage);
+        assertEquals("XML import should be set", "test-xml-import", newContent.xmlimport);
+        assertEquals("Custom should be set", "lesson=custom", newContent.custom);
+        
+        // Simulate calling insertContent with the POJO
+        Map<String, Object> contentMap = newContent.asMap();
+        assertNotNull("asMap() should not return null", contentMap);
+        assertEquals("asMap() should preserve tool ID", Long.valueOf(200L), contentMap.get("tool_id"));
+        assertEquals("asMap() should preserve title", "Lesson Content", contentMap.get("title"));
+        assertEquals("asMap() should preserve launch", "https://example.com/lesson/launch", contentMap.get("launch"));
+        assertEquals("asMap() should preserve newpage", Integer.valueOf(0), contentMap.get("newpage"));
+        assertEquals("asMap() should preserve xmlimport", "test-xml-import", contentMap.get("xmlimport"));
+        assertEquals("asMap() should preserve custom", "lesson=custom", contentMap.get("custom"));
+    }
+
+    @Test
+    public void testSakaiLTIUtilIntegration() {
+        // Test that SakaiLTIUtil POJO overloads work with realistic data
+        
+        // Create tool and content beans
+        LtiToolBean tool = new LtiToolBean();
+        tool.newpage = 1; // LTI_TOOL_NEWPAGE_ON
+        tool.frameheight = 800;
+        
+        LtiContentBean content = new LtiContentBean();
+        content.newpage = false; // Boolean for content
+        content.frameheight = 600;
+        content.id = 123L;
+        content.placementsecret = "test-secret";
+        
+        // Test getNewpage with POJOs
+        boolean newpage = SakaiLTIUtil.getNewpage(tool, content, false);
+        assertTrue("Tool newpage=1 should override content newpage=0", newpage);
+        
+        // Test getFrameHeight with POJOs
+        String height = SakaiLTIUtil.getFrameHeight(tool, content, "400px");
+        assertEquals("Content frameheight=600 should override tool frameheight=800", "600px", height);
+        
+        // Test getLaunchCodeKey with POJO
+        String launchKey = SakaiLTIUtil.getLaunchCodeKey(content);
+        assertNotNull("Launch code key should not be null", launchKey);
+        assertTrue("Launch code key should contain content ID", launchKey.contains("123"));
+        
+        // Test getLaunchCode with POJO
+        String launchCode = SakaiLTIUtil.getLaunchCode(content);
+        assertNotNull("Launch code should not be null", launchCode);
+        assertTrue("Launch code should contain content ID", launchCode.contains("123"));
+    }
+
+    @Test
+    public void testTypeSafetyBenefits() {
+        // Demonstrate the type safety benefits of POJO approach
+        
+        LtiContentBean content = new LtiContentBean();
+        content.id = 123L;
+        content.title = "Test Content";
+        content.toolId = 456L;
+        content.protect = true;
+        
+        // With POJOs, we get compile-time type checking
+        Long id = content.id;           // Compile-time verified as Long
+        String title = content.title;   // Compile-time verified as String
+        Long toolId = content.toolId;   // Compile-time verified as Long
+        Boolean protect = content.protect; // Compile-time verified as Boolean
+        
+        // No more casting or runtime type errors!
+        assertNotNull("ID should not be null", id);
+        assertEquals("ID should be Long", Long.class, id.getClass());
+        assertNotNull("Title should not be null", title);
+        assertEquals("Title should be String", String.class, title.getClass());
+        assertNotNull("Tool ID should not be null", toolId);
+        assertEquals("Tool ID should be Long", Long.class, toolId.getClass());
+        assertNotNull("Protect should not be null", protect);
+        assertEquals("Protect should be Boolean", Boolean.class, protect.getClass());
+        
+        // Compare with old map-based approach (commented out to show the difference):
+        /*
+        Map<String, Object> contentMap = new HashMap<>();
+        contentMap.put("id", 123L);
+        contentMap.put("title", "Test Content");
+        contentMap.put("tool_id", 456L);
+        contentMap.put("protect", true);
+        
+        // Old way - runtime casting, potential ClassCastException
+        Long oldId = (Long) contentMap.get("id");
+        String oldTitle = (String) contentMap.get("title");
+        Long oldToolId = (Long) contentMap.get("tool_id");
+        Boolean oldProtect = (Boolean) contentMap.get("protect");
+        */
+    }
+
+    @Test
+    public void testSecurityBenefits() {
+        // Demonstrate the security benefits of POJO toString() exclusions
+        
+        LtiToolBean tool = new LtiToolBean();
+        tool.id = 123L;
+        tool.title = "Test Tool";
+        tool.secret = "super-secret-key";
+        tool.lti13AutoToken = "auto-token-123";
+        tool.consumerkey = "consumer-key-456";
+        
+        LtiContentBean content = new LtiContentBean();
+        content.id = 456L;
+        content.title = "Test Content";
+        content.placementsecret = "placement-secret-789";
+        content.oldplacementsecret = "old-placement-secret-012";
+        
+        // Test that sensitive fields are excluded from toString()
+        String toolToString = tool.toString();
+        String contentToString = content.toString();
+        
+        // Sensitive fields should be excluded
+        assertFalse("Tool toString should not contain secret", toolToString.contains("super-secret-key"));
+        assertFalse("Tool toString should not contain lti13AutoToken", toolToString.contains("auto-token-123"));
+        assertFalse("Content toString should not contain placementsecret", contentToString.contains("placement-secret-789"));
+        assertFalse("Content toString should not contain oldplacementsecret", contentToString.contains("old-placement-secret-012"));
+        
+        // Non-sensitive fields should be included
+        assertTrue("Tool toString should contain title", toolToString.contains("Test Tool"));
+        assertTrue("Tool toString should contain consumerkey (not excluded)", toolToString.contains("consumer-key-456"));
+        assertTrue("Content toString should contain title", contentToString.contains("Test Content"));
+        
+        // This prevents accidental logging of sensitive data!
+    }
+}

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/LegacyShaUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/LegacyShaUtilTest.java
@@ -107,4 +107,25 @@ public class LegacyShaUtilTest {
 		assertFalse(abc_hash.equals(php_sha1_of_abc));
 	}
 
+	@Test
+	public void testMainMethodLogic() {
+		// This test covers the logic that was previously in the main() method
+		final String sample1 = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅ½";
+		final String sample2 = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅ½";
+		final String sample3 = "12345:/sites/foo/bar !@#$%^&*()_+|}{\":?><[]\';/.,'Áª£¢°¤¦¥»¼Ð­ÇÔÒ¹¿ö¬ ¨«Ï¶Ä©úÆûÂÉ¾Ö³²µ÷ÃÅÅ";
+
+		final String sample1Hash = LegacyShaUtil.sha1Hash(sample1);
+		final String sample2Hash = LegacyShaUtil.sha1Hash(sample2);
+		final String sample3Hash = LegacyShaUtil.sha1Hash(sample3);
+
+		// Test that identical strings produce identical hashes
+		assertEquals("Identical strings should produce identical hashes", sample1Hash, sample2Hash);
+
+		// Test that different strings produce different hashes
+		assertNotEquals("Different strings should produce different hashes", sample3Hash, sample1Hash);
+
+		// Test that byteToHex handles null correctly
+		assertNull("byteToHex should return null for null input", LegacyShaUtil.byteToHex(null));
+	}
+
 }

--- a/lti/lti-common/src/test/org/sakaiproject/lti13/LineItemUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti13/LineItemUtilTest.java
@@ -56,4 +56,37 @@ public class LineItemUtilTest {
 		assertEquals(li.submissionReview.url, "https://platform.example.com/act/849023/sub");
 	}
 
+	@Test
+	public void testGetDefaultLineItemOverload() {
+		// Create a test content bean
+		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		content.id = 123L;
+		content.toolId = 456L;
+		content.title = "Test Content";
+		content.siteId = "test-site";
+		
+		// Create equivalent map for comparison
+		java.util.Map<String, Object> contentMap = new java.util.HashMap<>();
+		contentMap.put("id", 123L);
+		contentMap.put("tool_id", 456L);
+		contentMap.put("title", "Test Content");
+		contentMap.put("SITE_ID", "test-site");
+		
+		// Test that the overloaded method delegates correctly by testing the asMap() conversion
+		// Since we can't easily mock the full Sakai environment, we test that the overloaded method
+		// delegates correctly by ensuring the asMap() conversion works as expected
+		java.util.Map<String, Object> contentAsMap = content.asMap();
+		assertNotNull("Content asMap should not be null", contentAsMap);
+		assertEquals("Content ID should match", Long.valueOf(123L), contentAsMap.get("id"));
+		assertEquals("Content tool ID should match", Long.valueOf(456L), contentAsMap.get("tool_id"));
+		assertEquals("Content title should match", "Test Content", contentAsMap.get("title"));
+		assertEquals("Content site ID should match", "test-site", contentAsMap.get("SITE_ID"));
+		
+		// Verify that both the bean and map produce equivalent results
+		assertEquals("Bean and map should have same ID", contentMap.get("id"), contentAsMap.get("id"));
+		assertEquals("Bean and map should have same tool_id", contentMap.get("tool_id"), contentAsMap.get("tool_id"));
+		assertEquals("Bean and map should have same title", contentMap.get("title"), contentAsMap.get("title"));
+		assertEquals("Bean and map should have same SITE_ID", contentMap.get("SITE_ID"), contentAsMap.get("SITE_ID"));
+	}
+
 }

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -330,7 +330,7 @@ public abstract class BaseLTIService implements LTIService {
 
 	@Override
 	public Object updateToolDao(Long key, org.sakaiproject.lti.beans.LtiToolBean tool, String siteId) {
-		return updateToolDao(key, tool.asMap(), siteId);
+		return updateToolDao(key, tool != null ? tool.asMap() : null, siteId);
 	}
 
 	private Object updateTool(Long key, Object newProps, String siteId) {
@@ -1605,27 +1605,27 @@ public abstract class BaseLTIService implements LTIService {
 
 	@Override
 	public Object insertTool(org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
-		return insertTool(toolBean.asMap(), siteId);
+		return insertTool(toolBean != null ? toolBean.asMap() : null, siteId);
 	}
 
 	@Override
 	public Object insertContent(org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
-		return insertContent(contentBean.asMap(), siteId);
+		return insertContent(contentBean != null ? contentBean.asMap() : null, siteId);
 	}
 
 	@Override
 	public Object updateTool(Long key, org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
-		return updateTool(key, toolBean.asMap(), siteId);
+		return updateTool(key, toolBean != null ? toolBean.asMap() : null, siteId);
 	}
 
 	@Override
 	public Object updateContent(Long key, org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
-		return updateContent(key, contentBean.asMap(), siteId);
+		return updateContent(key, contentBean != null ? contentBean.asMap() : null, siteId);
 	}
 
 	@Override
 	public String getContentLaunch(org.sakaiproject.lti.beans.LtiContentBean contentBean) {
-		return getContentLaunch(contentBean.asMap());
+		return getContentLaunch(contentBean != null ? contentBean.asMap() : null);
 	}
 
 }

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -328,6 +328,11 @@ public abstract class BaseLTIService implements LTIService {
 		return updateToolDao(key, newProps, siteId, true, true);
 	}
 
+	@Override
+	public Object updateToolDao(Long key, org.sakaiproject.lti.beans.LtiToolBean tool, String siteId) {
+		return updateToolDao(key, tool.asMap(), siteId);
+	}
+
 	private Object updateTool(Long key, Object newProps, String siteId) {
 		return updateToolDao(key, newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
@@ -585,6 +590,12 @@ public abstract class BaseLTIService implements LTIService {
 	}
 
 	@Override
+	public org.sakaiproject.lti.beans.LtiToolBean getToolBean(Long key, String siteId) {
+		Map<String, Object> toolMap = getTool(key, siteId);
+		return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+	}
+
+	@Override
 	public Map<String, Object> getToolDao(Long key, String siteId)
 	{
 		return getToolDao(key, siteId, true);
@@ -596,13 +607,43 @@ public abstract class BaseLTIService implements LTIService {
 	}
 
 	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId) {
+		List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
+		List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new ArrayList<>();
+		for (Map<String, Object> toolMap : toolMaps) {
+			toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+		}
+		return toolBeans;
+	}
+
+	@Override
 	public List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
 		return getToolsDao(search, order, first, last, siteId, isAdmin(siteId), includeStealthed);
 	}
 
 	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
+		List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
+		List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new ArrayList<>();
+		for (Map<String, Object> toolMap : toolMaps) {
+			toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+		}
+		return toolBeans;
+	}
+
+	@Override
 	public List<Map<String, Object>> getTools(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
 		return getToolsDao(search, order, first, last, siteId, isAdmin(siteId), includeStealthed, includeLaunchable);
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
+		List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed, includeLaunchable);
+		List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new ArrayList<>();
+		for (Map<String, Object> toolMap : toolMaps) {
+			toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+		}
+		return toolBeans;
 	}
 
 
@@ -636,6 +677,16 @@ public abstract class BaseLTIService implements LTIService {
 	@Override
     public List<Map<String, Object>> getToolsImportItem(String siteId) {
 		return getTools("lti_tools."+LTIService.LTI_PL_IMPORTITEM+" = 1", LTIService.LTI_TITLE, 0 ,0, siteId, false, true);
+	}
+
+	@Override
+    public List<org.sakaiproject.lti.beans.LtiToolBean> getToolsImportItemBeans(String siteId) {
+		List<Map<String, Object>> toolMaps = getToolsImportItem(siteId);
+		List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new ArrayList<>();
+		for (Map<String, Object> toolMap : toolMaps) {
+			toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+		}
+		return toolBeans;
 	}
 
 	@Override
@@ -723,6 +774,12 @@ public abstract class BaseLTIService implements LTIService {
 		return getContentDao(key, siteId, isAdmin(siteId));
 	}
 
+	@Override
+	public org.sakaiproject.lti.beans.LtiContentBean getContentBean(Long key, String siteId) {
+		Map<String, Object> contentMap = getContent(key, siteId);
+		return contentMap != null ? org.sakaiproject.lti.beans.LtiContentBean.of(contentMap) : null;
+	}
+
 	// This is with absolutely no site checking...
 	@Override
 	public Map<String, Object> getContentDao(Long key) {
@@ -738,6 +795,17 @@ public abstract class BaseLTIService implements LTIService {
 	public List<Map<String, Object>> getContents(String search, String order, int first, int last, String siteId)
 	{
 		return getContentsDao(search, order, first, last, siteId, isAdmin(siteId));
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiContentBean> getContentBeans(String search, String order, int first, int last, String siteId)
+	{
+		List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
+		List<org.sakaiproject.lti.beans.LtiContentBean> contentBeans = new ArrayList<>();
+		for (Map<String, Object> contentMap : contentMaps) {
+			contentBeans.add(org.sakaiproject.lti.beans.LtiContentBean.of(contentMap));
+		}
+		return contentBeans;
 	}
 
 	@Override
@@ -1453,6 +1521,111 @@ public abstract class BaseLTIService implements LTIService {
 
 		log.warn("Could not insert stub tool for content item {} in site {}", launchUrl, toSiteId);
 		return null;
+	}
+
+	// POJO overload method implementations - convert Map results to POJOs
+	
+	@Override
+	public org.sakaiproject.lti.beans.LtiToolBean getToolAsPojo(Long key, String siteId) {
+		Map<String, Object> toolMap = getTool(key, siteId);
+		return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+	}
+
+	@Override
+	public org.sakaiproject.lti.beans.LtiToolBean getToolDaoAsPojo(Long key, String siteId, boolean isAdminRole) {
+		Map<String, Object> toolMap = getToolDao(key, siteId, isAdminRole);
+		return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsPojos(String search, String order, int first, int last, String siteId) {
+		List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
+		return toolMaps.stream()
+				.map(org.sakaiproject.lti.beans.LtiToolBean::of)
+				.collect(java.util.stream.Collectors.toList());
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsPojos(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
+		List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
+		return toolMaps.stream()
+				.map(org.sakaiproject.lti.beans.LtiToolBean::of)
+				.collect(java.util.stream.Collectors.toList());
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolBean> getToolsLaunchAsPojos(String siteId) {
+		List<Map<String, Object>> toolMaps = getToolsLaunch(siteId);
+		return toolMaps.stream()
+				.map(org.sakaiproject.lti.beans.LtiToolBean::of)
+				.collect(java.util.stream.Collectors.toList());
+	}
+
+	@Override
+	public org.sakaiproject.lti.beans.LtiContentBean getContentAsPojo(Long key, String siteId) {
+		Map<String, Object> contentMap = getContent(key, siteId);
+		return contentMap != null ? org.sakaiproject.lti.beans.LtiContentBean.of(contentMap) : null;
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiContentBean> getContentsAsPojos(String search, String order, int first, int last, String siteId) {
+		List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
+		return contentMaps.stream()
+				.map(org.sakaiproject.lti.beans.LtiContentBean::of)
+				.collect(java.util.stream.Collectors.toList());
+	}
+
+	@Override
+	public org.sakaiproject.lti.beans.LtiToolSiteBean getToolSiteAsPojo(Long key, String siteId) {
+		Map<String, Object> toolSiteMap = getToolSiteById(key, siteId);
+		return toolSiteMap != null ? org.sakaiproject.lti.beans.LtiToolSiteBean.of(toolSiteMap) : null;
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiToolSiteBean> getToolSitesByToolIdAsPojos(String toolId, String siteId) {
+		List<Map<String, Object>> toolSiteMaps = getToolSitesByToolId(toolId, siteId);
+		return toolSiteMaps.stream()
+				.map(org.sakaiproject.lti.beans.LtiToolSiteBean::of)
+				.collect(java.util.stream.Collectors.toList());
+	}
+
+	@Override
+	public org.sakaiproject.lti.beans.LtiMembershipsJobBean getMembershipsJobAsPojo(String siteId) {
+		Map<String, Object> jobMap = getMembershipsJob(siteId);
+		return jobMap != null ? org.sakaiproject.lti.beans.LtiMembershipsJobBean.of(jobMap) : null;
+	}
+
+	@Override
+	public List<org.sakaiproject.lti.beans.LtiMembershipsJobBean> getMembershipsJobsAsPojos() {
+		List<Map<String, Object>> jobMaps = getMembershipsJobs();
+		return jobMaps.stream()
+				.map(org.sakaiproject.lti.beans.LtiMembershipsJobBean::of)
+				.collect(java.util.stream.Collectors.toList());
+	}
+
+	@Override
+	public Object insertTool(org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
+		return insertTool(toolBean.asMap(), siteId);
+	}
+
+	@Override
+	public Object insertContent(org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
+		return insertContent(contentBean.asMap(), siteId);
+	}
+
+	@Override
+	public Object updateTool(Long key, org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
+		return updateTool(key, toolBean.asMap(), siteId);
+	}
+
+	@Override
+	public Object updateContent(Long key, org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
+		return updateContent(key, contentBean.asMap(), siteId);
+	}
+
+	@Override
+	public String getContentLaunch(org.sakaiproject.lti.beans.LtiContentBean contentBean) {
+		return getContentLaunch(contentBean.asMap());
 	}
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds structured, type-safe LTI POJOs (base bean, tool, content, tool-site, memberships-job), POJO-based CRUD/launch APIs, and per-tool debug choice constants.

- **Refactor**
  - Core launch handlers, LTI13 flows and utilities updated to accept/return POJOs while preserving Map compatibility; improved precedence/behavior for frame height, new-page and debug handling.

- **Tests**
  - Extensive unit and integration tests covering POJO↔Map conversions, type coercion, edge/null cases, overload delegation, and sensitive-field exposure.

- **Chores**
  - Removed demo/test main entry points from utility classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->