### PR TITLE
SAK-49686 Overview force one widget to remain and warn user

### DIFF
--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1113,6 +1113,7 @@ manover.nowidgets = No widgets available to be added to this page.
 manover.tool.unavail = The widgets below are not available because the corresponding tools have not been included in the site. To add a widget listed below to your <em>Overview</em>, go to <em>Site Info</em>, select <strong>Manage Tools</strong>, and add its tool to the site. 
 manover.remove = Remove
 manover.remove.full = Remove widget from page
+manover.minwidget = At least one widget must remain on the Overview page.
 manover.add = Add
 manover.add.full = Add widget to page
 manover.save = Save

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -16576,19 +16576,13 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		Site site = (Site) state.getAttribute("site");
 		if (readPageForm(data, state))
 		{
-			SitePage page = (SitePage) state.getAttribute("overview");
-			if (page == null)
-			{
-				addAlert(state, rb.getString("manover.minwidget"));
-				return;
-			}
+		SitePage page = (SitePage) state.getAttribute("overview");
+		if (!validateMinWidget(page, state))
+		{
+			return;
+		}
 
-			List<ToolConfiguration> tools = page.getTools();
-			if (CollectionUtils.isEmpty(tools))
-			{
-				addAlert(state, rb.getString("manover.minwidget"));
-				return;
-			}
+		List<ToolConfiguration> tools = page.getTools();
 
 			try
 			{
@@ -16709,13 +16703,26 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		ParameterParser params = data.getParameters();
 
 		String id = params.getString("id");
+		if (StringUtils.isBlank(id)) {
+			return;
+		}
 		// make the tool so we have the id
 		SitePage page = (SitePage) state.getAttribute("overview");
+		if (page == null) {
+			return;
+		}
 		ToolConfiguration tool = page.addTool(id);
 		tool.setLayoutHints("0,0"); //assume top left, it will be sorted later-- val just cant be null
 
 		List<Tool> widgets = (List<Tool>) state.getAttribute("allWidgets");
+		if (widgets == null) {
+			widgets = findWidgets();
+			state.setAttribute("allWidgets", widgets);
+		}
 		List<ToolConfiguration> tools = (List<ToolConfiguration>) state.getAttribute("tools");
+		if (tools == null) {
+			tools = new ArrayList<>(page.getTools());
+		}
 
 		for(Tool widget: widgets){
 			if(widget.getId().equals(id)){
@@ -16738,8 +16745,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		List<ToolConfiguration> tools = (List<ToolConfiguration>) state.getAttribute("tools");
 		if ( tools == null ) return;
 
-		if (tools.size() <= 1) {
-			addAlert(state, rb.getString("manover.minwidget"));
+		if (tools.size() <= 1 || !validateMinWidget(page, state)) {
 			return;
 		}
 
@@ -16759,7 +16765,16 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 
 		state.setAttribute("tools", tools);
 	}
-	
+
+	private boolean validateMinWidget(SitePage page, SessionState state) {
+		if (page == null || CollectionUtils.isEmpty(page.getTools())) {
+			addAlert(state, rb.getString("manover.minwidget"));
+			return false;
+		}
+
+		return true;
+	}
+
 	private String getDateFormat(Date date) {
 		String f = userTimeService.shortPreciseLocalizedTimestamp(date.toInstant(), userTimeService.getLocalTimeZone(), comparator_locale);
 		return f;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -16576,11 +16576,23 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		Site site = (Site) state.getAttribute("site");
 		if (readPageForm(data, state))
 		{
+			SitePage page = (SitePage) state.getAttribute("overview");
+			if (page == null)
+			{
+				addAlert(state, rb.getString("manover.minwidget"));
+				return;
+			}
+
+			List<ToolConfiguration> tools = page.getTools();
+			if (CollectionUtils.isEmpty(tools))
+			{
+				addAlert(state, rb.getString("manover.minwidget"));
+				return;
+			}
+
 			try
 			{
-				SitePage page = (SitePage) state.getAttribute("overview");
 				SitePage savedPage = site.getPage(page.getId()); //old page, will update tool list.
-				List<ToolConfiguration> tools = page.getTools();
 
 				savedPage.setTools(tools);
 				savedPage.setLayout(page.getLayout());
@@ -16685,11 +16697,11 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		Set<String> categories = new HashSet<>();
 		categories.add("widget");
 
-		Set<Tool> widgets = toolManager.findTools(categories, null);
+		Set<Tool> widgets = toolManager.findTools(categories, null, false);
 
 		List<Tool> features = new ArrayList<>(widgets);
 		features.sort(new ToolTitleComparator());
-		return features;
+		return Collections.unmodifiableList(features);
 	}
 
 	public void doAdd_widget(RunData data){

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -3898,7 +3898,7 @@ public class SiteAction extends PagedResourceActionII {
 			//this will be all widgets available to use on overview page.
 			List<Tool> widgets;
 			if(state.getAttribute("allWidgets") == null){
-				widgets = (List<Tool>) findWidgets();
+				widgets = findWidgets();
 			}else {
 				widgets = (List<Tool>) state.getAttribute("allWidgets");
 			}
@@ -16681,17 +16681,14 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		return true;
 	}
 
-	private List findWidgets() {
-		// get the helpers
-		Set categories = new HashSet();
+	private List<Tool> findWidgets() {
+		Set<String> categories = new HashSet<>();
 		categories.add("widget");
-		Set widgets = toolManager.findTools(categories, null);
 
-		// make a list for sorting
-		List features = new Vector();
-		features.addAll(widgets);
-		//Collections.sort(features);
-		Collections.sort(features, new ToolTitleComparator());
+		Set<Tool> widgets = toolManager.findTools(categories, null);
+
+		List<Tool> features = new ArrayList<>(widgets);
+		features.sort(new ToolTitleComparator());
 		return features;
 	}
 
@@ -16728,6 +16725,11 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 		SitePage page = (SitePage) state.getAttribute("overview");
 		List<ToolConfiguration> tools = (List<ToolConfiguration>) state.getAttribute("tools");
 		if ( tools == null ) return;
+
+		if (tools.size() <= 1) {
+			addAlert(state, rb.getString("manover.minwidget"));
+			return;
+		}
 
 		List<ToolConfiguration> removedTools = (List<ToolConfiguration>) state.getAttribute("removedTools");
 		if(removedTools == null){

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
@@ -45,28 +45,43 @@
                             <tr>
                                 <td headers="left-column-move-header" class="buttonCol">
                                     #if ($toolCount > 1)
-                                        <a href="#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")" title="$tlang.getString("manover.up")">
-                                            <span class="si si-up"></span>
-                                        </a>
+                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.up")">
+                                            <span class="si si-up" aria-hidden="true"></span>
+                                            <span class="visually-hidden">$tlang.getString("manover.up")</span>
+                                        </button>
                                     #end
                                     #if ($toolCount < $tools.size())
-                                        <a href="#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")" title ="$tlang.getString("manover.down")">
-                                            <span class="si si-down"></span>
-                                        </a>
+                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.down")">
+                                            <span class="si si-down" aria-hidden="true"></span>
+                                            <span class="visually-hidden">$tlang.getString("manover.down")</span>
+                                        </button>
                                     #end
                                 </td>
                                 <td headers="left-column-title-header">
                                     <span class="titleSpan">$formattedText.escapeHtml($tool.Title)</span>
                                 </td>
                                 <td headers="left-column-remove-header" class="removeCol">
-                                    <a href="#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")" title="$tlang.getString("manover.remove.full")">
-                                        <span class="si si-close text-danger" aria-hidden="true"></span>
-                                    </a>
+                                    #if ($tools.size() > 1)
+                                        <button type="button" class="btn btn-link btn-sm p-0 text-danger" data-action-url='#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.remove.full")">
+                                            <span class="si si-close" aria-hidden="true"></span>
+                                            <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
+                                        </button>
+                                    #else
+                                        <button type="button" class="btn btn-link btn-sm p-0 text-muted" title="$tlang.getString("manover.minwidget")" disabled>
+                                            <span class="si si-close" aria-hidden="true"></span>
+                                            <span class="visually-hidden">$tlang.getString("manover.minwidget")</span>
+                                        </button>
+                                    #end
                                 </td>
                             </tr>
                         #end
                     </tbody>
                 </table>
+                #if ($tools.size() <= 1)
+                    <div class="alert alert-info py-2 mt-2" role="status">
+                        $tlang.getString("manover.minwidget")
+                    </div>
+                #end
             #else
                 <div class="instruction">
                     $tlang.getString("manover.notools")
@@ -95,26 +110,37 @@
                                         <span class="titleSpan">$formattedText.escapeHtml($tool.Title)</span>
                                     </td>
                                     <td headers="either-column-remove-header" class="removeCol">
-                                        <a href="#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")" title="$tlang.getString("manover.remove.full")">
-                                            <span class="si si-close text-danger" aria-hidden="true"></span>
-                                        </a>
+                                        #if ($tools.size() > 1)
+                                            <button type="button" class="btn btn-link btn-sm p-0 text-danger" data-action-url='#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.remove.full")">
+                                                <span class="si si-close" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
+                                            </button>
+                                        #else
+                                            <button type="button" class="btn btn-link btn-sm p-0 text-muted" title="$tlang.getString("manover.minwidget")" disabled>
+                                                <span class="si si-close" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.minwidget")</span>
+                                            </button>
+                                        #end
                                     </td>
                                     <td headers="either-column-move-header" class="buttonCol">
                                         #if ($leftToolCount > 1)
-                                            <a href="#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id) ")" title="$tlang.getString("manover.up")">
-                                                <span class="si si-up"></span>
-                                            </a>
+                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.up")">
+                                                <span class="si si-up" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.up")</span>
+                                            </button>
                                         #end
                                         #if ($leftToolCount < $leftTools.size())
-                                            <a href="#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id) ")" title ="$tlang.getString("manover.down")">
-                                                <span class="si si-down"></span>
-                                           </a>
+                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.down")">
+                                                <span class="si si-down" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.down")</span>
+                                           </button>
                                         #end
                                     </td>
                                     <td headers="either-column-move-header" class="buttonCol">
-                                        <a href="#toolLinkParam("$action" "doEdit_tool_right" "id=$formattedText.escapeUrl($tool.Id)")" title="$tlang.getString("manover.right")">
-                                            <span class="si si-right"></span>
-                                        </a>
+                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_right" "id=$formattedText.escapeUrl($tool.Id)")' title="$tlang.getString("manover.right")">
+                                            <span class="si si-right" aria-hidden="true"></span>
+                                            <span class="visually-hidden">$tlang.getString("manover.right")</span>
+                                        </button>
                                     </td>
                                 </tr>
                             #end
@@ -137,35 +163,53 @@
                                 #set ($rightToolCount=$rightToolCount + 1)
                                 <tr>
                                     <td headers="right-column-move-header" class="buttonCol">
-                                        <a href="#toolLinkParam("$action" "doEdit_tool_left" "id=$formattedText.escapeUrl($tool.Id)")" title="$tlang.getString("manover.left")">
-                                            <span class="si si-left"></span>
-                                        </a>
+                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_left" "id=$formattedText.escapeUrl($tool.Id)")' title="$tlang.getString("manover.left")">
+                                            <span class="si si-left" aria-hidden="true"></span>
+                                            <span class="visually-hidden">$tlang.getString("manover.left")</span>
+                                        </button>
                                     </td>
                                     <td headers="right-column-move-header" class="buttonCol">
                                         #if ($rightToolCount > 1)
-                                            <a href="#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id) ")" title="$tlang.getString("manover.up")">
-                                                <span class="si si-up"></span>
-                                            </a>
+                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.up")">
+                                                <span class="si si-up" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.up")</span>
+                                            </button>
                                         #end
                                         #if ($rightToolCount < $rightTools.size())
-                                            <a href="#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id) ")" title ="$tlang.getString("manover.down")">
-                                                <span class="si si-down"></span>
-                                            </a>
+                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.down")">
+                                                <span class="si si-down" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.down")</span>
+                                            </button>
                                         #end
                                     </td>
                                     <td headers="right-column-title-header">
                                         <span class="titleSpan">$formattedText.escapeHtml($tool.Title)</span>
                                     </td>
                                     <td headers="right-column-remove-header" class="removeCol">
-                                        <a href="#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")" title="$tlang.getString("manover.remove.full")">
-                                            <span class="si si-close text-danger " aria-hidden="true"></span>
-                                        </a>
+                                        #if ($tools.size() > 1)
+                                            <button type="button" class="btn btn-link btn-sm p-0 text-danger" data-action-url='#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.remove.full")">
+                                                <span class="si si-close" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
+                                            </button>
+                                        #else
+                                            <button type="button" class="btn btn-link btn-sm p-0 text-muted" title="$tlang.getString("manover.minwidget")" disabled>
+                                                <span class="si si-close" aria-hidden="true"></span>
+                                                <span class="visually-hidden">$tlang.getString("manover.minwidget")</span>
+                                            </button>
+                                        #end
                                     </td>
                                 </tr>
                             #end
                         </tbody>
                     </table>
                 </div>
