### PR TITLE
SAK-52032 WebComponents fix double load of profile

### DIFF
--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/profile-snippet.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/snippets/profile-snippet.vm
@@ -74,7 +74,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="${rloader.sit_closepage}"></button>
       </div>
       <div class="modal-body">
-        <sakai-account user-id="${loginUserId}"></sakai-account>
+        <sakai-account></sakai-account>
       </div>
     </div>
   </div>

--- a/webcomponents/tool/src/main/frontend/packages/sakai-account/src/SakaiAccount.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-account/src/SakaiAccount.js
@@ -50,8 +50,6 @@ export class SakaiAccount extends SakaiElement {
   connectedCallback() {
 
     super.connectedCallback();
-
-    this._loadUser();
   }
 
   attributeChangedCallback(name, oldValue, newValue) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Sakai Account component no longer auto-loads user profile on initial render.
  - Account details modal now uses a self-contained account tag (no explicit user-id passed).
  - Profile data now loads only when explicitly triggered; users may see an empty or loading state until the profile is fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->