### PR TITLE
SAK-44276 Samigo Two different published assessments have identical Published Assessment URLs

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -510,7 +510,21 @@ public class ConfirmPublishAssessmentListener
     String releaseTo = assessment.getAssessmentAccessControl().getReleaseTo();
     if (releaseTo != null) {
       // generate an alias to the pub assessment
-      String alias = AgentFacade.getAgentString() + (new Date()).getTime();
+      String alias;
+      // verify uniqueness and regenerate if necessary
+      PublishedAssessmentService publishedService = new PublishedAssessmentService();
+      int attempts = 0;
+      do {
+        if (attempts < 3) {
+          alias = AgentFacade.getAgentString() + (new Date()).getTime();
+        } else {
+          // generate a random value
+          long randomTimestamp = 1000000000000L + (long)(Math.random() * 8999999999999L);
+          alias = AgentFacade.getAgentString() + randomTimestamp;
+        }
+        attempts++;
+      } while (publishedService.aliasExists(alias));
+
       assessmentSettings.setAlias(alias);
 
       String server = ( (javax.servlet.http.HttpServletRequest) extContext.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueries.java
@@ -1603,6 +1603,24 @@ public class PublishedAssessmentFacadeQueries extends HibernateDaoSupport implem
         return null;
     }
 
+	/**
+	 * Fast check to verify if an ALIAS already exists in the database.
+	 * This method only returns true/false without loading the full assessment object.
+	 * Use this for ALIAS uniqueness validation during generation.
+	 *
+	 * @param alias The ALIAS to check
+	 * @return true if ALIAS exists, false otherwise
+	 */
+	public boolean aliasExists(final String alias) {
+		final HibernateCallback<List<Long>> hcb = session -> session
+				.createQuery("select count(m.id) from PublishedMetaData m where m.label = :label and m.entry = :entry")
+				.setParameter("label", "ALIAS")
+				.setParameter("entry", alias)
+				.list();
+		List<Long> list = getHibernateTemplate().execute(hcb);
+		return list.get(0) > 0;
+	}
+
 	public void saveOrUpdateMetaData(PublishedMetaData meta) {
 		int retryCount = PersistenceService.getInstance().getPersistenceHelper().getRetryCount();
 		while (retryCount > 0) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueriesAPI.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/PublishedAssessmentFacadeQueriesAPI.java
@@ -21,10 +21,10 @@
 
 package org.sakaiproject.tool.assessment.facade;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Collection;
 
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentAccessControl;
 import org.sakaiproject.tool.assessment.data.dao.assessment.AssessmentData;
@@ -41,6 +41,7 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemText;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedMetaData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData;
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AttachmentIfc;
@@ -48,7 +49,6 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentI
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionAttachmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
 import org.sakaiproject.tool.assessment.osid.shared.impl.IdImpl;
-import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
 
 public interface PublishedAssessmentFacadeQueriesAPI
 {
@@ -231,6 +231,8 @@ public interface PublishedAssessmentFacadeQueriesAPI
 
   public PublishedAssessmentFacade getPublishedAssessmentIdByMetaLabel(
       String label, String entry);
+
+  public boolean aliasExists(final String alias);
 
   public void saveOrUpdateMetaData(PublishedMetaData meta);
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
@@ -363,6 +363,12 @@ public class PublishedAssessmentService extends AssessmentService{
         getPublishedAssessmentIdByAlias(alias);
   }
 
+  public boolean aliasExists(final String alias) {
+    return PersistenceService.getInstance().
+        getPublishedAssessmentFacadeQueries().
+        aliasExists(alias);
+  }
+
   public void saveOrUpdateMetaData(PublishedMetaData meta) {
    PersistenceService.getInstance().getPublishedAssessmentFacadeQueries().
         saveOrUpdateMetaData(meta);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-44276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic generation and validation of unique assessment aliases during publish and bulk publish.
  - Fallback alias randomization to finalize a unique link when initial attempts collide.

- Bug Fixes
  - Resolves issues caused by duplicate assessment aliases that could lead to conflicting publish links.

- Chores
  - Added backend capability to quickly check alias availability to support reliable publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->