### PR TITLE
SAK-52021 Gradebook by groups - Error when trying to modify a published assessment with a category

### DIFF
--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -5757,7 +5757,7 @@ public class GradingServiceImpl implements GradingService {
                     boolean isCategoryInGradebook = false;
 
                     for (String groupId : groupList) {
-                        List<CategoryDefinition> categoryDefinitionList = getCategoryDefinitions(groupId, groupId);
+                        List<CategoryDefinition> categoryDefinitionList = getCategoryDefinitions(groupId, siteId);
 
                         boolean foundCategory = categoryDefinitionList.stream()
                             .anyMatch(category -> category.getId().equals(Long.parseLong(categoryId)));


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected category selection to use site-level categories instead of group-level, ensuring accurate and consistent category options in multi-select lists across the Gradebook.
  * Resolves mismatches where categories could appear missing or incorrect when filtering or assigning items by category for different groups.
  * Improves reliability of category-based workflows and reduces confusion from duplicate or inconsistent category listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->