### PR TITLE
SAK-51993 Kernel Add legacy-UTF8 protection around notification titles

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -491,8 +491,8 @@ public class FormattedTextImpl implements FormattedText
                     if (cr.getNumberOfErrors() > 0) {
                         // TODO currently no way to get internationalized versions of error messages
                         for (String errorMsg : cr.getErrorMessages()) {
-                            String i18nErrorMsg = new String(errorMsg.getBytes("ISO-8859-1"),"UTF8");
-                            formattedTextErrors.append(i18nErrorMsg + "<br/>");
+                            String i18nErrorMsg = new String(errorMsg.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+                            formattedTextErrors.append(i18nErrorMsg).append("<br/>");
                         }
                     }
                     val = cr.getCleanHTML();
@@ -542,12 +542,12 @@ public class FormattedTextImpl implements FormattedText
             // opportunity to work around the issue, rather than causing a tool stack trace
 
             log.error("Unexpected error processing text", e);
-            formattedTextErrors.append(getResourceLoader().getString("unknown_error_markup") + "\n");
+            formattedTextErrors.append(getResourceLoader().getString("unknown_error_markup")).append("\n");
             val = null;
         }
 
         // KNL-1075: re-do the way error messages are handled
-        if (formattedTextErrors.length() > 0) {
+        if (!formattedTextErrors.isEmpty()) {
             // allow one extra option to control logging in real time if desired
             logErrors = serverConfigurationService.getBoolean("content.cleaner.errors.logged", logErrors);
             if (showErrorToUser || showDetailedErrorToUser) {

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -491,8 +490,7 @@ public class FormattedTextImpl implements FormattedText
                     if (cr.getNumberOfErrors() > 0) {
                         // TODO currently no way to get internationalized versions of error messages
                         for (String errorMsg : cr.getErrorMessages()) {
-                            String i18nErrorMsg = new String(errorMsg.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
-                            formattedTextErrors.append(i18nErrorMsg).append("<br/>");
+                            formattedTextErrors.append(errorMsg).append("<br/>");
                         }
                     }
                     val = cr.getCleanHTML();

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -540,7 +540,7 @@ public class FormattedTextImpl implements FormattedText
             // opportunity to work around the issue, rather than causing a tool stack trace
 
             log.error("Unexpected error processing text", e);
-            formattedTextErrors.append(getResourceLoader().getString("unknown_error_markup")).append("\n");
+            formattedTextErrors.append(getResourceLoader().getString("unknown_error_markup")).append("<br/>");
             val = null;
         }
 

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/util/impl/FormattedTextImpl.java
@@ -545,7 +545,7 @@ public class FormattedTextImpl implements FormattedText
         }
 
         // KNL-1075: re-do the way error messages are handled
-        if (!formattedTextErrors.isEmpty()) {
+        if (formattedTextErrors.length() > 0) {
             // allow one extra option to control logging in real time if desired
             logErrors = serverConfigurationService.getBoolean("content.cleaner.errors.logged", logErrors);
             if (showErrorToUser || showDetailedErrorToUser) {

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/messaging/impl/UserMessagingServiceTestConfiguration.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/messaging/impl/UserMessagingServiceTestConfiguration.java
@@ -25,10 +25,13 @@ import org.sakaiproject.email.api.DigestService;
 import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.emailtemplateservice.api.EmailTemplateService;
 import org.sakaiproject.event.api.EventTrackingService;
-import org.sakaiproject.ignite.EagerIgniteSpringBean;
 import org.sakaiproject.test.SakaiTestConfiguration;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.util.api.FormattedText;
+import org.apache.ignite.IgniteSpringBean;
+import org.apache.ignite.IgniteCluster;
+import org.apache.ignite.IgniteMessaging;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,8 +39,6 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-import org.apache.ignite.IgniteCluster;
-import org.apache.ignite.IgniteMessaging;
 
 import lombok.Getter;
 
@@ -71,17 +72,6 @@ public class UserMessagingServiceTestConfiguration extends SakaiTestConfiguratio
         return mock(EventTrackingService.class);
     }
 
-    @Bean(name = "org.sakaiproject.ignite.SakaiIgnite")
-    public EagerIgniteSpringBean ignite() {
-
-        EagerIgniteSpringBean ignite = mock(EagerIgniteSpringBean.class);
-        IgniteCluster cluster = mock(IgniteCluster.class);
-        when(cluster.forLocal()).thenReturn(null);
-        IgniteMessaging messaging = mock(IgniteMessaging.class);
-        when(ignite.message(any())).thenReturn(messaging);
-        when(ignite.cluster()).thenReturn(cluster);
-        return ignite;
-    }
 
     @Bean(name = "org.sakaiproject.user.api.PreferencesService")
     public PreferencesService preferencesService() {
@@ -98,6 +88,25 @@ public class UserMessagingServiceTestConfiguration extends SakaiTestConfiguratio
         ServerConfigurationService scs = mock(ServerConfigurationService.class);
         when(scs.getInt("messaging.threadpool.size", 20)).thenReturn(20);
         return scs;
+    }
+
+    @Bean(name = "org.sakaiproject.util.api.FormattedText")
+    public FormattedText formattedText() {
+        FormattedText ft = mock(FormattedText.class);
+        when(ft.processFormattedText(any(String.class), any(StringBuilder.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(ft.convertFormattedTextToPlaintext(any(String.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        return ft;
+    }
+
+    @Bean(name = "org.sakaiproject.ignite.SakaiIgnite")
+    public IgniteSpringBean ignite() {
+        IgniteSpringBean ignite = mock(IgniteSpringBean.class);
+        IgniteCluster cluster = mock(IgniteCluster.class);
+        when(cluster.forLocal()).thenReturn(null);
+        IgniteMessaging messaging = mock(IgniteMessaging.class);
+        when(ignite.message(any())).thenReturn(messaging);
+        when(ignite.cluster()).thenReturn(cluster);
+        return ignite;
     }
 
 }

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -1446,7 +1446,7 @@ public class FormattedTextTest {
         Assert.assertFalse("Script tag should be removed", result.contains("<script>"));
 
         // If there are errors, check their encoding
-        if (!errors.isEmpty()) {
+        if (errors.length() > 0) {
             String errorString = errors.toString();
             System.out.println("AntiSamy errors: " + errorString);
 
@@ -1464,7 +1464,7 @@ public class FormattedTextTest {
         errors = new StringBuilder();
         result = formattedText.processFormattedText(internationalInput, errors);
 
-        if (!errors.isEmpty()) {
+        if (errors.length() > 0) {
             String errorString = errors.toString();
             System.out.println("International character errors: " + errorString);
 

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/FormattedTextTest.java
@@ -1430,4 +1430,135 @@ public class FormattedTextTest {
         Assert.assertEquals("Emoji 🙂", result);
     }
 
+    @Test
+    public void testAntiSamyErrorMessageEncoding() {
+        // This test verifies whether the charset conversion in AntiSamy error handling is necessary
+        // It tests with malicious input that should trigger AntiSamy validation errors
+
+        // Test with content that will trigger AntiSamy errors containing non-ASCII characters
+        String maliciousInput = "<script>alert('Tëst with unicode: © ñ');</script>";
+
+        // Process with FormattedText which uses AntiSamy internally
+        StringBuilder errors = new StringBuilder();
+        String result = formattedText.processFormattedText(maliciousInput, errors);
+
+        // The result should be cleaned (script tag removed)
+        Assert.assertFalse("Script tag should be removed", result.contains("<script>"));
+
+        // If there are errors, check their encoding
+        if (!errors.isEmpty()) {
+            String errorString = errors.toString();
+            System.out.println("AntiSamy errors: " + errorString);
+
+            // Test: can we find Unicode characters in the error messages?
+            // If the charset conversion is working correctly, we should see properly encoded text
+            // If not needed, the text should still be readable
+
+            // Basic check: error message should not contain corrupted encoding patterns
+            Assert.assertFalse("Error should not contain corrupted encoding",
+                errorString.contains("Ã") || errorString.contains("â€"));
+        }
+
+        // Test with HTML containing international characters that might trigger policy violations
+        String internationalInput = "<span style=\"color: red; font-family: 'Tëst Fönt'\">Tëst with ñøñ-ASCII: © ® € £</span>";
+        errors = new StringBuilder();
+        result = formattedText.processFormattedText(internationalInput, errors);
+
+        if (!errors.isEmpty()) {
+            String errorString = errors.toString();
+            System.out.println("International character errors: " + errorString);
+
+            // Verify error messages are readable and not double-encoded
+            Assert.assertFalse("Error should not contain double-encoded UTF-8",
+                errorString.contains("Ãª") || errorString.contains("Ã©"));
+        }
+    }
+
+    @Test
+    public void testAntiSamyCharsetRegressionDetection() {
+        // CRITICAL TEST: Verifies that AntiSamy error messages are properly UTF-8 encoded
+        // and that the old charset conversion workaround remains unnecessary.
+        // This test will FAIL if AntiSamy ever regresses to returning improperly encoded messages.
+
+        String testInput = "<script>alert('Test with é, ñ, ©');</script>";
+        boolean foundErrors = false;
+
+        // Manually test what AntiSamy returns directly (without FormattedText processing)
+        try {
+            // Get the AntiSamy instance from FormattedText
+            java.lang.reflect.Field antiSamyField = FormattedTextImpl.class.getDeclaredField("antiSamyHigh");
+            antiSamyField.setAccessible(true);
+            org.owasp.validator.html.AntiSamy antiSamy = (org.owasp.validator.html.AntiSamy) antiSamyField.get(formattedText);
+
+            org.owasp.validator.html.CleanResults results = antiSamy.scan(testInput);
+
+            System.out.println("\n=== AntiSamy Error Message Encoding Validation ===");
+
+            for (String errorMsg : results.getErrorMessages()) {
+                foundErrors = true;
+                System.out.println("Validating error: " + errorMsg);
+
+                // ASSERTION 1: Error message should not be null or empty
+                Assert.assertNotNull("AntiSamy error message should not be null", errorMsg);
+                Assert.assertFalse("AntiSamy error message should not be empty", errorMsg.trim().isEmpty());
+
+                // ASSERTION 2: Error message should be readable ASCII/UTF-8
+                // (AntiSamy error messages are typically in English)
+                boolean isReadableText = errorMsg.matches("[\\p{Print}\\p{Space}]*");
+                Assert.assertTrue("Error message should contain readable text: " + errorMsg, isReadableText);
+
+                // ASSERTION 3: The old charset conversion should be a no-op
+                String converted = new String(errorMsg.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1), java.nio.charset.StandardCharsets.UTF_8);
+                Assert.assertEquals(
+                    "CHARSET CONVERSION REGRESSION: AntiSamy error message changed after ISO-8859-1 to UTF-8 conversion. " +
+                    "This indicates AntiSamy may have regressed to returning improperly encoded messages. " +
+                    "Original: '" + errorMsg + "', Converted: '" + converted + "'",
+                    errorMsg, converted
+                );
+
+                // ASSERTION 4: Should not contain encoding corruption patterns
+                Assert.assertFalse("Error message contains UTF-8 corruption pattern (Ã): " + errorMsg,
+                    errorMsg.contains("Ã"));
+                Assert.assertFalse("Error message contains UTF-8 corruption pattern (â€): " + errorMsg,
+                    errorMsg.contains("â€"));
+                Assert.assertFalse("Error message contains UTF-8 corruption pattern (Ãª): " + errorMsg,
+                    errorMsg.contains("Ãª"));
+                Assert.assertFalse("Error message contains UTF-8 corruption pattern (Ã©): " + errorMsg,
+                    errorMsg.contains("Ã©"));
+
+                // ASSERTION 5: Byte arrays should be identical for properly encoded text
+                byte[] originalBytes = errorMsg.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                byte[] isoBytes = errorMsg.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1);
+
+                // For pure ASCII text (which AntiSamy error messages should be),
+                // UTF-8 and ISO-8859-1 encodings should be identical
+                boolean isPureAscii = true;
+                for (char c : errorMsg.toCharArray()) {
+                    if (c > 127) {
+                        isPureAscii = false;
+                        break;
+                    }
+                }
+
+                if (isPureAscii) {
+                    Assert.assertArrayEquals(
+                        "For ASCII text, UTF-8 and ISO-8859-1 byte arrays should be identical. " +
+                        "This suggests AntiSamy error messages remain pure ASCII as expected.",
+                        originalBytes, isoBytes
+                    );
+                }
+
+                System.out.println("  ✓ Error message properly encoded");
+            }
+
+            // ASSERTION 6: We should have found at least one error for our malicious input
+            Assert.assertTrue("Expected AntiSamy to report errors for script tag input", foundErrors);
+
+            System.out.println("=== VALIDATION PASSED: AntiSamy charset conversion remains unnecessary ===");
+
+        } catch (Exception e) {
+            Assert.fail("Could not access AntiSamy internals for validation: " + e.getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Notification titles are now optionally processed for consistent formatting before storage and displayed as plain text to users.

- Bug Fixes
  - Improved character-encoding handling to prevent garbled characters in error and formatted content.
  - Notifications now fall back more robustly to a usable title if formatting fails.

- Tests
  - Added tests verifying error-message encoding with international characters and emojis to prevent charset regressions.

- Chores
  - Updated test configuration to support the new formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->