### PR TITLE
SAK-52251 Lessons Subpages of a Lessons are imported as pseudo-orphans

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -44,10 +44,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Method;
 import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -83,9 +80,7 @@ import org.json.simple.parser.ParseException;
 import org.jsoup.Jsoup;
 import org.jsoup.select.Elements;
 import org.sakaiproject.authz.api.AuthzRealmLockException;
-import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
-import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -94,7 +89,6 @@ import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.EntityTransferrer;
 import org.sakaiproject.entity.api.HttpAccess;
 import org.sakaiproject.entity.api.Reference;
-import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.entity.cover.EntityManager;
 import org.sakaiproject.entitybroker.EntityReference;
@@ -105,6 +99,7 @@ import org.sakaiproject.entitybroker.entityprovider.capabilities.InputTranslatab
 import org.sakaiproject.entitybroker.entityprovider.capabilities.Statisticable;
 import org.sakaiproject.entitybroker.util.AbstractEntityProvider;
 import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.grading.api.ConflictingAssignmentNameException;
 import org.sakaiproject.lessonbuildertool.LessonBuilderAccessAPI;
 import org.sakaiproject.lessonbuildertool.SimplePage;
 import org.sakaiproject.lessonbuildertool.SimplePageGroup;
@@ -120,9 +115,8 @@ import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
 import org.sakaiproject.lessonbuildertool.tool.beans.OrphanPageFinder;
 import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.sakaiproject.memory.api.MemoryService;
-import org.sakaiproject.util.api.LinkMigrationHelper;
-import org.sakaiproject.grading.api.ConflictingAssignmentNameException;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
@@ -133,12 +127,12 @@ import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.SessionManager;
-import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.tool.api.ToolSession;
-import org.sakaiproject.util.RequestFilter;
+import org.sakaiproject.util.MergeConfig;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Xml;
+import org.sakaiproject.util.api.LinkMigrationHelper;
 import org.springframework.context.MessageSource;
 import org.w3c.dom.Attr;
 import org.w3c.dom.DOMException;
@@ -149,8 +143,6 @@ import org.w3c.dom.NodeList;
 
 import lombok.extern.slf4j.Slf4j;
 import uk.org.ponder.messageutil.MessageLocator;
-
-import org.sakaiproject.util.MergeConfig;
 
 /**
  * @author hedrick
@@ -571,7 +563,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		// Orphaned pages need not apply!
 		SimplePageBean simplePageBean = makeSimplePageBean(siteId);
 		OrphanPageFinder orphanFinder = simplePageBean.getOrphanFinder(siteId);
-		
+
 		Map<Long, List<Long>> pageToReferencedPages = findReferencedPagesByItems(siteId);
 
 		Set<Long> originalSelectedPageIds = new HashSet<>();
@@ -784,7 +776,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			}
 
 			// Create a new page in the destination site
-			SimplePage newPage = simplePageToolDao.makePage(toSiteId, null, orphanedPage.getTitle(), parentPageId, null);
+			SimplePage newPage = simplePageToolDao.makePage("0", toSiteId, orphanedPage.getTitle(), parentPageId, null);
 
 			// Copy essential properties
 			if (orphanedPage.getCssSheet() != null) {
@@ -850,7 +842,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 * This helps identify orphaned subpages that should be included in exports
 	 * but lack proper parent/topparent/toolid fields
 	 */