+                #if ($tools.size() <= 1)
+                    <div class="col-12 mt-2">
+                        <div class="alert alert-info py-2" role="status">
+                            $tlang.getString("manover.minwidget")
+                        </div>
+                    </div>
+                #end
             #else
                 <div class="instruction">
                     $tlang.getString("manover.notools")
@@ -190,10 +234,11 @@
                         #set ($widgetCount = 0)
                         #foreach ($widget in $availWidgets)
                             #set ($widgetCount=$widgetCount + 1)
-                            <li class="list-group-item-action">
-                                <a href="#toolLinkParam("$action" "doAdd_widget" "id=$formattedText.escapeUrl($widget.Id)")" title="$tlang.getString("manover.add.full")">
+                            <li class="list-group-item list-group-item-action d-flex align-items-center">
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2" data-action-url='#toolLinkParam("$action" "doAdd_widget" "id=$formattedText.escapeUrl($widget.Id)")' title="$tlang.getString("manover.add.full")">
                                     <span class="si si-add" aria-hidden="true"></span>
-                                </a>
+                                    <span class="visually-hidden">$tlang.getString("manover.add.full")</span>
+                                </button>
                                 <span class="widgetName">$formattedText.escapeHtml($widget.Title)</span>
                             </li>
                             #end
@@ -260,5 +305,19 @@
     $('input:radio[id="layout2"]').click(function() {
         $('#double-col').removeClass("d-none");
         $('#single-col').addClass("d-none");
+    });
+</script>
+
+<script>
+    document.addEventListener('click', function (event) {
+        const actionButton = event.target.closest('button[data-action-url]');
+        if (!actionButton) {
+            return;
+        }
+
+        const targetUrl = actionButton.getAttribute('data-action-url');
+        if (targetUrl) {
+            window.location.href = targetUrl;
+        }
     });
 </script>

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-manageOverview.vm
@@ -45,32 +45,32 @@
                             <tr>
                                 <td headers="left-column-move-header" class="buttonCol">
                                     #if ($toolCount > 1)
