### PR TITLE
SAK-52030 'lessonbuilder.folder.hidden' should create base folder 'hidden with accessible contents' instead of 'hidden'

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4319,10 +4319,10 @@
 # lessonbuilder.basefolder missing
 
 # Cause Lessons to hide the top-level folder it creates. It basefolder is
-# set, that's the folder that will be hidden. If not, the individual folders
+# set, that's the folder that will be hidden with access. If not, the individual folders
 # created for each page will be hidden.
 # DEFAULT: false
-# lessonbuilder.folder.hidden=true
+# lessonbuilder.folder.hidden.withaccess=true
 
 # Allow an institution to configure the name of the default CSS file. This file
 # can be supplied by the user to set site-specific CSS for Lessons. The file

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -4751,7 +4751,7 @@ public class SimplePageBean {
 				try {
 					ContentCollectionEdit edit = contentHostingService.addCollection(collectionId);
 					edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME, "LB-CSS");
-					//this folder should be hidden from access user
+					//this folder should be hidden with access from access user
 					edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, "true");
 					contentHostingService.commitCollection(edit);
 				}catch(Exception e) {
@@ -6532,7 +6532,7 @@ public class SimplePageBean {
 	public String getCollectionId(boolean urls) {
 		String siteId = getCurrentPage().getSiteId();
 		String baseDir = ServerConfigurationService.getString("lessonbuilder.basefolder", null);
-		boolean hiddenDir = ServerConfigurationService.getBoolean("lessonbuilder.folder.hidden",false);
+		boolean hiddenWithAccessDir = ServerConfigurationService.getBoolean("lessonbuilder.folder.hidden.withaccess",false);
 		String pageOwner = getCurrentPage().getOwner();
 		String collectionId;
 		String folder;
@@ -6548,16 +6548,14 @@ public class SimplePageBean {
 			    if (!baseDir.endsWith("/"))
 				baseDir = baseDir + "/";
 			    collectionId = collectionId + baseDir;
-			    // basedir which is hidden; have to create it if it doesn't exist, so we can make hidden
-			    if (hiddenDir) {
-				hiddenDir = false; // hiding base, done hide actual folder
+			    // basedir which is hidden; have to create it if it doesn't exist, so we can make hidden with access
 				try {
 				    try {
 					contentHostingService.checkCollection(collectionId);
 				    } catch (IdUnusedException idex) {
 					ContentCollectionEdit edit = contentHostingService.addCollection(collectionId);
 					edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME,  Validator.escapeResourceName(baseDir.substring(0,baseDir.length()-1)));
-					edit.setHidden();
+					edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, String.valueOf(hiddenWithAccessDir));
 					contentHostingService.commitCollection(edit);
 				    }
 				} catch (Exception ignore) {
@@ -6565,7 +6563,6 @@ public class SimplePageBean {
 				    // that will cause failure at a later stage where we can
 				    // return an error message. This may not be optimal.
 				}
-			    }
 			}
 			// actual folder. Use hierarchy of files
 			SimplePage page = getCurrentPage();
@@ -6633,8 +6630,7 @@ public class SimplePageBean {
 			try {
 				ContentCollectionEdit edit = contentHostingService.addCollection(root);
 				edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME,  Validator.escapeResourceName(getPageTitle()));
-				if (hiddenDir)
-				    edit.setHidden();
+				edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, String.valueOf(hiddenWithAccessDir));
 				contentHostingService.commitCollection(edit);
 				
 				// well, we got that far anyway
@@ -6650,8 +6646,7 @@ public class SimplePageBean {
 	    		edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME, "urls");
 	    	else {
 	    		edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_DISPLAY_NAME, Validator.escapeResourceName(getPageTitle()));
-			if (hiddenDir)
-			    edit.setHidden();
+	    		edit.getPropertiesEdit().addProperty(ResourceProperties.PROP_HIDDEN_WITH_ACCESSIBLE_CONTENT, String.valueOf(hiddenWithAccessDir));
 		}		
 	    	contentHostingService.commitCollection(edit);
 	    	return folder; // worked. use it


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The Lessons top-level folder now defaults to “hidden with access,” improving control over visibility while keeping content accessible via direct links or embedded use.
  - Newly created base directories and default resource/URL folders inherit this “hidden with access” behavior for consistent access control.
  - Users may no longer see the top-level Lessons folder in standard listings, but referenced materials remain available where linked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->