### PR TITLE
SAK-49900 Tasks should filter out future start dates

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/tasks/impl/TaskServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/tasks/impl/TaskServiceImpl.java
@@ -257,9 +257,14 @@ public class TaskServiceImpl implements TaskService, Observer {
     public List<UserTaskAdapterBean> getAllTasksForCurrentUserOnSite(String siteId) {
     	
         String userId = sessionManager.getCurrentSessionUserId();
+        Instant now = Instant.now();
 
         return userTaskRepository.findByUserIdAndSiteId(userId, siteId)
                 .stream()
+                .filter(ut -> {
+                    Instant starts = ut.getTask().getStarts();
+                    return starts == null || !starts.isAfter(now);
+                })
                 .map(ut -> {
                     UserTaskAdapterBean bean = new UserTaskAdapterBean();
                     BeanUtils.copyProperties(ut, bean);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site dashboards now hide tasks that have a start date/time in the future, preventing premature visibility.
  * Tasks automatically appear on dashboards once their start time is reached, improving the accuracy of what’s actionable “now.”
  * This change enhances clarity for students and instructors by aligning task visibility with intended availability. Due dates and other task properties are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->