-                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.up")">
-                                            <span class="si si-up" aria-hidden="true"></span>
-                                            <span class="visually-hidden">$tlang.getString("manover.up")</span>
-                                        </button>
-                                    #end
-                                    #if ($toolCount < $tools.size())
-                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.down")">
-                                            <span class="si si-down" aria-hidden="true"></span>
-                                            <span class="visually-hidden">$tlang.getString("manover.down")</span>
-                                        </button>
-                                    #end
+                                        <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.up")'>
+                                             <span class="si si-up" aria-hidden="true"></span>
+                                             <span class="visually-hidden">$tlang.getString("manover.up")</span>
+                                         </a>
+                                     #end
+                                     #if ($toolCount < $tools.size())
+                                        <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.down")'>
+                                             <span class="si si-down" aria-hidden="true"></span>
+                                             <span class="visually-hidden">$tlang.getString("manover.down")</span>
+                                         </a>
+                                     #end
                                 </td>
                                 <td headers="left-column-title-header">
                                     <span class="titleSpan">$formattedText.escapeHtml($tool.Title)</span>
                                 </td>
                                 <td headers="left-column-remove-header" class="removeCol">
                                     #if ($tools.size() > 1)
-                                        <button type="button" class="btn btn-link btn-sm p-0 text-danger" data-action-url='#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.remove.full")">
-                                            <span class="si si-close" aria-hidden="true"></span>
-                                            <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
-                                        </button>
+                                        <a class="btn btn-link btn-sm p-0 text-danger" href='#toolLinkParam($action "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.remove.full")'>
+                                             <span class="si si-close" aria-hidden="true"></span>
+                                             <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
+                                         </a>
                                     #else