-	private Map<Long, List<Long>> findReferencedPagesByItems(String siteId) {
+	public Map<Long, List<Long>> findReferencedPagesByItems(String siteId) {
 		List<SimplePage> allPages = simplePageToolDao.getSitePages(siteId);
 		return findReferencedPagesByItems(siteId, allPages);
 	}
@@ -860,11 +852,11 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 */
 	private Map<Long, List<Long>> findReferencedPagesByItems(String siteId, List<SimplePage> allPages) {
 		Map<Long, List<Long>> pageToReferencedPages = new HashMap<>();
-		
+
 		if (allPages == null || allPages.isEmpty()) {
 			return pageToReferencedPages;
 		}
-		
+
 		for (SimplePage page : allPages) {
 			List<SimplePageItem> items = simplePageToolDao.findItemsOnPage(page.getPageId());
 			if (items != null) {
@@ -887,8 +879,157 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				}
 			}
 		}
-		
+
 		return pageToReferencedPages;
+	}
+
+	/**
+	 * Builds a parent map from subpage references, considering only pages in pageMap (for selective import).
+	 * @param subpageRefs Map of parent page IDs to lists of child page IDs
+	 * @param pageMap Map of old page IDs to new page IDs (determines which pages are being imported)
+	 * @param calculatedParentMap Output map to populate with child -> parent relationships
+	 */
+	Map<Long, Long> buildParentMapFromReferences(Map<Long, List<Long>> subpageRefs, Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap) {
+		for (Map.Entry<Long, List<Long>> entry : subpageRefs.entrySet()) {
+			Long oldParentPageId = entry.getKey();
+			List<Long> oldChildPageIds = entry.getValue();
+
+			if (!pageMap.containsKey(oldParentPageId)) continue;
+
+			for (Long oldChildPageId : oldChildPageIds) {
+				if (pageMap.containsKey(oldChildPageId)) {
+					calculatedParentMap.put(oldChildPageId, oldParentPageId);
+				}
+			}
+		}
+		return calculatedParentMap;
+	}
+
+	/**
+	 * Calculates top parent relationships by walking up the parent chain.
+	 * @param calculatedParentMap Map of child -> parent relationships
+	 * @param calculatedTopParentMap Output map to populate with page -> top parent relationships
+	 */
+	Map<Long, Long> calculateTopParentMap(Map<Long, Long> calculatedParentMap, Map<Long, Long> calculatedTopParentMap) {
+		for (Long pageId : calculatedParentMap.keySet()) {
+			Long currentPageId = pageId;
+			Long topParent = null;
+			boolean cycleDetected = false;
+			Set<Long> visited = new HashSet<>();
+			while (calculatedParentMap.containsKey(currentPageId)) {
+				if (!visited.add(currentPageId)) {
+					log.warn("Cycle detected in page hierarchy at page {}", currentPageId);
+					cycleDetected = true;
+					break;
+				}
+				topParent = calculatedParentMap.get(currentPageId);
+				currentPageId = topParent;
+			}
+			if (!cycleDetected && topParent != null) {
+				calculatedTopParentMap.put(pageId, topParent);
+			}
+		}
+		return calculatedTopParentMap;
+	}
+
+	/**
+	 * Fills missing parent relationships from page XML attributes when item-based
+	 * references did not resolve them (e.g. cross-server archive with no live source site).
+	 */
+	void fillUnresolvedParentsFromXml(Map<Long, Element> pageElementMap, Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap) {
+		for (Map.Entry<Long, Element> pageEntry : pageElementMap.entrySet()) {
+			Long oldPageId = pageEntry.getKey();
+			if (calculatedParentMap.containsKey(oldPageId)) {
+				continue;
+			}
+			Element pageElement = pageEntry.getValue();
+			String parentAttr = pageElement.getAttribute("parent");
+			if (StringUtils.isNotEmpty(parentAttr)) {
+				long parentId = NumberUtils.toLong(parentAttr, 0L);
+				if (parentId > 0 && pageMap.containsKey(parentId) && pageMap.containsKey(oldPageId)) {
+					calculatedParentMap.put(oldPageId, parentId);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Applies calculated parent/topParent values onto newly imported pages (new IDs from pageMap).
+	 * @return number of pages updated
+	 */
+	int applyCalculatedHierarchy(Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap, Map<Long, Long> calculatedTopParentMap) {
+		int hierarchyUpdates = 0;
+		for (Map.Entry<Long, Long> entry : pageMap.entrySet()) {
+			Long oldPageId = entry.getKey();
+			Long newPageId = entry.getValue();
+
+			SimplePage page = simplePageToolDao.getPage(newPageId);
+			if (page == null) {
+				continue;
+			}
+
+			boolean updated = false;
+
+			if (calculatedParentMap.containsKey(oldPageId)) {
+				Long oldParentId = calculatedParentMap.get(oldPageId);
+				Long newParentId = pageMap.get(oldParentId);
+				if (newParentId != null) {
+					page.setParent(newParentId);
+					updated = true;
+				}
+			}
+
+			if (calculatedTopParentMap.containsKey(oldPageId)) {
+				Long oldTopParentId = calculatedTopParentMap.get(oldPageId);
+				Long newTopParentId = pageMap.get(oldTopParentId);
+				if (newTopParentId != null) {
+					page.setTopParent(newTopParentId);
+					updated = true;
+				}
+			}
+
+			if (updated) {
+				simplePageToolDao.quickUpdate(page);
+				hierarchyUpdates++;
+			}
+		}
+		return hierarchyUpdates;
+	}
+
+	/**
+	 * Copies the top-level Lesson toolId onto imported child pages so they are not left as
+	 * toolId "0" / empty (pseudo-orphans). Must run after top-level pages have their real toolId.
+	 * @return number of child pages updated
+	 */
+	int updateChildPageToolIds(Map<Long, Long> pageMap, Map<Long, Long> calculatedTopParentMap) {
+		int toolIdUpdates = 0;
+		for (Map.Entry<Long, Long> entry : pageMap.entrySet()) {
+			Long oldPageId = entry.getKey();
+			Long newPageId = entry.getValue();
+
+			if (!calculatedTopParentMap.containsKey(oldPageId)) {
+				continue;
+			}
+
+			Long oldTopParentId = calculatedTopParentMap.get(oldPageId);
+			Long newTopParentId = pageMap.get(oldTopParentId);
+			if (newTopParentId == null) {
+				continue;
+			}
+
+			SimplePage page = simplePageToolDao.getPage(newPageId);
+			SimplePage topParentPage = simplePageToolDao.getPage(newTopParentId);
+
+			if (page != null && topParentPage != null && topParentPage.getToolId() != null
+					&& !"0".equals(topParentPage.getToolId())
+					&& !topParentPage.getToolId().equals(page.getToolId())) {
+				page.setToolId(topParentPage.getToolId());
+				simplePageToolDao.quickUpdate(page);
+				toolIdUpdates++;
+				log.debug("Updated toolId {} for page {} from topparent {}", topParentPage.getToolId(), newPageId, newTopParentId);
+			}
+		}
+		return toolIdUpdates;
 	}
 
 	/**
@@ -981,14 +1122,9 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			} catch (Exception impossible) {};
 		}
 
-		Site fromSite = null;
-		try {
-			fromSite = siteService.getSite(fromSiteId);
-		} catch (Exception impossible) {
-			fromSite = null;
-		};
+		Optional<Site> fromSite = siteService.getOptionalSite(fromSiteId);
 
-		boolean isSameServer = fromSite != null;
+		boolean isSameServer = fromSite.isPresent();
 
 		NodeList allChildrenNodes = element.getChildNodes();
 		int length = allChildrenNodes.getLength();
@@ -1836,7 +1972,8 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					toolsReused.put(title, page.getPageId());
 					reused = true;
 				} else {
-					page = simplePageToolDao.makePage("0", siteId, title, 0L, 0L);
+					// Create page with initial toolId, parent relationships will be set later
+					page = simplePageToolDao.makePage("0", siteId, title, null, null);
 					log.debug("Created new page {}", page.getPageId());
 				}
 
@@ -1901,7 +2038,21 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				pageElementMap.put(oldPageId, pageElement);
 			}
 
-			log.debug("Starting second pass over pages ({}) {} to create items", pageElementMap.size(), pageMap);
+			log.debug("Starting hierarchy calculation for {} pages", pageMap.size());
+
+			Map<Long, Long> calculatedParentMap = new HashMap<>();
+			Map<Long, Long> calculatedTopParentMap = new HashMap<>();
+
+			// Get parent-child relationships from source site
+			Map<Long, List<Long>> subpageRefs = findReferencedPagesByItems(fromSiteId);
+			buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
+			fillUnresolvedParentsFromXml(pageElementMap, pageMap, calculatedParentMap);
+			calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
+
+			int hierarchyUpdates = applyCalculatedHierarchy(pageMap, calculatedParentMap, calculatedTopParentMap);
+			if (hierarchyUpdates > 0) {
+				log.debug("Updated page hierarchies for {} imported pages", hierarchyUpdates);
+			}
 
 			// Process pages we inserted (in PageElementMap) to create the items
 			boolean needFix = false;
@@ -2079,6 +2230,12 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				log.debug(result);
 				results.append(result);
 			}
+
+			int toolIdUpdates = updateChildPageToolIds(pageMap, calculatedTopParentMap);
+			if (toolIdUpdates > 0) {
+				log.debug("Updated toolIds for {} child pages", toolIdUpdates);
+			}
+
 			results.append("merging lessonbuilder tool " + siteId + " (" + count + ") items.\n");
 		}
 		catch (DOMException e)
@@ -2179,16 +2336,16 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		// Get orphan finder to identify problematic pages
 		SimplePageBean simplePageBean = makeSimplePageBean(fromContext);
 		OrphanPageFinder orphanFinder = simplePageBean.getOrphanFinder(fromContext);
-		
+
 		List<SimplePage> sitePages = simplePageToolDao.getSitePages(fromContext);
 		if (sitePages == null || sitePages.isEmpty()) {
 			return Collections.emptyList();
 		}
-		
+
 		// Find pages referenced by items, but only from valid (non-orphan) pages
 		Map<Long, List<Long>> referencedPages = findReferencedPagesByItems(fromContext, sitePages);
 		Set<Long> validReferencedPageIds = new HashSet<>();
-		
+
 		for (Map.Entry<Long, List<Long>> entry : referencedPages.entrySet()) {
 			Long referencingPageId = entry.getKey();
 			// Only include references from pages that are not orphans

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducer.java
@@ -842,20 +842,24 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 * This helps identify orphaned subpages that should be included in exports
 	 * but lack proper parent/topparent/toolid fields
 	 */
-	public Map<Long, List<Long>> findReferencedPagesByItems(String siteId) {
+	private Map<Long, List<Long>> findReferencedPagesByItems(String siteId) {
 		List<SimplePage> allPages = simplePageToolDao.getSitePages(siteId);
-		return findReferencedPagesByItems(siteId, allPages);
+		return findReferencedPagesByItems(allPages);
 	}
 
 	/**
-	 * Finds pages referenced by SimplePageItems of type PAGE (subpages)
+	 * Finds pages referenced by PAGE items for selective export.
 	 */
-	private Map<Long, List<Long>> findReferencedPagesByItems(String siteId, List<SimplePage> allPages) {
+	private Map<Long, List<Long>> findReferencedPagesByItems(List<SimplePage> allPages) {
 		Map<Long, List<Long>> pageToReferencedPages = new HashMap<>();
 
 		if (allPages == null || allPages.isEmpty()) {
 			return pageToReferencedPages;
 		}
+
+		Set<Long> pageIds = allPages.stream()
+			.map(SimplePage::getPageId)
+			.collect(Collectors.toSet());
 
 		for (SimplePage page : allPages) {
 			List<SimplePageItem> items = simplePageToolDao.findItemsOnPage(page.getPageId());
@@ -864,9 +868,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					if (item.getType() == SimplePageItem.PAGE) {
 						try {
 							Long referencedPageId = Long.valueOf(item.getSakaiId());
-							// Verify that the referenced page exists
-							SimplePage referencedPage = simplePageToolDao.getPage(referencedPageId);
-							if (referencedPage != null && siteId.equals(referencedPage.getSiteId())) {
+							if (pageIds.contains(referencedPageId)) {
 								pageToReferencedPages.computeIfAbsent(page.getPageId(), k -> new ArrayList<>())
 									.add(referencedPageId);
 								log.debug("Found subpage reference: page {} references subpage {}", page.getPageId(), referencedPageId);
@@ -884,48 +886,35 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	}
 
 	/**
-	 * Builds a parent map from subpage references, considering only pages in pageMap (for selective import).
-	 * @param subpageRefs Map of parent page IDs to lists of child page IDs
-	 * @param pageMap Map of old page IDs to new page IDs (determines which pages are being imported)
-	 * @param calculatedParentMap Output map to populate with child -> parent relationships
-	 */
-	Map<Long, Long> buildParentMapFromReferences(Map<Long, List<Long>> subpageRefs, Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap) {
-		for (Map.Entry<Long, List<Long>> entry : subpageRefs.entrySet()) {
-			Long oldParentPageId = entry.getKey();
-			List<Long> oldChildPageIds = entry.getValue();
-
-			if (!pageMap.containsKey(oldParentPageId)) continue;
-
-			for (Long oldChildPageId : oldChildPageIds) {
-				if (pageMap.containsKey(oldChildPageId)) {
-					calculatedParentMap.put(oldChildPageId, oldParentPageId);
-				}
-			}
-		}
-		return calculatedParentMap;
-	}
-
-	/**
 	 * Calculates top parent relationships by walking up the parent chain.
 	 * @param calculatedParentMap Map of child -> parent relationships
 	 * @param calculatedTopParentMap Output map to populate with page -> top parent relationships
 	 */
-	Map<Long, Long> calculateTopParentMap(Map<Long, Long> calculatedParentMap, Map<Long, Long> calculatedTopParentMap) {
+	private Map<Long, Long> calculateTopParentMap(Map<Long, Long> calculatedParentMap, Map<Long, Long> calculatedTopParentMap) {
+		Set<Long> invalidHierarchyPageIds = new HashSet<>();
 		for (Long pageId : calculatedParentMap.keySet()) {
 			Long currentPageId = pageId;
-			Long topParent = null;
-			boolean cycleDetected = false;
 			Set<Long> visited = new HashSet<>();
 			while (calculatedParentMap.containsKey(currentPageId)) {
 				if (!visited.add(currentPageId)) {
 					log.warn("Cycle detected in page hierarchy at page {}", currentPageId);
-					cycleDetected = true;
+					invalidHierarchyPageIds.addAll(visited);
 					break;
 				}
+				currentPageId = calculatedParentMap.get(currentPageId);
+			}
+		}
+
+		invalidHierarchyPageIds.forEach(calculatedParentMap::remove);
+
+		for (Long pageId : calculatedParentMap.keySet()) {
+			Long currentPageId = pageId;
+			Long topParent = null;
+			while (calculatedParentMap.containsKey(currentPageId)) {
 				topParent = calculatedParentMap.get(currentPageId);
 				currentPageId = topParent;
 			}
-			if (!cycleDetected && topParent != null) {
+			if (topParent != null) {
 				calculatedTopParentMap.put(pageId, topParent);
 			}
 		}
@@ -933,31 +922,10 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	}
 
 	/**
-	 * Fills missing parent relationships from page XML attributes when item-based
-	 * references did not resolve them (e.g. cross-server archive with no live source site).
-	 */
-	void fillUnresolvedParentsFromXml(Map<Long, Element> pageElementMap, Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap) {
-		for (Map.Entry<Long, Element> pageEntry : pageElementMap.entrySet()) {
-			Long oldPageId = pageEntry.getKey();
-			if (calculatedParentMap.containsKey(oldPageId)) {
-				continue;
-			}
-			Element pageElement = pageEntry.getValue();
-			String parentAttr = pageElement.getAttribute("parent");
-			if (StringUtils.isNotEmpty(parentAttr)) {
-				long parentId = NumberUtils.toLong(parentAttr, 0L);
-				if (parentId > 0 && pageMap.containsKey(parentId) && pageMap.containsKey(oldPageId)) {
-					calculatedParentMap.put(oldPageId, parentId);
-				}
-			}
-		}
-	}
-
-	/**
 	 * Applies calculated parent/topParent values onto newly imported pages (new IDs from pageMap).
 	 * @return number of pages updated
 	 */
-	int applyCalculatedHierarchy(Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap, Map<Long, Long> calculatedTopParentMap) {
+	private int applyCalculatedHierarchy(Map<Long, Long> pageMap, Map<Long, Long> calculatedParentMap, Map<Long, Long> calculatedTopParentMap) {
 		int hierarchyUpdates = 0;
 		for (Map.Entry<Long, Long> entry : pageMap.entrySet()) {
 			Long oldPageId = entry.getKey();
@@ -1001,7 +969,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 	 * toolId "0" / empty (pseudo-orphans). Must run after top-level pages have their real toolId.
 	 * @return number of child pages updated
 	 */
-	int updateChildPageToolIds(Map<Long, Long> pageMap, Map<Long, Long> calculatedTopParentMap) {
+	private int updateChildPageToolIds(Map<Long, Long> pageMap, Map<Long, Long> calculatedTopParentMap) {
 		int toolIdUpdates = 0;
 		for (Map.Entry<Long, Long> entry : pageMap.entrySet()) {
 			Long oldPageId = entry.getKey();
@@ -1735,11 +1703,10 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 			return "Lessons merge stopped siteId is not provided";
 		}
 
-		// Check if there is nothing to import and build trees of pages in the import
+		// Build the archive hierarchy once. Immediate parents remain authoritative;
+		// roots are derived separately for duplicate detection.
 		NodeList lessonBuilderTools = root.getElementsByTagName("lessonbuilder");
-		boolean lessonHasContent = false;
 		Map<Long, String> placementPageMap = new HashMap<>();
-		Map<Long, Long> parentPage = new HashMap<>();
 
 		for (int toolIndex = 0; toolIndex < lessonBuilderTools.getLength(); toolIndex++) {
 			Node lessonBuilderNode = lessonBuilderTools.item(toolIndex);
@@ -1751,49 +1718,73 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 					log.debug("Found root lessonbuilder {} {}", rootPageName, rootPageId);
 					placementPageMap.put(rootPageId, rootPageName);
 				}
+			}
+		}
 
-				NodeList lessonPages = lessonBuilderElement.getElementsByTagName("page");
-				for (int pageIndex = 0; pageIndex < lessonPages.getLength(); pageIndex++) {
-					Element currentPage = (Element) lessonPages.item(pageIndex);
-					Long pageId = NumberUtils.toLong(currentPage.getAttribute("pageid"), 0L); // Lower case is correct
-					Long pageParentId = NumberUtils.toLong(currentPage.getAttribute("parent"), 0L);
-					if ( pageId > 0 && pageParentId > 0 ) {
-						parentPage.put(pageId, pageParentId);
-					} else if ( pageId > 0 ) {
-						parentPage.put(pageId, pageId);  // Top level page is its own parent
-					}
+		NodeList pageNodes = root.getElementsByTagName("page");
+		boolean lessonHasContent = false;
+		Set<Long> archivePageIds = new HashSet<>();
+		Map<Long, String> archivePageTitles = new HashMap<>();
+		Map<Long, Long> archiveParentMap = new HashMap<>();
+		Map<Long, Set<Long>> archiveParentCandidates = new HashMap<>();
 
-					NodeList pageItems = currentPage.getElementsByTagName("item");
+		for (int pageIndex = 0; pageIndex < pageNodes.getLength(); pageIndex++) {
+			Node pageNode = pageNodes.item(pageIndex);
+			if (pageNode.getNodeType() != Node.ELEMENT_NODE) continue;
 
-					if (pageItems != null && pageItems.getLength() > 0) {
-						lessonHasContent = true;
-					}
+			Element currentPage = (Element) pageNode;
+			Long pageId = NumberUtils.toLong(currentPage.getAttribute("pageid"), 0L);
+			if (pageId < 1) continue;
+
+			archivePageIds.add(pageId);
+			archivePageTitles.put(pageId, currentPage.getAttribute("title"));
+
+			Long pageParentId = NumberUtils.toLong(currentPage.getAttribute("parent"), 0L);
+			if (pageParentId > 0 && !placementPageMap.containsKey(pageId)) {
+				archiveParentMap.put(pageId, pageParentId);
+			}
+
+			NodeList pageItems = currentPage.getElementsByTagName("item");
+			if (pageItems.getLength() > 0) {
+				lessonHasContent = true;
+			}
+			for (int itemIndex = 0; itemIndex < pageItems.getLength(); itemIndex++) {
+				Node itemNode = pageItems.item(itemIndex);
+				if (itemNode.getNodeType() != Node.ELEMENT_NODE) continue;
+
+				Element itemElement = (Element) itemNode;
+				int itemType = NumberUtils.toInt(itemElement.getAttribute("type"), -1);
+				boolean nextPage = Boolean.parseBoolean(itemElement.getAttribute("nextpage"));
+				Long referencedPageId = NumberUtils.toLong(itemElement.getAttribute("sakaiid"), 0L);
+				if (itemType == SimplePageItem.PAGE && !nextPage && referencedPageId > 0) {
+					archiveParentCandidates.computeIfAbsent(referencedPageId, key -> new HashSet<>()).add(pageId);
 				}
 			}
 		}
+
+		for (Map.Entry<Long, Set<Long>> entry : archiveParentCandidates.entrySet()) {
+			Long childPageId = entry.getKey();
+			Set<Long> candidateParents = entry.getValue();
+			if (!archiveParentMap.containsKey(childPageId) && !placementPageMap.containsKey(childPageId)
+					&& archivePageIds.contains(childPageId) && candidateParents.size() == 1) {
+				Long candidateParentId = candidateParents.iterator().next();
+				if (archivePageIds.contains(candidateParentId)) {
+					archiveParentMap.put(childPageId, candidateParentId);
+				}
+			} else if (!archiveParentMap.containsKey(childPageId) && candidateParents.size() > 1) {
+				log.warn("Unable to infer parent for page {} because it is referenced by multiple pages {}", childPageId, candidateParents);
+			}
+		}
+
+		Map<Long, Long> archiveTopParentMap = new HashMap<>();
+		calculateTopParentMap(archiveParentMap, archiveTopParentMap);
 
 		if (!lessonHasContent) {
 			log.debug("No lessonbuilder pages to import");
 			return "No lessonbuilder pages to import";
 		}
 
-		// Do the transitive closure
-		log.debug("Pre-transitive closure {} {}", placementPageMap, parentPage);
-		for(int i=0; i< 1000; i++ ) {
-			boolean changed = false;
-			for (Map.Entry<Long, Long> entry : parentPage.entrySet()) {
-				Long page = entry.getKey();
-				Long parent = entry.getValue();
-				if ( parent < 1 ) continue;
-				Long parentOfParent = parentPage.getOrDefault(parent, 0L);
-				if ( parentOfParent < 1 ) continue;
-				log.debug("Walking page {} up tree from {} to {}", page, parent, parentOfParent);
-				changed = true;
-				parentPage.put(page, parentOfParent);
-			}
-			if ( changed ) break;
-		}
-		log.debug("Post-transitive closure {} {}", placementPageMap, parentPage);
+		log.debug("Archive hierarchy placements={} parents={} topParents={}", placementPageMap, archiveParentMap, archiveTopParentMap);
 
 		// If this is a transferCopy operation, cleanup is handled based on the user's
 		// selection before we are called and we put items into existing or new placements
@@ -1879,8 +1870,6 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		log.debug("Finished scanning placements full {} empty {} / {}", fullPlacements, emptyTopLevelPageIds, emptySakaiIds);
 
 		// Lets start the actual merge()
-		NodeList pageNodes = root.getElementsByTagName("page");
-
 		Map <Long,Long> pageMap = new HashMap<Long,Long>();
 
 		// a convenient map of the xml page id and its corresponding element
@@ -1890,33 +1879,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 		String oldServer = root.getAttribute("server");
 
-		// Scan pages and find the root pages in the import
-
-		log.debug("Scanning for root pages in the import");
-		Map<Long, String> rootOldPageIds = new HashMap<>();
 		int numPages = pageNodes.getLength();
-		for (int p = 0; p < numPages; p++) {
-			Node pageNode = pageNodes.item(p);
-			if (pageNode.getNodeType() != Node.ELEMENT_NODE) continue;
-
-			Element pageElement = (Element) pageNode;
-			String title = pageElement.getAttribute("title");
-			if (title == null) continue;
-
-			String oldPageIdString = pageElement.getAttribute("pageid");
-			Long oldPageId = NumberUtils.toLong(oldPageIdString, 0L);
-			if ( oldPageId < 1 ) continue;
-
-			String oldParentString = pageElement.getAttribute("parent");
-			Long oldParent = NumberUtils.toLong(oldParentString, 0L);
-			if ( oldParent < 1 ) {
-				log.debug("Found root page in archive pageId {}", oldPageId);
-				rootOldPageIds.put(oldPageId, title);
-			}
-		}
-
-		log.debug("Found root pages in import {}", rootOldPageIds);
-
 		Map<String, Long> toolsReused = new HashMap<>();
 
 		// create pages first, build up map of old to new page.
@@ -1941,10 +1904,11 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 
 				// Duplicate remove:
 				// Check if the page is associated with an existing complete top level page/placement
-				// Recall that parentPage really points to the top page above a page because we
-				// walked up the tree to compute the closure of the child-parent relationships
-				Long rootPageId = parentPage.getOrDefault(oldPageId, 0L);
-				String rootTitle = rootOldPageIds.getOrDefault(rootPageId, null);
+				Long rootPageId = archiveTopParentMap.getOrDefault(oldPageId, oldPageId);
+				String rootTitle = placementPageMap.get(rootPageId);
+				if (StringUtils.isBlank(rootTitle)) {
+					rootTitle = archivePageTitles.get(rootPageId);
+				}
 				if ( StringUtils.isNotBlank(rootTitle) && fullPlacements.containsKey(rootTitle) ) {
 					log.debug("Skipping page {} because root page {} {} is already in site {}", oldPageId, rootPageId, rootTitle, siteId);
 					continue;
@@ -1955,7 +1919,9 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				SimplePage page = null;
 				boolean reused = false;
 				log.debug("Extracting {} oldPageId: {} parent {} isTransferCopy {}", title, oldPageId, oldParentId, isTransferCopy);
-				if ( ! isTransferCopy && oldParentId < 1 ) {
+				boolean archiveRoot = placementPageMap.containsKey(oldPageId)
+					|| (!archiveParentMap.containsKey(oldPageId) && !archiveParentCandidates.containsKey(oldPageId));
+				if ( ! isTransferCopy && archiveRoot ) {
 					Long emptyPageId = emptyTopLevelPageIds.get(title);
 					log.debug("Extracting page {} oldPageId: {} emptyPageId {}", title, oldPageId, emptyPageId);
 
@@ -2038,18 +2004,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				pageElementMap.put(oldPageId, pageElement);
 			}
 
-			log.debug("Starting hierarchy calculation for {} pages", pageMap.size());
-
-			Map<Long, Long> calculatedParentMap = new HashMap<>();
-			Map<Long, Long> calculatedTopParentMap = new HashMap<>();
-
-			// Get parent-child relationships from source site
-			Map<Long, List<Long>> subpageRefs = findReferencedPagesByItems(fromSiteId);
-			buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
-			fillUnresolvedParentsFromXml(pageElementMap, pageMap, calculatedParentMap);
-			calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
-
-			int hierarchyUpdates = applyCalculatedHierarchy(pageMap, calculatedParentMap, calculatedTopParentMap);
+			int hierarchyUpdates = applyCalculatedHierarchy(pageMap, archiveParentMap, archiveTopParentMap);
 			if (hierarchyUpdates > 0) {
 				log.debug("Updated page hierarchies for {} imported pages", hierarchyUpdates);
 			}
@@ -2231,7 +2186,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 				results.append(result);
 			}
 
-			int toolIdUpdates = updateChildPageToolIds(pageMap, calculatedTopParentMap);
+			int toolIdUpdates = updateChildPageToolIds(pageMap, archiveTopParentMap);
 			if (toolIdUpdates > 0) {
 				log.debug("Updated toolIds for {} child pages", toolIdUpdates);
 			}
@@ -2343,7 +2298,7 @@ public class LessonBuilderEntityProducer extends AbstractEntityProvider
 		}
 
 		// Find pages referenced by items, but only from valid (non-orphan) pages
-		Map<Long, List<Long>> referencedPages = findReferencedPagesByItems(fromContext, sitePages);
+		Map<Long, List<Long>> referencedPages = findReferencedPagesByItems(sitePages);
 		Set<Long> validReferencedPageIds = new HashSet<>();
 
 		for (Map.Entry<Long, List<Long>> entry : referencedPages.entrySet()) {

--- a/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducerTest.java
+++ b/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducerTest.java
@@ -19,12 +19,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.parsers.DocumentBuilderFactory;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
@@ -32,7 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,7 +41,14 @@ import org.sakaiproject.lessonbuildertool.SimplePage;
 import org.sakaiproject.lessonbuildertool.SimplePageImpl;
 import org.sakaiproject.lessonbuildertool.SimplePageItem;
 import org.sakaiproject.lessonbuildertool.SimplePageItemImpl;
+import org.sakaiproject.lessonbuildertool.api.LessonBuilderConstants;
 import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SitePage;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.ToolConfiguration;
+import org.sakaiproject.util.MergeConfig;
+import org.sakaiproject.util.Xml;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -60,10 +65,14 @@ public class LessonBuilderEntityProducerTest {
     @Mock
     private Reference ref;
 
+    @Mock
+    private SiteService siteService;
+
     @Before
     public void setUp() {
         producer = new LessonBuilderEntityProducer();
         producer.setSimplePageToolDao(dao);
+        producer.setSiteService(siteService);
     }
 
     @Test
@@ -126,334 +135,165 @@ public class LessonBuilderEntityProducerTest {
     }
 
     /**
-     * findReferencedPagesByItems identifies parent-child links from PAGE items.
+     * SAK-52251: exercise the archive-only merge workflow with no live source site. A
+     * pseudo-orphan with no archived parent is recovered from its regular PAGE reference,
+     * an archived parent remains authoritative when another page links to it, and neither
+     * next-page nor regular links to a placed top-level page alter either placement.
      */
     @Test
-    public void testFindReferencedPagesByItems() {
-        String siteId = "test-site-1";
+    public void testMergeRestoresPseudoOrphanWithoutReparentingLinkedPages() throws Exception {
+        String sourceSiteId = "source-site";
+        String destinationSiteId = "destination-site";
 
-        SimplePage parentPage = newPage(100L, siteId, "Parent Page", "tool-abc", null, null);
-        SimplePage subpage1 = newPage(101L, siteId, "Subpage 1", "tool-abc", 100L, 100L);
-        SimplePage subpage2 = newPage(102L, siteId, "Subpage 2", "tool-abc", 100L, 100L);
+        long oldPageA = 100L;
+        long oldPageB = 200L;
+        long oldPseudoOrphan = 300L;
+        long oldSharedPage = 400L;
+        long newPageA = 1100L;
+        long newPageB = 1200L;
+        long newPseudoOrphan = 1300L;
+        long newSharedPage = 1400L;
 
-        List<SimplePageItem> allItems = new ArrayList<>();
-        allItems.add(pageItem(1L, 100L, "101"));
-        allItems.add(pageItem(2L, 100L, "102"));
-        SimplePageItem textItem = new SimplePageItemImpl();
-        textItem.setId(3L);
-        textItem.setPageId(100L);
-        textItem.setType(SimplePageItem.TEXT);
-        textItem.setHtml("Some text");
-        allItems.add(textItem);
+        Map<Long, List<SimplePageItem>> itemsByPage = new HashMap<>();
+        Map<Long, SimplePage> pagesById = new HashMap<>();
 
-        when(dao.getSitePages(siteId)).thenReturn(List.of(parentPage, subpage1, subpage2));
-        when(dao.findItemsOnPage(100L)).thenReturn(allItems);
-        when(dao.getPage(101L)).thenReturn(subpage1);
-        when(dao.getPage(102L)).thenReturn(subpage2);
+        when(dao.findItemsOnPage(Mockito.anyLong())).thenAnswer(invocation ->
+                itemsByPage.getOrDefault(invocation.getArgument(0), List.of()));
+        when(dao.getPage(Mockito.anyLong())).thenAnswer(invocation -> pagesById.get(invocation.getArgument(0)));
 
-        Map<Long, List<Long>> result = producer.findReferencedPagesByItems(siteId);
+        Map<String, Long> importedPageIds = Map.of(
+                "Lesson A", newPageA,
+                "Lesson B", newPageB,
+                "Pseudo orphan", newPseudoOrphan,
+                "Shared page", newSharedPage);
+        when(dao.makePage(Mockito.eq("0"), Mockito.eq(destinationSiteId), Mockito.anyString(), Mockito.isNull(), Mockito.isNull()))
+                .thenAnswer(invocation -> {
+                    String title = invocation.getArgument(2);
+                    SimplePage page = newPage(importedPageIds.get(title), destinationSiteId, title, "0", null, null);
+                    pagesById.put(page.getPageId(), page);
+                    return page;
+                });
 
-        assertNotNull(result);
-        assertTrue(result.containsKey(100L));
-        List<Long> referencedPages = result.get(100L);
-        assertEquals(2, referencedPages.size());
-        assertTrue(referencedPages.contains(101L));
-        assertTrue(referencedPages.contains(102L));
-    }
-
-    /**
-     * Pseudo-orphan intermediate pages (toolId "0") must still be scanned so nested
-     * subpages are discovered when re-importing a previously broken site.
-     */
-    @Test
-    public void testFindReferencedPagesByItemsIncludesPseudoOrphanIntermediates() {
-        String siteId = "test-site-pseudo";
-
-        // Broken import left Subpage 1 as toolId "0" with null parent, but it still has a PAGE item
-        SimplePage page1 = newPage(200L, siteId, "Page 1", "sakai-page-tool", null, null);
-        SimplePage sub1 = newPage(201L, siteId, "Subpage 1", "0", null, null);
-        SimplePage nested = newPage(202L, siteId, "Nested", "0", null, null);
-
-        when(dao.getSitePages(siteId)).thenReturn(List.of(page1, sub1, nested));
-        when(dao.findItemsOnPage(200L)).thenReturn(List.of(pageItem(1L, 200L, "201")));
-        when(dao.findItemsOnPage(201L)).thenReturn(List.of(pageItem(2L, 201L, "202")));
-        when(dao.getPage(201L)).thenReturn(sub1);
-        when(dao.getPage(202L)).thenReturn(nested);
-
-        Map<Long, List<Long>> result = producer.findReferencedPagesByItems(siteId);
-
-        assertTrue(result.containsKey(200L));
-        assertEquals(List.of(201L), result.get(200L));
-        assertTrue("Pseudo-orphan intermediate must contribute nested refs", result.containsKey(201L));
-        assertEquals(List.of(202L), result.get(201L));
-    }
-
-    /**
-     * Hierarchy maps from item references (including nested).
-     */
-    @Test
-    public void testHierarchyCalculationFromReferences() {
-        Map<Long, List<Long>> subpageRefs = new HashMap<>();
-        subpageRefs.put(100L, List.of(101L, 102L));
-        subpageRefs.put(101L, List.of(103L));
-
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(100L, 100L);
-        pageMap.put(101L, 101L);
-        pageMap.put(102L, 102L);
-        pageMap.put(103L, 103L);
-
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
-
-        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
-        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
-
-        assertEquals(Long.valueOf(100L), calculatedParentMap.get(101L));
-        assertEquals(Long.valueOf(100L), calculatedParentMap.get(102L));
-        assertEquals(Long.valueOf(101L), calculatedParentMap.get(103L));
-
-        assertEquals(Long.valueOf(100L), calculatedTopParentMap.get(101L));
-        assertEquals(Long.valueOf(100L), calculatedTopParentMap.get(102L));
-        assertEquals(Long.valueOf(100L), calculatedTopParentMap.get(103L));
-    }
-
-    /**
-     * Selective import only links pages present in pageMap.
-     */
-    @Test
-    public void testHierarchyCalculationWithSelectiveImport() {
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(100L, 5000L);
-        pageMap.put(101L, 5001L);
-
-        Map<Long, List<Long>> subpageRefs = new HashMap<>();
-        subpageRefs.put(100L, List.of(101L, 102L));
-        subpageRefs.put(200L, List.of(103L));
-
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
-
-        assertEquals(Long.valueOf(100L), calculatedParentMap.get(101L));
-        assertFalse(calculatedParentMap.containsKey(102L));
-        assertFalse(calculatedParentMap.containsKey(103L));
-    }
-
-    /**
-     * Cycles in the parent map must not hang and must not invent a topParent.
-     */
-    @Test
-    public void testCalculateTopParentMapDetectsCycles() {
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        calculatedParentMap.put(1L, 2L);
-        calculatedParentMap.put(2L, 1L);
-
-        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
-        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
-
-        assertTrue(calculatedTopParentMap.isEmpty());
-    }
-
-    /**
-     * XML parent attributes fill gaps when item refs are unavailable (cross-server archive).
-     */
-    @Test
-    public void testFillUnresolvedParentsFromXml() throws Exception {
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-        Element pageEl = doc.createElement("page");
-        pageEl.setAttribute("parent", "100");
-
-        Map<Long, Element> pageElementMap = new HashMap<>();
-        pageElementMap.put(101L, pageEl);
-
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(100L, 5000L);
-        pageMap.put(101L, 5001L);
-
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        producer.fillUnresolvedParentsFromXml(pageElementMap, pageMap, calculatedParentMap);
-
-        assertEquals(Long.valueOf(100L), calculatedParentMap.get(101L));
-    }
-
-    /**
-     * parent="0" / empty must not invent relationships (matches the old broken export).
-     */
-    @Test
-    public void testFillUnresolvedParentsFromXmlIgnoresZeroParent() throws Exception {
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-        Element pageEl = doc.createElement("page");
-        pageEl.setAttribute("parent", "0");
-
-        Map<Long, Element> pageElementMap = new HashMap<>();
-        pageElementMap.put(101L, pageEl);
-
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(100L, 5000L);
-        pageMap.put(101L, 5001L);
-
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        producer.fillUnresolvedParentsFromXml(pageElementMap, pageMap, calculatedParentMap);
-
-        assertFalse(calculatedParentMap.containsKey(101L));
-    }
-
-    /**
-     * SAK-52251: after import, subpages must not remain as pseudo-orphans
-     * (toolId "0", parent/topParent null/0). They must share the top Lesson toolId
-     * and point parent/topParent at the new top-level page.
-     *
-     * Expected shape (new IDs):
-     *   Page 1:   toolId=sakai-page-xyz, parent=null, topParent=null
-     *   Subpage1: toolId=sakai-page-xyz, parent=Page1, topParent=Page1
-     *   Subpage2: toolId=sakai-page-xyz, parent=Page1, topParent=Page1
-     */
-    @Test
-    public void testImportAppliesHierarchyAndToolIdLikeSiteImport() {
-        String destSiteId = "site-2";
-        String realToolId = "sakai-page-xyz";
-
-        // Old source ids
-        long oldPage1 = 7953115L;
-        long oldSub1 = 7953116L;
-        long oldSub2 = 7953117L;
-
-        // New destination ids after makePage("0", site, title, null, null)
-        long newPage1 = 9001L;
-        long newSub1 = 9002L;
-        long newSub2 = 9003L;
-
-        SimplePage importedPage1 = newPage(newPage1, destSiteId, "Page 1", "0", null, null);
-        SimplePage importedSub1 = newPage(newSub1, destSiteId, "Subpage 1", "0", null, null);
-        SimplePage importedSub2 = newPage(newSub2, destSiteId, "Subpage 2", "0", null, null);
-
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(oldPage1, newPage1);
-        pageMap.put(oldSub1, newSub1);
-        pageMap.put(oldSub2, newSub2);
-
-        Map<Long, List<Long>> subpageRefs = new HashMap<>();
-        subpageRefs.put(oldPage1, List.of(oldSub1, oldSub2));
-
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
-        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
-        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
-
-        when(dao.getPage(newPage1)).thenReturn(importedPage1);
-        when(dao.getPage(newSub1)).thenReturn(importedSub1);
-        when(dao.getPage(newSub2)).thenReturn(importedSub2);
+        AtomicLong importedItemId = new AtomicLong(1000L);
+        when(dao.makeItem(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    long pageId = invocation.getArgument(0);
+                    int sequence = invocation.getArgument(1);
+                    int type = invocation.getArgument(2);
+                    String sakaiId = invocation.getArgument(3);
+                    String name = invocation.getArgument(4);
+                    SimplePageItem item = new SimplePageItemImpl();
+                    item.setId(importedItemId.incrementAndGet());
+                    item.setPageId(pageId);
+                    item.setSequence(sequence);
+                    item.setType(type);
+                    item.setSakaiId(sakaiId);
+                    item.setName(name);
+                    itemsByPage.computeIfAbsent(pageId, key -> new ArrayList<>()).add(item);
+                    return item;
+                });
+        when(dao.quickSaveItem(Mockito.any())).thenReturn(true);
         when(dao.quickUpdate(Mockito.any())).thenReturn(true);
 
-        int hierarchyUpdates = producer.applyCalculatedHierarchy(pageMap, calculatedParentMap, calculatedTopParentMap);
-        assertEquals(2, hierarchyUpdates);
+        Site destinationSite = Mockito.mock(Site.class);
+        when(destinationSite.getId()).thenReturn(destinationSiteId);
+        when(destinationSite.getTools(Mockito.any(String[].class))).thenReturn(List.of());
+        when(siteService.getSite(destinationSiteId)).thenReturn(destinationSite);
+        when(siteService.getOptionalSite(sourceSiteId)).thenReturn(Optional.empty());
 
-        // Simulate placement creation assigning the real toolId to the top-level page
-        importedPage1.setToolId(realToolId);
-        importedPage1.setParent(null);
-        importedPage1.setTopParent(null);
+        SitePage navigationPageA = Mockito.mock(SitePage.class);
+        SitePage navigationPageB = Mockito.mock(SitePage.class);
+        ToolConfiguration placementA = Mockito.mock(ToolConfiguration.class);
+        ToolConfiguration placementB = Mockito.mock(ToolConfiguration.class);
+        when(destinationSite.addPage()).thenReturn(navigationPageA, navigationPageB);
+        when(navigationPageA.addTool(LessonBuilderConstants.TOOL_ID)).thenReturn(placementA);
+        when(navigationPageB.addTool(LessonBuilderConstants.TOOL_ID)).thenReturn(placementB);
+        when(navigationPageA.getId()).thenReturn("navigation-a");
+        when(navigationPageB.getId()).thenReturn("navigation-b");
+        when(placementA.getPageId()).thenReturn("destination-placement-a");
+        when(placementB.getPageId()).thenReturn("destination-placement-b");
 
-        int toolIdUpdates = producer.updateChildPageToolIds(pageMap, calculatedTopParentMap);
-        assertEquals(2, toolIdUpdates);
+        Document document = Xml.createDocument();
+        Element root = document.createElement("service");
+        document.appendChild(root);
+        Element lessonBuilder = document.createElement("lessonbuilder");
+        root.appendChild(lessonBuilder);
 
-        // Top-level Lesson stays a root
-        assertEquals(realToolId, importedPage1.getToolId());
-        assertNull(importedPage1.getParent());
-        assertNull(importedPage1.getTopParent());
+        Element pageA = pageElement(document, oldPageA, sourceSiteId, "Lesson A", null);
+        addPageItem(document, pageA, 1L, oldPageA, oldPseudoOrphan, false, "Pseudo orphan");
+        addPageItem(document, pageA, 2L, oldPageA, oldPageB, true, "Lesson B");
+        lessonBuilder.appendChild(pageA);
 
-        // Subpages are linked and share the Lesson toolId (not "0")
-        assertEquals(Long.valueOf(newPage1), importedSub1.getParent());
-        assertEquals(Long.valueOf(newPage1), importedSub1.getTopParent());
-        assertEquals(realToolId, importedSub1.getToolId());
+        Element pageB = pageElement(document, oldPageB, sourceSiteId, "Lesson B", null);
+        addPageItem(document, pageB, 3L, oldPageB, oldSharedPage, false, "Shared page");
+        addPageItem(document, pageB, 4L, oldPageB, oldPageA, false, "Lesson A");
+        lessonBuilder.appendChild(pageB);
+        lessonBuilder.appendChild(pageElement(document, oldPseudoOrphan, sourceSiteId, "Pseudo orphan", null));
+        lessonBuilder.appendChild(pageElement(document, oldSharedPage, sourceSiteId, "Shared page", oldPageA));
+        lessonBuilder.appendChild(placementElement(document, oldPageA, "Lesson A"));
+        lessonBuilder.appendChild(placementElement(document, oldPageB, "Lesson B"));
 
-        assertEquals(Long.valueOf(newPage1), importedSub2.getParent());
-        assertEquals(Long.valueOf(newPage1), importedSub2.getTopParent());
-        assertEquals(realToolId, importedSub2.getToolId());
+        String result = producer.mergeInternal(destinationSiteId, root, "", sourceSiteId,
+                new MergeConfig(), new HashMap<>(), false);
 
-        verify(dao, atLeastOnce()).quickUpdate(importedSub1);
-        verify(dao, atLeastOnce()).quickUpdate(importedSub2);
+        assertFalse(result, result.contains("failed"));
+
+        SimplePage importedPageA = pagesById.get(newPageA);
+        SimplePage importedPageB = pagesById.get(newPageB);
+        SimplePage importedPseudoOrphan = pagesById.get(newPseudoOrphan);
+        SimplePage importedSharedPage = pagesById.get(newSharedPage);
+
+        assertNull(importedPageA.getParent());
+        assertNull(importedPageA.getTopParent());
+        assertEquals("destination-placement-a", importedPageA.getToolId());
+        assertNull(importedPageB.getParent());
+        assertNull(importedPageB.getTopParent());
+        assertEquals("destination-placement-b", importedPageB.getToolId());
+
+        assertEquals(Long.valueOf(newPageA), importedPseudoOrphan.getParent());
+        assertEquals(Long.valueOf(newPageA), importedPseudoOrphan.getTopParent());
+        assertEquals("destination-placement-a", importedPseudoOrphan.getToolId());
+
+        assertEquals(Long.valueOf(newPageA), importedSharedPage.getParent());
+        assertEquals(Long.valueOf(newPageA), importedSharedPage.getTopParent());
+        assertEquals("destination-placement-a", importedSharedPage.getToolId());
+
+        verify(dao, never()).getPage(oldPseudoOrphan);
+        verify(dao, never()).getPage(oldSharedPage);
     }
 
-    /**
-     * Re-import from a site whose subpages are already pseudo-orphans: item refs on the
-     * top Lesson (and on intermediate pseudo-orphans) still rebuild hierarchy + toolId.
-     */
-    @Test
-    public void testReimportFromPseudoOrphanSourceRebuildsNestedHierarchy() {
-        String sourceSiteId = "site-2-broken";
-        String destSiteId = "site-3";
-        String realToolId = "dest-tool-placement";
-
-        // Source: Page1 OK; Sub1 and Nested are pseudo-orphans (toolId 0 / null parents)
-        long srcPage1 = 100L;
-        long srcSub1 = 101L;
-        long srcNested = 102L;
-
-        SimplePage srcPage1Page = newPage(srcPage1, sourceSiteId, "Page 1", "src-tool", null, null);
-        SimplePage srcSub1Page = newPage(srcSub1, sourceSiteId, "Subpage 1", "0", null, null);
-        SimplePage srcNestedPage = newPage(srcNested, sourceSiteId, "Nested", "0", null, null);
-
-        when(dao.getSitePages(sourceSiteId)).thenReturn(List.of(srcPage1Page, srcSub1Page, srcNestedPage));
-        when(dao.findItemsOnPage(srcPage1)).thenReturn(List.of(pageItem(1L, srcPage1, "101")));
-        when(dao.findItemsOnPage(srcSub1)).thenReturn(List.of(pageItem(2L, srcSub1, "102")));
-        when(dao.getPage(srcSub1)).thenReturn(srcSub1Page);
-        when(dao.getPage(srcNested)).thenReturn(srcNestedPage);
-
-        Map<Long, List<Long>> subpageRefs = producer.findReferencedPagesByItems(sourceSiteId);
-        assertEquals(List.of(101L), subpageRefs.get(100L));
-        assertEquals(List.of(102L), subpageRefs.get(101L));
-
-        long newPage1 = 2001L;
-        long newSub1 = 2002L;
-        long newNested = 2003L;
-
-        SimplePage destPage1 = newPage(newPage1, destSiteId, "Page 1", "0", null, null);
-        SimplePage destSub1 = newPage(newSub1, destSiteId, "Subpage 1", "0", null, null);
-        SimplePage destNested = newPage(newNested, destSiteId, "Nested", "0", null, null);
-
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(srcPage1, newPage1);
-        pageMap.put(srcSub1, newSub1);
-        pageMap.put(srcNested, newNested);
-
-        Map<Long, Long> calculatedParentMap = new HashMap<>();
-        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
-        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
-        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
-
-        when(dao.getPage(newPage1)).thenReturn(destPage1);
-        when(dao.getPage(newSub1)).thenReturn(destSub1);
-        when(dao.getPage(newNested)).thenReturn(destNested);
-        when(dao.quickUpdate(Mockito.any())).thenReturn(true);
-
-        assertEquals(2, producer.applyCalculatedHierarchy(pageMap, calculatedParentMap, calculatedTopParentMap));
-
-        destPage1.setToolId(realToolId);
-        assertEquals(2, producer.updateChildPageToolIds(pageMap, calculatedTopParentMap));
-
-        assertEquals(Long.valueOf(newPage1), destSub1.getParent());
-        assertEquals(Long.valueOf(newPage1), destSub1.getTopParent());
-        assertEquals(realToolId, destSub1.getToolId());
-
-        assertEquals(Long.valueOf(newSub1), destNested.getParent());
-        assertEquals(Long.valueOf(newPage1), destNested.getTopParent());
-        assertEquals(realToolId, destNested.getToolId());
+    private static Element pageElement(Document document, long pageId, String siteId, String title, Long parentId) {
+        Element page = document.createElement("page");
+        page.setAttribute("pageid", Long.toString(pageId));
+        page.setAttribute("siteid", siteId);
+        page.setAttribute("title", title);
+        if (parentId != null) {
+            page.setAttribute("parent", parentId.toString());
+        }
+        return page;
     }
 
-    /**
-     * Top-level pages are not in calculatedTopParentMap, so their toolId is left alone.
-     */
-    @Test
-    public void testUpdateChildPageToolIdsDoesNotTouchTopLevel() {
-        Map<Long, Long> pageMap = new HashMap<>();
-        pageMap.put(100L, 5000L);
+    private static void addPageItem(Document document, Element page, long itemId, long pageId,
+            long referencedPageId, boolean nextPage, String name) {
+        Element item = document.createElement("item");
+        item.setAttribute("id", Long.toString(itemId));
+        item.setAttribute("pageId", Long.toString(pageId));
+        item.setAttribute("sequence", Long.toString(itemId));
+        item.setAttribute("type", Integer.toString(SimplePageItem.PAGE));
+        item.setAttribute("sakaiid", Long.toString(referencedPageId));
+        item.setAttribute("name", name);
+        item.setAttribute("nextpage", Boolean.toString(nextPage));
+        item.setAttribute("gradebookPoints", "null");
+        item.setAttribute("altPoints", "null");
+        page.appendChild(item);
+    }
 
-        SimplePage top = newPage(5000L, "site", "Page 1", "real-tool", null, null);
-
-        int updates = producer.updateChildPageToolIds(pageMap, new HashMap<>());
-        assertEquals(0, updates);
-        assertEquals("real-tool", top.getToolId());
-        verify(dao, never()).quickUpdate(top);
+    private static Element placementElement(Document document, long pageId, String name) {
+        Element placement = document.createElement("lessonbuilder");
+        placement.setAttribute("toolid", Long.toString(pageId));
+        placement.setAttribute("pageId", Long.toString(pageId));
+        placement.setAttribute("name", name);
+        return placement;
     }
 
     private static SimplePage newPage(long pageId, String siteId, String title, String toolId, Long parent, Long topParent) {
@@ -465,14 +305,5 @@ public class LessonBuilderEntityProducerTest {
         page.setParent(parent);
         page.setTopParent(topParent);
         return page;
-    }
-
-    private static SimplePageItem pageItem(long id, long pageId, String sakaiId) {
-        SimplePageItem item = new SimplePageItemImpl();
-        item.setId(id);
-        item.setPageId(pageId);
-        item.setType(SimplePageItem.PAGE);
-        item.setSakaiId(sakaiId);
-        return item;
     }
 }

--- a/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducerTest.java
+++ b/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/LessonBuilderEntityProducerTest.java
@@ -15,20 +15,37 @@
  */
 package org.sakaiproject.lessonbuildertool.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.lessonbuildertool.SimplePage;
+import org.sakaiproject.lessonbuildertool.SimplePageImpl;
 import org.sakaiproject.lessonbuildertool.SimplePageItem;
+import org.sakaiproject.lessonbuildertool.SimplePageItemImpl;
 import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 public class LessonBuilderEntityProducerTest {
 
@@ -108,4 +125,354 @@ public class LessonBuilderEntityProducerTest {
         Mockito.verify(ref).set("sakai:lessonbuilder", "site", "/site/siteId", null, "/site/siteId");
     }
 
+    /**
+     * findReferencedPagesByItems identifies parent-child links from PAGE items.
+     */
+    @Test
+    public void testFindReferencedPagesByItems() {
+        String siteId = "test-site-1";
+
+        SimplePage parentPage = newPage(100L, siteId, "Parent Page", "tool-abc", null, null);
+        SimplePage subpage1 = newPage(101L, siteId, "Subpage 1", "tool-abc", 100L, 100L);
+        SimplePage subpage2 = newPage(102L, siteId, "Subpage 2", "tool-abc", 100L, 100L);
+
+        List<SimplePageItem> allItems = new ArrayList<>();
+        allItems.add(pageItem(1L, 100L, "101"));
+        allItems.add(pageItem(2L, 100L, "102"));
+        SimplePageItem textItem = new SimplePageItemImpl();
+        textItem.setId(3L);
+        textItem.setPageId(100L);
+        textItem.setType(SimplePageItem.TEXT);
+        textItem.setHtml("Some text");
+        allItems.add(textItem);
+
+        when(dao.getSitePages(siteId)).thenReturn(List.of(parentPage, subpage1, subpage2));
+        when(dao.findItemsOnPage(100L)).thenReturn(allItems);
+        when(dao.getPage(101L)).thenReturn(subpage1);
+        when(dao.getPage(102L)).thenReturn(subpage2);
+
+        Map<Long, List<Long>> result = producer.findReferencedPagesByItems(siteId);
+
+        assertNotNull(result);
+        assertTrue(result.containsKey(100L));
+        List<Long> referencedPages = result.get(100L);
+        assertEquals(2, referencedPages.size());
+        assertTrue(referencedPages.contains(101L));
+        assertTrue(referencedPages.contains(102L));
+    }
+
+    /**
+     * Pseudo-orphan intermediate pages (toolId "0") must still be scanned so nested
+     * subpages are discovered when re-importing a previously broken site.
+     */
+    @Test
+    public void testFindReferencedPagesByItemsIncludesPseudoOrphanIntermediates() {
+        String siteId = "test-site-pseudo";
+
+        // Broken import left Subpage 1 as toolId "0" with null parent, but it still has a PAGE item
+        SimplePage page1 = newPage(200L, siteId, "Page 1", "sakai-page-tool", null, null);
+        SimplePage sub1 = newPage(201L, siteId, "Subpage 1", "0", null, null);
+        SimplePage nested = newPage(202L, siteId, "Nested", "0", null, null);
+
+        when(dao.getSitePages(siteId)).thenReturn(List.of(page1, sub1, nested));
+        when(dao.findItemsOnPage(200L)).thenReturn(List.of(pageItem(1L, 200L, "201")));
+        when(dao.findItemsOnPage(201L)).thenReturn(List.of(pageItem(2L, 201L, "202")));
+        when(dao.getPage(201L)).thenReturn(sub1);
+        when(dao.getPage(202L)).thenReturn(nested);
+
+        Map<Long, List<Long>> result = producer.findReferencedPagesByItems(siteId);
+
+        assertTrue(result.containsKey(200L));
+        assertEquals(List.of(201L), result.get(200L));
+        assertTrue("Pseudo-orphan intermediate must contribute nested refs", result.containsKey(201L));
+        assertEquals(List.of(202L), result.get(201L));
+    }
+
+    /**
+     * Hierarchy maps from item references (including nested).
+     */
+    @Test
+    public void testHierarchyCalculationFromReferences() {
+        Map<Long, List<Long>> subpageRefs = new HashMap<>();
+        subpageRefs.put(100L, List.of(101L, 102L));
+        subpageRefs.put(101L, List.of(103L));
+
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(100L, 100L);
+        pageMap.put(101L, 101L);
+        pageMap.put(102L, 102L);
+        pageMap.put(103L, 103L);
+
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
+
+        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
+        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
+
+        assertEquals(Long.valueOf(100L), calculatedParentMap.get(101L));
+        assertEquals(Long.valueOf(100L), calculatedParentMap.get(102L));
+        assertEquals(Long.valueOf(101L), calculatedParentMap.get(103L));
+
+        assertEquals(Long.valueOf(100L), calculatedTopParentMap.get(101L));
+        assertEquals(Long.valueOf(100L), calculatedTopParentMap.get(102L));
+        assertEquals(Long.valueOf(100L), calculatedTopParentMap.get(103L));
+    }
+
+    /**
+     * Selective import only links pages present in pageMap.
+     */
+    @Test
+    public void testHierarchyCalculationWithSelectiveImport() {
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(100L, 5000L);
+        pageMap.put(101L, 5001L);
+
+        Map<Long, List<Long>> subpageRefs = new HashMap<>();
+        subpageRefs.put(100L, List.of(101L, 102L));
+        subpageRefs.put(200L, List.of(103L));
+
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
+
+        assertEquals(Long.valueOf(100L), calculatedParentMap.get(101L));
+        assertFalse(calculatedParentMap.containsKey(102L));
+        assertFalse(calculatedParentMap.containsKey(103L));
+    }
+
+    /**
+     * Cycles in the parent map must not hang and must not invent a topParent.
+     */
+    @Test
+    public void testCalculateTopParentMapDetectsCycles() {
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        calculatedParentMap.put(1L, 2L);
+        calculatedParentMap.put(2L, 1L);
+
+        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
+        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
+
+        assertTrue(calculatedTopParentMap.isEmpty());
+    }
+
+    /**
+     * XML parent attributes fill gaps when item refs are unavailable (cross-server archive).
+     */
+    @Test
+    public void testFillUnresolvedParentsFromXml() throws Exception {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element pageEl = doc.createElement("page");
+        pageEl.setAttribute("parent", "100");
+
+        Map<Long, Element> pageElementMap = new HashMap<>();
+        pageElementMap.put(101L, pageEl);
+
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(100L, 5000L);
+        pageMap.put(101L, 5001L);
+
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        producer.fillUnresolvedParentsFromXml(pageElementMap, pageMap, calculatedParentMap);
+
+        assertEquals(Long.valueOf(100L), calculatedParentMap.get(101L));
+    }
+
+    /**
+     * parent="0" / empty must not invent relationships (matches the old broken export).
+     */
+    @Test
+    public void testFillUnresolvedParentsFromXmlIgnoresZeroParent() throws Exception {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element pageEl = doc.createElement("page");
+        pageEl.setAttribute("parent", "0");
+
+        Map<Long, Element> pageElementMap = new HashMap<>();
+        pageElementMap.put(101L, pageEl);
+
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(100L, 5000L);
+        pageMap.put(101L, 5001L);
+
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        producer.fillUnresolvedParentsFromXml(pageElementMap, pageMap, calculatedParentMap);
+
+        assertFalse(calculatedParentMap.containsKey(101L));
+    }
+
+    /**
+     * SAK-52251: after import, subpages must not remain as pseudo-orphans
+     * (toolId "0", parent/topParent null/0). They must share the top Lesson toolId
+     * and point parent/topParent at the new top-level page.
+     *
+     * Expected shape (new IDs):
+     *   Page 1:   toolId=sakai-page-xyz, parent=null, topParent=null
+     *   Subpage1: toolId=sakai-page-xyz, parent=Page1, topParent=Page1
+     *   Subpage2: toolId=sakai-page-xyz, parent=Page1, topParent=Page1
+     */
+    @Test
+    public void testImportAppliesHierarchyAndToolIdLikeSiteImport() {
+        String destSiteId = "site-2";
+        String realToolId = "sakai-page-xyz";
+
+        // Old source ids
+        long oldPage1 = 7953115L;
+        long oldSub1 = 7953116L;
+        long oldSub2 = 7953117L;
+
+        // New destination ids after makePage("0", site, title, null, null)
+        long newPage1 = 9001L;
+        long newSub1 = 9002L;
+        long newSub2 = 9003L;
+
+        SimplePage importedPage1 = newPage(newPage1, destSiteId, "Page 1", "0", null, null);
+        SimplePage importedSub1 = newPage(newSub1, destSiteId, "Subpage 1", "0", null, null);
+        SimplePage importedSub2 = newPage(newSub2, destSiteId, "Subpage 2", "0", null, null);
+
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(oldPage1, newPage1);
+        pageMap.put(oldSub1, newSub1);
+        pageMap.put(oldSub2, newSub2);
+
+        Map<Long, List<Long>> subpageRefs = new HashMap<>();
+        subpageRefs.put(oldPage1, List.of(oldSub1, oldSub2));
+
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
+        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
+        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
+
+        when(dao.getPage(newPage1)).thenReturn(importedPage1);
+        when(dao.getPage(newSub1)).thenReturn(importedSub1);
+        when(dao.getPage(newSub2)).thenReturn(importedSub2);
+        when(dao.quickUpdate(Mockito.any())).thenReturn(true);
+
+        int hierarchyUpdates = producer.applyCalculatedHierarchy(pageMap, calculatedParentMap, calculatedTopParentMap);
+        assertEquals(2, hierarchyUpdates);
+
+        // Simulate placement creation assigning the real toolId to the top-level page
+        importedPage1.setToolId(realToolId);
+        importedPage1.setParent(null);
+        importedPage1.setTopParent(null);
+
+        int toolIdUpdates = producer.updateChildPageToolIds(pageMap, calculatedTopParentMap);
+        assertEquals(2, toolIdUpdates);
+
+        // Top-level Lesson stays a root
+        assertEquals(realToolId, importedPage1.getToolId());
+        assertNull(importedPage1.getParent());
+        assertNull(importedPage1.getTopParent());
+
+        // Subpages are linked and share the Lesson toolId (not "0")
+        assertEquals(Long.valueOf(newPage1), importedSub1.getParent());
+        assertEquals(Long.valueOf(newPage1), importedSub1.getTopParent());
+        assertEquals(realToolId, importedSub1.getToolId());
+
+        assertEquals(Long.valueOf(newPage1), importedSub2.getParent());
+        assertEquals(Long.valueOf(newPage1), importedSub2.getTopParent());
+        assertEquals(realToolId, importedSub2.getToolId());
+
+        verify(dao, atLeastOnce()).quickUpdate(importedSub1);
+        verify(dao, atLeastOnce()).quickUpdate(importedSub2);
+    }
+
+    /**
+     * Re-import from a site whose subpages are already pseudo-orphans: item refs on the
+     * top Lesson (and on intermediate pseudo-orphans) still rebuild hierarchy + toolId.
+     */
+    @Test
+    public void testReimportFromPseudoOrphanSourceRebuildsNestedHierarchy() {
+        String sourceSiteId = "site-2-broken";
+        String destSiteId = "site-3";
+        String realToolId = "dest-tool-placement";
+
+        // Source: Page1 OK; Sub1 and Nested are pseudo-orphans (toolId 0 / null parents)
+        long srcPage1 = 100L;
+        long srcSub1 = 101L;
+        long srcNested = 102L;
+
+        SimplePage srcPage1Page = newPage(srcPage1, sourceSiteId, "Page 1", "src-tool", null, null);
+        SimplePage srcSub1Page = newPage(srcSub1, sourceSiteId, "Subpage 1", "0", null, null);
+        SimplePage srcNestedPage = newPage(srcNested, sourceSiteId, "Nested", "0", null, null);
+
+        when(dao.getSitePages(sourceSiteId)).thenReturn(List.of(srcPage1Page, srcSub1Page, srcNestedPage));
+        when(dao.findItemsOnPage(srcPage1)).thenReturn(List.of(pageItem(1L, srcPage1, "101")));
+        when(dao.findItemsOnPage(srcSub1)).thenReturn(List.of(pageItem(2L, srcSub1, "102")));
+        when(dao.getPage(srcSub1)).thenReturn(srcSub1Page);
+        when(dao.getPage(srcNested)).thenReturn(srcNestedPage);
+
+        Map<Long, List<Long>> subpageRefs = producer.findReferencedPagesByItems(sourceSiteId);
+        assertEquals(List.of(101L), subpageRefs.get(100L));
+        assertEquals(List.of(102L), subpageRefs.get(101L));
+
+        long newPage1 = 2001L;
+        long newSub1 = 2002L;
+        long newNested = 2003L;
+
+        SimplePage destPage1 = newPage(newPage1, destSiteId, "Page 1", "0", null, null);
+        SimplePage destSub1 = newPage(newSub1, destSiteId, "Subpage 1", "0", null, null);
+        SimplePage destNested = newPage(newNested, destSiteId, "Nested", "0", null, null);
+
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(srcPage1, newPage1);
+        pageMap.put(srcSub1, newSub1);
+        pageMap.put(srcNested, newNested);
+
+        Map<Long, Long> calculatedParentMap = new HashMap<>();
+        Map<Long, Long> calculatedTopParentMap = new HashMap<>();
+        producer.buildParentMapFromReferences(subpageRefs, pageMap, calculatedParentMap);
+        producer.calculateTopParentMap(calculatedParentMap, calculatedTopParentMap);
+
+        when(dao.getPage(newPage1)).thenReturn(destPage1);
+        when(dao.getPage(newSub1)).thenReturn(destSub1);
+        when(dao.getPage(newNested)).thenReturn(destNested);
+        when(dao.quickUpdate(Mockito.any())).thenReturn(true);
+
+        assertEquals(2, producer.applyCalculatedHierarchy(pageMap, calculatedParentMap, calculatedTopParentMap));
+
+        destPage1.setToolId(realToolId);
+        assertEquals(2, producer.updateChildPageToolIds(pageMap, calculatedTopParentMap));
+
+        assertEquals(Long.valueOf(newPage1), destSub1.getParent());
+        assertEquals(Long.valueOf(newPage1), destSub1.getTopParent());
+        assertEquals(realToolId, destSub1.getToolId());
+
+        assertEquals(Long.valueOf(newSub1), destNested.getParent());
+        assertEquals(Long.valueOf(newPage1), destNested.getTopParent());
+        assertEquals(realToolId, destNested.getToolId());
+    }
+
+    /**
+     * Top-level pages are not in calculatedTopParentMap, so their toolId is left alone.
+     */
+    @Test
+    public void testUpdateChildPageToolIdsDoesNotTouchTopLevel() {
+        Map<Long, Long> pageMap = new HashMap<>();
+        pageMap.put(100L, 5000L);
+
+        SimplePage top = newPage(5000L, "site", "Page 1", "real-tool", null, null);
+
+        int updates = producer.updateChildPageToolIds(pageMap, new HashMap<>());
+        assertEquals(0, updates);
+        assertEquals("real-tool", top.getToolId());
+        verify(dao, never()).quickUpdate(top);
+    }
+
+    private static SimplePage newPage(long pageId, String siteId, String title, String toolId, Long parent, Long topParent) {
+        SimplePage page = new SimplePageImpl();
+        page.setPageId(pageId);
+        page.setSiteId(siteId);
+        page.setTitle(title);
+        page.setToolId(toolId);
+        page.setParent(parent);
+        page.setTopParent(topParent);
+        return page;
+    }
+
+    private static SimplePageItem pageItem(long id, long pageId, String sakaiId) {
+        SimplePageItem item = new SimplePageItemImpl();
+        item.setId(id);
+        item.setPageId(pageId);
+        item.setType(SimplePageItem.PAGE);
+        item.setSakaiId(sakaiId);
+        return item;
+    }
 }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed referenced-page discovery to support import/merge workflows and improved cross-server hierarchy handling.

* **Bug Fixes**
  * Improved reconstruction and application of page hierarchies during import/merge, preserving parent/child/top-parent relationships, deferring initial linkage for new pages, and skipping placeholder/orphaned pages.
  * Added fallbacks for cross-server imports and XML attributes; enhanced robustness, logging, and counters for hierarchy updates.

* **Tests**
  * Added tests for referenced-page discovery, orphan skipping, hierarchy/top-parent calculation, and selective-import propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->