### PR TITLE
SAK-51690 webcomponents fix select box styling in dark mode in shadow-dom elements

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-element/src/SakaiShadowElement.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-element/src/SakaiShadowElement.js
@@ -66,6 +66,12 @@ export class SakaiShadowElement extends LitElement {
       select[multiple], select[size]:not([size='1']) {
         background-image: none;
       }
+      .form-select,
+      select:not([multiple]):not([size]) {
+        background-image: var(--select-background-image-url) !important;
+        background-repeat: no-repeat;
+        appearance: none;
+      }
     `
   ];
 }


### PR DESCRIPTION

Root Cause: Shadow DOM components (like sakai-site-picker) were isolated from the global CSS that applies the --select-background-image-url variable to select elements. While the CSS variable was defined correctly in the theme files (light theme uses icon-arrow-down.png, dark theme uses icon-arrow-down-dark.png), the shadow DOM wasn't getting the CSS rule that applies this variable to .form-select elements.

Solution: Updated SakaiShadowElement.js to include CSS that explicitly applies the --select-background-image-url variable to form-select elements within shadow DOM components. This ensures all shadow DOM select boxes (like in sakai-site-picker) now properly inherit the theme-appropriate dropdown arrow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for custom background images on single-select dropdowns, enabling themed visuals across the app.
  - Ensured consistent, modern styling for form selects by standardizing their appearance across browsers.

- Style
  - Updated select element styling so non-multiselect dropdowns display a customizable background image and hide default native arrows.
  - Preserved existing behavior for multiselects and sized selects, maintaining clarity between control types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->