-                                        <button type="button" class="btn btn-link btn-sm p-0 text-muted" title="$tlang.getString("manover.minwidget")" disabled>
+                                        <a class="btn btn-link btn-sm p-0 text-muted disabled" href="#" title="$tlang.getString("manover.minwidget")" aria-disabled="true" tabindex="-1">
                                             <span class="si si-close" aria-hidden="true"></span>
                                             <span class="visually-hidden">$tlang.getString("manover.minwidget")</span>
-                                        </button>
+                                        </a>
                                     #end
                                 </td>
                             </tr>
@@ -111,36 +111,36 @@
                                     </td>
                                     <td headers="either-column-remove-header" class="removeCol">
                                         #if ($tools.size() > 1)
-                                            <button type="button" class="btn btn-link btn-sm p-0 text-danger" data-action-url='#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.remove.full")">
+                                            <a class="btn btn-link btn-sm p-0 text-danger" href='#toolLinkParam($action "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.remove.full")'>
                                                 <span class="si si-close" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
-                                            </button>
+                                            </a>
                                         #else
-                                            <button type="button" class="btn btn-link btn-sm p-0 text-muted" title="$tlang.getString("manover.minwidget")" disabled>
+                                            <a class="btn btn-link btn-sm p-0 text-muted disabled" href="#" title="$tlang.getString("manover.minwidget")" aria-disabled="true" tabindex="-1">
                                                 <span class="si si-close" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.minwidget")</span>
