### PR TITLE
SAK-51973 Lessons color rules in dark mode

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
+++ b/library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss
@@ -130,6 +130,12 @@
 	}
 	.colgray a[href], .colgray-trans a[href]{
 		color: var(--sakai-color-gray--darker-6);
+		&:visited,
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--sakai-color-gray--darker-6);
+		}
 	}
 	//legacy red
 	.colred, .colred-trans {
@@ -139,7 +145,16 @@
 	.colred .commentDiv, .colred .studentContentTable, .colred .questionDiv .contentCol, .colred .forumSummaryHeaderDiv, .colred .announcementsHeaderDiv, .colred-trans .commentDiv, .colred-trans .studentContentTable, .colred-trans .questionDiv .contentCol {
 		background-color: var(--sakai-color-red--lighter-4);
 	}
-	.colred a[href], .colred h3.author, .colred-trans a[href], .colred-trans h3.author {
+	.colred a[href], .colred-trans a[href] {
+		color: var(--sakai-color-red--darker-6);
+		&:visited,
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--sakai-color-red--darker-6);
+		}
+	}
+	.colred h3.author, .colred-trans h3.author {
 		color: var(--sakai-color-red--darker-6);
 	}
 	//legacy blue
@@ -152,6 +167,12 @@
 	}
 	.colblue a[href], .colblue-trans a[href] {
 		color: var(--sakai-color-blue--darker-6);
+		&:visited,
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--sakai-color-blue--darker-6);
+		}
 	}
 	//legacy green
 	.colgreen, .colgreen-trans {
@@ -163,6 +184,12 @@
 	}
 	.colgreen a[href], .colgreen-trans a[href] {
 		color: var(--sakai-color-green--darker-6);
+		&:visited,
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--sakai-color-green--darker-6);
+		}
 	}
 	//legacy yellow
 	.colyellow, .colyellow-trans {
@@ -172,7 +199,16 @@
 	.colyellow .commentDiv, .colyellow .studentContentTable, .colyellow .questionDiv .contentCol, .colyellow .forumSummaryHeaderDiv, .colyellow .announcementsHeaderDiv, .colyellow-trans .commentDiv, .colyellow-trans .studentContentTable, .colyellow-trans .questionDiv .contentCol {
 		background-color: var(--sakai-color-gold--lighter-4);
 	}
-	.colyellow a[href],.colyellow h3.author, .colyellow-trans a[href],.colyellow-trans h3.author {
+	.colyellow a[href], .colyellow-trans a[href] {
+		color: var(--sakai-color-gold--darker-6);
+		&:visited,
+		&:hover,
+		&:focus,
+		&:active {
+			color: var(--sakai-color-gold--darker-6);
+		}
+	}
+	.colyellow h3.author, .colyellow-trans h3.author {
 		color: var(--sakai-color-gold--darker-6);
 	}
 	.usebutton,
@@ -260,9 +296,18 @@
 			border: 1px solid var(#{$shade2});
 		}
 		
-		.coln#{$name} {
+		.coln#{$name}, .coln#{$name}-trans {
 			.questionDiv .contentCol, .checklistDiv {
 				@extend .sakai-colorize#{$shade4};
+				a[href]:not(.usebutton) {
+					color: inherit;
+					&:visited,
+					&:hover,
+					&:focus,
+					&:active {
+						color: inherit;
+					}
+				}
 			}
 			input[type="submit"].question-submit,
 			.linkCell .addStudentContent,


### PR DESCRIPTION
 - Extended the legacy Lessons color rules so themed links keep their computed high-contrast color across all states (:visited, :hover, :focus, :active), avoiding the light-theme hover fallback that caused contrast loss in dark mode. library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss:130-205
  - Updated the sakaiLessonsLayoutColorScheme mixin so color-themed content areas (questionDiv .contentCol, checklistDiv) hand their link styling down via inherit, guaranteeing the same WCAG-safe foreground chosen by the sakai-colorize helper while preventing the dark navy on dark background regression. library/src/skins/default/src/sass/modules/tool/lessonbuilder/_lessonbuilder.scss:263-285