-                                            </button>
+                                            </a>
                                         #end
                                     </td>
                                     <td headers="either-column-move-header" class="buttonCol">
                                         #if ($leftToolCount > 1)
-                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.up")">
+                                            <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.up")'>
                                                 <span class="si si-up" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.up")</span>
-                                            </button>
+                                            </a>
                                         #end
                                         #if ($leftToolCount < $leftTools.size())
-                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.down")">
-                                                <span class="si si-down" aria-hidden="true"></span>
-                                                <span class="visually-hidden">$tlang.getString("manover.down")</span>
-                                           </button>
+                                            <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.down")'>
+                                                 <span class="si si-down" aria-hidden="true"></span>
+                                                 <span class="visually-hidden">$tlang.getString("manover.down")</span>
+                                           </a>
                                         #end
                                     </td>
                                     <td headers="either-column-move-header" class="buttonCol">
-                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_right" "id=$formattedText.escapeUrl($tool.Id)")' title="$tlang.getString("manover.right")">
+                                        <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_right" "id=$formattedText.escapeUrl($tool.Id)")' title='$tlang.getString("manover.right")'>
                                             <span class="si si-right" aria-hidden="true"></span>
                                             <span class="visually-hidden">$tlang.getString("manover.right")</span>
-                                        </button>
+                                        </a>
                                     </td>
                                 </tr>
                             #end
@@ -163,23 +163,23 @@
                                 #set ($rightToolCount=$rightToolCount + 1)
                                 <tr>
                                     <td headers="right-column-move-header" class="buttonCol">
-                                        <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_left" "id=$formattedText.escapeUrl($tool.Id)")' title="$tlang.getString("manover.left")">
+                                        <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_left" "id=$formattedText.escapeUrl($tool.Id)")' title='$tlang.getString("manover.left")'>
                                             <span class="si si-left" aria-hidden="true"></span>
                                             <span class="visually-hidden">$tlang.getString("manover.left")</span>
-                                        </button>
+                                        </a>
                                     </td>
                                     <td headers="right-column-move-header" class="buttonCol">
                                         #if ($rightToolCount > 1)
-                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.up")">
+                                            <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_up" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.up")'>
                                                 <span class="si si-up" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.up")</span>
-                                            </button>
+                                            </a>
                                         #end
                                         #if ($rightToolCount < $rightTools.size())
-                                            <button type="button" class="btn btn-link btn-sm p-0" data-action-url='#toolLinkParam("$action" "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.down")">
+                                            <a class="btn btn-link btn-sm p-0" href='#toolLinkParam($action "doEdit_tool_down" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.down")'>
                                                 <span class="si si-down" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.down")</span>
-                                            </button>
+                                            </a>
                                         #end
                                     </td>
                                     <td headers="right-column-title-header">
@@ -187,15 +187,15 @@
                                     </td>
                                     <td headers="right-column-remove-header" class="removeCol">
                                         #if ($tools.size() > 1)
-                                            <button type="button" class="btn btn-link btn-sm p-0 text-danger" data-action-url='#toolLinkParam("$action" "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title="$tlang.getString("manover.remove.full")">
+                                            <a class="btn btn-link btn-sm p-0 text-danger" href='#toolLinkParam($action "doRemove_widget" "id=$formattedText.escapeUrl($tool.Tool.Id)")' title='$tlang.getString("manover.remove.full")'>
                                                 <span class="si si-close" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.remove.full")</span>
-                                            </button>
+                                            </a>
                                         #else
-                                            <button type="button" class="btn btn-link btn-sm p-0 text-muted" title="$tlang.getString("manover.minwidget")" disabled>
+                                            <a class="btn btn-link btn-sm p-0 text-muted disabled" href="#" title="$tlang.getString("manover.minwidget")" aria-disabled="true" tabindex="-1">
                                                 <span class="si si-close" aria-hidden="true"></span>
                                                 <span class="visually-hidden">$tlang.getString("manover.minwidget")</span>
-                                            </button>
+                                            </a>
                                         #end
                                     </td>
                                 </tr>
@@ -235,10 +235,10 @@
                         #foreach ($widget in $availWidgets)
                             #set ($widgetCount=$widgetCount + 1)
                             <li class="list-group-item list-group-item-action d-flex align-items-center">
-                                <button type="button" class="btn btn-link btn-sm p-0 me-2" data-action-url='#toolLinkParam("$action" "doAdd_widget" "id=$formattedText.escapeUrl($widget.Id)")' title="$tlang.getString("manover.add.full")">
+                                <a class="btn btn-link btn-sm p-0 me-2" href='#toolLinkParam($action "doAdd_widget" "id=$formattedText.escapeUrl($widget.Id)")' title='$tlang.getString("manover.add.full")'>
                                     <span class="si si-add" aria-hidden="true"></span>
                                     <span class="visually-hidden">$tlang.getString("manover.add.full")</span>
-                                </button>
+                                </a>
                                 <span class="widgetName">$formattedText.escapeHtml($widget.Title)</span>
                             </li>
                             #end
@@ -305,19 +305,5 @@
     $('input:radio[id="layout2"]').click(function() {
         $('#double-col').removeClass("d-none");
         $('#single-col').addClass("d-none");
-    });
-</script>
-
-<script>
-    document.addEventListener('click', function (event) {
-        const actionButton = event.target.closest('button[data-action-url]');
-        if (!actionButton) {
-            return;
-        }
-
-        const targetUrl = actionButton.getAttribute('data-action-url');
-        if (targetUrl) {
-            window.location.href = targetUrl;
-        }
     });
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Prevents removing the last widget on the Overview page; shows an alert and informational message when only one widget remains.
  * Adds a localized message for the minimum widget requirement.

* Refactor
  * Safer handling of widget lists and save flow to prevent errors when pages or widget lists are missing.

* Style / Accessibility
  * Replaces link controls with consistent button-style controls, adds ARIA/visually-hidden labels, and applies uniform styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->