### PR TITLE
SAK-52359 LTI flows and utilities migrated to bean-centric processing while preserving existing map-based compatibility

### DIFF
--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -21,10 +21,16 @@
 
 package org.sakaiproject.lti.api;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiMembershipsJobBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
+import org.sakaiproject.lti.beans.LtiToolSiteBean;
 import org.sakaiproject.site.api.Site;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -549,7 +555,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * Bean overload: filter content using tool/content beans (delegates to Map version).
      * Obtains content map, filters in place, then persists filtered values back to the bean.
      */
-    default void filterContent(org.sakaiproject.lti.beans.LtiContentBean content, org.sakaiproject.lti.beans.LtiToolBean tool) {
+    default void filterContent(LtiContentBean content, LtiToolBean tool) {
         if (content == null) {
             return;
         }
@@ -586,7 +592,7 @@ public interface LTIService extends LTISubstitutionsFilter {
     /**
      * Bean overload: filter custom substitutions using tool bean (delegates to Map version).
      */
-    default void filterCustomSubstitutions(Properties properties, org.sakaiproject.lti.beans.LtiToolBean tool, Site site) {
+    default void filterCustomSubstitutions(Properties properties, LtiToolBean tool, Site site) {
         filterCustomSubstitutions(properties, tool != null ? tool.asMap() : null, site);
     }
 
@@ -716,20 +722,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiToolBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiToolBean getToolAsBean(Long key, String siteId) {
+    default LtiToolBean getToolAsBean(Long key, String siteId) {
         Map<String, Object> toolMap = getTool(key, siteId);
-        return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
-    }
-
-    /**
-     * Get a single LTI tool as a Bean (alias for getToolAsBean)
-     * @param key The tool ID
-     * @param siteId The site ID
-     * @return LtiToolBean or null if not found
-     */
-    default org.sakaiproject.lti.beans.LtiToolBean getToolBean(Long key, String siteId) {
-        Map<String, Object> toolMap = getTool(key, siteId);
-        return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+        return toolMap != null ? LtiToolBean.of(toolMap) : null;
     }
 
     /**
@@ -739,9 +734,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param isAdminRole Whether to bypass security checks
      * @return LtiToolBean instance or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiToolBean getToolDaoAsBean(Long key, String siteId, boolean isAdminRole) {
+    default LtiToolBean getToolDaoAsBean(Long key, String siteId, boolean isAdminRole) {
         Map<String, Object> toolMap = getToolDao(key, siteId, isAdminRole);
-        return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+        return toolMap != null ? LtiToolBean.of(toolMap) : null;
     }
 
     // ------------------------------------------------------------------------------------
@@ -759,29 +754,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId) {
+    default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
         return toolMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolBean::of)
-                .collect(java.util.stream.Collectors.toList());
-    }
-
-    /**
-     * Get a list of LTI tools as Beans (alias for getToolsAsBeans)
-     * @param search Search criteria
-     * @param order Sort order
-     * @param first First result index
-     * @param last Last result index
-     * @param siteId The site ID
-     * @return List of LtiToolBean objects
-     */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId) {
-        List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
-        }
-        return toolBeans;
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -794,30 +771,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param includeStealthed Whether to include stealthed tools
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
+    default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
         return toolMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolBean::of)
-                .collect(java.util.stream.Collectors.toList());
-    }
-
-    /**
-     * Get a list of LTI tools as Beans with stealthed option (alias for getToolsAsBeans)
-     * @param search Search criteria
-     * @param order Sort order
-     * @param first First result index
-     * @param last Last result index
-     * @param siteId The site ID
-     * @param includeStealthed Whether to include stealthed tools
-     * @return List of LtiToolBean objects
-     */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
-        List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
-        }
-        return toolBeans;
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -831,13 +789,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param includeLaunchable Whether to include only launchable tools
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
+    default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed, includeLaunchable);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
-        }
-        return toolBeans;
+        return toolMaps.stream()
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -845,11 +801,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsLaunchAsBeans(String siteId) {
+    default List<LtiToolBean> getToolsLaunchAsBeans(String siteId) {
         List<Map<String, Object>> toolMaps = getToolsLaunch(siteId);
         return toolMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -857,11 +813,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsImportItemBeans(String siteId) {
+    default List<LtiToolBean> getToolsImportItemBeans(String siteId) {
         List<Map<String, Object>> toolMaps = getToolsImportItem(siteId);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
+        List<LtiToolBean> toolBeans = new ArrayList<>();
         for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+            toolBeans.add(LtiToolBean.of(toolMap));
         }
         return toolBeans;
     }
@@ -878,20 +834,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiContentBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiContentBean getContentAsBean(Long key, String siteId) {
+    default LtiContentBean getContentAsBean(Long key, String siteId) {
         Map<String, Object> contentMap = getContent(key, siteId);
-        return contentMap != null ? org.sakaiproject.lti.beans.LtiContentBean.of(contentMap) : null;
-    }
-
-    /**
-     * Get a single LTI content item as a Bean (alias for getContentAsBean)
-     * @param key The content ID
-     * @param siteId The site ID
-     * @return LtiContentBean or null if not found
-     */
-    default org.sakaiproject.lti.beans.LtiContentBean getContentBean(Long key, String siteId) {
-        Map<String, Object> contentMap = getContent(key, siteId);
-        return contentMap != null ? org.sakaiproject.lti.beans.LtiContentBean.of(contentMap) : null;
+        return contentMap != null ? LtiContentBean.of(contentMap) : null;
     }
 
     // ------------------------------------------------------------------------------------
@@ -909,29 +854,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiContentBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiContentBean> getContentsAsBeans(String search, String order, int first, int last, String siteId) {
+    default List<LtiContentBean> getContentsAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
         return contentMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiContentBean::of)
-                .collect(java.util.stream.Collectors.toList());
-    }
-
-    /**
-     * Get a list of LTI content items as Beans (alias for getContentsAsBeans)
-     * @param search Search criteria
-     * @param order Sort order
-     * @param first First result index
-     * @param last Last result index
-     * @param siteId The site ID
-     * @return List of LtiContentBean objects
-     */
-    default List<org.sakaiproject.lti.beans.LtiContentBean> getContentBeans(String search, String order, int first, int last, String siteId) {
-        List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
-        List<org.sakaiproject.lti.beans.LtiContentBean> contentBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> contentMap : contentMaps) {
-            contentBeans.add(org.sakaiproject.lti.beans.LtiContentBean.of(contentMap));
-        }
-        return contentBeans;
+                .map(LtiContentBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -943,11 +870,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiContentBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId) {
+    default List<LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> contentMaps = getContentsDao(search, order, first, last, siteId);
-        List<org.sakaiproject.lti.beans.LtiContentBean> contentBeans = new java.util.ArrayList<>();
+        List<LtiContentBean> contentBeans = new ArrayList<>();
         for (Map<String, Object> contentMap : contentMaps) {
-            contentBeans.add(org.sakaiproject.lti.beans.LtiContentBean.of(contentMap));
+            contentBeans.add(LtiContentBean.of(contentMap));
         }
         return contentBeans;
     }
@@ -962,11 +889,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param isAdminRole Whether to bypass security checks
      * @return List of LtiContentBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId, boolean isAdminRole) {
+    default List<LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId, boolean isAdminRole) {
         List<Map<String, Object>> contentMaps = getContentsDao(search, order, first, last, siteId, isAdminRole);
-        List<org.sakaiproject.lti.beans.LtiContentBean> contentBeans = new java.util.ArrayList<>();
+        List<LtiContentBean> contentBeans = new ArrayList<>();
         for (Map<String, Object> contentMap : contentMaps) {
-            contentBeans.add(org.sakaiproject.lti.beans.LtiContentBean.of(contentMap));
+            contentBeans.add(LtiContentBean.of(contentMap));
         }
         return contentBeans;
     }
@@ -983,9 +910,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiToolSiteBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiToolSiteBean getToolSiteAsBean(Long key, String siteId) {
+    default LtiToolSiteBean getToolSiteAsBean(Long key, String siteId) {
         Map<String, Object> toolSiteMap = getToolSiteById(key, siteId);
-        return toolSiteMap != null ? org.sakaiproject.lti.beans.LtiToolSiteBean.of(toolSiteMap) : null;
+        return toolSiteMap != null ? LtiToolSiteBean.of(toolSiteMap) : null;
     }
 
     /**
@@ -994,11 +921,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolSiteBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolSiteBean> getToolSitesByToolIdAsBeans(String toolId, String siteId) {
+    default List<LtiToolSiteBean> getToolSitesByToolIdAsBeans(String toolId, String siteId) {
         List<Map<String, Object>> toolSiteMaps = getToolSitesByToolId(toolId, siteId);
         return toolSiteMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolSiteBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiToolSiteBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -1012,20 +939,20 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiMembershipsJobBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiMembershipsJobBean getMembershipsJobAsBean(String siteId) {
+    default LtiMembershipsJobBean getMembershipsJobAsBean(String siteId) {
         Map<String, Object> jobMap = getMembershipsJob(siteId);
-        return jobMap != null ? org.sakaiproject.lti.beans.LtiMembershipsJobBean.of(jobMap) : null;
+        return jobMap != null ? LtiMembershipsJobBean.of(jobMap) : null;
     }
 
     /**
      * Get all LTI memberships jobs as Beans
      * @return List of LtiMembershipsJobBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiMembershipsJobBean> getMembershipsJobsAsBeans() {
+    default List<LtiMembershipsJobBean> getMembershipsJobsAsBeans() {
         List<Map<String, Object>> jobMaps = getMembershipsJobs();
         return jobMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiMembershipsJobBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiMembershipsJobBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -1040,8 +967,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The ID of the inserted tool
      */
-    default Object insertTool(org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
-        return insertTool(toolBean != null ? toolBean.asMap() : null, siteId);
+    default Object insertTool(LtiToolBean toolBean, String siteId) {
+        if (toolBean == null) {
+            throw new IllegalArgumentException("toolBean must not be null");
+        }
+        return insertTool(toolBean.asMap(), siteId);
     }
 
     /**
@@ -1050,8 +980,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The ID of the inserted content
      */
-    default Object insertContent(org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
-        return insertContent(contentBean != null ? contentBean.asMap() : null, siteId);
+    default Object insertContent(LtiContentBean contentBean, String siteId) {
+        if (contentBean == null) {
+            throw new IllegalArgumentException("contentBean must not be null");
+        }
+        return insertContent(contentBean.asMap(), siteId);
     }
 
     /**
@@ -1061,7 +994,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The result of the update operation
      */
-    default Object updateTool(Long key, org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
+    default Object updateTool(Long key, LtiToolBean toolBean, String siteId) {
         return updateTool(key, toolBean != null ? toolBean.asMap() : null, siteId);
     }
 
@@ -1072,7 +1005,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId the site id
      * @return the result
      */
-    default Object updateToolDao(Long key, org.sakaiproject.lti.beans.LtiToolBean tool, String siteId) {
+    default Object updateToolDao(Long key, LtiToolBean tool, String siteId) {
         return updateToolDao(key, tool != null ? tool.asMap() : null, siteId);
     }
 
@@ -1083,7 +1016,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The result of the update operation
      */
-    default Object updateContent(Long key, org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
+    default Object updateContent(Long key, LtiContentBean contentBean, String siteId) {
         return updateContent(key, contentBean != null ? contentBean.asMap() : null, siteId);
     }
 
@@ -1097,7 +1030,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param contentBean The content data as Bean
      * @return The launch URL
      */
-    default String getContentLaunch(org.sakaiproject.lti.beans.LtiContentBean contentBean) {
+    default String getContentLaunch(LtiContentBean contentBean) {
         return getContentLaunch(contentBean != null ? contentBean.asMap() : null);
     }
 
@@ -1114,7 +1047,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String fieldinfo) {
+    default String formOutput(LtiToolBean toolBean, String fieldinfo) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formOutput(toolMap, fieldinfo);
     }
@@ -1125,7 +1058,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String[] formDefinition) {
+    default String formOutput(LtiToolBean toolBean, String[] formDefinition) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formOutput(toolMap, formDefinition);
     }
@@ -1136,7 +1069,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String fieldinfo) {
+    default String formOutput(LtiContentBean contentBean, String fieldinfo) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formOutput(contentMap, fieldinfo);
     }
@@ -1147,7 +1080,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String[] formDefinition) {
+    default String formOutput(LtiContentBean contentBean, String[] formDefinition) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formOutput(contentMap, formDefinition);
     }
@@ -1158,7 +1091,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String fieldinfo) {
+    default String formOutput(LtiToolSiteBean toolSiteBean, String fieldinfo) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formOutput(toolSiteMap, fieldinfo);
     }
@@ -1169,7 +1102,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String[] formDefinition) {
+    default String formOutput(LtiToolSiteBean toolSiteBean, String[] formDefinition) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formOutput(toolSiteMap, formDefinition);
     }
@@ -1187,7 +1120,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String fieldinfo) {
+    default String formInput(LtiToolBean toolBean, String fieldinfo) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formInput(toolMap, fieldinfo);
     }
@@ -1198,7 +1131,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String[] formDefinition) {
+    default String formInput(LtiToolBean toolBean, String[] formDefinition) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formInput(toolMap, formDefinition);
     }
@@ -1209,7 +1142,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String fieldinfo) {
+    default String formInput(LtiContentBean contentBean, String fieldinfo) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formInput(contentMap, fieldinfo);
     }
@@ -1220,7 +1153,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String[] formDefinition) {
+    default String formInput(LtiContentBean contentBean, String[] formDefinition) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formInput(contentMap, formDefinition);
     }
@@ -1231,7 +1164,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String fieldinfo) {
+    default String formInput(LtiToolSiteBean toolSiteBean, String fieldinfo) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formInput(toolSiteMap, fieldinfo);
     }
@@ -1242,7 +1175,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String[] formDefinition) {
+    default String formInput(LtiToolSiteBean toolSiteBean, String[] formDefinition) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formInput(toolSiteMap, formDefinition);
     }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -555,15 +555,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * Bean overload: filter content using tool/content beans (delegates to Map version).
      * Obtains content map, filters in place, then persists filtered values back to the bean.
      */
-    default void filterContent(LtiContentBean content, LtiToolBean tool) {
-        if (content == null) {
-            return;
-        }
-        Map<String, Object> contentMap = content.asMap();
-        Map<String, Object> toolMap = (tool != null) ? tool.asMap() : null;
-        filterContent(contentMap, toolMap);
-        content.applyFromMap(contentMap);
-    }
+    void filterContent(LtiContentBean content, LtiToolBean tool);
 
     // These can be static and moved to the tool, or at least split off into a Foorm UI
 
@@ -592,9 +584,7 @@ public interface LTIService extends LTISubstitutionsFilter {
     /**
      * Bean overload: filter custom substitutions using tool bean (delegates to Map version).
      */
-    default void filterCustomSubstitutions(Properties properties, LtiToolBean tool, Site site) {
-        filterCustomSubstitutions(properties, tool != null ? tool.asMap() : null, site);
-    }
+    void filterCustomSubstitutions(Properties properties, LtiToolBean tool, Site site);
 
     List<Map<String, Object>> getToolSitesByToolId(String toolId, String siteId);
 

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -621,30 +621,13 @@ public interface LTIService extends LTISubstitutionsFilter {
     Element archiveContentByKey(Document doc, Long contentKey, String siteId);
 
     /**
-     * Extract a tool and content from an LTI content element in XML.
-     * Primary overload; populates the beans in place.
+     * Extract a tool and content from an LTI content element in XML
      *
      * @param  element  The sakai-lti-content tag
-     * @param  content  Bean to populate with content (may be null to skip)
-     * @param  tool  Bean to populate with nested tool (may be null to skip)
+     * @param  content  An empty map to return the content item
+     * @param  tool  An empty map to return the tool associated with content item
      */
-    void mergeContent(Element element, org.sakaiproject.lti.beans.LtiContentBean content, org.sakaiproject.lti.beans.LtiToolBean tool);
-
-    /**
-     * Extract a tool and content from an LTI content element in XML.
-     * Shims to bean overload; populates the maps.
-     */
-    default void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool) {
-        org.sakaiproject.lti.beans.LtiContentBean contentBean = new org.sakaiproject.lti.beans.LtiContentBean();
-        org.sakaiproject.lti.beans.LtiToolBean toolBean = new org.sakaiproject.lti.beans.LtiToolBean();
-        mergeContent(element, contentBean, toolBean);
-        if (content != null) {
-            content.putAll(contentBean.asMap());
-        }
-        if (tool != null) {
-            tool.putAll(toolBean.asMap());
-        }
-    }
+    void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool);
 
     /**
      * Import a content item and link it to an existing or new tool

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -21,7 +21,7 @@
 
 package org.sakaiproject.lti.api;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -746,6 +746,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
+        if (toolMaps == null) {
+            return Collections.emptyList();
+        }
         return toolMaps.stream()
                 .map(LtiToolBean::of)
                 .collect(Collectors.toList());
@@ -763,6 +766,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
+        if (toolMaps == null) {
+            return Collections.emptyList();
+        }
         return toolMaps.stream()
                 .map(LtiToolBean::of)
                 .collect(Collectors.toList());
@@ -781,6 +787,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed, includeLaunchable);
+        if (toolMaps == null) {
+            return Collections.emptyList();
+        }
         return toolMaps.stream()
                 .map(LtiToolBean::of)
                 .collect(Collectors.toList());
@@ -793,6 +802,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiToolBean> getToolsLaunchAsBeans(String siteId) {
         List<Map<String, Object>> toolMaps = getToolsLaunch(siteId);
+        if (toolMaps == null) {
+            return Collections.emptyList();
+        }
         return toolMaps.stream()
                 .map(LtiToolBean::of)
                 .collect(Collectors.toList());
@@ -803,13 +815,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<LtiToolBean> getToolsImportItemBeans(String siteId) {
+    default List<LtiToolBean> getToolsImportItemAsBeans(String siteId) {
         List<Map<String, Object>> toolMaps = getToolsImportItem(siteId);
-        List<LtiToolBean> toolBeans = new ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(LtiToolBean.of(toolMap));
+        if (toolMaps == null) {
+            return Collections.emptyList();
         }
-        return toolBeans;
+        return toolMaps.stream()
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -846,6 +859,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiContentBean> getContentsAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
+        if (contentMaps == null) {
+            return Collections.emptyList();
+        }
         return contentMaps.stream()
                 .map(LtiContentBean::of)
                 .collect(Collectors.toList());
@@ -862,11 +878,12 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> contentMaps = getContentsDao(search, order, first, last, siteId);
-        List<LtiContentBean> contentBeans = new ArrayList<>();
-        for (Map<String, Object> contentMap : contentMaps) {
-            contentBeans.add(LtiContentBean.of(contentMap));
+        if (contentMaps == null) {
+            return Collections.emptyList();
         }
-        return contentBeans;
+        return contentMaps.stream()
+                .map(LtiContentBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -881,11 +898,12 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId, boolean isAdminRole) {
         List<Map<String, Object>> contentMaps = getContentsDao(search, order, first, last, siteId, isAdminRole);
-        List<LtiContentBean> contentBeans = new ArrayList<>();
-        for (Map<String, Object> contentMap : contentMaps) {
-            contentBeans.add(LtiContentBean.of(contentMap));
+        if (contentMaps == null) {
+            return Collections.emptyList();
         }
-        return contentBeans;
+        return contentMaps.stream()
+                .map(LtiContentBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -913,6 +931,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiToolSiteBean> getToolSitesByToolIdAsBeans(String toolId, String siteId) {
         List<Map<String, Object>> toolSiteMaps = getToolSitesByToolId(toolId, siteId);
+        if (toolSiteMaps == null) {
+            return Collections.emptyList();
+        }
         return toolSiteMaps.stream()
                 .map(LtiToolSiteBean::of)
                 .collect(Collectors.toList());
@@ -940,6 +961,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      */
     default List<LtiMembershipsJobBean> getMembershipsJobsAsBeans() {
         List<Map<String, Object>> jobMaps = getMembershipsJobs();
+        if (jobMaps == null) {
+            return Collections.emptyList();
+        }
         return jobMaps.stream()
                 .map(LtiMembershipsJobBean::of)
                 .collect(Collectors.toList());

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiContentBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiContentBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -30,6 +34,10 @@ import lombok.ToString;
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Stack;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import org.sakaiproject.lti.api.LTIService;
 
@@ -43,42 +51,62 @@ import org.sakaiproject.lti.api.LTIService;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
 @ToString(exclude = {"placementsecret", "oldplacementsecret"})
-public class LtiContentBean extends LTIBaseBean {
+public class LtiContentBean extends FoormBaseBean {
 
-    // Core fields from CONTENT_MODEL
-    public Long id;                    // CONTENT_MODEL: "id:key:archive=true"
-    public Long toolId;                // CONTENT_MODEL: "tool_id:integer:hidden=true"
-    public String siteId;              // CONTENT_MODEL: "SITE_ID:text:label=bl_content_site_id:required=true:maxlength=99:role=admin"
-    public String title;               // CONTENT_MODEL: "title:text:label=bl_title:required=true:maxlength=1024:archive=true"
-    public String description;         // CONTENT_MODEL: "description:textarea:label=bl_description:maxlength=4096:archive=true"
-    public Integer frameheight;        // CONTENT_MODEL: "frameheight:integer:label=bl_frameheight:archive=true"
-    public Boolean newpage;            // CONTENT_MODEL: "newpage:checkbox:label=bl_newpage:archive=true"
-    public Boolean protect;            // CONTENT_MODEL: "protect:checkbox:label=bl_protect:role=admin"
-    public Boolean debug;              // CONTENT_MODEL: "debug:checkbox:label=bl_debug"
-    // LTI fields from CONTENT_MODEL
-    public String custom;              // CONTENT_MODEL: "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384:archive=true"
-    public String launch;              // CONTENT_MODEL: "launch:url:label=bl_launch:hidden=true:maxlength=1024:archive=true"
-    public String xmlimport;           // CONTENT_MODEL: "xmlimport:text:hidden=true:maxlength=1M"
-    public String settings;            // CONTENT_MODEL: "settings:text:hidden=true:maxlength=1M"
-    public String contentitem;         // CONTENT_MODEL: "contentitem:text:label=bl_contentitem:rows=5:cols=25:maxlength=1M:hidden=true:archive=true"
-    public String placement;           // CONTENT_MODEL: "placement:text:hidden=true:maxlength=256"
-    public String placementsecret;     // CONTENT_MODEL: "placementsecret:text:hidden=true:maxlength=512"
-    public String oldplacementsecret;  // CONTENT_MODEL: "oldplacementsecret:text:hidden=true:maxlength=512"
-    // Timestamps from CONTENT_MODEL
-    public Date createdAt;             // CONTENT_MODEL: "created_at:autodate"
-    public Date updatedAt;             // CONTENT_MODEL: "updated_at:autodate"
-
-    // Extra fields that can be populated from joins (CONTENT_EXTRA_FIELDS)
-    public String siteTitle;           // CONTENT_EXTRA_FIELDS: "SITE_TITLE:text:table=SAKAI_SITE:realname=TITLE"
-    public String siteContactName;     // CONTENT_EXTRA_FIELDS: "SITE_CONTACT_NAME:text:table=ssp1:realname=VALUE"
-    public String siteContactEmail;    // CONTENT_EXTRA_FIELDS: "SITE_CONTACT_EMAIL:text:table=ssp2:realname=VALUE"
-    public String attribution;         // CONTENT_EXTRA_FIELDS: "ATTRIBUTION:text:table=ssp3:realname=VALUE"
-    public String url;                 // CONTENT_EXTRA_FIELDS: "URL:text:table=ssp4:realname=VALUE"
-    public String searchUrl;           // CONTENT_EXTRA_FIELDS: "searchURL:text:table=ssp5:realname=VALUE"
+    @FoormField(value = "id", type = FoormType.KEY, archive = true)
+    public Long id;
+    @FoormField(value = "tool_id", type = FoormType.INTEGER, hidden = true)
+    public Long toolId;
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, label = "bl_content_site_id", required = true, maxlength = 99, role = "admin")
+    public String siteId;
+    @FoormField(value = "title", type = FoormType.TEXT, label = "bl_title", required = true, maxlength = 1024, archive = true)
+    public String title;
+    @FoormField(value = "description", type = FoormType.TEXTAREA, label = "bl_description", maxlength = 4096, archive = true)
+    public String description;
+    @FoormField(value = "frameheight", type = FoormType.INTEGER, label = "bl_frameheight", archive = true)
+    public Integer frameheight;
+    @FoormField(value = "newpage", type = FoormType.CHECKBOX, label = "bl_newpage", archive = true)
+    public Boolean newpage;
+    @FoormField(value = "protect", type = FoormType.CHECKBOX, label = "bl_protect", role = "admin")
+    public Boolean protect;
+    @FoormField(value = "debug", type = FoormType.CHECKBOX, label = "bl_debug")
+    public Boolean debug;
+    @FoormField(value = "custom", type = FoormType.TEXTAREA, label = "bl_custom", rows = 5, cols = 25, maxlength = 16384, archive = true)
+    public String custom;
+    @FoormField(value = "launch", type = FoormType.URL, label = "bl_launch", hidden = true, maxlength = 1024, archive = true)
+    public String launch;
+    @FoormField(value = "xmlimport", type = FoormType.TEXT, hidden = true)
+    public String xmlimport;
+    @FoormField(value = "settings", type = FoormType.TEXT, hidden = true)
+    public String settings;
+    @FoormField(value = "contentitem", type = FoormType.TEXTAREA, label = "bl_contentitem", rows = 5, cols = 25, hidden = true, archive = true)
+    public String contentitem;
+    @FoormField(value = "placement", type = FoormType.TEXT, hidden = true, maxlength = 256)
+    public String placement;
+    @FoormField(value = "placementsecret", type = FoormType.TEXT, hidden = true, maxlength = 512)
+    public String placementsecret;
+    @FoormField(value = "oldplacementsecret", type = FoormType.TEXT, hidden = true, maxlength = 512)
+    public String oldplacementsecret;
+    @FoormField(value = "created_at", type = FoormType.AUTODATE)
+    public Date createdAt;
+    @FoormField(value = "updated_at", type = FoormType.AUTODATE)
+    public Date updatedAt;
+    @FoormField(value = "SITE_TITLE", type = FoormType.TEXT)
+    public String siteTitle;
+    @FoormField(value = "SITE_CONTACT_NAME", type = FoormType.TEXT)
+    public String siteContactName;
+    @FoormField(value = "SITE_CONTACT_EMAIL", type = FoormType.TEXT)
+    public String siteContactEmail;
+    @FoormField(value = "ATTRIBUTION", type = FoormType.TEXT)
+    public String attribution;
+    @FoormField(value = "URL", type = FoormType.TEXT)
+    public String url;
+    @FoormField(value = "searchURL", type = FoormType.TEXT)
+    public String searchUrl;
 
     /**
      * Creates an LtiContentBean instance from a Map<String, Object>.
-     * 
+     *
      * @param map The map containing LTI content data
      * @return LtiContentBean instance populated from the map
      */
@@ -86,44 +114,46 @@ public class LtiContentBean extends LTIBaseBean {
         if (map == null) {
             return null;
         }
-        
         LtiContentBean content = new LtiContentBean();
-        
-        // Core fields
-        content.setId(getLongValue(map, LTIService.LTI_ID));
-        content.setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
-        content.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
-        content.setTitle(getStringValue(map, LTIService.LTI_TITLE));
-        content.setDescription(getStringValue(map, LTIService.LTI_DESCRIPTION));
-        content.setFrameheight(getIntegerValue(map, LTIService.LTI_FRAMEHEIGHT));
-        content.setNewpage(getBooleanValue(map, LTIService.LTI_NEWPAGE));
-        content.setProtect(getBooleanValue(map, LTIService.LTI_PROTECT));
-        content.setDebug(getBooleanValue(map, LTIService.LTI_DEBUG));
-        
-        // LTI fields
-        content.setCustom(getStringValue(map, LTIService.LTI_CUSTOM));
-        content.setLaunch(getStringValue(map, LTIService.LTI_LAUNCH));
-        content.setXmlimport(getStringValue(map, LTIService.LTI_XMLIMPORT));
-        content.setSettings(getStringValue(map, LTIService.LTI_SETTINGS));
-        content.setContentitem(getStringValue(map, "contentitem"));
-        content.setPlacement(getStringValue(map, "placement"));
-        content.setPlacementsecret(getStringValue(map, LTIService.LTI_PLACEMENTSECRET));
-        content.setOldplacementsecret(getStringValue(map, LTIService.LTI_OLDPLACEMENTSECRET));
-        
-        
-        // Timestamps
-        content.setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
-        content.setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
-        
-        // Extra fields from joins
-        content.setSiteTitle(getStringValue(map, "SITE_TITLE"));
-        content.setSiteContactName(getStringValue(map, "SITE_CONTACT_NAME"));
-        content.setSiteContactEmail(getStringValue(map, "SITE_CONTACT_EMAIL"));
-        content.setAttribution(getStringValue(map, "ATTRIBUTION"));
-        content.setUrl(getStringValue(map, "URL"));
-        content.setSearchUrl(getStringValue(map, "searchURL"));
-        
+        content.applyFromMap(map);
         return content;
+    }
+
+    /**
+     * Applies map values to this bean's fields. Used to persist filtered or
+     * mutated map data back into the bean (e.g. after filterContent).
+     *
+     * @param map The map containing LTI content data (null is a no-op)
+     */
+    public void applyFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return;
+        }
+        setId(getLongValue(map, LTIService.LTI_ID));
+        setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
+        setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
+        setTitle(getStringValue(map, LTIService.LTI_TITLE));
+        setDescription(getStringValue(map, LTIService.LTI_DESCRIPTION));
+        setFrameheight(getIntegerValue(map, LTIService.LTI_FRAMEHEIGHT));
+        setNewpage(getBooleanValue(map, LTIService.LTI_NEWPAGE));
+        setProtect(getBooleanValue(map, LTIService.LTI_PROTECT));
+        setDebug(getBooleanValue(map, LTIService.LTI_DEBUG));
+        setCustom(getStringValue(map, LTIService.LTI_CUSTOM));
+        setLaunch(getStringValue(map, LTIService.LTI_LAUNCH));
+        setXmlimport(getStringValue(map, LTIService.LTI_XMLIMPORT));
+        setSettings(getStringValue(map, LTIService.LTI_SETTINGS));
+        setContentitem(getStringValue(map, "contentitem"));
+        setPlacement(getStringValue(map, "placement"));
+        setPlacementsecret(getStringValue(map, LTIService.LTI_PLACEMENTSECRET));
+        setOldplacementsecret(getStringValue(map, LTIService.LTI_OLDPLACEMENTSECRET));
+        setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
+        setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
+        setSiteTitle(getStringValue(map, "SITE_TITLE"));
+        setSiteContactName(getStringValue(map, "SITE_CONTACT_NAME"));
+        setSiteContactEmail(getStringValue(map, "SITE_CONTACT_EMAIL"));
+        setAttribution(getStringValue(map, "ATTRIBUTION"));
+        setUrl(getStringValue(map, "URL"));
+        setSearchUrl(getStringValue(map, "searchURL"));
     }
 
     /**
@@ -169,6 +199,52 @@ public class LtiContentBean extends LTIBaseBean {
         putIfNotNull(map, "searchURL", searchUrl);
         
         return map;
+    }
+
+    /**
+     * Creates an LtiContentBean from an archive XML element.
+     * Uses the same format as {@link #toXml} (child elements per archivable field).
+     * For use in archive/import flows.
+     *
+     * @param element the sakai-lti-content element (or equivalent)
+     * @return new bean populated from the element, or null if element is null
+     */
+    public static LtiContentBean fromXml(Element element) {
+        if (element == null) {
+            return null;
+        }
+        LtiContentBean bean = new LtiContentBean();
+        bean.populateFromArchiveElement(element);
+        return bean;
+    }
+
+    /**
+     * Serializes this bean to an XML element in archive format.
+     * Uses the same structure as the existing archive process (child elements per archivable field).
+     * For use in archive/export flows.
+     *
+     * @param doc   the document to create elements in
+     * @param stack parent stack; if null or empty, the element is appended to doc; otherwise to stack.peek()
+     * @return the created element, or null if doc is null
+     */
+    public Element toXml(Document doc, Stack<Element> stack) {
+        if (doc == null) {
+            return null;
+        }
+        Element el = toArchiveElement(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG);
+        if (el == null) {
+            return null;
+        }
+        if (stack == null || stack.isEmpty()) {
+            doc.appendChild(el);
+        } else {
+            stack.peek().appendChild(el);
+        }
+        if (stack != null) {
+            stack.push(el);
+            stack.pop();
+        }
+        return el;
     }
 
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiMembershipsJobBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiMembershipsJobBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -42,14 +46,18 @@ import org.sakaiproject.lti.api.LTIService;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
 @ToString
-public class LtiMembershipsJobBean extends LTIBaseBean {
+public class LtiMembershipsJobBean extends FoormBaseBean {
 
-    // Fields from MEMBERSHIPS_JOBS_MODEL
-    public String siteId;              // MEMBERSHIPS_JOBS_MODEL: "SITE_ID:text:maxlength=99:required=true"
-    public String membershipsId;       // MEMBERSHIPS_JOBS_MODEL: "memberships_id:text:maxlength=256:required=true"
-    public String membershipsUrl;      // MEMBERSHIPS_JOBS_MODEL: "memberships_url:text:maxlength=4000:required=true"
-    public String consumerkey;         // MEMBERSHIPS_JOBS_MODEL: "consumerkey:text:label=bl_consumerkey:maxlength=1024"
-    public String ltiVersion;          // MEMBERSHIPS_JOBS_MODEL: "lti_version:text:maxlength=32:required=true"
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, maxlength = 99, required = true)
+    public String siteId;
+    @FoormField(value = "memberships_id", type = FoormType.TEXT, maxlength = 256, required = true)
+    public String membershipsId;
+    @FoormField(value = "memberships_url", type = FoormType.TEXT, maxlength = 4000, required = true)
+    public String membershipsUrl;
+    @FoormField(value = "consumerkey", type = FoormType.TEXT, label = "bl_consumerkey", maxlength = 1024)
+    public String consumerkey;
+    @FoormField(value = "lti_version", type = FoormType.TEXT, maxlength = 32, required = true)
+    public String ltiVersion;
 
     /**
      * Creates an LtiMembershipsJobBean instance from a Map<String, Object>.

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -30,94 +34,185 @@ import lombok.ToString;
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.Stack;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import org.sakaiproject.lti.api.LTIService;
 
 /**
  * Transfer object for LTI Tools.
  * Based on the TOOL_MODEL from LTIService.
+ * <p>
+ * Includes <em>non-persisted</em> fields that round-trip between bean and map in
+ * {@link #of(java.util.Map)} and {@link #asMap()} but are never stored: launch-flow fields
+ * ({@link #toolState}, {@link #platformState}, {@link #relaunchUrl}, {@link #origSiteIdNull}) and
+ * archive-only {@link #sakaiToolChecksum}.
+ * </p>
  */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
-@ToString(exclude = {"secret", "lti13AutoToken"})
-public class LtiToolBean extends LTIBaseBean {
+@ToString(exclude = {"secret", "lti13AutoToken", "toolState", "platformState", "relaunchUrl", "origSiteIdNull", "sakaiToolChecksum"})
+public class LtiToolBean extends FoormBaseBean {
 
-    // Core fields from TOOL_MODEL
-    public Long id;                    // TOOL_MODEL: "id:key:archive=true"
-    public String siteId;              // TOOL_MODEL: "SITE_ID:text:maxlength=99:role=admin"
-    public String title;               // TOOL_MODEL: "title:text:label=bl_title:required=true:maxlength=1024:archive=true"
-    public String description;         // TOOL_MODEL: "description:textarea:label=bl_description:maxlength=4096:archive=true"
-    public String status;              // TOOL_MODEL: "status:radio:label=bl_status:choices=enable,disable"
-    public String visible;             // TOOL_MODEL: "visible:radio:label=bl_visible:choices=visible,stealth:role=admin"
-    public Long deploymentId;          // TOOL_MODEL: "deployment_id:integer:hidden=true:archive=true"
-    public String launch;              // TOOL_MODEL: "launch:url:label=bl_launch:maxlength=1024:required=true:archive=true"
-    public Integer newpage;            // TOOL_MODEL: "newpage:radio:label=bl_newpage:choices=off,on,content:archive=true"
-    public Integer frameheight;        // TOOL_MODEL: "frameheight:integer:label=bl_frameheight:archive=true"
-    public String faIcon;              // TOOL_MODEL: "fa_icon:text:label=bl_fa_icon:maxlength=1024:archive=true"
+    @Override
+    protected Set<String> getExcludedArchiveFieldNames() {
+        return Set.of(LTIService.SAKAI_TOOL_CHECKSUM);
+    }
+
+    @FoormField(value = "id", type = FoormType.KEY, archive = true)
+    public Long id;
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, maxlength = 99, role = "admin")
+    public String siteId;
+    @FoormField(value = "title", type = FoormType.TEXT, label = "bl_title", required = true, maxlength = 1024, archive = true)
+    public String title;
+    @FoormField(value = "description", type = FoormType.TEXTAREA, label = "bl_description", maxlength = 4096, archive = true)
+    public String description;
+    @FoormField(value = "status", type = FoormType.RADIO, label = "bl_status", choices = {"enable", "disable"})
+    public String status;
+    @FoormField(value = "visible", type = FoormType.RADIO, label = "bl_visible", choices = {"visible", "stealth"}, role = "admin")
+    public String visible;
+    @FoormField(value = "deployment_id", type = FoormType.INTEGER, hidden = true, archive = true)
+    public Long deploymentId;
+    @FoormField(value = "launch", type = FoormType.URL, label = "bl_launch", maxlength = 1024, required = true, archive = true)
+    public String launch;
+    @FoormField(value = "newpage", type = FoormType.RADIO, label = "bl_newpage", choices = {"off", "on", "content"}, archive = true)
+    public Integer newpage;
+    @FoormField(value = "frameheight", type = FoormType.INTEGER, label = "bl_frameheight", archive = true)
+    public Integer frameheight;
+    @FoormField(value = "fa_icon", type = FoormType.TEXT, label = "bl_fa_icon", maxlength = 1024, archive = true)
+    public String faIcon;
     
-    // Message Types (pl_ prefix for backwards compatibility) from TOOL_MODEL
-    public Boolean plLaunch;           // TOOL_MODEL: "pl_launch:checkbox:label=bl_pl_launch:archive=true"
-    public Boolean plLinkselection;    // TOOL_MODEL: "pl_linkselection:checkbox:label=bl_pl_linkselection:archive=true"
-    public Boolean plContextlaunch;    // TOOL_MODEL: "pl_contextlaunch:checkbox:label=bl_pl_contextlaunch:hidden=true"
+    @FoormField(value = "pl_launch", type = FoormType.CHECKBOX, label = "bl_pl_launch", archive = true)
+    public Boolean plLaunch;
+    @FoormField(value = "pl_linkselection", type = FoormType.CHECKBOX, label = "bl_pl_linkselection", archive = true)
+    public Boolean plLinkselection;
+    @FoormField(value = "pl_contextlaunch", type = FoormType.CHECKBOX, label = "bl_pl_contextlaunch", hidden = true)
+    public Boolean plContextlaunch;
+
+    @FoormField(value = "pl_lessonsselection", type = FoormType.CHECKBOX, label = "bl_pl_lessonsselection", archive = true)
+    public Boolean plLessonsselection;
+    @FoormField(value = "pl_contenteditor", type = FoormType.CHECKBOX, label = "bl_pl_contenteditor", archive = true)
+    public Boolean plContenteditor;
+    @FoormField(value = "pl_assessmentselection", type = FoormType.CHECKBOX, label = "bl_pl_assessmentselection", archive = true)
+    public Boolean plAssessmentselection;
+    @FoormField(value = "pl_coursenav", type = FoormType.CHECKBOX, label = "bl_pl_coursenav", archive = true)
+    public Boolean plCoursenav;
+    @FoormField(value = "pl_importitem", type = FoormType.CHECKBOX, label = "bl_pl_importitem", role = "admin", archive = true)
+    public Boolean plImportitem;
+    @FoormField(value = "pl_fileitem", type = FoormType.CHECKBOX, label = "bl_pl_fileitem", role = "admin", hidden = true, archive = true)
+    public Boolean plFileitem;
     
-    // Placements from TOOL_MODEL
-    public Boolean plLessonsselection;     // TOOL_MODEL: "pl_lessonsselection:checkbox:label=bl_pl_lessonsselection:archive=true"
-    public Boolean plContenteditor;        // TOOL_MODEL: "pl_contenteditor:checkbox:label=bl_pl_contenteditor:archive=true"
-    public Boolean plAssessmentselection;  // TOOL_MODEL: "pl_assessmentselection:checkbox:label=bl_pl_assessmentselection:archive=true"
-    public Boolean plCoursenav;            // TOOL_MODEL: "pl_coursenav:checkbox:label=bl_pl_coursenav:archive=true"
-    public Boolean plImportitem;           // TOOL_MODEL: "pl_importitem:checkbox:label=bl_pl_importitem:role=admin:archive=true"
-    public Boolean plFileitem;             // TOOL_MODEL: "pl_fileitem:checkbox:label=bl_pl_fileitem:role=admin:hidden=true:archive=true"
+    @FoormField(value = "sendname", type = FoormType.CHECKBOX, label = "bl_sendname", archive = true)
+    public Boolean sendname;
+    @FoormField(value = "sendemailaddr", type = FoormType.CHECKBOX, label = "bl_sendemailaddr", archive = true)
+    public Boolean sendemailaddr;
+    @FoormField(value = "pl_privacy", type = FoormType.CHECKBOX, label = "bl_pl_privacy", role = "admin")
+    public Boolean plPrivacy;
+
+    @FoormField(value = "allowoutcomes", type = FoormType.CHECKBOX, label = "bl_allowoutcomes", archive = true)
+    public Boolean allowoutcomes;
+    @FoormField(value = "allowlineitems", type = FoormType.CHECKBOX, label = "bl_allowlineitems", archive = true)
+    public Boolean allowlineitems;
+    @FoormField(value = "allowroster", type = FoormType.CHECKBOX, label = "bl_allowroster", archive = true)
+    public Boolean allowroster;
     
-    // Privacy from TOOL_MODEL
-    public Boolean sendname;           // TOOL_MODEL: "sendname:checkbox:label=bl_sendname:archive=true"
-    public Boolean sendemailaddr;      // TOOL_MODEL: "sendemailaddr:checkbox:label=bl_sendemailaddr:archive=true"
-    public Boolean plPrivacy;          // TOOL_MODEL: "pl_privacy:checkbox:label=bl_pl_privacy:role=admin"
+    @FoormField(value = "debug", type = FoormType.RADIO, label = "bl_debug", choices = {"off", "on", "content"})
+    public Integer debug;
+    @FoormField(value = "siteinfoconfig", type = FoormType.RADIO, label = "bl_siteinfoconfig", advanced = true, choices = {"bypass", "config"})
+    public String siteinfoconfig;
+    @FoormField(value = "splash", type = FoormType.TEXTAREA, label = "bl_splash", rows = 5, cols = 25, maxlength = 16384)
+    public String splash;
+    @FoormField(value = "custom", type = FoormType.TEXTAREA, label = "bl_custom", rows = 5, cols = 25, maxlength = 16384, archive = true)
+    public String custom;
+    @FoormField(value = "rolemap", type = FoormType.TEXTAREA, label = "bl_rolemap", rows = 5, cols = 25, maxlength = 16384, role = "admin", archive = true)
+    public String rolemap;
+    @FoormField(value = "lti13", type = FoormType.RADIO, label = "bl_lti13", choices = {"off", "on", "both"}, role = "admin", archive = true)
+    public Integer lti13;
     
-    // Services from TOOL_MODEL
-    public Boolean allowoutcomes;      // TOOL_MODEL: "allowoutcomes:checkbox:label=bl_allowoutcomes:archive=true"
-    public Boolean allowlineitems;     // TOOL_MODEL: "allowlineitems:checkbox:label=bl_allowlineitems:archive=true"
-    public Boolean allowroster;        // TOOL_MODEL: "allowroster:checkbox:label=bl_allowroster:archive=true"
+    @FoormField(value = "lti13_tool_keyset", type = FoormType.TEXT, label = "bl_lti13_tool_keyset", maxlength = 1024, role = "admin")
+    public String lti13ToolKeyset;
+    @FoormField(value = "lti13_oidc_endpoint", type = FoormType.TEXT, label = "bl_lti13_oidc_endpoint", maxlength = 1024, role = "admin")
+    public String lti13OidcEndpoint;
+    @FoormField(value = "lti13_oidc_redirect", type = FoormType.TEXT, label = "bl_lti13_oidc_redirect", maxlength = 1024, role = "admin")
+    public String lti13OidcRedirect;
+
+    @FoormField(value = "lti13_lms_issuer", type = FoormType.TEXT, label = "bl_lti13_lms_issuer", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsIssuer;
+    @FoormField(value = "lti13_client_id", type = FoormType.TEXT, label = "bl_lti13_client_id", readonly = true, maxlength = 1024, role = "admin")
+    public String lti13ClientId;
+    @FoormField(value = "lti13_lms_deployment_id", type = FoormType.TEXT, label = "bl_lti13_lms_deployment_id", readonly = true, maxlength = 1024, role = "admin")
+    public String lti13LmsDeploymentId;
+    @FoormField(value = "lti13_lms_keyset", type = FoormType.TEXT, label = "bl_lti13_lms_keyset", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsKeyset;
+    @FoormField(value = "lti13_lms_endpoint", type = FoormType.TEXT, label = "bl_lti13_lms_endpoint", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsEndpoint;
+    @FoormField(value = "lti13_lms_token", type = FoormType.TEXT, label = "bl_lti13_lms_token", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsToken;
     
-    // Configuration fields from TOOL_MODEL
-    public Integer debug;              // TOOL_MODEL: "debug:radio:label=bl_debug:choices=off,on,content"
-    public String siteinfoconfig;      // TOOL_MODEL: "siteinfoconfig:radio:label=bl_siteinfoconfig:advanced:choices=bypass,config"
-    public String splash;              // TOOL_MODEL: "splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384"
-    public String custom;              // TOOL_MODEL: "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384:archive=true"
-    public String rolemap;             // TOOL_MODEL: "rolemap:textarea:label=bl_rolemap:rows=5:cols=25:maxlength=16384:role=admin:archive=true"
-    public Integer lti13;              // TOOL_MODEL: "lti13:radio:label=bl_lti13:choices=off,on,both:role=admin:archive=true"
-    
-    // LTI 1.3 security values from the tool from TOOL_MODEL
-    public String lti13ToolKeyset;     // TOOL_MODEL: "lti13_tool_keyset:text:label=bl_lti13_tool_keyset:maxlength=1024:role=admin"
-    public String lti13OidcEndpoint;   // TOOL_MODEL: "lti13_oidc_endpoint:text:label=bl_lti13_oidc_endpoint:maxlength=1024:role=admin"
-    public String lti13OidcRedirect;   // TOOL_MODEL: "lti13_oidc_redirect:text:label=bl_lti13_oidc_redirect:maxlength=1024:role=admin"
-    
-    // LTI 1.3 security values from the LMS from TOOL_MODEL
-    public String lti13LmsIssuer;      // TOOL_MODEL: "lti13_lms_issuer:text:label=bl_lti13_lms_issuer:readonly=true:persist=false:maxlength=1024:role=admin"
-    public String lti13ClientId;       // TOOL_MODEL: "lti13_client_id:text:label=bl_lti13_client_id:readonly=true:maxlength=1024:role=admin"
-    public String lti13LmsDeploymentId; // TOOL_MODEL: "lti13_lms_deployment_id:text:label=bl_lti13_lms_deployment_id:readonly=true:maxlength=1024:role=admin"
-    public String lti13LmsKeyset;      // TOOL_MODEL: "lti13_lms_keyset:text:label=bl_lti13_lms_keyset:readonly=true:persist=false:maxlength=1024:role=admin"
-    public String lti13LmsEndpoint;    // TOOL_MODEL: "lti13_lms_endpoint:text:label=bl_lti13_lms_endpoint:readonly=true:persist=false:maxlength=1024:role=admin"
-    public String lti13LmsToken;       // TOOL_MODEL: "lti13_lms_token:text:label=bl_lti13_lms_token:readonly=true:persist=false:maxlength=1024:role=admin"
-    
-    // LTI 1.1 security arrangement from TOOL_MODEL
-    public String consumerkey;         // TOOL_MODEL: "consumerkey:text:label=bl_consumerkey:maxlength=1024"
-    public String secret;              // TOOL_MODEL: "secret:text:label=bl_secret:maxlength=1024"
-    public String xmlimport;           // TOOL_MODEL: "xmlimport:textarea:hidden=true:maxlength=1M"
-    public String lti13AutoToken;      // TOOL_MODEL: "lti13_auto_token:text:hidden=true:maxlength=1024"
-    public Integer lti13AutoState;     // TOOL_MODEL: "lti13_auto_state:integer:hidden=true"
-    public String lti13AutoRegistration; // TOOL_MODEL: "lti13_auto_registration:textarea:hidden=true:maxlength=1M"
-    public String sakaiToolChecksum;   // TOOL_MODEL: "sakai_tool_checksum:text:maxlength=99:hidden=true:persist=false:archive=true"
-    
-    // Timestamps from TOOL_MODEL
-    public Date createdAt;             // TOOL_MODEL: "created_at:autodate"
-    public Date updatedAt;             // TOOL_MODEL: "updated_at:autodate"
-    
-    // Live attributes - computed fields that may be present in Map data
-    public Long ltiContentCount;       // Live attribute: "lti_content_count" from database joins
-    public Long ltiSiteCount;          // Live attribute: "lti_site_count" from database joins
+    @FoormField(value = "consumerkey", type = FoormType.TEXT, label = "bl_consumerkey", maxlength = 1024)
+    public String consumerkey;
+    @FoormField(value = "secret", type = FoormType.TEXT, label = "bl_secret", maxlength = 1024)
+    public String secret;
+    @FoormField(value = "xmlimport", type = FoormType.TEXTAREA, hidden = true)
+    public String xmlimport;
+    @FoormField(value = "lti13_auto_token", type = FoormType.TEXT, hidden = true, maxlength = 1024)
+    public String lti13AutoToken;
+    @FoormField(value = "lti13_auto_state", type = FoormType.INTEGER, hidden = true)
+    public Integer lti13AutoState;
+    @FoormField(value = "lti13_auto_registration", type = FoormType.TEXTAREA, hidden = true)
+    public String lti13AutoRegistration;
+
+    @FoormField(value = "created_at", type = FoormType.AUTODATE)
+    public Date createdAt;
+    @FoormField(value = "updated_at", type = FoormType.AUTODATE)
+    public Date updatedAt;
+
+    @FoormField(value = "lti_content_count", type = FoormType.INTEGER)
+    public Long ltiContentCount;
+    @FoormField(value = "lti_site_count", type = FoormType.INTEGER)
+    public Long ltiSiteCount;
+
+    /**
+     * Launch-flow only fields.
+     * <p>
+     * These fields are <strong>not persisted</strong> to the tool record. They round-trip between
+     * bean and map in {@link #of(java.util.Map)} and {@link #asMap()}, but are never stored in the
+     * database. They are used only during the launch request/response flow. The platform may
+     * receive them as request parameters (e.g. when building a Content Item or LTI 1.1 launch URL)
+     * and should pass them through so they can be sent back to the tool in the launch payload,
+     * allowing the tool to restore context or continue a flow.
+     * </p>
+     * <ul>
+     *   <li><strong>toolState</strong> – Opaque value set by the tool (e.g. in a Content Item
+     *       request) and returned in the launch so the tool can resume state.</li>
+     *   <li><strong>platformState</strong> – Opaque value set by the platform and returned in the
+     *       launch for platform-specific state.</li>
+     *   <li><strong>relaunchUrl</strong> – URL the platform may use for a "relaunch" or "open in new
+     *       window" action; returned in the launch so the tool can offer a consistent relaunch
+     *       link.</li>
+     *   <li><strong>origSiteIdNull</strong> – Internal: set to {@code "true"} when the tool’s
+     *       stored site id was null before the launch context was applied; used by the LTI 1.3
+     *       OIDC redirect flow.</li>
+     *   <li><strong>sakaiToolChecksum</strong> – Computed checksum for tool import/export archives;
+     *       round-trips in {@link #asMap()} and {@link #of(java.util.Map)} but is never stored.</li>
+     * </ul>
+     */
+    @FoormField(value = "tool_state", type = FoormType.TEXT, persist = false)
+    public String toolState;
+    @FoormField(value = "platform_state", type = FoormType.TEXT, persist = false)
+    public String platformState;
+    @FoormField(value = "relaunch_url", type = FoormType.TEXT, persist = false)
+    public String relaunchUrl;
+    @FoormField(value = "orig_site_id_null", type = FoormType.TEXT, persist = false)
+    public String origSiteIdNull;
+    @FoormField(value = "sakai_tool_checksum", type = FoormType.TEXT, maxlength = 99, hidden = true, persist = false, archive = true)
+    public String sakaiToolChecksum;
 
     /**
      * Creates an LtiToolBean instance from a Map<String, Object>.
@@ -206,6 +301,12 @@ public class LtiToolBean extends LTIBaseBean {
         tool.setLtiContentCount(getLongValue(map, "lti_content_count"));
         tool.setLtiSiteCount(getLongValue(map, "lti_site_count"));
         
+        // Launch-flow only (not persisted)
+        tool.setToolState(getStringValue(map, "tool_state"));
+        tool.setPlatformState(getStringValue(map, "platform_state"));
+        tool.setRelaunchUrl(getStringValue(map, "relaunch_url"));
+        tool.setOrigSiteIdNull(getStringValue(map, "orig_site_id_null"));
+        
         return tool;
     }
 
@@ -281,7 +382,6 @@ public class LtiToolBean extends LTIBaseBean {
         putIfNotNull(map, "lti13_auto_token", lti13AutoToken);
         putIfNotNull(map, "lti13_auto_state", lti13AutoState);
         putIfNotNull(map, "lti13_auto_registration", lti13AutoRegistration);
-        putIfNotNull(map, "sakai_tool_checksum", sakaiToolChecksum);
         
         // Timestamps
         putIfNotNull(map, LTIService.LTI_CREATED_AT, createdAt);
@@ -291,7 +391,61 @@ public class LtiToolBean extends LTIBaseBean {
         putIfNotNull(map, "lti_content_count", ltiContentCount);
         putIfNotNull(map, "lti_site_count", ltiSiteCount);
         
+        // Non-persisted
+        putIfNotNull(map, "tool_state", toolState);
+        putIfNotNull(map, "platform_state", platformState);
+        putIfNotNull(map, "relaunch_url", relaunchUrl);
+        putIfNotNull(map, "orig_site_id_null", origSiteIdNull);
+        putIfNotNull(map, "sakai_tool_checksum", sakaiToolChecksum);
+        
         return map;
+    }
+
+    /**
+     * Creates an LtiToolBean from an archive XML element.
+     * Uses the same format as {@link #toXml} (child elements per archivable field).
+     * For use in archive/import flows.
+     *
+     * @param element the sakai-lti-tool element (or equivalent)
+     * @return new bean populated from the element, or null if element is null
+     */
+    public static LtiToolBean fromXml(Element element) {
+        if (element == null) {
+            return null;
+        }
+        LtiToolBean bean = new LtiToolBean();
+        bean.populateFromArchiveElement(element);
+        return bean;
+    }
+
+    /**
+     * Serializes this bean to an XML element in archive format.
+     * Uses the same structure as the existing archive process (child elements per archivable field).
+     * For use in archive/export flows. The checksum is not included; add it separately if needed
+     * (e.g. via SakaiLTIUtil.archiveToolBean).
+     *
+     * @param doc   the document to create elements in
+     * @param stack parent stack; if null or empty, the element is appended to doc; otherwise to stack.peek()
+     * @return the created element, or null if doc is null
+     */
+    public Element toXml(Document doc, Stack<Element> stack) {
+        if (doc == null) {
+            return null;
+        }
+        Element el = toArchiveElement(doc, LTIService.ARCHIVE_LTI_TOOL_TAG);
+        if (el == null) {
+            return null;
+        }
+        if (stack == null || stack.isEmpty()) {
+            doc.appendChild(el);
+        } else {
+            stack.peek().appendChild(el);
+        }
+        if (stack != null) {
+            stack.push(el);
+            stack.pop();
+        }
+        return el;
     }
 
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -39,15 +43,20 @@ import org.sakaiproject.lti.api.LTIService;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
-public class LtiToolSiteBean extends LTIBaseBean {
+public class LtiToolSiteBean extends FoormBaseBean {
 
-    // Fields from TOOL_SITE_MODEL
-    public Long id;                    // TOOL_SITE_MODEL: "id:key"
-    public Long toolId;                // TOOL_SITE_MODEL: "tool_id:integer:hidden=true"
-    public String siteId;              // TOOL_SITE_MODEL: "SITE_ID:text:label=bl_tool_site_SITE_ID:required=true:maxlength=99:role=admin"
-    public String notes;               // TOOL_SITE_MODEL: "notes:text:label=bl_tool_site_notes:maxlength=1024"
-    public Date createdAt;             // TOOL_SITE_MODEL: "created_at:autodate"
-    public Date updatedAt;             // TOOL_SITE_MODEL: "updated_at:autodate"
+    @FoormField(value = "id", type = FoormType.KEY)
+    public Long id;
+    @FoormField(value = "tool_id", type = FoormType.INTEGER, hidden = true)
+    public Long toolId;
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, label = "bl_tool_site_SITE_ID", required = true, maxlength = 99, role = "admin")
+    public String siteId;
+    @FoormField(value = "notes", type = FoormType.TEXT, label = "bl_tool_site_notes", maxlength = 1024)
+    public String notes;
+    @FoormField(value = "created_at", type = FoormType.AUTODATE)
+    public Date createdAt;
+    @FoormField(value = "updated_at", type = FoormType.AUTODATE)
+    public Date updatedAt;
 
     /**
      * Creates an LtiToolSiteBean instance from a Map<String, Object>.

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormBaseBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormBaseBean.java
@@ -18,24 +18,32 @@
  * permissions and limitations under the License.
  */
 
-package org.sakaiproject.lti.beans;
+package org.sakaiproject.lti.foorm;
 
+import java.lang.reflect.Field;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Base class providing common type conversion utilities for LTI Beans.
- * These methods handle the robust conversion of Object types from database results
- * to strongly-typed Bean fields, similar to the LTIUtil conversion methods.
- *
- * Implementation assistance provided by Claude AI for comprehensive type conversion
- * and robust database number handling across SQLite, Oracle, and MySQL systems.
+ * Base class for beans with {@link FoormField} annotations and type conversion utilities.
+ * Provides robust conversion of Object types from database results to strongly-typed fields,
+ * and reflection-based access by canonical field name for Foorm-annotated subclasses.
+ * <p>
+ * Named in homage to the someday long-gone Foorm code.
  */
 @Slf4j
-public abstract class LTIBaseBean {
+public abstract class FoormBaseBean {
 
     /**
      * Safely converts a map value to a String.
@@ -308,5 +316,196 @@ public abstract class LTIBaseBean {
         if (value != null) {
             map.put(key, value ? Integer.valueOf(1) : Integer.valueOf(0));
         }
+    }
+
+    // --- FoormField reflection (for archive, etc.) ---
+
+    private static final Map<Class<?>, Map<String, Field>> FIELDS_CACHE = new ConcurrentHashMap<>();
+
+    protected static Map<String, Field> getFieldsForClass(Class<?> clazz) {
+        return FIELDS_CACHE.computeIfAbsent(clazz, c -> {
+            Map<String, Field> map = new ConcurrentHashMap<>();
+            for (Field f : c.getDeclaredFields()) {
+                FoormField ann = f.getAnnotation(FoormField.class);
+                if (ann != null) {
+                    f.setAccessible(true);
+                    map.put(ann.value(), f);
+                }
+            }
+            return map;
+        });
+    }
+
+    /**
+     * Returns the value of the property identified by its canonical field name.
+     *
+     * @param fieldName Canonical name from {@link FoormField} (e.g. {@code deployment_id}, {@code SITE_ID})
+     * @return The property value, or null if the field is unknown or its value is null
+     */
+    public Object getValueByFieldName(String fieldName) {
+        Field f = getFieldsForClass(getClass()).get(fieldName);
+        if (f == null) {
+            return null;
+        }
+        try {
+            return f.get(this);
+        } catch (IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the {@link FoormField} annotation for a field name, or null if unknown.
+     */
+    public FoormField getFoormFieldByFieldName(String fieldName) {
+        Field f = getFieldsForClass(getClass()).get(fieldName);
+        return f != null ? f.getAnnotation(FoormField.class) : null;
+    }
+
+    /**
+     * Field names to omit from archive output. Override in subclasses (e.g. to exclude
+     * computed fields like checksum that are appended separately).
+     */
+    protected Set<String> getExcludedArchiveFieldNames() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Produces an archive XML element for this bean. Iterates over fields with
+     * {@link FoormField#archive()}{@code == true}, excluding any in
+     * {@link #getExcludedArchiveFieldNames()}, and appends child elements.
+     *
+     * @param doc     The document to create elements in
+     * @param tagName Root element tag name (e.g. {@code sakai-lti-tool})
+     * @return The root element with archivable fields as children, or null if doc is null
+     */
+    public Element toArchiveElement(Document doc, String tagName) {
+        if (doc == null) {
+            return null;
+        }
+        Set<String> excluded = getExcludedArchiveFieldNames();
+        Element root = doc.createElement(tagName);
+        for (Field f : getClass().getDeclaredFields()) {
+            FoormField ann = f.getAnnotation(FoormField.class);
+            if (ann == null || !ann.archive() || excluded.contains(ann.value())) {
+                continue;
+            }
+            String field = ann.value();
+            Object o = getValueByFieldName(field);
+            if (o == null) {
+                continue;
+            }
+            String text = formatArchiveValue(o, ann.type());
+            if (text == null) {
+                continue;
+            }
+            Element child = doc.createElement(field);
+            child.setTextContent(text);
+            root.appendChild(child);
+        }
+        return root;
+    }
+
+    /**
+     * Formats a value for archive XML based on its FoormType.
+     */
+    protected static String formatArchiveValue(Object o, FoormType type) {
+        if (o == null) {
+            return null;
+        }
+        if (type == FoormType.CHECKBOX
+                || type == FoormType.RADIO
+                || type == FoormType.INTEGER
+                || type == FoormType.KEY) {
+            if (o instanceof Boolean) {
+                return Boolean.TRUE.equals(o) ? "1" : "0";
+            }
+        }
+        if (o instanceof Date) {
+            return String.valueOf(((Date) o).getTime());
+        }
+        return o.toString();
+    }
+
+    /**
+     * Populates this bean from an archive XML element. Iterates over child elements,
+     * and for each tag name matching an archivable {@link FoormField}, parses the
+     * text content and sets the corresponding field. Skips fields in
+     * {@link #getExcludedArchiveFieldNames()} (same filter as export) and children
+     * that are not archivable (e.g. nested {@code sakai-lti-tool}).
+     *
+     * @param element The archive element (e.g. {@code sakai-lti-tool}) containing children
+     */
+    public void populateFromArchiveElement(Element element) {
+        if (element == null) {
+            return;
+        }
+        Map<String, Field> fieldsByName = getFieldsForClass(getClass());
+        NodeList children = element.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = children.item(i);
+            if (n.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element child = (Element) n;
+            String tagName = child.getTagName();
+            Field f = fieldsByName.get(tagName);
+            if (f == null) {
+                continue;
+            }
+            FoormField ann = f.getAnnotation(FoormField.class);
+            if (ann == null || !ann.archive()) {
+                continue;
+            }
+            if (getExcludedArchiveFieldNames().contains(tagName)) {
+                continue;
+            }
+            String text = child.getTextContent();
+            if (text == null || text.isEmpty()) {
+                continue;
+            }
+            Object value = parseArchiveValue(text.trim(), f);
+            if (value == null) {
+                continue;
+            }
+            try {
+                f.set(this, value);
+            } catch (IllegalAccessException e) {
+                log.debug("Could not set field {}: {}", tagName, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Parses archive XML text content into the correct type for the given field.
+     */
+    protected static Object parseArchiveValue(String text, Field f) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        Class<?> type = f.getType();
+        try {
+            if (type == Boolean.class || type == boolean.class) {
+                return "1".equals(text) || "true".equalsIgnoreCase(text) || "yes".equalsIgnoreCase(text);
+            }
+            if (type == Integer.class || type == int.class) {
+                if (text.contains(".")) {
+                    return Integer.valueOf((int) Double.parseDouble(text));
+                }
+                return Integer.valueOf(text);
+            }
+            if (type == Long.class || type == long.class) {
+                if (text.contains(".")) {
+                    return Long.valueOf((long) Double.parseDouble(text));
+                }
+                return Long.valueOf(text);
+            }
+            if (type == Date.class) {
+                return new Date(Long.parseLong(text));
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        return text;
     }
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormBaseBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormBaseBean.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.w3c.dom.Document;
+import org.w3c.dom.DOMException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -399,7 +400,14 @@ public abstract class FoormBaseBean {
             if (text == null) {
                 continue;
             }
-            Element child = doc.createElement(field);
+            Element child;
+            try {
+                child = doc.createElement(field);
+            } catch (DOMException | IllegalArgumentException e) {
+                log.error("Skipping archive field '{}' due to invalid XML element name in {}: {}",
+                        field, getClass().getName(), e.getMessage(), e);
+                continue;
+            }
             child.setTextContent(text);
             root.appendChild(child);
         }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormField.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormField.java
@@ -1,0 +1,82 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.lti.foorm;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declarative field metadata for form generation, validation, archive, and persistence.
+ * <p>
+ * Replaces the Foorm model string format with strongly typed attributes.
+ * Multi-valued attributes like {@link #choices()} and {@link #fields()} use arrays to preserve order.
+ * </p>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FoormField {
+	/** Canonical field name (archive XML element, DB column). */
+	String value();
+
+	/** Field type. */
+	FoormType type() default FoormType.TEXT;
+
+	/** Label key for UI. */
+	String label() default "";
+
+	/** Whether the field is required. */
+	boolean required() default false;
+
+	/** Max length (0 = no limit). */
+	int maxlength() default 0;
+
+	/** Whether the field is included in archive XML. */
+	boolean archive() default false;
+
+	/** Whether the field is hidden in forms. */
+	boolean hidden() default false;
+
+	/** Role required to edit (e.g. "admin"). */
+	String role() default "";
+
+	/** Whether the field is read-only. */
+	boolean readonly() default false;
+
+	/** Whether the field is persisted (false for computed/transient). */
+	boolean persist() default true;
+
+	/** For radio: ordered choices. */
+	String[] choices() default {};
+
+	/** For header: ordered child field names. */
+	String[] fields() default {};
+
+	/** For textarea: rows. */
+	int rows() default 0;
+
+	/** For textarea: cols. */
+	int cols() default 0;
+
+	/** Whether shown in advanced section. */
+	boolean advanced() default false;
+}

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormType.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormType.java
@@ -1,0 +1,36 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.lti.foorm;
+
+/**
+ * Foorm field type for form generation, validation, archive, and persistence.
+ */
+public enum FoormType {
+	KEY,
+	TEXT,
+	TEXTAREA,
+	CHECKBOX,
+	RADIO,
+	INTEGER,
+	URL,
+	AUTODATE,
+	HEADER
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/foorm/FoormBaseBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/foorm/FoormBaseBeanTest.java
@@ -1,0 +1,358 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.lti.foorm;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Unit tests for FoormBaseBean reflection, archive, and type handling.
+ */
+public class FoormBaseBeanTest {
+
+    private Date testDate;
+
+    /**
+     * Minimal FoormBaseBean subclass for testing reflection and archive behavior.
+     */
+    public static class MinimalFoormBean extends FoormBaseBean {
+        @FoormField(value = "id", type = FoormType.KEY, archive = true)
+        public Long id;
+        @FoormField(value = "title", type = FoormType.TEXT, archive = true)
+        public String title;
+        @FoormField(value = "count", type = FoormType.INTEGER, archive = true)
+        public Integer count;
+        @FoormField(value = "active", type = FoormType.CHECKBOX, archive = true)
+        public Boolean active;
+        @FoormField(value = "state", type = FoormType.RADIO, archive = true)
+        public Integer state;
+        @FoormField(value = "created", type = FoormType.AUTODATE, archive = true)
+        public Date created;
+        @FoormField(value = "notes", type = FoormType.TEXT)
+        public String notes;
+    }
+
+    /**
+     * Bean that overrides getExcludedArchiveFieldNames to exclude a field.
+     */
+    public static class BeanWithExclusion extends FoormBaseBean {
+        @FoormField(value = "id", type = FoormType.KEY, archive = true)
+        public Long id;
+        @FoormField(value = "secret", type = FoormType.TEXT, archive = true)
+        public String secret;
+
+        @Override
+        protected Set<String> getExcludedArchiveFieldNames() {
+            return Set.of("secret");
+        }
+    }
+
+    @Before
+    public void setUp() {
+        testDate = new Date();
+    }
+
+    // --- getValueByFieldName / getFoormFieldByFieldName ---
+
+    @Test
+    public void testGetValueByFieldName() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 42L;
+        bean.title = "Test Title";
+        bean.count = 99;
+        bean.active = true;
+        bean.notes = "not archived";
+
+        assertEquals(Long.valueOf(42L), bean.getValueByFieldName("id"));
+        assertEquals("Test Title", bean.getValueByFieldName("title"));
+        assertEquals(Integer.valueOf(99), bean.getValueByFieldName("count"));
+        assertEquals(Boolean.TRUE, bean.getValueByFieldName("active"));
+        assertEquals("not archived", bean.getValueByFieldName("notes"));
+    }
+
+    @Test
+    public void testGetValueByFieldNameUnknownField() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        assertNull(bean.getValueByFieldName("unknown_field"));
+    }
+
+    @Test
+    public void testGetValueByFieldNameNullValue() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        assertNull(bean.getValueByFieldName("id"));
+        assertNull(bean.getValueByFieldName("title"));
+    }
+
+    @Test
+    public void testGetFoormFieldByFieldName() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        FoormField idField = bean.getFoormFieldByFieldName("id");
+        assertNotNull(idField);
+        assertEquals("id", idField.value());
+        assertEquals(FoormType.KEY, idField.type());
+        assertTrue(idField.archive());
+
+        FoormField notesField = bean.getFoormFieldByFieldName("notes");
+        assertNotNull(notesField);
+        assertEquals("notes", notesField.value());
+        assertFalse(notesField.archive());
+    }
+
+    @Test
+    public void testGetFoormFieldByFieldNameUnknown() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        assertNull(bean.getFoormFieldByFieldName("nonexistent"));
+    }
+
+    // --- toArchiveElement ---
+
+    @Test
+    public void testToArchiveElementNullDocument() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        bean.title = "x";
+        assertNull(bean.toArchiveElement(null, "root"));
+    }
+
+    @Test
+    public void testToArchiveElementOnlyArchivableFields() throws ParserConfigurationException {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 123L;
+        bean.title = "Archive Me";
+        bean.count = 7;
+        bean.active = true;
+        bean.state = 1;
+        bean.created = testDate;
+        bean.notes = "should not appear";
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = bean.toArchiveElement(doc, "test-bean");
+
+        assertNotNull(root);
+        assertEquals("test-bean", root.getTagName());
+
+        Map<String, String> children = getChildElementsAsMap(root);
+        assertTrue(children.containsKey("id"));
+        assertTrue(children.containsKey("title"));
+        assertTrue(children.containsKey("count"));
+        assertTrue(children.containsKey("active"));
+        assertTrue(children.containsKey("state"));
+        assertTrue(children.containsKey("created"));
+        assertFalse(children.containsKey("notes"));
+
+        assertEquals("123", children.get("id"));
+        assertEquals("Archive Me", children.get("title"));
+        assertEquals("7", children.get("count"));
+        assertEquals("1", children.get("active"));
+        assertEquals("1", children.get("state"));
+        assertEquals(String.valueOf(testDate.getTime()), children.get("created"));
+    }
+
+    @Test
+    public void testToArchiveElementSkipsNullFields() throws ParserConfigurationException {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        bean.title = null;
+        bean.count = null;
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = bean.toArchiveElement(doc, "test-bean");
+
+        Map<String, String> children = getChildElementsAsMap(root);
+        assertEquals(1, children.size());
+        assertEquals("1", children.get("id"));
+    }
+
+    @Test
+    public void testToArchiveElementRespectsExcludedFields() throws ParserConfigurationException {
+        BeanWithExclusion bean = new BeanWithExclusion();
+        bean.id = 999L;
+        bean.secret = "super-secret";
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = bean.toArchiveElement(doc, "bean-with-exclusion");
+
+        Map<String, String> children = getChildElementsAsMap(root);
+        assertTrue(children.containsKey("id"));
+        assertFalse(children.containsKey("secret"));
+        assertEquals("999", children.get("id"));
+    }
+
+    // --- populateFromArchiveElement ---
+
+    @Test
+    public void testPopulateFromArchiveElementNullInput() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        bean.populateFromArchiveElement(null);
+        assertEquals(Long.valueOf(1L), bean.id);
+    }
+
+    @Test
+    public void testPopulateFromArchiveElement() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "456");
+        appendChild(root, "title", "Populated Title");
+        appendChild(root, "count", "21");
+        appendChild(root, "active", "1");
+        appendChild(root, "state", "2");
+        appendChild(root, "created", String.valueOf(testDate.getTime()));
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(456L), bean.id);
+        assertEquals("Populated Title", bean.title);
+        assertEquals(Integer.valueOf(21), bean.count);
+        assertTrue(bean.active);
+        assertEquals(Integer.valueOf(2), bean.state);
+        assertEquals(testDate, bean.created);
+    }
+
+    @Test
+    public void testPopulateFromArchiveElementIgnoresNonArchivable() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "1");
+        appendChild(root, "notes", "should be ignored");  // notes has archive=false
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(1L), bean.id);
+        assertNull(bean.notes);  // notes not archivable, so not parsed
+    }
+
+    @Test
+    public void testPopulateFromArchiveElementIgnoresUnknownTags() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "1");
+        appendChild(root, "unknown_tag", "value");
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(1L), bean.id);
+    }
+
+    // --- Archive round-trip ---
+
+    @Test
+    public void testArchiveRoundTrip() throws ParserConfigurationException {
+        MinimalFoormBean original = new MinimalFoormBean();
+        original.id = 777L;
+        original.title = "Round Trip Test";
+        original.count = 42;
+        original.active = false;
+        original.state = 0;
+        original.created = testDate;
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element el = original.toArchiveElement(doc, "minimal");
+        doc.appendChild(el);
+
+        MinimalFoormBean restored = new MinimalFoormBean();
+        restored.populateFromArchiveElement(el);
+
+        assertEquals(original.id, restored.id);
+        assertEquals(original.title, restored.title);
+        assertEquals(original.count, restored.count);
+        assertEquals(original.active, restored.active);
+        assertEquals(original.state, restored.state);
+        assertEquals(original.created, restored.created);
+    }
+
+    @Test
+    public void testParseArchiveValueBooleanVariants() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "1");
+        appendChild(root, "active", "true");
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+        assertTrue(bean.active);
+
+        root.getElementsByTagName("active").item(0).setTextContent("1");
+        MinimalFoormBean bean2 = new MinimalFoormBean();
+        bean2.populateFromArchiveElement(root);
+        assertTrue(bean2.active);
+
+        root.getElementsByTagName("active").item(0).setTextContent("yes");
+        MinimalFoormBean bean3 = new MinimalFoormBean();
+        bean3.populateFromArchiveElement(root);
+        assertTrue(bean3.active);
+    }
+
+    @Test
+    public void testParseArchiveValueDecimalTruncation() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "123.99");
+        appendChild(root, "count", "456.7");
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(123L), bean.id);
+        assertEquals(Integer.valueOf(456), bean.count);
+    }
+
+    // --- Helpers ---
+
+    private static Map<String, String> getChildElementsAsMap(Element parent) {
+        Map<String, String> map = new HashMap<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = children.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE) {
+                Element e = (Element) n;
+                map.put(e.getTagName(), e.getTextContent());
+            }
+        }
+        return map;
+    }
+
+    private static void appendChild(Element parent, String tagName, String textContent) {
+        Document doc = parent.getOwnerDocument();
+        Element child = doc.createElement(tagName);
+        child.setTextContent(textContent);
+        parent.appendChild(child);
+    }
+}

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -1388,7 +1388,7 @@ public class LTI13Servlet extends HttpServlet {
 		int paging = NumberUtils.toInt(pagingstr, -1);
 		if ( paging > 0 && ( limit < 0 || limit > paging ) ) limit = paging;
 
-		// int allowOutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
+		// int allowOutcomes = (tool.allowoutcomes != null && Boolean.TRUE.equals(tool.allowoutcomes)) ? 1 : 0;
 
 		/* SAK-47261 - Scope NRPS to Context, not Resource Link
 		String assignment_name = (String) content.title;

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -843,7 +843,9 @@ public class SakaiLTIUtil {
 		ToolConfiguration placement = SiteService.findTool(placementId);
 		Properties config = placement.getConfig();
 		String roleMapProp = StringUtils.trimToNull(getCorrectProperty(config, LTIService.LTI_ROLEMAP, placement));
-		addRoleInfo(props, null, user, context, LtiToolBean.of(roleMapProp != null ? Collections.singletonMap(LTIService.LTI_ROLEMAP, roleMapProp) : null));
+		// Deliberately minimal/ephemeral bean used only to supply tool.rolemap to addRoleInfo (LtiToolBean.of, roleMapProp, LTIService.LTI_ROLEMAP)
+		LtiToolBean minimalToolWithRoleMap = LtiToolBean.of(roleMapProp != null ? Collections.singletonMap(LTIService.LTI_ROLEMAP, roleMapProp) : null);
+		addRoleInfo(props, null, user, context, minimalToolWithRoleMap);
 		addSiteInfo(props, null, site);
 
 		// Add Placement Information
@@ -3593,10 +3595,10 @@ public class SakaiLTIUtil {
 		if (tool == null) return false;
 		Integer lti13 = tool.getLti13();
 		if (lti13 == null) return true;
-		long v = lti13.longValue();
-		if (v == LTIService.LTI13_LTI11) return true;
-		if (v == LTIService.LTI13_LTI13) return false;
-		if (v == LTIService.LTI13_BOTH) return true;
+		int v = lti13.intValue();
+		if (v == LTIService.LTI13_LTI11.intValue()) return true;
+		if (v == LTIService.LTI13_LTI13.intValue()) return false;
+		if (v == LTIService.LTI13_BOTH.intValue()) return true;
 		return true;
 	}
 
@@ -3615,10 +3617,10 @@ public class SakaiLTIUtil {
 		if (tool == null) return false;
 		Integer lti13 = tool.getLti13();
 		if (lti13 == null) return false;
-		long v = lti13.longValue();
-		if (v == LTIService.LTI13_LTI11) return false;
-		if (v == LTIService.LTI13_LTI13) return true;
-		if (v == LTIService.LTI13_BOTH) return true;
+		int v = lti13.intValue();
+		if (v == LTIService.LTI13_LTI11.intValue()) return false;
+		if (v == LTIService.LTI13_LTI13.intValue()) return true;
+		if (v == LTIService.LTI13_BOTH.intValue()) return true;
 		return false;
 	}
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -77,6 +78,8 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.grading.api.model.Gradebook;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.portal.util.CSSUtils;
 import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.grading.api.AssessmentNotFoundException;
@@ -288,7 +291,7 @@ public class SakaiLTIUtil {
 
 		// Look at a Placement and come up with the launch urls, and
 		// other launch parameters to drive the launch.
-		public static boolean loadFromPlacement(Properties info, Properties launch, Placement placement) {
+		private static boolean loadFromPlacement(Properties info, Properties launch, Placement placement) {
 			Properties config = placement.getConfig();
 			log.debug("Sakai properties={}", config);
 			String launch_url = StringUtils.trimToNull(getCorrectProperty(config, LTIService.LTI_LAUNCH, placement));
@@ -324,7 +327,7 @@ public class SakaiLTIUtil {
 			return false;
 		}
 
-		public static void parseCustom(Properties info, String customstr) {
+		private static void parseCustom(Properties info, String customstr) {
 			if (customstr != null) {
 				String splitChar = "\n";
 				if (customstr.trim().indexOf("\n") == -1) {
@@ -492,7 +495,7 @@ public class SakaiLTIUtil {
 		}
 
 
-	public static void addSiteInfo(Properties props, Properties lti13subst, Site site) {
+	private static void addSiteInfo(Properties props, Properties lti13subst, Site site) {
 		if (site != null) {
 			String context_type = site.getType();
 			if (context_type != null && context_type.toLowerCase().contains("course")) {
@@ -563,9 +566,9 @@ public class SakaiLTIUtil {
 		setProperty(props, LTIConstants.LAUNCH_PRESENTATION_RETURN_URL, returnUrl);
 	}
 
-	public static void addUserInfo(Properties ltiProps, Properties lti13subst, User user, Map<String, Object> tool) {
-		int releasename = LTIUtil.toInt(tool.get(LTIService.LTI_SENDNAME));
-		int releaseemail = LTIUtil.toInt(tool.get(LTIService.LTI_SENDEMAILADDR));
+	private static void addUserInfo(Properties ltiProps, Properties lti13subst, User user, LtiToolBean tool) {
+		int releasename = (tool != null && Boolean.TRUE.equals(tool.sendname)) ? 1 : 0;
+		int releaseemail = (tool != null && Boolean.TRUE.equals(tool.sendemailaddr)) ? 1 : 0;
 		if (user != null) {
 			setProperty(ltiProps, LTIConstants.USER_ID, user.getId());
 			setProperty(lti13subst, LTICustomVars.USER_ID, user.getId());
@@ -604,7 +607,7 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static String getCurrentUserSakaiRole(User user, String context) {
+	private static String getCurrentUserSakaiRole(User user, String context) {
 		if (user == null) return null;
 
 		String realmId = SiteService.siteReference(context);
@@ -632,7 +635,7 @@ public class SakaiLTIUtil {
 		return null;
 	}
 
-	public static String getFallBackRole(String context) {
+	private static String getFallBackRole(String context) {
 		if (SecurityService.isSuperUser()) {
 			return LTI13ConstantsUtil.ROLE_INSTRUCTOR + ","
 				+ LTI13ConstantsUtil.ROLE_CONTEXT_ADMIN + ","
@@ -643,7 +646,8 @@ public class SakaiLTIUtil {
 		return LTI13ConstantsUtil.ROLE_LEARNER;
 	}
 
-	public static void addRoleInfo(Properties props, Properties lti13subst, User user, String context, String roleMapProp) {
+	private static void addRoleInfo(Properties props, Properties lti13subst, User user, String context, LtiToolBean tool) {
+		String roleMapProp = (tool != null && tool.rolemap != null) ? tool.rolemap : null;
 
 		String sakaiRole = SecurityService.isSuperUser() ? "admin" : getCurrentUserSakaiRole(user, context);
 
@@ -839,7 +843,7 @@ public class SakaiLTIUtil {
 		ToolConfiguration placement = SiteService.findTool(placementId);
 		Properties config = placement.getConfig();
 		String roleMapProp = StringUtils.trimToNull(getCorrectProperty(config, LTIService.LTI_ROLEMAP, placement));
-		addRoleInfo(props, null, user, context, roleMapProp);
+		addRoleInfo(props, null, user, context, LtiToolBean.of(roleMapProp != null ? Collections.singletonMap(LTIService.LTI_ROLEMAP, roleMapProp) : null));
 		addSiteInfo(props, null, site);
 
 		// Add Placement Information
@@ -847,7 +851,7 @@ public class SakaiLTIUtil {
 		return true;
 	}
 
-	public static void addPlacementInfo(Properties props, String placementId) {
+	private static void addPlacementInfo(Properties props, String placementId) {
 
 		// Get the placement to see if we are to release information
 		ToolConfiguration placement = SiteService.findTool(placementId);
@@ -962,7 +966,7 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static void addConsumerData(Properties props, Properties custom) {
+	private static void addConsumerData(Properties props, Properties custom) {
 		final String defaultName =  ServerConfigurationService.getString("serverName",
 			ServerConfigurationService.getString("serverUrl","localhost.sakailms"));
 
@@ -999,7 +1003,7 @@ public class SakaiLTIUtil {
 	// Custom variable substitutions extensions follow the form of
 	// $com.example.Foo.bar
 	// http://www.imsglobal.org/spec/lti/v1p3/#custom-variables
-	public static void addPropertyExtensionData(Properties props, Properties custom) {
+	private static void addPropertyExtensionData(Properties props, Properties custom) {
 		org.sakaiproject.component.api.ServerConfigurationService serverConfigurationService =
 			(org.sakaiproject.component.api.ServerConfigurationService) ComponentManager.get("org.sakaiproject.component.api.ServerConfigurationService");
 		if ( serverConfigurationService == null ) return;
@@ -1020,7 +1024,7 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static void addGlobalData(Site site, Properties props, Properties custom, ResourceLoader rb) {
+	private static void addGlobalData(Site site, Properties props, Properties custom, ResourceLoader rb) {
 		if (rb != null) {
 			String locale = rb.getLocale().toString();
 			setProperty(props, LTIConstants.LAUNCH_PRESENTATION_LOCALE, locale);
@@ -1065,7 +1069,7 @@ public class SakaiLTIUtil {
 
 		// This must return an HTML message as the [0] in the array
 		// If things are successful - the launch URL is in [1]
-		public static String[] postLaunchHTML(Map<String, Object> content, Map<String, Object> tool,
+		public static String[] postLaunchHTML(LtiContentBean content, LtiToolBean tool,
 				String state, String nonce, LTIService ltiService, ResourceLoader rb) {
 
 			log.debug("state={} nonce={}", state, nonce);
@@ -1076,21 +1080,20 @@ public class SakaiLTIUtil {
 				return postError("<p>" + getRB(rb, "error.tool.missing", "Tool item is missing or improperly configured.") + "</p>");
 			}
 
-			int status = LTIUtil.toInt(tool.get(LTIService.LTI_STATUS));
-			if (status == 1) {
+			if ("disable".equals(tool.status)) {
 				return postError("<p>" + getRB(rb, "tool.disabled", "Tool is currently disabled") + "</p>");
 			}
 
 			// Go with the content url first
-			String launch_url = (String) content.get(LTIService.LTI_LAUNCH);
+			String launch_url = content.launch;
 			if (launch_url == null) {
-				launch_url = (String) tool.get(LTIService.LTI_LAUNCH);
+				launch_url = tool.launch;
 			}
 			if (launch_url == null) {
 				return postError("<p>" + getRB(rb, "error.nolaunch", "This tool is not yet configured.") + "</p>");
 			}
 
-			String context = (String) content.get(LTIService.LTI_SITE_ID);
+			String context = content.siteId;
 			Site site;
 			try {
 				site = SiteService.getSite(context);
@@ -1105,8 +1108,8 @@ public class SakaiLTIUtil {
 			gradingService.initializeGradebooksForSite(context);
 
 			// See if there are the necessary items
-			String secret = getSecret(tool, content);
-			String key = getKey(tool, content);
+			String secret = getSecret(tool);
+			String key = getKey(tool);
 
 			if (LTIService.LTI_SECRET_INCOMPLETE.equals(key) && LTIService.LTI_SECRET_INCOMPLETE.equals(secret)) {
 				return postError("<p>" + getRB(rb, "error.tool.partial", "Tool item is incomplete, missing a key and secret.") + "</p>");
@@ -1125,7 +1128,7 @@ public class SakaiLTIUtil {
 			setProperty(ltiProps, LTIConstants.LTI_VERSION, LTIConstants.LTI_VERSION_1);
 			addGlobalData(site, ltiProps, lti13subst, rb);
 			addSiteInfo(ltiProps, lti13subst, site);
-			addRoleInfo(ltiProps, lti13subst, user, context, (String) tool.get(LTIService.LTI_ROLEMAP));
+			addRoleInfo(ltiProps, lti13subst, user, context, tool);
 			addUserInfo(ltiProps, lti13subst, user, tool);
 
 			String resource_link_id = getResourceLinkId(content);
@@ -1138,15 +1141,15 @@ public class SakaiLTIUtil {
 			setProperty(toolProps, LTIService.LTI_SECRET, secret);
 			setProperty(toolProps, LTI_PORTLET_KEY, key);
 
-			int debug = LTIUtil.toInt(tool.get(LTIService.LTI_DEBUG));
+			int debug = (tool.debug != null) ? tool.debug : 0;
 			if (debug == 2) {
-				debug = LTIUtil.toInt(content.get(LTIService.LTI_DEBUG));
+				debug = (content.debug != null && content.debug) ? 1 : 0;
 			}
 			setProperty(toolProps, LTIService.LTI_DEBUG, debug + "");
 
-			int frameheight = LTIUtil.toInt(content.get(LTIService.LTI_FRAMEHEIGHT));
+			int frameheight = (content.frameheight != null && content.frameheight > 0) ? content.frameheight : 0;
 			if (frameheight < 1) {
-				frameheight = LTIUtil.toInt(tool.get(LTIService.LTI_FRAMEHEIGHT));
+				frameheight = (tool.frameheight != null && tool.frameheight > 0) ? tool.frameheight : 0;
 			}
 
 			setProperty(toolProps, LTIService.LTI_FRAMEHEIGHT, frameheight + "");
@@ -1154,10 +1157,10 @@ public class SakaiLTIUtil {
 
 			int newpage = getNewpage(tool, content, true) ? 1 : 0;
 			String title = getToolTitle(tool, content, "");
-			String description = (String) content.get(LTIService.LTI_DESCRIPTION);
+			String description = content.description;
 
 			// SAK-40044 - If there is no description, we fall back to the pre-21 description in JSON
-			String content_settings = (String) content.get(LTIService.LTI_SETTINGS);
+			String content_settings = content.settings;
 			JSONObject content_json = org.tsugi.lti.LTIUtil.parseJSONObject(content_settings);
 			if (StringUtils.isBlank(description) ) {
 				description = (String) content_json.get(LTIService.LTI_DESCRIPTION);
@@ -1199,9 +1202,9 @@ public class SakaiLTIUtil {
 				setProperty(lti13subst, subKey, value);
 			}
 
-			int allowoutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
-			int allowroster = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWROSTER));
-			String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+			int allowoutcomes = (tool.allowoutcomes != null && tool.allowoutcomes) ? 1 : 0;
+			int allowroster = (tool.allowroster != null && tool.allowroster) ? 1 : 0;
+			String placement_secret = content.placementsecret;
 
 			String result_sourcedid = getSourceDID(user, resource_link_id, placement_secret);
 			log.debug("allowoutcomes={} allowroster={} result_sourcedid={}",
@@ -1240,15 +1243,14 @@ public class SakaiLTIUtil {
 			// Construct the ultimate custom values for Launch
 			Properties custom = new Properties();
 
-			String contentCustom = (String) content.get(LTIService.LTI_CUSTOM);
+			String contentCustom = content.custom;
 			contentCustom = adjustCustom(contentCustom);
 			mergeLTI1Custom(custom, contentCustom);
 
-			String toolCustom = (String) tool.get(LTIService.LTI_CUSTOM);
+			String toolCustom = tool.custom;
 			toolCustom = adjustCustom(toolCustom);
 			mergeLTI1Custom(custom, toolCustom);
 
-			// See if there are any locally deployed substitutions
 			ltiService.filterCustomSubstitutions(lti13subst, tool, site);
 
 			log.debug("lti13subst={}", lti13subst);
@@ -1266,6 +1268,11 @@ public class SakaiLTIUtil {
 				return postLaunchJWT(toolProps, ltiProps, site, tool, content, rb);
 			}
 			return postLaunchHTML(toolProps, ltiProps, rb);
+		}
+
+		public static String[] postLaunchHTML(Map<String, Object> content, Map<String, Object> tool,
+				String state, String nonce, LTIService ltiService, ResourceLoader rb) {
+			return postLaunchHTML(LtiContentBean.of(content), LtiToolBean.of(tool), state, nonce, ltiService, rb);
 		}
 
 		/**
@@ -1286,12 +1293,15 @@ public class SakaiLTIUtil {
 		/**
 		 * Create a ContentItem from the current request (may throw runtime)
 		 */
-		public static ContentItem getContentItemFromRequest(Map<String, Object> tool) {
+		public static ContentItem getContentItemFromRequest(LtiToolBean tool) {
+			if (tool == null) {
+				throw new RuntimeException("Tool is null");
+			}
 
 			Placement placement = ToolManager.getCurrentPlacement();
 			String siteId = placement.getContext();
 
-			String toolSiteId = (String) tool.get(LTIService.LTI_SITE_ID);
+			String toolSiteId = tool.siteId;
 			if (toolSiteId != null && !toolSiteId.equals(siteId)) {
 				throw new RuntimeException("Incorrect site id");
 			}
@@ -1310,7 +1320,7 @@ public class SakaiLTIUtil {
 			ContentItem contentItem = new ContentItem(req);
 
 			String oauth_consumer_key = req.getParameter("oauth_consumer_key");
-			String oauth_secret = (String) tool.get(LTIService.LTI_SECRET);
+			String oauth_secret = getSecret(tool);
 			oauth_secret = decryptSecret(oauth_secret);
 
 			String URL = getOurServletPath(req);
@@ -1325,60 +1335,54 @@ public class SakaiLTIUtil {
 			return contentItem;
 		}
 
+		public static ContentItem getContentItemFromRequest(Map<String, Object> tool) {
+			return getContentItemFromRequest(LtiToolBean.of(tool));
+		}
+
 		/**
-		 * getPublicKey - Get the appropriate public key for use for an incoming request
+		 * getPublicKey - Get the appropriate public key for use for an incoming request (bean overload)
 		 */
-		public static Key getPublicKey(Map<String, Object> tool, String id_token)
-		{
+		public static Key getPublicKey(LtiToolBean tool, String id_token) {
+			if (tool == null) {
+				throw new RuntimeException("Tool is null");
+			}
 			JSONObject jsonHeader = LTI13JwtUtil.jsonJwtHeader(id_token);
 			if (jsonHeader == null) {
 				throw new RuntimeException("Could not parse Jwt Header in client_assertion");
 			}
 			String incoming_kid = (String) jsonHeader.get("kid");
 
-			String tool_keyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+			String tool_keyset = tool.lti13ToolKeyset;
 			if (tool_keyset == null) {
 				throw new RuntimeException("Could not find tool keyset url");
 			}
 
-			Key publicKey = null;
-			if ( tool_keyset != null ) {
-				log.debug("Retrieving kid="+incoming_kid+" from "+tool_keyset);
-
-				// TODO: Read from Earle's super-cluster-cache one day - SAK-43700
-				try {
-					publicKey = LTI13KeySetUtil.getKeyFromKeySet(incoming_kid, tool_keyset);
-				} catch (Exception e) {
-					log.error(e.toString(), e);
-					log.debug("Stacktrace:", e);
-					// Sorry - too many exceptions to explain here - lets keep it simple after logging it
-					throw new RuntimeException("Unable to retrieve kid="+incoming_kid+" from "+tool_keyset+" detail="+e.toString());
-				}
-				// TODO: Store in Earle's super-cluster-cache one day - SAK-43700
-
+			log.debug("Retrieving kid={} from {}", incoming_kid, tool_keyset);
+			try {
+				return LTI13KeySetUtil.getKeyFromKeySet(incoming_kid, tool_keyset);
+			} catch (Exception e) {
+				log.error(e.toString(), e);
+				log.debug("Stacktrace:", e);
+				throw new RuntimeException("Unable to retrieve kid=" + incoming_kid + " from " + tool_keyset + " detail=" + e.toString());
 			}
-			return publicKey;
+		}
+
+		private static Key getPublicKey(Map<String, Object> tool, String id_token) {
+			return getPublicKey(LtiToolBean.of(tool), id_token);
 		}
 
 		/**
-		 * getPublicKey - Get the appropriate public key for use for an incoming request
-		 * @param tool the tool bean
-		 * @param id_token the id token
-		 * @return the public key
+		 * Create a DeepLinkResponse from the current request (may throw runtime). Bean overload.
 		 */
-	public static Key getPublicKey(org.sakaiproject.lti.beans.LtiToolBean tool, String id_token) {
-		return getPublicKey(tool != null ? tool.asMap() : null, id_token);
-	}
-
-		/**
-		 * Create a ContentItem from the current request (may throw runtime)
-		 */
-		public static DeepLinkResponse getDeepLinkFromToken(Map<String, Object> tool, String id_token) {
+		public static DeepLinkResponse getDeepLinkFromToken(LtiToolBean tool, String id_token) {
+			if (tool == null) {
+				throw new RuntimeException("Tool is null");
+			}
 
 			Placement placement = ToolManager.getCurrentPlacement();
 			String siteId = placement.getContext();
 
-			String toolSiteId = (String) tool.get(LTIService.LTI_SITE_ID);
+			String toolSiteId = tool.siteId;
 			if (toolSiteId != null && !toolSiteId.equals(siteId)) {
 				throw new RuntimeException("Incorrect site id");
 			}
@@ -1394,10 +1398,8 @@ public class SakaiLTIUtil {
 				log.warn(lti_errorlog);
 			}
 
-			// May throw a RunTimeException on our behalf :)
 			Key publicKey = SakaiLTIUtil.getPublicKey(tool, id_token);
 
-			// Fill up the object, validate and return
 			DeepLinkResponse dlr = new DeepLinkResponse(id_token);
 			if ( ! dlr.validate(publicKey) ) {
 				throw new RuntimeException("Could not verify signature");
@@ -1406,27 +1408,26 @@ public class SakaiLTIUtil {
 			return dlr;
 		}
 
+		public static DeepLinkResponse getDeepLinkFromToken(Map<String, Object> tool, String id_token) {
+			return getDeepLinkFromToken(LtiToolBean.of(tool), id_token);
+		}
+
 		/**
-		 * An LTI ContentItemSelectionRequest launch
-		 *
-		 * This must return an HTML message as the [0] in the array If things are
-		 * successful - the launch URL is in [1]
+		 * An LTI ContentItemSelectionRequest launch. Bean overload.
 		 */
-		public static String[] postContentItemSelectionRequest(Long toolKey, Map<String, Object> tool,
+		public static String[] postContentItemSelectionRequest(Long toolKey, LtiToolBean tool,
 				String state, String nonce, ResourceLoader rb, String contentReturn, Properties dataProps) {
 			if (tool == null) {
 				return postError("<p>" + getRB(rb, "error.tool.missing", "Tool is missing or improperly configured.") + "</p>");
 			}
 
-			String launch_url = (String) tool.get("launch");
+			String launch_url = tool.launch;
 			if (launch_url == null) {
 				return postError("<p>" + getRB(rb, "error.tool.noreg", "This tool is has no launch url.") + "</p>");
 			}
 
-			String consumerkey = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-			String secret = (String) tool.get(LTIService.LTI_SECRET);
-
-			// If secret is encrypted, decrypt it
+			String consumerkey = tool.consumerkey;
+			String secret = getSecret(tool);
 			secret = decryptSecret(secret);
 
 			boolean isLTI13 = isLTI13(tool);
@@ -1498,7 +1499,7 @@ public class SakaiLTIUtil {
 			setProperty(ltiProps, LTIConstants.CONTENT_ITEM_RETURN_URL, contentReturn);
 
 			// This must always be there
-			String context = (String) tool.get(LTIService.LTI_SITE_ID);
+			String context = tool.siteId;
 			Site site;
 			try {
 				site = SiteService.getSite(context);
@@ -1517,10 +1518,8 @@ public class SakaiLTIUtil {
 			Properties lti13subst = new Properties();
 			addGlobalData(site, ltiProps, lti13subst, rb);
 			addSiteInfo(ltiProps, lti13subst, site);
-			addRoleInfo(ltiProps, lti13subst, user, context, (String) tool.get(LTIService.LTI_ROLEMAP));
+			addRoleInfo(ltiProps, lti13subst, user, context, tool);
 
-			int releasename = LTIUtil.toInt(tool.get(LTIService.LTI_SENDNAME));
-			int releaseemail = LTIUtil.toInt(tool.get(LTIService.LTI_SENDEMAILADDR));
 			addUserInfo(ltiProps, lti13subst, user, tool);
 
 			// Don't sent the normal return URL when we are doing ContentItem launch
@@ -1530,16 +1529,15 @@ public class SakaiLTIUtil {
 				ltiProps.remove(LTIConstants.LAUNCH_PRESENTATION_RETURN_URL);
 			}
 
-			boolean dodebug = LTIUtil.toInt(tool.get(LTIService.LTI_DEBUG)) == 1;
+			boolean dodebug = (tool.debug != null && tool.debug == 1);
 
 			// Merge all the sources of custom vaues and run the substitution
 			Properties custom = new Properties();
 
-			String toolCustom = (String) tool.get(LTIService.LTI_CUSTOM);
+			String toolCustom = tool.custom;
 			toolCustom = adjustCustom(toolCustom);
 			mergeLTI1Custom(custom, toolCustom);
 
-			// See if there are any locally deployed substitutions
 			LTIService ltiService = (LTIService) ComponentManager.get("org.sakaiproject.lti.api.LTIService");
 			ltiService.filterCustomSubstitutions(lti13subst, tool, site);
 
@@ -1561,17 +1559,13 @@ public class SakaiLTIUtil {
 				setProperty(toolProps, "nonce", nonce);  // So far LTI 1.3 only
 				toolProps.put(LTIService.LTI_DEBUG, dodebug ? "1" : "0");
 
-				Map<String, Object> content = null;
-				return postLaunchJWT(toolProps, ltiProps, site, tool, content, rb);
+				return postLaunchJWT(toolProps, ltiProps, site, tool, null, rb);
 			}
 
 			// LTI 1.1.2
-			String tool_state = (String) tool.get("tool_state");
-			if ( StringUtils.isNotEmpty(tool_state) ) setProperty(ltiProps, "tool_state", tool_state);
-			String platform_state = (String) tool.get("platform_state");
-			if ( StringUtils.isNotEmpty(platform_state) ) setProperty(ltiProps, "platform_state", platform_state);
-			String relaunch_url = (String) tool.get("relaunch_url");
-			if ( StringUtils.isNotEmpty(relaunch_url) ) setProperty(ltiProps, "relaunch_url", relaunch_url);
+			if ( StringUtils.isNotEmpty(tool.toolState) ) setProperty(ltiProps, "tool_state", tool.toolState);
+			if ( StringUtils.isNotEmpty(tool.platformState) ) setProperty(ltiProps, "platform_state", tool.platformState);
+			if ( StringUtils.isNotEmpty(tool.relaunchUrl) ) setProperty(ltiProps, "relaunch_url", tool.relaunchUrl);
 
 			String submit_form_id = java.util.UUID.randomUUID().toString() + "";
 			boolean autosubmit = !dodebug;
@@ -1591,6 +1585,11 @@ public class SakaiLTIUtil {
 
 			String[] retval = {postData, launch_url};
 			return retval;
+		}
+
+		public static String[] postContentItemSelectionRequest(Long toolKey, Map<String, Object> tool,
+				String state, String nonce, ResourceLoader rb, String contentReturn, Properties dataProps) {
+			return postContentItemSelectionRequest(toolKey, LtiToolBean.of(tool), state, nonce, rb, contentReturn, dataProps);
 		}
 
 		// This must return an HTML message as the [0] in the array
@@ -1757,7 +1756,15 @@ public class SakaiLTIUtil {
 
 		public static String[] postLaunchJWT(Properties toolProps, Properties ltiProps,
 				Site site, Map<String, Object> tool, Map<String, Object> content, ResourceLoader rb) {
+			return postLaunchJWT(toolProps, ltiProps, site, LtiToolBean.of(tool), LtiContentBean.of(content), rb);
+		}
+
+		public static String[] postLaunchJWT(Properties toolProps, Properties ltiProps,
+				Site site, LtiToolBean tool, LtiContentBean content, ResourceLoader rb) {
 			log.debug("postLaunchJWT LTI 1.3");
+			if (tool == null) {
+				return postError("<p>" + getRB(rb, "error.missing", "Not configured") + "</p>");
+			}
 			String launch_url = toolProps.getProperty("secure_launch_url");
 			if (launch_url == null) {
 				launch_url = toolProps.getProperty("launch_url");
@@ -1768,16 +1775,16 @@ public class SakaiLTIUtil {
 
 			HttpServletRequest req = ToolUtils.getRequestFromThreadLocal();
 
-			String orig_site_id_null = (String) tool.get("orig_site_id_null");
+			String orig_site_id_null = tool.origSiteIdNull;
 			String site_id = null;
 			if ( ! "true".equals(orig_site_id_null) ) {
-				site_id = (String) tool.get(LTIService.LTI_SITE_ID);
+				site_id = tool.siteId;
 			}
 
-			String client_id = (String) tool.get(LTIService.LTI13_CLIENT_ID);
+			String client_id = tool.lti13ClientId;
 			String placement_secret = null;
 			if (content != null) {
-				placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+				placement_secret = content.placementsecret;
 			}
 
 		/*
@@ -1829,7 +1836,7 @@ public class SakaiLTIUtil {
 
 			SakaiLineItem sakaiLineItem = null;
 			if ( content != null ) {
-				String lineItemStr = (String) content.get(LTIService.LTI_LINEITEM);
+				String lineItemStr = content.contentitem;
 				sakaiLineItem = LineItemUtil.parseLineItem(lineItemStr);
 			}
 
@@ -1881,8 +1888,8 @@ public class SakaiLTIUtil {
 
 			// Construct the LTI 1.1 -> LTIAdvantage transition claim
 			// https://www.imsglobal.org/spec/lti/v1p3/migr#lti-1-1-migration-claim
-			String oauth_consumer_key = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-			String oauth_secret = (String) tool.get(LTIService.LTI_SECRET);
+			String oauth_consumer_key = tool.consumerkey;
+			String oauth_secret = getSecret(tool);
 			oauth_secret = decryptSecret(oauth_secret);
 			if ( oauth_consumer_key != null && oauth_secret != null ) {
 				lj.lti11_transition = new LTI11Transition();
@@ -1939,9 +1946,9 @@ public class SakaiLTIUtil {
 				lj.custom.put(custom_key, custom_val);
 			}
 
-			int allowOutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
-			int allowRoster = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWROSTER));
-			int allowLineItems = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWLINEITEMS));
+			int allowOutcomes = (tool.allowoutcomes != null && Boolean.TRUE.equals(tool.allowoutcomes)) ? 1 : 0;
+			int allowRoster = (tool.allowroster != null && Boolean.TRUE.equals(tool.allowroster)) ? 1 : 0;
+			int allowLineItems = (tool.allowlineitems != null && Boolean.TRUE.equals(tool.allowlineitems)) ? 1 : 0;
 
 			String sourcedid = ltiProps.getProperty("lis_result_sourcedid");
 
@@ -2119,7 +2126,7 @@ public class SakaiLTIUtil {
 			state = StringUtils.trimToNull(state);
 
 			// This is a comma separated list of valid redirect URLs - lame as heck
-			String lti13_tool_redirect = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_TOOL_REDIRECT));
+			String lti13_tool_redirect = StringUtils.trimToNull(tool.lti13OidcRedirect);
 
 			// If we have been told to send this to a redirect_uri instead of a launch...
 			String redirect_uri = req.getParameter("redirect_uri");
@@ -2196,11 +2203,15 @@ public class SakaiLTIUtil {
 		}
 
 		/*
-		 * get a signed placement from a content item
+		 * get a signed placement from a content item. Bean overload.
 		 */
+		public static String getResourceLinkId(LtiContentBean content) {
+			if (content == null || content.id == null) return null;
+			return "content:" + content.id;
+		}
+
 		public static String getResourceLinkId(Map<String, Object> content) {
-			String resource_link_id = "content:" + content.get(LTIService.LTI_ID);
-			return resource_link_id;
+			return getResourceLinkId(LtiContentBean.of(content));
 		}
 
 		public static String getSignedPlacement(String context_id, String resource_link_id, String placementSecret) {
@@ -2214,32 +2225,51 @@ public class SakaiLTIUtil {
 		}
 
 		/*
-		 * get a signed placement from a content item
+		 * get a signed placement from a content item. Bean overload.
 		 */
-		public static String getSignedPlacement(Map<String, Object> content) {
-			String context_id = (String) content.get(LTIService.LTI_SITE_ID);
-			String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+		public static String getSignedPlacement(LtiContentBean content) {
+			if (content == null) return null;
+			String context_id = content.getSiteId();
+			String placement_secret = content.getPlacementsecret();
 			String resource_link_id = getResourceLinkId(content);
-			String signed_placement = null;
-			if ( placement_secret != null ) {
-				signed_placement = getSignedPlacement(context_id, resource_link_id, placement_secret);
-			}
-			return signed_placement;
+			if (placement_secret == null) return null;
+			return getSignedPlacement(context_id, resource_link_id, placement_secret);
 		}
 
-		public static String trackResourceLinkID(Map<String, Object> oldContent) {
-			boolean retval = false;
+		public static String getSignedPlacement(Map<String, Object> content) {
+			return getSignedPlacement(LtiContentBean.of(content));
+		}
 
-			String old_settings = (String) oldContent.get(LTIService.LTI_SETTINGS);
+		/**
+		 * Get the id_history string for oldContent. Primary implementation.
+		 */
+		public static String trackResourceLinkID(LtiContentBean oldContent) {
+			if (oldContent == null) {
+				return null;
+			}
+			String old_settings = oldContent.getSettings();
 			JSONObject old_json = LTIUtil.parseJSONObject(old_settings);
-			String old_id_history = (String) old_json.get(LTIService.LTI_ID_HISTORY);
+			String old_id_history = old_json != null ? (String) old_json.get(LTIService.LTI_ID_HISTORY) : null;
 
 			String old_resource_link_id = getResourceLinkId(oldContent);
 
-			String id_history = LTIUtil.mergeCSV(old_id_history, null, old_resource_link_id);
-			return id_history;
+			return LTIUtil.mergeCSV(old_id_history, null, old_resource_link_id);
 		}
 
+		/** Map shim for backward compatibility; prefer bean overload. */
+		public static String trackResourceLinkID(Map<String, Object> oldContent) {
+			return trackResourceLinkID(LtiContentBean.of(oldContent));
+		}
+
+		public static boolean trackResourceLinkID(LtiContentBean newContent, LtiContentBean oldContent) {
+			return trackResourceLinkID(newContent != null ? newContent.asMap() : null, oldContent != null ? oldContent.asMap() : null);
+		}
+
+		/**
+		 * Not yet bean-primary: mutates {@code newContent} in place (puts updated LTI_SETTINGS).
+		 * Callers expect the same map reference to be updated for persistence. Will be migrated
+		 * when the persistence layer is audited.
+		 */
 		public static boolean trackResourceLinkID(Map<String, Object> newContent, Map<String, Object> oldContent) {
 			boolean retval = false;
 
@@ -2261,7 +2291,7 @@ public class SakaiLTIUtil {
 			return true;
 		}
 
-		public static String[] postError(String str) {
+		private static String[] postError(String str) {
 			String[] retval = {str};
 			return retval;
 		}
@@ -2274,7 +2304,7 @@ public class SakaiLTIUtil {
 		}
 
 		// To make absolutely sure we never send an XSS, we clean these values
-		public static void setProperty(Properties props, String key, String value) {
+		private static void setProperty(Properties props, String key, String value) {
 			if (value == null) {
 				return;
 			}
@@ -2603,14 +2633,19 @@ public class SakaiLTIUtil {
 	 * If the scoreGiven is null, we are clearing out the grade value.
 	 * Note that scoreObj.userId is subject, not userId (naming inconsistency in IMS specs but we have to follow here).
 	 */
-	public static Object handleGradebookLTI13(Site site,  Long tool_id, Map<String, Object> content, String userId,
+	public static Object handleGradebookLTI13(Site site, Long tool_id, Map<String, Object> content, String userId,
+			Long lineitem_key, Score scoreObj) {
+		return handleGradebookLTI13(site, tool_id, LtiContentBean.of(content), userId, lineitem_key, scoreObj);
+	}
+
+	public static Object handleGradebookLTI13(Site site, Long tool_id, LtiContentBean content, String userId,
 			Long lineitem_key, Score scoreObj) {
 
 		Object retval;
 		String title;
 
-		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}", 
-			site.getId(), tool_id, (content == null ? "null" : content.get(LTIService.LTI_ID)), lineitem_key, userId, scoreObj);
+		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}",
+			site.getId(), tool_id, (content == null ? "null" : content.id), lineitem_key, userId, scoreObj);
 
 		// An empty / null score given means to delete the score
 		SakaiLineItem lineItem = new SakaiLineItem();
@@ -2643,16 +2678,16 @@ public class SakaiLTIUtil {
 			} finally {
 				popAdvisor(); // Remove security advisor
 			}
-			title = (String) content.get(LTIService.LTI_TITLE);
+			title = content.title;
 			if (title == null || title.length() < 1) {
-				log.error("Could not determine content title {}", content.get(LTIService.LTI_ID));
-				return "Could not determine content title key="+content.get(LTIService.LTI_ID);
+				log.error("Could not determine content title {}", content.id);
+				return "Could not determine content title key=" + content.id;
 			}
 			gradebookColumn = getGradebookColumn(site, userId, title, lineItem, tool_id, content);
 		} else {
 			gradebookColumn = LineItemUtil.getColumnByKeyDAO(siteId, tool_id, lineitem_key);
 			if ( gradebookColumn == null || gradebookColumn.getName() == null ) {
-				log.error("Could not determine assignment_name title {}", content.get(LTIService.LTI_ID));
+				log.error("Could not determine assignment_name title {}", (content != null ? content.id : null));
 				return "Unable to load column for lineitem_key="+lineitem_key;
 			}
 
@@ -2767,14 +2802,12 @@ public class SakaiLTIUtil {
 	 * @param scoreObj the score object
 	 * @return the result
 	 */
-	public static Object handleGradebookLTI13(Site site, Long tool_id, org.sakaiproject.lti.beans.LtiContentBean content, String userId, Long lineitem_key, Score scoreObj) {
-		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}", site.getId(), tool_id, (content == null ? "null" : content.id), lineitem_key, userId, scoreObj);
-		return handleGradebookLTI13(site, tool_id, (content == null ? null : content.asMap()), userId, lineitem_key, scoreObj);
+	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, Map<String, Object> content) {
+		return getAssignment(site, LtiContentBean.of(content));
 	}
 
-	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, Map<String, Object> content) {
-
-		Long contentId = LTIUtil.toLongNull(content.get(LTIService.LTI_ID));
+	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, LtiContentBean content) {
+		Long contentId = (content != null) ? content.getId() : null;
 		if ( contentId == null ) return null;
 
 		pushAdvisor();
@@ -2786,7 +2819,7 @@ public class SakaiLTIUtil {
 			for (org.sakaiproject.assignment.api.model.Assignment a : assignments) {
 				Integer assignmentContentId = a.getContentId();
 				if ( assignmentContentId == null ) continue;
-				if ( ! assignmentContentId.equals(contentId.intValue()) ) continue;
+				if ( contentId.longValue() != assignmentContentId.longValue() ) continue;
 				return a;
 			}
 			return null;
@@ -2979,6 +3012,10 @@ public class SakaiLTIUtil {
 	}
 
 	public static org.sakaiproject.grading.api.Assignment getGradebookColumn(Site site, String userId, String title, SakaiLineItem lineItem, Long tool_id, Map<String, Object> content) {
+		return getGradebookColumn(site, userId, title, lineItem, tool_id, LtiContentBean.of(content));
+	}
+
+	public static org.sakaiproject.grading.api.Assignment getGradebookColumn(Site site, String userId, String title, SakaiLineItem lineItem, Long tool_id, LtiContentBean content) {
 		// Look up the gradebook columns so we can find the max points
 		GradingService gradingService = (GradingService) ComponentManager.get("org.sakaiproject.grading.api.GradingService");
 
@@ -3021,7 +3058,7 @@ public class SakaiLTIUtil {
 				returnColumn.setExternallyMaintained(false);
 				returnColumn.setName(title);
 				if ( tool_id != null && content != null ) {
-					String external_id = LineItemUtil.constructExternalId(tool_id, content, lineItem);
+					String external_id = LineItemUtil.constructExternalId(content, lineItem);
 					returnColumn.setExternalAppName(LineItemUtil.GB_EXTERNAL_APP_NAME);
 					returnColumn.setExternalId(external_id);
 				}
@@ -3233,52 +3270,44 @@ public class SakaiLTIUtil {
 	/**
 	 * getLaunchCodeKey - Return the launch code key for a content item
 	 */
-	public static String getLaunchCodeKey(org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getLaunchCodeKey(content != null ? content.asMap() : null);
+	public static String getLaunchCodeKey(LtiContentBean content) {
+		if (content == null) return SESSION_LAUNCH_CODE + "0";
+		int id = (content.getId() != null) ? content.getId().intValue() : 0;
+		return SESSION_LAUNCH_CODE + id;
 	}
 
 	public static String getLaunchCodeKey(Map<String, Object> content) {
-		if (content == null) return SESSION_LAUNCH_CODE + "0";
-		int id = LTIUtil.toInt(content.get(LTIService.LTI_ID));
-		return SESSION_LAUNCH_CODE + id;
+		return getLaunchCodeKey(LtiContentBean.of(content));
 	}
 
 	/**
 	 * getLaunchCode - Return the launch code for a content item
 	 */
-	public static String getLaunchCode(org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getLaunchCode(content != null ? content.asMap() : null);
+	public static String getLaunchCode(LtiContentBean content) {
+		if (content == null) return LTI13Util.timeStampSign("0", null);
+		String content_id = (content.getId() != null) ? content.getId().toString() : "0";
+		String placement_secret = content.getPlacementsecret();
+		return LTI13Util.timeStampSign(content_id, placement_secret);
 	}
 
 	public static String getLaunchCode(Map<String, Object> content) {
-		if (content == null) {
-			return LTI13Util.timeStampSign("0", null);
-		}
-		/*
-		long now = (new java.util.Date()).getTime();
-		int id = LTIUtil.toInt(content.get(LTIService.LTI_ID));
-		String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
-		String base_string = id + ":" + now + ":" + placement_secret;
-		String signature = LegacyShaUtil.sha256Hash(base_string);
-		String retval = id + ":" + now + ":" + signature;
-		*/
-		String content_id = content.get(LTIService.LTI_ID).toString();
-		String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
-		String retval = LTI13Util.timeStampSign(content_id, placement_secret);
-		return retval;
+		return getLaunchCode(LtiContentBean.of(content));
 	}
 
 	/**
-	 * checkLaunchCode - check to see if a launch code is properly signed and not expired
+	 * checkLaunchCode - check to see if a launch code is properly signed and not expired. Bean overload.
 	 */
+	public static boolean checkLaunchCode(LtiContentBean content, String launch_code) {
+		if (content == null) return false;
+		String content_id = (content.getId() != null) ? content.getId().toString() : "0";
+		if (!launch_code.contains(":" + content_id + ":")) return false;
+		String placement_secret = content.getPlacementsecret();
+		int delta = 5 * 60; // Five minutes
+		return LTI13Util.timeStampCheckSign(launch_code, placement_secret, delta);
+	}
+
 	public static boolean checkLaunchCode(Map<String, Object> content, String launch_code) {
-		String content_id = content.get(LTIService.LTI_ID).toString();
-		// Make sure that the token belongs to this content item
-		if ( ! launch_code.contains(":"+content_id+":") ) return false;
-		String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
-		int delta = 5*60*60; // Five minutes
-		boolean retval = LTI13Util.timeStampCheckSign(launch_code, placement_secret, delta);
-		return retval;
+		return checkLaunchCode(LtiContentBean.of(content), launch_code);
 	}
 
 	/**
@@ -3362,26 +3391,34 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static Map<String, Object> findBestToolMatch(boolean global, String launchUrl, String importCheckSum, List<Map<String,Object>> tools)
+	/**
+	 * Find the best tool match. Primary implementation; operates on beans.
+	 */
+	public static LtiToolBean findBestToolMatchBean(boolean global, String launchUrl, String importCheckSum, List<LtiToolBean> tools)
 	{
-		boolean local = ! global;  // Makes it easier to read :)
+		if (tools == null) {
+			return null;
+		}
+		boolean local = ! global;
 
 		// Next we look for a tool with a checksum match
 		if ( StringUtils.isNotEmpty(importCheckSum) ) {
-			for ( Map<String,Object> tool : tools ) {
+			for ( LtiToolBean tool : tools ) {
+				if (tool == null) continue;
 				String toolCheckSum = computeToolCheckSum(tool);
 				if ( StringUtils.isEmpty(toolCheckSum) ) continue;
 				if ( toolCheckSum.equals(importCheckSum) ) {
-					log.debug("Found tool {} with matching checksum {}", tool.get(LTIService.LTI_ID), toolCheckSum);
+					log.debug("Found tool {} with matching checksum {}", tool.getId(), toolCheckSum);
 					return tool;
 				}
 			}
 		}
 
 		// Next we look for a tool with an exact match
-		for ( Map<String,Object> tool : tools ) {
-			String toolLaunch = (String) tool.get(LTIService.LTI_LAUNCH);
-			String toolSite = (String) tool.get(LTIService.LTI_SITE_ID);
+		for ( LtiToolBean tool : tools ) {
+			if (tool == null) continue;
+			String toolLaunch = tool.getLaunch();
+			String toolSite = tool.getSiteId();
 
 			if ( local && StringUtils.trimToNull(toolSite) == null ) continue;
 			if ( global && StringUtils.trimToNull(toolSite) != null ) continue;
@@ -3395,11 +3432,11 @@ public class SakaiLTIUtil {
 		// Next we snip off the query string and check again
 		String launchUrlBase = stripOffQuery(launchUrl);
 
-		// Look for tool with an query-less match
-		// https://www.py4e.com/mod/gift/
-		for ( Map<String,Object> tool : tools ) {
-			String toolLaunchBase = stripOffQuery((String) tool.get(LTIService.LTI_LAUNCH));
-			String toolSite = (String) tool.get(LTIService.LTI_SITE_ID);
+		// Look for tool with query-less match
+		for ( LtiToolBean tool : tools ) {
+			if (tool == null) continue;
+			String toolLaunchBase = stripOffQuery(tool.getLaunch());
+			String toolSite = tool.getSiteId();
 
 			if ( local && StringUtils.trimToNull(toolSite) == null ) continue;
 			if ( global && StringUtils.trimToNull(toolSite) != null ) continue;
@@ -3411,13 +3448,12 @@ public class SakaiLTIUtil {
 		}
 
 		// Find the longest prefix
-		// https://www.py4e.com/mod/   <-- Selected
-		// https://www.py4e.com/
 		String bestPrefix = "";
-		Map<String,Object> bestTool = null;
-		for ( Map<String,Object> tool : tools ) {
-			String toolLaunch = (String) tool.get(LTIService.LTI_LAUNCH);
-			String toolSite = (String) tool.get(LTIService.LTI_SITE_ID);
+		LtiToolBean bestTool = null;
+		for ( LtiToolBean tool : tools ) {
+			if (tool == null) continue;
+			String toolLaunch = tool.getLaunch();
+			String toolSite = tool.getSiteId();
 
 			if ( local && StringUtils.trimToNull(toolSite) == null ) continue;
 			if ( global && StringUtils.trimToNull(toolSite) != null ) continue;
@@ -3441,45 +3477,49 @@ public class SakaiLTIUtil {
 			}
 		}
 
-		// After all that - still nothing
 		return null;
-
-	}
-
-	public static Map<String, Object> findBestToolMatch(String launchUrl, String toolCheckSum, List<Map<String,Object>> tools)
-	{
-		// Example launch URL:
-		// https://www.py4e.com/mod/gift/?quiz=02-Python.txt
-
-		boolean global = true;
-		Map<String,Object> retval = findBestToolMatch(!global, launchUrl, toolCheckSum, tools);
-
-		if ( retval != null ) return retval;
-
-		retval = findBestToolMatch(global, launchUrl, toolCheckSum, tools);
-		return retval;
 	}
 
 	/**
-	 * Bean overload for findBestToolMatch
+	 * Find the best tool match. Tries local then global. Primary implementation.
 	 */
-	public static org.sakaiproject.lti.beans.LtiToolBean findBestToolMatchBean(String launchUrl, String toolCheckSum, List<org.sakaiproject.lti.beans.LtiToolBean> tools)
+	public static LtiToolBean findBestToolMatchBean(String launchUrl, String toolCheckSum, List<LtiToolBean> tools)
 	{
-		// Guard against null tools parameter
 		if (tools == null) {
 			return null;
 		}
-		
-		// Convert Beans to maps for the existing logic
-		List<Map<String,Object>> toolMaps = new ArrayList<>();
-		for (org.sakaiproject.lti.beans.LtiToolBean tool : tools) {
+		boolean global = true;
+		LtiToolBean retval = findBestToolMatchBean(!global, launchUrl, toolCheckSum, tools);
+		if ( retval != null ) return retval;
+		return findBestToolMatchBean(global, launchUrl, toolCheckSum, tools);
+	}
+
+	/** Map shim for backward compatibility; prefer bean overload. */
+	public static Map<String, Object> findBestToolMatch(boolean global, String launchUrl, String importCheckSum, List<Map<String,Object>> tools)
+	{
+		if (tools == null) return null;
+		List<LtiToolBean> toolBeans = new ArrayList<>();
+		for (Map<String, Object> tool : tools) {
 			if (tool != null) {
-				toolMaps.add(tool.asMap());
+				toolBeans.add(LtiToolBean.of(tool));
 			}
 		}
+		LtiToolBean result = findBestToolMatchBean(global, launchUrl, importCheckSum, toolBeans);
+		return result != null ? result.asMap() : null;
+	}
 
-		Map<String,Object> result = findBestToolMatch(launchUrl, toolCheckSum, toolMaps);
-		return result != null ? org.sakaiproject.lti.beans.LtiToolBean.of(result) : null;
+	/** Map shim for backward compatibility; prefer bean overload. */
+	public static Map<String, Object> findBestToolMatch(String launchUrl, String toolCheckSum, List<Map<String,Object>> tools)
+	{
+		if (tools == null) return null;
+		List<LtiToolBean> toolBeans = new ArrayList<>();
+		for (Map<String, Object> tool : tools) {
+			if (tool != null) {
+				toolBeans.add(LtiToolBean.of(tool));
+			}
+		}
+		LtiToolBean result = findBestToolMatchBean(launchUrl, toolCheckSum, toolBeans);
+		return result != null ? result.asMap() : null;
 	}
 
 	public static String getStringNull(Object value) {
@@ -3593,240 +3633,316 @@ public class SakaiLTIUtil {
 	}
 
 	/**
-	 *  Check if we are an LTI 1.1 launch or not
+	 *  Check if we are an LTI 1.1 launch or not. Bean overload.
 	 */
-	public static boolean isLTI11(Map<String, Object> tool) {
-		if ( tool == null ) return false;
-		Long toolLTI13 = LTIUtil.toLong(tool.get(LTIService.LTI13));
-		if ( toolLTI13.equals(LTIService.LTI13_LTI11) ) return true;
-		if ( toolLTI13.equals(LTIService.LTI13_LTI13) ) return false;
-		if ( toolLTI13.equals(LTIService.LTI13_BOTH) ) return true;
+	public static boolean isLTI11(LtiToolBean tool) {
+		if (tool == null) return false;
+		Integer lti13 = tool.getLti13();
+		if (lti13 == null) return true;
+		long v = lti13.longValue();
+		if (v == LTIService.LTI13_LTI11) return true;
+		if (v == LTIService.LTI13_LTI13) return false;
+		if (v == LTIService.LTI13_BOTH) return true;
 		return true;
 	}
 
+	/**
+	 *  Check if we are an LTI 1.1 launch or not
+	 */
+	public static boolean isLTI11(Map<String, Object> tool) {
+		return isLTI11(LtiToolBean.of(tool));
+	}
+
+
+	/**
+	 *  Check if we are an LTI 1.3 launch or not. Bean overload.
+	 */
+	public static boolean isLTI13(LtiToolBean tool) {
+		if (tool == null) return false;
+		Integer lti13 = tool.getLti13();
+		if (lti13 == null) return false;
+		long v = lti13.longValue();
+		if (v == LTIService.LTI13_LTI11) return false;
+		if (v == LTIService.LTI13_LTI13) return true;
+		if (v == LTIService.LTI13_BOTH) return true;
+		return false;
+	}
 
 	/**
 	 *  Check if we are an LTI 1.3 launch or not
 	 */
 	public static boolean isLTI13(Map<String, Object> tool) {
-		if ( tool == null ) return false;
-		Long toolLTI13 = LTIUtil.toLong(tool.get(LTIService.LTI13));
-		if ( toolLTI13.equals(LTIService.LTI13_LTI11) ) return false;
-		if ( toolLTI13.equals(LTIService.LTI13_LTI13) ) return true;
-		if ( toolLTI13.equals(LTIService.LTI13_BOTH) ) return true;
-		return false;  // Default of null or other funky value is LTI 1.1
+		return isLTI13(LtiToolBean.of(tool));
 	}
 
 	/**
-	 * Get the secret based on inheritance rules
+	 * Get the secret for the tool. Content does not have secret; only tool is used.
 	 */
-	public static String getSecret(Map<String, Object> tool, Map<String, Object> content) {
-		String secret = null;
-		if ( content != null ) {
-			secret = (String) content.get(LTIService.LTI_SECRET);
-		}
-		if (secret == null) {
-			secret = (String) tool.get(LTIService.LTI_SECRET);
-		}
-		return secret;
+	public static String getSecret(LtiToolBean tool) {
+		return (tool != null) ? tool.getSecret() : null;
 	}
 
 	/**
-	 * Get the consumer key based on inheritance rules
+	 * Get the consumer key for the tool. Content does not have consumerkey; only tool is used.
 	 */
-	public static String getKey(Map<String, Object> tool, Map<String, Object> content) {
-		String key = null;
-		if ( content != null ) {
-			key = (String) content.get(LTIService.LTI_CONSUMERKEY);
-		}
-		if (key == null) {
-			key = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-		}
-		return key;
+	public static String getKey(LtiToolBean tool) {
+		return (tool != null) ? tool.getConsumerkey() : null;
 	}
 
 	/**
 	 * Get the correct frameheight for a content / combination based on inheritance rules
 	 */
-	public static String getFrameHeight(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, String defaultValue) {
-		return getFrameHeight(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
-	}
-
-	public static String getFrameHeight(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
+	public static String getFrameHeight(LtiToolBean tool, LtiContentBean content, String defaultValue) {
 		String height = defaultValue;
 
 		// Check tool first (default behavior)
-		if ( tool != null ) {
-			Long toolFrameHeight = LTIUtil.toLong(tool.get(LTIService.LTI_FRAMEHEIGHT), -1L);
-			if ( toolFrameHeight > 0 )  height = toolFrameHeight + "px";
+		if (tool != null && tool.getFrameheight() != null && tool.getFrameheight() > 0) {
+			height = tool.getFrameheight() + "px";
 		}
 
 		// Check content second (content overrides tool if not null)
-		if (content != null) {
-			Long contentFrameHeight = LTIUtil.toLong(content.get(LTIService.LTI_FRAMEHEIGHT));
-			if ( contentFrameHeight > 0 ) height = contentFrameHeight + "px";
+		if (content != null && content.getFrameheight() != null && content.getFrameheight() > 0) {
+			height = content.getFrameheight() + "px";
 		}
 
 		return height;
 	}
 
+	public static String getFrameHeight(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
+		return getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
+	}
+
 	/**
 	 * Get the new page setting for a content / combination based on inheritance rules
 	 */
-	public static boolean getNewpage(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, boolean defaultValue) {
-		return getNewpage(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
-	}
-
-	public static boolean getNewpage(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+	public static boolean getNewpage(LtiToolBean tool, LtiContentBean content, boolean defaultValue) {
 		boolean newpage = defaultValue;
 
 		// Check content first (lower priority)
-		if (content != null ) {
-			Object contentNewpageObj = content.get(LTIService.LTI_NEWPAGE);
-			if ( contentNewpageObj != null ) {
-				if (contentNewpageObj instanceof Boolean) {
-					newpage = (Boolean) contentNewpageObj;
-				} else {
-					Long contentNewpage = LTIUtil.toLongNull(contentNewpageObj);
-					if ( contentNewpage != null ) newpage = (contentNewpage != 0);
-				}
-			}
+		if (content != null && content.getNewpage() != null) {
+			newpage = content.getNewpage();
 		}
 
 		// Check tool second (higher priority - overrides content)
-		if ( tool != null ) {
-			Long toolNewpage = LTIUtil.toLongNull(tool.get(LTIService.LTI_NEWPAGE));
-
-			if ( toolNewpage != null ) {
-				// Leave this alone for LTIService.LTI_TOOL_NEWPAGE_CONTENT
-				if ( toolNewpage == LTIService.LTI_TOOL_NEWPAGE_OFF ) newpage = false;
-				if ( toolNewpage == LTIService.LTI_TOOL_NEWPAGE_ON ) newpage = true;
-			}
+		if (tool != null && tool.getNewpage() != null) {
+			if (tool.getNewpage() == LTIService.LTI_TOOL_NEWPAGE_OFF) newpage = false;
+			if (tool.getNewpage() == LTIService.LTI_TOOL_NEWPAGE_ON) newpage = true;
 		}
 		return newpage;
+	}
+
+	public static boolean getNewpage(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+		return getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
 	}
 
 	/**
 	 * Get the debug setting for a content / tool combination based on inheritance rules
 	 */
-	public static boolean getDebug(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, boolean defaultValue) {
-		return getDebug(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
-	}
-
-	public static boolean getDebug(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+	public static boolean getDebug(LtiToolBean tool, LtiContentBean content, boolean defaultValue) {
 		boolean debug = defaultValue;
 
 		// Check content first (lower priority)
-		if (content != null ) {
-			Object contentDebugObj = content.get(LTIService.LTI_DEBUG);
-			if ( contentDebugObj != null ) {
-				if (contentDebugObj instanceof Boolean) {
-					debug = (Boolean) contentDebugObj;
-				} else {
-					Long contentDebug = LTIUtil.toLongNull(contentDebugObj);
-					if ( contentDebug != null ) debug = (contentDebug != 0);
-				}
-			}
+		if (content != null && content.getDebug() != null) {
+			debug = content.getDebug();
 		}
 
 		// Check tool second (higher priority - overrides content)
-		if ( tool != null ) {
-			Long toolDebug = LTIUtil.toLongNull(tool.get(LTIService.LTI_DEBUG));
-
-			if ( toolDebug != null ) {
-				// Leave this alone for LTIService.LTI_TOOL_DEBUG_CONTENT
-				if ( toolDebug == LTIService.LTI_TOOL_DEBUG_OFF ) debug = false;
-				if ( toolDebug == LTIService.LTI_TOOL_DEBUG_ON ) debug = true;
-				// toolDebug == 2 (CONTENT) - leave content value as-is
-			}
+		if (tool != null && tool.getDebug() != null) {
+			if (tool.getDebug() == LTIService.LTI_TOOL_DEBUG_OFF) debug = false;
+			if (tool.getDebug() == LTIService.LTI_TOOL_DEBUG_ON) debug = true;
 		}
 		return debug;
+	}
+
+	/** Map shim for backward compatibility; prefer bean overload. */
+	private static boolean getDebug(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+		return getDebug(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
+	}
+
+	/**
+	 * Get the title for a content / tool combination based on inheritance rules. Bean overload.
+	 */
+	public static String getToolTitle(LtiToolBean tool, LtiContentBean content, String defaultValue) {
+		String title = defaultValue;
+
+		if (tool != null && StringUtils.isNotEmpty(tool.getTitle())) {
+			title = tool.getTitle();
+		}
+
+		if (content != null && StringUtils.isNotEmpty(content.getTitle())) {
+			title = content.getTitle();
+		}
+
+		return title;
 	}
 
 	/**
 	 * Get the title for a content / combination based on inheritance rules
 	 */
 	public static String getToolTitle(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
-		String title = defaultValue;
-
-		if ( tool != null ) {
-			String toolTitle = (String) tool.get(LTIService.LTI_TITLE);
-			if ( StringUtils.isNotEmpty(toolTitle) ) title = toolTitle;
-		}
-
-		if (content != null ) {
-			String contentTitle = (String) content.get(LTIService.LTI_TITLE);
-			if ( StringUtils.isNotEmpty(contentTitle) ) title = contentTitle;
-		}
-
-		return title;
+		return getToolTitle(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
 	}
 
-	public static Element archiveTool(Document doc, Map<String, Object> tool) {
-		Element retval = Foorm.archiveThing(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, LTIService.TOOL_MODEL, tool);
+	public static Element archiveTool(Document doc, LtiToolBean tool) {
+		return archiveToolBean(doc, tool);
+	}
+
+	/**
+	 * Archive an LTI tool from a bean. Primary implementation; all other archiveTool
+	 * overloads delegate here.
+	 */
+	public static Element archiveToolBean(Document doc, LtiToolBean tool) {
+		if (tool == null) {
+			return null;
+		}
+		Element retval = tool.toArchiveElement(doc, LTIService.ARCHIVE_LTI_TOOL_TAG);
 		String checksum = computeToolCheckSum(tool);
-		if ( checksum != null ) {
-			Element newElement = doc.createElement(LTIService.SAKAI_TOOL_CHECKSUM);
-			newElement.setTextContent(checksum);
-			retval.appendChild(newElement);
+		if (checksum != null) {
+			Element checksumEl = doc.createElement(LTIService.SAKAI_TOOL_CHECKSUM);
+			checksumEl.setTextContent(checksum);
+			retval.appendChild(checksumEl);
 		}
 		return retval;
 	}
 
-	public static Element archiveContent(Document doc, Map<String, Object> content, Map<String, Object> tool) {
-		// Check if the content launchURL is empty - if so, inherit from tool for the future
-		Map<String, Object> contentCopy = new HashMap(content);
-		String launchUrl = (String) contentCopy.get(LTIService.LTI_LAUNCH);
-		if ( tool != null && StringUtils.isEmpty(launchUrl) ) contentCopy.put(LTIService.LTI_LAUNCH, tool.get(LTIService.LTI_LAUNCH));
-		Element retval = Foorm.archiveThing(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG, LTIService.CONTENT_MODEL, contentCopy);
+	public static Element archiveTool(Document doc, Map<String, Object> tool) {
+		return archiveToolBean(doc, tool != null ? LtiToolBean.of(tool) : null);
+	}
 
-		if ( tool != null ) {
-			Element toolElement = archiveTool(doc, tool);
+	public static Element archiveContent(Document doc, LtiContentBean content, LtiToolBean tool) {
+		return archiveContentBean(doc, content, tool);
+	}
+
+	/**
+	 * Archive LTI content (and optional nested tool). Primary implementation;
+	 * all other archiveContent overloads delegate here.
+	 */
+	public static Element archiveContentBean(Document doc, LtiContentBean content, LtiToolBean tool) {
+		if (content == null) {
+			return null;
+		}
+		LtiContentBean contentToArchive = content;
+		if (tool != null && StringUtils.isEmpty(content.getLaunch()) && StringUtils.isNotEmpty(tool.getLaunch())) {
+			Map<String, Object> contentMap = content.asMap();
+			contentMap.put(LTIService.LTI_LAUNCH, tool.getLaunch());
+			contentToArchive = LtiContentBean.of(contentMap);
+		}
+		Element retval = contentToArchive.toArchiveElement(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG);
+		if (tool != null) {
+			Element toolElement = archiveToolBean(doc, tool);
 			retval.appendChild(toolElement);
 		}
 		return retval;
 	}
 
-	public static void mergeTool(Element element, Map<String, Object> tool) {
-		Foorm.mergeThing(element, LTIService.TOOL_MODEL, tool);
+	public static Element archiveContent(Document doc, Map<String, Object> content, Map<String, Object> tool) {
+		return archiveContentBean(doc,
+				content != null ? LtiContentBean.of(content) : null,
+				tool != null ? LtiToolBean.of(tool) : null);
 	}
 
-	public static void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool) {
-		Foorm.mergeThing(element, LTIService.CONTENT_MODEL, content);
-		if ( tool != null ) {
+	public static void mergeTool(Element element, LtiToolBean tool) {
+		mergeToolBean(element, tool);
+	}
+
+	/**
+	 * Populates a tool bean from an archive XML element. Primary implementation.
+	 */
+	public static void mergeToolBean(Element element, LtiToolBean tool) {
+		if (element != null && tool != null) {
+			tool.populateFromArchiveElement(element);
+		}
+	}
+
+	/**
+	 * Not yet bean-primary: mutates {@code tool} in place via putAll.
+	 * Callers pass their Map for archive import and expect it populated. Will be migrated
+	 * when the persistence/archive layer is audited.
+	 */
+	public static void mergeTool(Element element, Map<String, Object> tool) {
+		if (element == null || tool == null) {
+			return;
+		}
+		LtiToolBean bean = new LtiToolBean();
+		mergeToolBean(element, bean);
+		tool.putAll(bean.asMap());
+	}
+
+	public static void mergeContent(Element element, LtiContentBean content, LtiToolBean tool) {
+		mergeContentBean(element, content, tool);
+	}
+
+	/**
+	 * Populates content and tool beans from an archive XML element. Primary implementation.
+	 */
+	public static void mergeContentBean(Element element, LtiContentBean content, LtiToolBean tool) {
+		if (element == null) {
+			return;
+		}
+		if (content != null) {
+			content.populateFromArchiveElement(element);
+		}
+		if (tool != null) {
 			NodeList nl = element.getElementsByTagName(LTIService.ARCHIVE_LTI_TOOL_TAG);
-			if ( nl.getLength() >= 1 ) {
+			if (nl.getLength() >= 1) {
 				Node toolNode = nl.item(0);
-				if ( toolNode.getNodeType() == Node.ELEMENT_NODE ) {
+				if (toolNode.getNodeType() == Node.ELEMENT_NODE) {
 					Element toolElement = (Element) toolNode;
-					mergeTool(toolElement, tool);
+					mergeToolBean(toolElement, tool);
 				}
 			}
 		}
 	}
 
-	public static String computeToolCheckSum(Map<String, Object> tool) {
-		if ( tool == null ) return null;
-		if ( StringUtils.isEmpty((String) tool.get(LTIService.LTI_LAUNCH)) ) return null;
-		if ( StringUtils.isNotEmpty((String) tool.get(LTIService.LTI_CONSUMERKEY)) &&
-			StringUtils.isNotEmpty((String) tool.get(LTIService.LTI_SECRET)) ) {
-			// Enough
-		} else if ( StringUtils.isNotEmpty((String) tool.get(LTIService.LTI13_CLIENT_ID)) &&
-			StringUtils.isNotEmpty((String) tool.get(LTIService.LTI13_TOOL_KEYSET)) ) {
-			// Enough
+	/**
+	 * Not yet bean-primary: mutates {@code content} and {@code tool} in place via putAll.
+	 * Callers pass their Maps for archive import and expect them populated. Will be migrated
+	 * when the persistence/archive layer is audited.
+	 */
+	public static void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool) {
+		if (element == null) {
+			return;
+		}
+		if (content != null) {
+			LtiContentBean contentBean = new LtiContentBean();
+			mergeContentBean(element, contentBean, null);
+			content.putAll(contentBean.asMap());
+		}
+		if (tool != null) {
+			NodeList nl = element.getElementsByTagName(LTIService.ARCHIVE_LTI_TOOL_TAG);
+			if (nl.getLength() >= 1) {
+				Node toolNode = nl.item(0);
+				if (toolNode.getNodeType() == Node.ELEMENT_NODE) {
+					Element toolElement = (Element) toolNode;
+					LtiToolBean toolBean = new LtiToolBean();
+					mergeToolBean(toolElement, toolBean);
+					tool.putAll(toolBean.asMap());
+				}
+			}
+		}
+	}
+
+	public static String computeToolCheckSum(LtiToolBean tool) {
+		if (tool == null) return null;
+		if (StringUtils.isEmpty(tool.launch)) return null;
+		if (StringUtils.isNotEmpty(tool.consumerkey) && StringUtils.isNotEmpty(tool.secret)) {
+			// LTI 1.1
+		} else if (StringUtils.isNotEmpty(tool.lti13ClientId) && StringUtils.isNotEmpty(tool.lti13ToolKeyset)) {
+			// LTI 1.3
 		} else {
 			return null;
 		}
-
 		StringBuffer sb = new StringBuffer();
-		sb.append((String) tool.get(LTIService.LTI_SECRET));
-		sb.append((String) tool.get(LTIService.LTI_CONSUMERKEY));
-		sb.append((String) tool.get(LTIService.LTI13_CLIENT_ID));
-		sb.append((String) tool.get(LTIService.LTI13_TOOL_KEYSET));
-		sb.append((String) tool.get(LTIService.LTI_LAUNCH));
+		sb.append(tool.secret != null ? tool.secret : "");
+		sb.append(tool.consumerkey != null ? tool.consumerkey : "");
+		sb.append(tool.lti13ClientId != null ? tool.lti13ClientId : "");
+		sb.append(tool.lti13ToolKeyset != null ? tool.lti13ToolKeyset : "");
+		sb.append(tool.launch != null ? tool.launch : "");
+		return LTI13Util.sha256(sb.toString());
+	}
 
-		String retval = LTI13Util.sha256(sb.toString());
-		return retval;
+	public static String computeToolCheckSum(Map<String, Object> tool) {
+		return computeToolCheckSum(LtiToolBean.of(tool));
 	}
 
 	// /access/lti/site/22153323-3037-480f-b979-c630e3e2b3cf/content:1
@@ -3848,22 +3964,29 @@ public class SakaiLTIUtil {
 		return -1L;
 	}
 
-	public static String getContentLaunch(Map<String, Object> content) {
-		if ( content == null ) return null;
-		int key = LTIUtil.toInt(content.get(LTIService.LTI_ID));
-		String siteId = (String) content.get(LTIService.LTI_SITE_ID);
-		if (key < 0 || siteId == null)
-			return null;
+	public static String getContentLaunch(LtiContentBean content) {
+		if (content == null) return null;
+		Long id = content.getId();
+		long key = (id != null) ? id.longValue() : -1L;
+		String siteId = content.getSiteId();
+		if (key < 0 || siteId == null) return null;
 		return LTIService.LAUNCH_PREFIX + siteId + "/content:" + key;
 	}
 
-	public static String getToolLaunch(Map<String, Object> tool, String siteId) {
-		if ( tool == null ) return null;
-		if ( siteId == null ) return null;
-		int key = LTIUtil.toInt(tool.get(LTIService.LTI_ID));
-		if (key < 0 || siteId == null)
-			return null;
+	public static String getContentLaunch(Map<String, Object> content) {
+		return getContentLaunch(LtiContentBean.of(content));
+	}
+
+	public static String getToolLaunch(LtiToolBean tool, String siteId) {
+		if (tool == null || siteId == null) return null;
+		Long id = tool.getId();
+		long key = (id != null) ? id.longValue() : -1L;
+		if (key < 0) return null;
 		return LTIService.LAUNCH_PREFIX + siteId + "/tool:" + key;
+	}
+
+	public static String getToolLaunch(Map<String, Object> tool, String siteId) {
+		return getToolLaunch(LtiToolBean.of(tool), siteId);
 	}
 
 	public static String getExportUrl(String siteId, String filterId, ExportType exportType) {

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -3253,7 +3253,7 @@ public class SakaiLTIUtil {
 	 */
 	public static String getLaunchCodeKey(LtiContentBean content) {
 		if (content == null) return SESSION_LAUNCH_CODE + "0";
-		int id = (content.getId() != null) ? content.getId().intValue() : 0;
+		String id = (content.getId() != null) ? content.getId().toString() : "0";
 		return SESSION_LAUNCH_CODE + id;
 	}
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -1369,10 +1369,6 @@ public class SakaiLTIUtil {
 			}
 		}
 
-		private static Key getPublicKey(Map<String, Object> tool, String id_token) {
-			return getPublicKey(LtiToolBean.of(tool), id_token);
-		}
-
 		/**
 		 * Create a DeepLinkResponse from the current request (may throw runtime). Bean overload.
 		 */
@@ -3282,6 +3278,7 @@ public class SakaiLTIUtil {
 	 */
 	public static boolean checkLaunchCode(LtiContentBean content, String launch_code) {
 		if (content == null) return false;
+		if (launch_code == null || launch_code.trim().isEmpty()) return false;
 		String content_id = (content.getId() != null) ? content.getId().toString() : "0";
 		if (!launch_code.contains(":" + content_id + ":")) return false;
 		String placement_secret = content.getPlacementsecret();
@@ -3708,11 +3705,6 @@ public class SakaiLTIUtil {
 			if (tool.getDebug() == LTIService.LTI_TOOL_DEBUG_ON) debug = true;
 		}
 		return debug;
-	}
-
-	/** Map shim for backward compatibility; prefer bean overload. */
-	private static boolean getDebug(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
-		return getDebug(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
 	}
 
 	/**

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -49,6 +49,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.util.foorm.Foorm;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 
 import org.sakaiproject.grading.api.GradingService;
@@ -154,6 +155,19 @@ public class LineItemUtil {
 		}
 	}
 	// tool_id|content_id|resourceId|tag|
+	/**
+	 * Construct the GB_EXTERNAL_ID for LTI AGS entries
+	 * @param content - The content item (can be null)
+	 * @param lineItem - The lineItem to insert
+	 * @return The properly formatted external id, or null if content is null or has no tool id
+	 */
+	public static String constructExternalId(LtiContentBean content, SakaiLineItem lineItem) {
+		if (content == null) return null;
+		Long toolId = content.getToolId();
+		if (toolId == null) return null;
+		return constructExternalIdImpl(toolId, content.getId(), lineItem);
+	}
+
 	/**
 	 * Construct the GB_EXTERNAL_ID for LTI AGS entries
 	 * @param content - The content item cannot be null
@@ -676,7 +690,7 @@ public class LineItemUtil {
 				String assignmentReference = org.sakaiproject.assignment.api.AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference();
 				Integer assignmentContentId = a.getContentId();
 				if ( assignmentContentId == null ) continue;
-				Map<String, Object> content = ltiService.getContent(assignmentContentId.longValue(), context_id);
+				LtiContentBean content = ltiService.getContentAsBean(assignmentContentId.longValue(), context_id);
 				if ( content == null ) continue;
 				retval.put(assignmentReference, constructExternalId(content, null));
 			}
@@ -1153,6 +1167,23 @@ public class LineItemUtil {
 
 	/*
 	 * This is the statically constructed line item for a content item - if this is used, it will create
+	 * a line item when a score is first received. Bean overload using bean-based SakaiLTIUtil methods.
+	 */
+	public static SakaiLineItem constructLineItem(LtiContentBean content) {
+		if (content == null) return null;
+		String signed_placement = SakaiLTIUtil.getSignedPlacement(content);
+		SakaiLineItem li = new SakaiLineItem();
+		li.label = content.getTitle();
+		li.resourceLinkId = SakaiLTIUtil.getResourceLinkId(content);
+		if ( signed_placement != null ) {
+			li.id = getOurServerUrl() + LTI13_PATH + "lineitem/" + signed_placement;
+		}
+		li.scoreMaximum = 100.0;
+		return li;
+	}
+
+	/*
+	 * This is the statically constructed line item for a content item - if this is used, it will create
 	 * a line item when a score is first received
 	 */
 	public static SakaiLineItem constructLineItem(Map<String, Object> content) {
@@ -1194,13 +1225,29 @@ public class LineItemUtil {
 	}
 
 	/**
-	 * Gets the default lineItem for a content launch with content bean
+	 * Gets the default lineItem for a content launch with content bean. Uses bean-based SakaiLTIUtil methods.
 	 * @param site the site
 	 * @param content the content bean
 	 * @return the default line item
 	 */
-	public static SakaiLineItem getDefaultLineItem(Site site, org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getDefaultLineItem(site, content != null ? content.asMap() : null);
+	public static SakaiLineItem getDefaultLineItem(Site site, LtiContentBean content) {
+		if (content == null) return null;
+		String signed_placement = SakaiLTIUtil.getSignedPlacement(content);
+		Long tool_id = content.getToolId();
+		log.debug("signed_placement={}; site id={}; tool_id={}", signed_placement, site.getId(), tool_id);
+		List<SakaiLineItem> toolItems = LineItemUtil.getLineItemsForTool(signed_placement, site, tool_id, null /* filter */);
+		String title = content.getTitle();
+		for (SakaiLineItem item : toolItems) {
+			if ( item.label == null) continue;
+			if ( item.label.equals(title) ) {
+				return item;
+			}
+		}
+		String autoConstruct = ServerConfigurationService.getString(LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM, LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_DEFAULT);
+		if ( LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_TRUE.equals(autoConstruct) ) {
+			return constructLineItem(content);
+		}
+		return null;
 	}
 
 	/**

--- a/lti/lti-common/src/test/org/sakaiproject/lti/beans/LTIBeanIntegrationTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/beans/LTIBeanIntegrationTest.java
@@ -104,7 +104,7 @@ public class LTIBeanIntegrationTest {
         // 3. Create new content bean
         // 4. Insert content
         
-        // Create a list of tool beans (simulating what would come from ltiService.getToolBeans())
+        // Create a list of tool beans (simulating what would come from ltiService.getToolsAsBeans())
         List<LtiToolBean> tools = new ArrayList<>();
         
         LtiToolBean tool1 = new LtiToolBean();

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -1389,29 +1389,29 @@ public class SakaiLTIUtilTest {
 		contentMap.put("id", 123L);
 		contentMap.put("placementsecret", "test-secret");
 
-		// Test getNewpage delegation (bean path; Map data via of())
+		// Test getNewpage delegation: Bean overload vs direct Map-based method
 		boolean pojoResult = SakaiLTIUtil.getNewpage(toolBean, contentBean, false);
-		boolean mapResult = SakaiLTIUtil.getNewpage(LtiToolBean.of(toolMap), LtiContentBean.of(contentMap), false);
+		boolean mapResult = SakaiLTIUtil.getNewpage(toolMap, contentMap, false);
 		assertEquals("Bean and Map getNewpage should produce same result", pojoResult, mapResult);
 
-		// Test getFrameHeight delegation
+		// Test getFrameHeight delegation: Bean overload vs direct Map-based method
 		String pojoHeight = SakaiLTIUtil.getFrameHeight(toolBean, contentBean, "400px");
-		String mapHeight = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(toolMap), LtiContentBean.of(contentMap), "400px");
+		String mapHeight = SakaiLTIUtil.getFrameHeight(toolMap, contentMap, "400px");
 		assertEquals("Bean and Map getFrameHeight should produce same result", pojoHeight, mapHeight);
 
-		// Test getLaunchCodeKey delegation
+		// Test getLaunchCodeKey delegation: Bean overload vs direct Map-based method
 		String pojoKey = SakaiLTIUtil.getLaunchCodeKey(contentBean);
-		String mapKey = SakaiLTIUtil.getLaunchCodeKey(LtiContentBean.of(contentMap));
+		String mapKey = SakaiLTIUtil.getLaunchCodeKey(contentMap);
 		assertEquals("Bean and Map getLaunchCodeKey should produce same result", pojoKey, mapKey);
 
-		// Test getLaunchCode delegation - both should produce valid codes
+		// Test getLaunchCode delegation: Bean overload vs direct Map-based method
 		String pojoCode = SakaiLTIUtil.getLaunchCode(contentBean);
-		String mapCode = SakaiLTIUtil.getLaunchCode(LtiContentBean.of(contentMap));
-		
+		String mapCode = SakaiLTIUtil.getLaunchCode(contentMap);
+
 		// Both codes should be valid (time-dependent, so they won't be identical)
 		assertTrue("Bean getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentBean, pojoCode));
-		assertTrue("Map getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(LtiContentBean.of(contentMap), mapCode));
-		
+		assertTrue("Map getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentMap, mapCode));
+
 		// Both codes should contain the content ID
 		assertTrue("Bean code should contain content ID", pojoCode.contains(":123:"));
 		assertTrue("Map code should contain content ID", mapCode.contains(":123:"));

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -38,11 +38,15 @@ import java.util.stream.Collectors;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import org.json.simple.JSONObject;
 
 import org.sakaiproject.util.Xml;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.tsugi.lti.LTIUtil;
 import org.tsugi.lti.LTIConstants;
@@ -160,20 +164,23 @@ public class SakaiLTIUtilTest {
 		Map<String, Object> content = new TreeMap<String, Object>();
 		content.put(LTIService.LTI_ID, "42");
 		content.put(LTIService.LTI_PLACEMENTSECRET, "xyzzy");
+		LtiContentBean contentBean = LtiContentBean.of(content);
 
-		String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(content);
+		String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(contentBean);
 		assertEquals(launch_code_key,"launch_code:42");
 
-		String launch_code = SakaiLTIUtil.getLaunchCode(content);
-		assertTrue(SakaiLTIUtil.checkLaunchCode(content, launch_code));
+		String launch_code = SakaiLTIUtil.getLaunchCode(contentBean);
+		assertTrue(SakaiLTIUtil.checkLaunchCode(contentBean, launch_code));
 
 		content.put(LTIService.LTI_PLACEMENTSECRET, "wrong");
-		assertFalse(SakaiLTIUtil.checkLaunchCode(content, launch_code));
+		contentBean = LtiContentBean.of(content);
+		assertFalse(SakaiLTIUtil.checkLaunchCode(contentBean, launch_code));
 
 		// Correct password different id
 		content.put(LTIService.LTI_ID, "43");
 		content.put(LTIService.LTI_PLACEMENTSECRET, "xyzzy");
-		assertFalse(SakaiLTIUtil.checkLaunchCode(content, launch_code));
+		contentBean = LtiContentBean.of(content);
+		assertFalse(SakaiLTIUtil.checkLaunchCode(contentBean, launch_code));
 	}
 
 	@Test
@@ -758,41 +765,41 @@ public class SakaiLTIUtilTest {
 		Map<String, Object> tool = new HashMap();
 		Map<String, Object> content = new HashMap();
 
-		// Run default tests
-		boolean retval = SakaiLTIUtil.getNewpage((Map<String, Object>) null, (Map<String, Object>) null, true);
+		// Run default tests (bean overload with null)
+		boolean retval = SakaiLTIUtil.getNewpage((LtiToolBean) null, (LtiContentBean) null, true);
 		assertEquals(retval, true);
-		retval = SakaiLTIUtil.getNewpage((Map<String, Object>) null, (Map<String, Object>) null, false);
+		retval = SakaiLTIUtil.getNewpage((LtiToolBean) null, (LtiContentBean) null, false);
 		assertEquals(retval, false);
 
 		// No data means default comes through
-		retval = SakaiLTIUtil.getNewpage(tool, content, true);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), true);
 		assertEquals(retval, true);
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, false);
 
 		// Only content
 		content.put(LTIService.LTI_NEWPAGE, 0L);
-		retval = SakaiLTIUtil.getNewpage(tool, content, true);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), true);
 		assertEquals(retval, false);
 		content.put(LTIService.LTI_NEWPAGE, 1L);
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, true);
 
 		// Tool wins
 		tool.put(LTIService.LTI_NEWPAGE, LTIService.LTI_TOOL_NEWPAGE_OFF);
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, false);
 
 		tool.put(LTIService.LTI_NEWPAGE, Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_ON));
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, true);
 
 		// Let content win
 		tool.put(LTIService.LTI_NEWPAGE, Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT));
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, true);
 		content.put(LTIService.LTI_NEWPAGE, 0L);
-		retval = SakaiLTIUtil.getNewpage(tool, content, true);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), true);
 		assertEquals(retval, false);
 	}
 
@@ -800,33 +807,33 @@ public class SakaiLTIUtilTest {
 	public void testGetFrameHeight() {
 		Map<String, Object> tool = new HashMap();
 		Map<String, Object> content = new HashMap();
-		String retval = SakaiLTIUtil.getFrameHeight((Map<String, Object>) null, (Map<String, Object>) null, "1200px");
+		String retval = SakaiLTIUtil.getFrameHeight((LtiToolBean) null, (LtiContentBean) null, "1200px");
 		assertEquals(retval, "1200px");
 
 		// Both are empty
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "1200px");
 
 		content.put(LTIService.LTI_FRAMEHEIGHT, Long.valueOf(42));
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "42px");
 
 		// Tool is empty
 		content.put(LTIService.LTI_FRAMEHEIGHT, Long.valueOf(42));
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "42px");
 
 		// Strings work as well - just in case
 		content.put(LTIService.LTI_FRAMEHEIGHT, "44");
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "44px");
 
 		tool.put(LTIService.LTI_FRAMEHEIGHT, Long.valueOf(100));
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "44px");
 
 		// Content takes precedence over tool
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "44px");
 	}
 
@@ -846,14 +853,23 @@ public class SakaiLTIUtilTest {
 
 		Element element = SakaiLTIUtil.archiveContent(doc, content, null);
 		root.appendChild(element);
-		String xmlOut = Xml.writeDocumentToString(doc);
-		assertEquals(xmlOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><sakai-lti-content><title>An LTI title</title><description>An LTI DESCRIPTION</description><frameheight>42</frameheight><newpage>1</newpage><launch>http://localhost:a-launch?x=42</launch></sakai-lti-content></root>");
+		Map<String, String> expectedContent = new HashMap<>();
+		expectedContent.put("title", "An LTI title");
+		expectedContent.put("description", "An LTI DESCRIPTION");
+		expectedContent.put("frameheight", "42");
+		expectedContent.put("newpage", "1");
+		expectedContent.put("launch", "http://localhost:a-launch?x=42");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG, expectedContent, LTIService.ARCHIVE_LTI_TOOL_TAG);
 
 		Map<String, Object> content2  = new HashMap();
 		SakaiLTIUtil.mergeContent(element, content2, null);
-		assertNotEquals(content, content2);
-		content.remove(LTIService.LTI_TOOL_ID);
-		assertEquals(content, content2);
+		Map<String, Object> expectedContentMap = new HashMap();
+		expectedContentMap.put(LTIService.LTI_FRAMEHEIGHT, 42);
+		expectedContentMap.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedContentMap.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedContentMap.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedContentMap.put(LTIService.LTI_NEWPAGE, 1);
+		assertEquals(expectedContentMap, content2);
 	}
 
 	@Test
@@ -870,28 +886,116 @@ public class SakaiLTIUtilTest {
 		tool.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
 		tool.put(LTIService.LTI_NEWPAGE, 1L);
 
-		tool.put(LTIService.LTI_SENDNAME, "please");  // Wil export (bad data) will not import
+		tool.put(LTIService.LTI_SENDNAME, "please");  // Bad data: bean path normalizes to 0/1
 		tool.put(LTIService.LTI_SECRET, "verysecure");  // Should not come back - Not archived
 		tool.put(LTIService.LTI_CONSUMERKEY, "key12345");  // Should not come back - Not archived
 
 		Element element = SakaiLTIUtil.archiveTool(doc, tool);
 		root.appendChild(element);
-		String xmlOut = Xml.writeDocumentToString(doc);
-		assertEquals(xmlOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><sakai-lti-tool><title>An LTI title</title><description>An LTI DESCRIPTION</description><launch>http://localhost:a-launch?x=42</launch><newpage>1</newpage><frameheight>42</frameheight><sendname>please</sendname><lti13>1</lti13><sakai_tool_checksum>85RP91sSzHqtxBIkTrknaShQlL52r0JLOfKvaLJT4Gc=</sakai_tool_checksum></sakai-lti-tool></root>");
+		Map<String, String> expectedToolElements = new HashMap<>();
+		expectedToolElements.put("title", "An LTI title");
+		expectedToolElements.put("description", "An LTI DESCRIPTION");
+		expectedToolElements.put("launch", "http://localhost:a-launch?x=42");
+		expectedToolElements.put("newpage", "1");
+		expectedToolElements.put("frameheight", "42");
+		expectedToolElements.put("sendname", "0");  // Bean path normalizes non-boolean to 0
+		expectedToolElements.put("lti13", "1");
+		expectedToolElements.put("sakai_tool_checksum", "Jon1MG0AtWlH0fcbHrOJ9L/PNb+mti8syZ2b6OGf0Rw=");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedToolElements, null);
 
 		Map<String, Object> tool2 = new HashMap();
 		SakaiLTIUtil.mergeTool(element, tool2);
 		assertNotEquals(tool, tool2);
-		assertEquals((String) (tool2.get(LTIService.SAKAI_TOOL_CHECKSUM)), "85RP91sSzHqtxBIkTrknaShQlL52r0JLOfKvaLJT4Gc=");
+		assertNull("Checksum is excluded from rehydration (getExcludedArchiveFieldNames)", tool2.get(LTIService.SAKAI_TOOL_CHECKSUM));
 		tool.remove(LTIService.LTI_SECRET);
 		assertNotEquals(tool, tool2);
 		tool.remove(LTIService.LTI_CONSUMERKEY);
 		assertNotEquals(tool, tool2);
 		tool.remove(LTIService.LTI_SENDNAME);
-		assertNotEquals(tool, tool2);
 		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
-		assertTrue(tool.equals(tool2));
-		assertEquals(tool, tool2);
+		tool2.remove(LTIService.LTI_SENDNAME);  // Bean path exports "0"; exclude for equivalence
+		Map<String, Object> expectedTool = new HashMap();
+		expectedTool.put(LTIService.LTI_FRAMEHEIGHT, 42);
+		expectedTool.put(LTIService.LTI13, 1);
+		expectedTool.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedTool.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedTool.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedTool.put(LTIService.LTI_NEWPAGE, 1);
+		assertEquals(expectedTool, tool2);
+	}
+
+	@Test
+	public void testArchiveMergeToolBean() {
+		Document doc = Xml.createDocument();
+		Element root = doc.createElement("root");
+		doc.appendChild(root);
+
+		LtiToolBean tool = new LtiToolBean();
+		tool.setFrameheight(42);
+		tool.setLti13(LTIService.LTI13_LTI13.intValue());
+		tool.setLaunch("http://localhost:a-launch?x=42");
+		tool.setTitle("An LTI title");
+		tool.setDescription("An LTI DESCRIPTION");
+		tool.setNewpage(1);
+		tool.setSendname(false);
+		tool.setSecret("verysecure");
+		tool.setConsumerkey("key12345");
+
+		Element element = SakaiLTIUtil.archiveToolBean(doc, tool);
+		root.appendChild(element);
+		Map<String, String> expectedToolElements = new HashMap<>();
+		expectedToolElements.put("title", "An LTI title");
+		expectedToolElements.put("description", "An LTI DESCRIPTION");
+		expectedToolElements.put("launch", "http://localhost:a-launch?x=42");
+		expectedToolElements.put("newpage", "1");
+		expectedToolElements.put("frameheight", "42");
+		expectedToolElements.put("sendname", "0");
+		expectedToolElements.put("lti13", "1");
+		expectedToolElements.put("sakai_tool_checksum", "Jon1MG0AtWlH0fcbHrOJ9L/PNb+mti8syZ2b6OGf0Rw=");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedToolElements, null);
+
+		// Round-trip: merge XML back into a map and verify we get the same tool data.
+		// mergeTool parses the sakai-lti-tool element and populates tool2 with element values.
+		// Checksum is excluded from rehydration (getExcludedArchiveFieldNames), so we assert it is null.
+		Map<String, Object> tool2 = new HashMap();
+		SakaiLTIUtil.mergeTool(element, tool2);
+		assertNull("Checksum is excluded from rehydration (getExcludedArchiveFieldNames)", tool2.get(LTIService.SAKAI_TOOL_CHECKSUM));
+		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
+		Map<String, Object> expected = new HashMap();
+		expected.put(LTIService.LTI_TITLE, "An LTI title");
+		expected.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expected.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expected.put(LTIService.LTI_NEWPAGE, 1);
+		expected.put(LTIService.LTI_FRAMEHEIGHT, 42);
+		expected.put(LTIService.LTI_SENDNAME, 0);
+		expected.put(LTIService.LTI13, 1);
+		assertEquals(expected, tool2);
+	}
+
+	/**
+	 * Asserts that the first element with the given tag in doc has child elements equivalent
+	 * to expected (same tag names and text content, ignoring order). Optionally excludes
+	 * a nested child tag when building the map (e.g. exclude sakai-lti-tool when checking
+	 * content element's direct fields).
+	 */
+	private void assertElementXmlEquivalent(Document doc, String tagName, Map<String, String> expected, String excludeChildTag) {
+		NodeList nodes = doc.getElementsByTagName(tagName);
+		assertNotNull(tagName + " element should exist", nodes);
+		assertTrue(tagName + " element should exist", nodes.getLength() >= 1);
+		Element el = (Element) nodes.item(0);
+		Map<String, String> actual = new HashMap<>();
+		NodeList children = el.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node n = children.item(i);
+			if (n.getNodeType() == Node.ELEMENT_NODE) {
+				Element e = (Element) n;
+				if (excludeChildTag != null && excludeChildTag.equals(e.getTagName())) {
+					continue;
+				}
+				actual.put(e.getTagName(), e.getTextContent());
+			}
+		}
+		assertEquals(tagName + " XML elements should be equivalent (order-independent)", expected, actual);
 	}
 
 	public void mapDump(String header, Map<String, Object> dump)
@@ -928,23 +1032,47 @@ public class SakaiLTIUtilTest {
 
 		Element element = SakaiLTIUtil.archiveContent(doc, content, tool);
 		root.appendChild(element);
-		String xmlOut = Xml.writeDocumentToString(doc);
-		assertEquals(xmlOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><sakai-lti-content><title>An LTI title</title><description>An LTI DESCRIPTION</description><frameheight>42</frameheight><newpage>1</newpage><launch>http://localhost:a-launch?x=42</launch><sakai-lti-tool><title>An LTI title</title><description>An LTI DESCRIPTION</description><launch>http://localhost:a-launch?x=42</launch><newpage>1</newpage><frameheight>42</frameheight><lti13>1</lti13><sakai_tool_checksum>ASRHSVgrhBjDbhkLEZpWa/IueI9FwFwTxSjnU5uNCB0=</sakai_tool_checksum></sakai-lti-tool></sakai-lti-content></root>");
+		Map<String, String> expectedContent = new HashMap<>();
+		expectedContent.put("title", "An LTI title");
+		expectedContent.put("description", "An LTI DESCRIPTION");
+		expectedContent.put("frameheight", "42");
+		expectedContent.put("newpage", "1");
+		expectedContent.put("launch", "http://localhost:a-launch?x=42");
+		Map<String, String> expectedTool = new HashMap<>();
+		expectedTool.put("title", "An LTI title");
+		expectedTool.put("description", "An LTI DESCRIPTION");
+		expectedTool.put("launch", "http://localhost:a-launch?x=42");
+		expectedTool.put("newpage", "1");
+		expectedTool.put("frameheight", "42");
+		expectedTool.put("lti13", "1");
+		expectedTool.put("sakai_tool_checksum", "BF6JwVmB1Y1kgPxP4WnAS30BnWzJP46IpmKKrKCSfaw=");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG, expectedContent, LTIService.ARCHIVE_LTI_TOOL_TAG);
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedTool, null);
 
 		Map<String, Object> content2  = new HashMap();
 		Map<String, Object> tool2  = new HashMap();
 		SakaiLTIUtil.mergeContent(element, content2, tool2);
-		assertEquals(content, content2);
-		assertNotEquals(tool, tool2);
-		tool.remove(LTIService.LTI_CONSUMERKEY);
-		tool.remove(LTIService.LTI_SECRET);
+		Map<String, Object> expectedContentMap = new HashMap();
+		expectedContentMap.put(LTIService.LTI_FRAMEHEIGHT, 42);
+		expectedContentMap.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedContentMap.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedContentMap.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedContentMap.put(LTIService.LTI_NEWPAGE, 1);
+		assertEquals(expectedContentMap, content2);
 		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
-		assertEquals(tool, tool2);
+		Map<String, Object> expectedToolMap = new HashMap();
+		expectedToolMap.put(LTIService.LTI_FRAMEHEIGHT, 42);
+		expectedToolMap.put(LTIService.LTI13, 1);
+		expectedToolMap.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedToolMap.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedToolMap.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedToolMap.put(LTIService.LTI_NEWPAGE, 1);
+		assertEquals(expectedToolMap, tool2);
 	}
 
 	@Test
 	public void testToolCheckSum() {
-		String test = SakaiLTIUtil.computeToolCheckSum(null);
+		String test = SakaiLTIUtil.computeToolCheckSum((LtiToolBean) null);
 		assertEquals(test, null);
 
 		Map<String, Object> tool = new HashMap();
@@ -962,29 +1090,29 @@ public class SakaiLTIUtilTest {
 		tool.put(LTIService.LTI_CONSUMERKEY, "key12345");
 
 		test = SakaiLTIUtil.computeToolCheckSum(tool);
-		assertEquals(test, "ASRHSVgrhBjDbhkLEZpWa/IueI9FwFwTxSjnU5uNCB0=");
+		assertEquals(test, "BF6JwVmB1Y1kgPxP4WnAS30BnWzJP46IpmKKrKCSfaw=");
 	}
 
 	@Test
 	public void testLTIUrls() {
-		String launchUrl = SakaiLTIUtil.getContentLaunch(null);
+		String launchUrl = SakaiLTIUtil.getContentLaunch((LtiContentBean) null);
 		assertEquals(launchUrl, null);
-		launchUrl = SakaiLTIUtil.getToolLaunch(null, null);
+		launchUrl = SakaiLTIUtil.getToolLaunch((LtiToolBean) null, null);
 		assertEquals(launchUrl, null);
-		launchUrl = SakaiLTIUtil.getToolLaunch(null, "siteid-was-here");
+		launchUrl = SakaiLTIUtil.getToolLaunch((LtiToolBean) null, "siteid-was-here");
 		assertEquals(launchUrl, null);
 
 		Map<String, Object> tool = new HashMap();
 		tool.put(LTIService.LTI_ID, Long.valueOf(42));
-		launchUrl = SakaiLTIUtil.getToolLaunch(tool, "siteid-was-here");
+		launchUrl = SakaiLTIUtil.getToolLaunch(LtiToolBean.of(tool), "siteid-was-here");
 		assertEquals(launchUrl, "/access/lti/site/siteid-was-here/tool:42");
 
 		Map<String, Object> content = new HashMap();
 		content.put(LTIService.LTI_ID, Long.valueOf(43));
-		launchUrl = SakaiLTIUtil.getContentLaunch(content);
+		launchUrl = SakaiLTIUtil.getContentLaunch(LtiContentBean.of(content));
 		assertEquals(launchUrl, null);
 		content.put(LTIService.LTI_SITE_ID, "siteid-was-here");
-		launchUrl = SakaiLTIUtil.getContentLaunch(content);
+		launchUrl = SakaiLTIUtil.getContentLaunch(LtiContentBean.of(content));
 		assertEquals(launchUrl, "/access/lti/site/siteid-was-here/content:43");
 
 		Long contentKey = SakaiLTIUtil.getContentKeyFromLaunch(launchUrl);
@@ -1073,47 +1201,27 @@ public class SakaiLTIUtilTest {
 		// We'll test with a null keyset to avoid making real HTTP requests
 
 		// Create a test tool bean with null keyset
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.lti13ToolKeyset = null; // This should cause a RuntimeException
 
-		// Create equivalent map for comparison
-		Map<String, Object> toolMap = new HashMap<>();
-		toolMap.put(LTIService.LTI13_TOOL_KEYSET, null);
-
-		// Test that both methods fail with the same exception for null keyset
+		// Test that bean method fails with exception for null keyset (Map-based impl is now private)
 		String idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2lkIn0.eyJpc3MiOiJ0ZXN0Iiwic3ViIjoidGVzdCIsImF1ZCI6InRlc3QiLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMzYwMH0.test";
-
-		Exception pojoException = null;
-		Exception mapException = null;
 
 		try {
 			SakaiLTIUtil.getPublicKey(tool, idToken);
 			fail("Expected RuntimeException for null keyset");
 		} catch (Exception e) {
-			pojoException = e;
+			assertNotNull("Bean method should throw exception", e);
 		}
-
-		try {
-			SakaiLTIUtil.getPublicKey(toolMap, idToken);
-			fail("Expected RuntimeException for null keyset");
-		} catch (Exception e) {
-			mapException = e;
-		}
-
-		// Both should fail with the same type of exception
-		assertNotNull("Bean method should throw exception", pojoException);
-		assertNotNull("Map method should throw exception", mapException);
-		assertEquals("Both methods should throw the same type of exception",
-					mapException.getClass(), pojoException.getClass());
 	}
 
 	@Test
 	public void testGetNewpageOverload() {
 		// Test the Bean overload of getNewpage method
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.newpage = 1; // LTI_TOOL_NEWPAGE_ON
 
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.newpage = false; // Boolean for content
 
 		// Test with tool setting (should override default)
@@ -1144,17 +1252,17 @@ public class SakaiLTIUtilTest {
 		assertFalse("Tool newpage=2 should allow content newpage=false to take precedence", result);
 
 		// Test with null parameters
-		result = SakaiLTIUtil.getNewpage((org.sakaiproject.lti.beans.LtiToolBean) null, (org.sakaiproject.lti.beans.LtiContentBean) null, false);
+		result = SakaiLTIUtil.getNewpage((LtiToolBean) null, (LtiContentBean) null, false);
 		assertFalse("Default should be used when both parameters are null", result);
 	}
 
 	@Test
 	public void testGetDebugOverload() {
 		// Test the Bean overload of getDebug method
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.debug = 1; // LTI_TOOL_DEBUG_ON
 
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.debug = false; // Boolean for content
 
 		// Test with tool setting (should override default)
@@ -1185,17 +1293,17 @@ public class SakaiLTIUtilTest {
 		assertFalse("Tool debug=2 should allow content debug=false to take precedence", result);
 
 		// Test with null parameters
-		result = SakaiLTIUtil.getDebug((org.sakaiproject.lti.beans.LtiToolBean) null, (org.sakaiproject.lti.beans.LtiContentBean) null, false);
+		result = SakaiLTIUtil.getDebug((LtiToolBean) null, (LtiContentBean) null, false);
 		assertFalse("Default should be used when both parameters are null", result);
 	}
 
 	@Test
 	public void testGetFrameHeightOverload() {
 		// Test the Bean overload of getFrameHeight method
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.frameheight = 800;
 
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.frameheight = 600;
 
 		// Test with both tool and content (content should override tool)
@@ -1220,14 +1328,14 @@ public class SakaiLTIUtilTest {
 		assertEquals("Default should be used when both are null", "400px", result);
 
 		// Test with null parameters
-		result = SakaiLTIUtil.getFrameHeight((org.sakaiproject.lti.beans.LtiToolBean) null, (org.sakaiproject.lti.beans.LtiContentBean) null, "300px");
+		result = SakaiLTIUtil.getFrameHeight((LtiToolBean) null, (LtiContentBean) null, "300px");
 		assertEquals("Default should be used when both parameters are null", "300px", result);
 	}
 
 	@Test
 	public void testGetLaunchCodeKeyOverload() {
 		// Test the Bean overload of getLaunchCodeKey method
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.id = 123L;
 
 		String result = SakaiLTIUtil.getLaunchCodeKey(content);
@@ -1235,14 +1343,14 @@ public class SakaiLTIUtilTest {
 		assertTrue("Launch code key should contain session prefix and ID", result.contains("123"));
 
 		// Test with null content
-		result = SakaiLTIUtil.getLaunchCodeKey((org.sakaiproject.lti.beans.LtiContentBean) null);
+		result = SakaiLTIUtil.getLaunchCodeKey((LtiContentBean) null);
 		assertNotNull("Launch code key should not be null even with null content", result);
 	}
 
 	@Test
 	public void testGetLaunchCodeOverload() {
 		// Test the Bean overload of getLaunchCode method
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.id = 456L;
 		content.placementsecret = "test-secret";
 
@@ -1251,7 +1359,7 @@ public class SakaiLTIUtilTest {
 		assertTrue("Launch code should contain content ID", result.contains("456"));
 
 		// Test with null content
-		result = SakaiLTIUtil.getLaunchCode((org.sakaiproject.lti.beans.LtiContentBean) null);
+		result = SakaiLTIUtil.getLaunchCode((LtiContentBean) null);
 		assertNotNull("Launch code should not be null even with null content", result);
 	}
 
@@ -1261,7 +1369,7 @@ public class SakaiLTIUtilTest {
 		// by ensuring they produce the same results
 
 		// Create equivalent Bean and Map objects
-		org.sakaiproject.lti.beans.LtiToolBean toolBean = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean toolBean = new LtiToolBean();
 		toolBean.newpage = 1; // LTI_TOOL_NEWPAGE_ON
 		toolBean.frameheight = 800;
 
@@ -1269,7 +1377,7 @@ public class SakaiLTIUtilTest {
 		toolMap.put("newpage", 1);
 		toolMap.put("frameheight", 800);
 
-		org.sakaiproject.lti.beans.LtiContentBean contentBean = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean contentBean = new LtiContentBean();
 		contentBean.newpage = false; // Boolean for content
 		contentBean.frameheight = 600;
 		contentBean.id = 123L;
@@ -1281,28 +1389,28 @@ public class SakaiLTIUtilTest {
 		contentMap.put("id", 123L);
 		contentMap.put("placementsecret", "test-secret");
 
-		// Test getNewpage delegation
+		// Test getNewpage delegation (bean path; Map data via of())
 		boolean pojoResult = SakaiLTIUtil.getNewpage(toolBean, contentBean, false);
-		boolean mapResult = SakaiLTIUtil.getNewpage(toolMap, contentMap, false);
+		boolean mapResult = SakaiLTIUtil.getNewpage(LtiToolBean.of(toolMap), LtiContentBean.of(contentMap), false);
 		assertEquals("Bean and Map getNewpage should produce same result", pojoResult, mapResult);
 
 		// Test getFrameHeight delegation
 		String pojoHeight = SakaiLTIUtil.getFrameHeight(toolBean, contentBean, "400px");
-		String mapHeight = SakaiLTIUtil.getFrameHeight(toolMap, contentMap, "400px");
+		String mapHeight = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(toolMap), LtiContentBean.of(contentMap), "400px");
 		assertEquals("Bean and Map getFrameHeight should produce same result", pojoHeight, mapHeight);
 
 		// Test getLaunchCodeKey delegation
 		String pojoKey = SakaiLTIUtil.getLaunchCodeKey(contentBean);
-		String mapKey = SakaiLTIUtil.getLaunchCodeKey(contentMap);
+		String mapKey = SakaiLTIUtil.getLaunchCodeKey(LtiContentBean.of(contentMap));
 		assertEquals("Bean and Map getLaunchCodeKey should produce same result", pojoKey, mapKey);
 
 		// Test getLaunchCode delegation - both should produce valid codes
 		String pojoCode = SakaiLTIUtil.getLaunchCode(contentBean);
-		String mapCode = SakaiLTIUtil.getLaunchCode(contentMap);
+		String mapCode = SakaiLTIUtil.getLaunchCode(LtiContentBean.of(contentMap));
 		
 		// Both codes should be valid (time-dependent, so they won't be identical)
-		assertTrue("Bean getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentBean.asMap(), pojoCode));
-		assertTrue("Map getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentMap, mapCode));
+		assertTrue("Bean getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentBean, pojoCode));
+		assertTrue("Map getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(LtiContentBean.of(contentMap), mapCode));
 		
 		// Both codes should contain the content ID
 		assertTrue("Bean code should contain content ID", pojoCode.contains(":123:"));
@@ -1312,16 +1420,16 @@ public class SakaiLTIUtilTest {
 	@Test
 	public void testFindBestToolMatchBeanNullHandling() {
 		// Test null tools parameter
-		org.sakaiproject.lti.beans.LtiToolBean result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", null);
+		LtiToolBean result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", null);
 		assertNull("findBestToolMatchBean should return null when tools is null", result);
 		
 		// Test empty tools list
-		List<org.sakaiproject.lti.beans.LtiToolBean> emptyTools = new ArrayList<>();
+		List<LtiToolBean> emptyTools = new ArrayList<>();
 		result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", emptyTools);
 		assertNull("findBestToolMatchBean should return null when tools list is empty", result);
 		
 		// Test tools list with null entries
-		List<org.sakaiproject.lti.beans.LtiToolBean> toolsWithNulls = new ArrayList<>();
+		List<LtiToolBean> toolsWithNulls = new ArrayList<>();
 		toolsWithNulls.add(null);
 		toolsWithNulls.add(null);
 		result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", toolsWithNulls);

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -1210,7 +1210,7 @@ public class SakaiLTIUtilTest {
 		try {
 			SakaiLTIUtil.getPublicKey(tool, idToken);
 			fail("Expected RuntimeException for null keyset");
-		} catch (Exception e) {
+		} catch (RuntimeException e) {
 			assertNotNull("Bean method should throw exception", e);
 		}
 	}

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -49,8 +49,6 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.api.LTISubstitutionsFilter;
-import org.sakaiproject.lti.beans.LtiContentBean;
-import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.SiteService;
@@ -1103,23 +1101,23 @@ public abstract class BaseLTIService implements LTIService {
 	public Element archiveContentByKey(Document doc, Long contentKey, String siteId) {
 		if ( contentKey == null ) return null;
 
-		org.sakaiproject.lti.beans.LtiContentBean contentBean = this.getContentAsBean(contentKey.longValue(), siteId);
-		if ( contentBean == null ) return null;
+		Map<String, Object> content = this.getContent(contentKey.longValue(), siteId);
+		if ( content == null ) return null;
 
-		Long toolKey = contentBean.getToolId();
+		Long toolKey = LTIUtil.toLong(content.get(LTIService.LTI_TOOL_ID));
 		if (toolKey == null) return null;
 
-		org.sakaiproject.lti.beans.LtiToolBean toolBean = this.getToolAsBean(toolKey, siteId);
-		if (toolBean == null) return null;
+		Map<String, Object> tool = this.getTool(toolKey, siteId);
+		if (tool == null) return null;
 
-		Element retval = SakaiLTIUtil.archiveContent(doc, contentBean, toolBean);
+		Element retval = SakaiLTIUtil.archiveContent(doc, content, tool);
 
 		return retval;
 	}
 
 	@Override
-	public void mergeContent(Element element, LtiContentBean content, LtiToolBean tool) {
-		SakaiLTIUtil.mergeContentBean(element, content, tool);
+	public void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool) {
+		SakaiLTIUtil.mergeContent(element, content, tool);
 	}
 
 	@Override
@@ -1131,62 +1129,67 @@ public abstract class BaseLTIService implements LTIService {
 		Node toolNode = nl.item(0);
 		if ( toolNode.getNodeType() != Node.ELEMENT_NODE ) return null;
 
-		Element contentElement = (Element) toolNode;
-		LtiContentBean contentBean = new LtiContentBean();
-		LtiToolBean toolBean = new LtiToolBean();
-		mergeContent(contentElement, contentBean, toolBean);
-
-		String contentErrors = validateContent(contentBean.asMap());
+		Element toolElement = (Element) toolNode;
+		Map<String, Object> content = new HashMap();
+		Map<String, Object> tool = new HashMap();
+		this.mergeContent(toolElement, content, tool);
+		String contentErrors = this.validateContent(content);
 		if ( contentErrors != null ) {
 			log.warn("import found invalid content tag {}", contentErrors);
 			return null;
 		}
 
-		String toolErrors = validateTool(toolBean.asMap());
+		String toolErrors = this.validateTool(tool);
 		if ( toolErrors != null ) {
 			log.warn("import found invalid tool tag {}", toolErrors);
 			return null;
 		}
 
-		String launchUrl = contentBean.getLaunch();
+		// Lets find the right tool to associate with
+		// See also lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
+		String launchUrl = (String) content.get(LTIService.LTI_LAUNCH);
 		if ( launchUrl == null ) {
 			log.warn("lti content import could not find launch url");
 			return null;
 		}
 
 		log.debug("LTI Import launchUrl {}", launchUrl);
-		String toolCheckSum = toolBean.getSakaiToolChecksum();
-		List<LtiToolBean> toolBeans = getToolsAsBeans(null, null, 0, 0, siteId);
-		LtiToolBean theTool = SakaiLTIUtil.findBestToolMatchBean(launchUrl, toolCheckSum, toolBeans);
+		String toolCheckSum = (String) tool.get(LTIService.SAKAI_TOOL_CHECKSUM);
+		List<Map<String, Object>> tools = this.getTools(null, null, 0, 0, siteId);
+		Map<String, Object> theTool = SakaiLTIUtil.findBestToolMatch(launchUrl, toolCheckSum, tools);
 		if ( theTool == null ) {
-			Object result = insertTool(toolBean, siteId);
+			Object result = this.insertTool(tool, siteId);
 			if ( ! (result instanceof Long) ) {
 				log.info("Could not insert tool {}", result);
 				return null;
 			}
-			theTool = getToolAsBean((Long) result, siteId);
+			theTool = this.getTool((Long) result, siteId);
 		}
 
+		Map<String, Object> theContent = null;
 		if ( theTool == null ) {
 			log.info("No tool to associate to content item {}", launchUrl);
 			return null;
+		} else {
+			Long toolId = LTIUtil.toLongNull(theTool.get(LTIService.LTI_ID));
+			log.debug("Matched toolId={} for launchUrl={}", toolId, launchUrl);
+			content.put(LTIService.LTI_TOOL_ID, toolId.intValue());
+			Object result = this.insertContent(convertToProperties(content), siteId);
+			if ( ! (result instanceof Long) ) {
+				log.info("Could not insert content {}", result);
+				return null;
+			}
+
+			theContent = this.getContent((Long) result, siteId);
+			if ( theContent == null) {
+				log.warn("Could not re-retrieve inserted content item {}", launchUrl);
+				return null;
+			} else {
+				Long contentKey = LTIUtil.toLongNull(theContent.get(LTIService.LTI_ID));
+				log.debug("Created contentKey={} for launchUrl={}", contentKey, launchUrl);
+				return contentKey;
+			}
 		}
-		Long toolId = theTool.getId();
-		log.debug("Matched toolId={} for launchUrl={}", toolId, launchUrl);
-		contentBean.setToolId(toolId);
-		Object result = insertContent(contentBean, siteId);
-		if ( ! (result instanceof Long) ) {
-			log.info("Could not insert content {}", result);
-			return null;
-		}
-		LtiContentBean theContent = getContentAsBean((Long) result, siteId);
-		if ( theContent == null ) {
-			log.warn("Could not re-retrieve inserted content item {}", launchUrl);
-			return null;
-		}
-		Long contentKey = theContent.getId();
-		log.debug("Created contentKey={} for launchUrl={}", contentKey, launchUrl);
-		return contentKey;
 	}
 
 	@Override

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -49,6 +49,8 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.api.LTISubstitutionsFilter;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.SiteService;
@@ -402,6 +404,17 @@ public abstract class BaseLTIService implements LTIService {
 		int newpage = getInt(tool.get(LTIService.LTI_NEWPAGE));
 		if ( newpage == 2 ) newpage = getInt(content.get(LTIService.LTI_NEWPAGE));
 		content.put(LTIService.LTI_NEWPAGE, newpage+"");
+	}
+
+	@Override
+	public void filterContent(LtiContentBean content, LtiToolBean tool) {
+		if (content == null) {
+			return;
+		}
+		Map<String, Object> contentMap = content.asMap();
+		Map<String, Object> toolMap = (tool != null) ? tool.asMap() : null;
+		filterContent(contentMap, toolMap);
+		content.applyFromMap(contentMap);
 	}
 
 	public static Integer getCorrectProperty(String propName, Map<String, Object> content,
@@ -1062,6 +1075,11 @@ public abstract class BaseLTIService implements LTIService {
 	@Override
 	public void filterCustomSubstitutions(Properties properties, Map<String, Object> tool, Site site) {
 		filters.forEach(filter -> filter.filterCustomSubstitutions(properties, tool, site));
+	}
+
+	@Override
+	public void filterCustomSubstitutions(Properties properties, LtiToolBean tool, Site site) {
+		filterCustomSubstitutions(properties, tool != null ? tool.asMap() : null, site);
 	}
 
 	@Override

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -49,6 +49,8 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.api.LTISubstitutionsFilter;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.SiteService;
@@ -1101,23 +1103,23 @@ public abstract class BaseLTIService implements LTIService {
 	public Element archiveContentByKey(Document doc, Long contentKey, String siteId) {
 		if ( contentKey == null ) return null;
 
-		Map<String, Object> content = this.getContent(contentKey.longValue(), siteId);
-		if ( content == null ) return null;
+		org.sakaiproject.lti.beans.LtiContentBean contentBean = this.getContentAsBean(contentKey.longValue(), siteId);
+		if ( contentBean == null ) return null;
 
-		Long toolKey = LTIUtil.toLong(content.get(LTIService.LTI_TOOL_ID));
+		Long toolKey = contentBean.getToolId();
 		if (toolKey == null) return null;
 
-		Map<String, Object> tool = this.getTool(toolKey, siteId);
-		if (tool == null) return null;
+		org.sakaiproject.lti.beans.LtiToolBean toolBean = this.getToolAsBean(toolKey, siteId);
+		if (toolBean == null) return null;
 
-		Element retval = SakaiLTIUtil.archiveContent(doc, content, tool);
+		Element retval = SakaiLTIUtil.archiveContent(doc, contentBean, toolBean);
 
 		return retval;
 	}
 
 	@Override
-	public void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool) {
-		SakaiLTIUtil.mergeContent(element, content, tool);
+	public void mergeContent(Element element, LtiContentBean content, LtiToolBean tool) {
+		SakaiLTIUtil.mergeContentBean(element, content, tool);
 	}
 
 	@Override
@@ -1129,67 +1131,62 @@ public abstract class BaseLTIService implements LTIService {
 		Node toolNode = nl.item(0);
 		if ( toolNode.getNodeType() != Node.ELEMENT_NODE ) return null;
 
-		Element toolElement = (Element) toolNode;
-		Map<String, Object> content = new HashMap();
-		Map<String, Object> tool = new HashMap();
-		this.mergeContent(toolElement, content, tool);
-		String contentErrors = this.validateContent(content);
+		Element contentElement = (Element) toolNode;
+		LtiContentBean contentBean = new LtiContentBean();
+		LtiToolBean toolBean = new LtiToolBean();
+		mergeContent(contentElement, contentBean, toolBean);
+
+		String contentErrors = validateContent(contentBean.asMap());
 		if ( contentErrors != null ) {
 			log.warn("import found invalid content tag {}", contentErrors);
 			return null;
 		}
 
-		String toolErrors = this.validateTool(tool);
+		String toolErrors = validateTool(toolBean.asMap());
 		if ( toolErrors != null ) {
 			log.warn("import found invalid tool tag {}", toolErrors);
 			return null;
 		}
 
-		// Lets find the right tool to associate with
-		// See also lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
-		String launchUrl = (String) content.get(LTIService.LTI_LAUNCH);
+		String launchUrl = contentBean.getLaunch();
 		if ( launchUrl == null ) {
 			log.warn("lti content import could not find launch url");
 			return null;
 		}
 
-		log.debug("LTI Import launchUrl {}",launchUrl);
-		String toolCheckSum = (String) tool.get(LTIService.SAKAI_TOOL_CHECKSUM);
-		List<Map<String,Object>> tools = this.getTools(null,null,0,0, siteId);
-		Map<String, Object> theTool = SakaiLTIUtil.findBestToolMatch(launchUrl, toolCheckSum, tools);
+		log.debug("LTI Import launchUrl {}", launchUrl);
+		String toolCheckSum = toolBean.getSakaiToolChecksum();
+		List<LtiToolBean> toolBeans = getToolsAsBeans(null, null, 0, 0, siteId);
+		LtiToolBean theTool = SakaiLTIUtil.findBestToolMatchBean(launchUrl, toolCheckSum, toolBeans);
 		if ( theTool == null ) {
-				Object result = this.insertTool(tool, siteId);
-				if ( ! (result instanceof Long) ) {
-					log.info("Could not insert tool {}", result);
-					return null;
-				}
-				theTool = this.getTool((Long) result, siteId);
+			Object result = insertTool(toolBean, siteId);
+			if ( ! (result instanceof Long) ) {
+				log.info("Could not insert tool {}", result);
+				return null;
+			}
+			theTool = getToolAsBean((Long) result, siteId);
 		}
 
-		Map<String, Object> theContent = null;
 		if ( theTool == null ) {
 			log.info("No tool to associate to content item {}", launchUrl);
 			return null;
-		} else {
-			Long toolId = LTIUtil.toLongNull(theTool.get(LTIService.LTI_ID));
-			log.debug("Matched toolId={} for launchUrl={}", toolId, launchUrl);
-			content.put(LTIService.LTI_TOOL_ID, toolId.intValue());
-			Object result = this.insertContent(convertToProperties(content), siteId);
-			if ( ! (result instanceof Long) ) {
-				log.info("Could not insert content {}", result);
-				return null;
-			}
-
-			theContent = this.getContent((Long) result, siteId);
-			if ( theContent == null) {
-				log.warn("Could not re-retrieve inserted content item {}", launchUrl);
-				return null;
-			} else {
-				Long contentKey = LTIUtil.toLongNull(theContent.get(LTIService.LTI_ID));
-				log.debug("Created contentKey={} for launchUrl={}", contentKey, launchUrl);
-				return contentKey;
-			}
 		}
+		Long toolId = theTool.getId();
+		log.debug("Matched toolId={} for launchUrl={}", toolId, launchUrl);
+		contentBean.setToolId(toolId);
+		Object result = insertContent(contentBean, siteId);
+		if ( ! (result instanceof Long) ) {
+			log.info("Could not insert content {}", result);
+			return null;
+		}
+		LtiContentBean theContent = getContentAsBean((Long) result, siteId);
+		if ( theContent == null ) {
+			log.warn("Could not re-retrieve inserted content item {}", launchUrl);
+			return null;
+		}
+		Long contentKey = theContent.getId();
+		log.debug("Created contentKey={} for launchUrl={}", contentKey, launchUrl);
+		return contentKey;
 	}
 
 	@Override

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
@@ -20,7 +20,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +30,8 @@ import org.quartz.JobExecutionException;
 import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;
@@ -62,27 +63,29 @@ public class LTIReportingJob implements Job {
         String from = context.getMergedJobDataMap().getString("from");
 
 
-        Map<String, Object> tool = ltiService.getToolDao(toolId, null);
+        LtiToolBean tool = ltiService.getToolDaoAsBean(Long.valueOf(toolId), null, true);
         if (tool == null) {
             log.warn("Failed to find LTI tool for {}", toolId);
             return;
         }
 
-        String toolTitle = (String) tool.get("title");
+        String toolTitle = tool.getTitle();
 
         DateFormat sqlDf = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, rb.getLocale());
         Instant instant = Instant.now().minus(period, ChronoUnit.MILLIS);
         String fromDate = sqlDf.format(Date.from(instant));
 
         String search = "tool_id:"+ "#exact#"+ toolId+ "#&#"+ "created_at:"+ "#date#>"+ fromDate ;
-        List<Map<String, Object>> contents = ltiService.getContentsDao(search, null, 0, 0, null);
+        List<LtiContentBean> contents = ltiService.getContentsDaoAsBeans(search, null, 0, 0, null);
         DateFormat df = DateFormat.getDateTimeInstance( DateFormat.SHORT, DateFormat.SHORT, rb.getLocale());
 
         boolean sendEmail = false;
         StringBuilder email = new StringBuilder();
         email.append(rb.getFormattedMessage("new.tools.body.header", toolTitle, formatDuration(period)));
-        for(Map<String, Object> content : contents) {
-            String siteId = (String)content.get("SITE_ID");
+        for (LtiContentBean content : contents) {
+            if (content == null) continue;
+            String siteId = content.getSiteId();
+            if (siteId == null) continue;
             try {
                 Site site = siteService.getSite(siteId);
                 // TODO Check the LTI tool is still in the site.

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
@@ -74,6 +74,8 @@ import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.lti.api.LTIExportService;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 
@@ -304,10 +306,8 @@ public class LTISecurityServiceImpl implements EntityProducer {
 					identifier the End-User might use to log in (if necessary).
 	*/
 	private void redirectOIDC(HttpServletRequest req, HttpServletResponse res,
-		Map<String, Object> content, Map<String, Object> tool, String oidc_endpoint, ResourceLoader rb)
+		LtiContentBean content, LtiToolBean tool, String oidc_endpoint, ResourceLoader rb)
 	{
-		// req.getRequestURL()=http://localhost:8080/access/lti/site/85fd092b-1755-4aa9-8abc-e6549527dce0/content:0
-		// req.getRequestURI()=/access/lti/site/85fd092b-1755-4aa9-8abc-e6549527dce0/content:0
 		String login_hint = req.getRequestURI();
 		String query_string = req.getQueryString();
 		String messageTypeParm = req.getParameter(SakaiLTIUtil.MESSAGE_TYPE_PARAMETER);
@@ -316,14 +316,12 @@ public class LTISecurityServiceImpl implements EntityProducer {
 			login_hint = login_hint + "?" + query_string;
 		}
 
-
-		String launch_url = StringUtils.trimToNull((String) tool.get(LTIService.LTI_LAUNCH));
+		String launch_url = StringUtils.trimToNull(tool.launch);
 		if ( content != null ) {
-			String content_launch_url = StringUtils.trimToNull((String) content.get(LTIService.LTI_LAUNCH));
+			String content_launch_url = StringUtils.trimToNull(content.launch);
 			if ( content_launch_url != null ) launch_url = content_launch_url;
 
-			// See if we have a lineItem associated with this launch in case we need it later
-			String lineItemStr = (String) content.get(LTIService.LTI_LINEITEM);
+			String lineItemStr = content.contentitem;
 			SakaiLineItem sakaiLineItem = LineItemUtil.parseLineItem(lineItemStr);
 
 			if ( SakaiLTIUtil.MESSAGE_TYPE_PARAMETER_CONTENT_REVIEW.equals(messageTypeParm)) {
@@ -331,7 +329,7 @@ public class LTISecurityServiceImpl implements EntityProducer {
 			}
 		}
 
-		String client_id = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_CLIENT_ID));
+		String client_id = StringUtils.trimToNull(tool.lti13ClientId);
 		String deployment_id = ServerConfigurationService.getString(SakaiLTIUtil.LTI13_DEPLOYMENT_ID, SakaiLTIUtil.LTI13_DEPLOYMENT_ID_DEFAULT);
 
 		// Use Base64DoubleUrlEncodeSafe to ensure proper URL-safe encoding
@@ -356,13 +354,12 @@ public class LTISecurityServiceImpl implements EntityProducer {
 	}
 
 	/**
-	 * Do some sanity checking on the aunch data to make sure we have enough to accomplish the launch
+	 * Do some sanity checking on the launch data to make sure we have enough to accomplish the launch
 	 */
 	private boolean sanityCheck(HttpServletRequest req, HttpServletResponse res,
-		Map<String, Object> content, Map<String, Object> tool, ResourceLoader rb)
+		LtiContentBean content, LtiToolBean tool, ResourceLoader rb)
 	{
-
-		String oidc_endpoint = (String) tool.get(LTIService.LTI13_TOOL_ENDPOINT);
+		String oidc_endpoint = tool.lti13OidcEndpoint;
 		if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isBlank(oidc_endpoint) ) {
 			String errorMessage = "<p>" + SakaiLTIUtil.getRB(rb, "error.no.oidc_endpoint", "Missing oidc_endpoint value for LTI 1.3 launch") + "</p>";
 			org.tsugi.lti.LTIUtil.sendHTMLPage(res, errorMessage);
@@ -392,8 +389,6 @@ public class LTISecurityServiceImpl implements EntityProducer {
 				String [] retval = null;
 				if ( refId.startsWith("tool:") && refId.length() > 5 )
 				{
-					Map<String,Object> tool;
-
 					String toolStr = refId.substring(5);
 					String contentReturn = req.getParameter("contentReturn");
 					Enumeration attrs =  req.getParameterNames();
@@ -411,93 +406,92 @@ public class LTISecurityServiceImpl implements EntityProducer {
 						throw new EntityNotDefinedException("Could not load tool");
 					}
 
-					tool = ltiService.getToolDao(toolKey, ref.getContext());
-					if (tool == null ) {
+					LtiToolBean toolBean = ltiService.getToolDaoAsBean(toolKey, ref.getContext(), true);
+					if (toolBean == null ) {
 						throw new EntityNotDefinedException("Could not load tool");
 					}
 
 					// Save for LTI 13 Issuer
-					String orig_site_id = StringUtils.trimToNull((String) tool.get(LTIService.LTI_SITE_ID));
-					if ( orig_site_id == null ) {
-						tool.put("orig_site_id_null", "true");
+					if ( StringUtils.isBlank(toolBean.siteId) ) {
+						toolBean.origSiteIdNull = "true";
 					}
-					tool.put(LTIService.LTI_SITE_ID, ref.getContext());
+					toolBean.siteId = ref.getContext();
+
+					// Launch-flow only: pass through from request so they are sent back in the launch
+					String toolStateParam = req.getParameter("tool_state");
+					if (toolStateParam != null) toolBean.toolState = toolStateParam;
+					String platformStateParam = req.getParameter("platform_state");
+					if (platformStateParam != null) toolBean.platformState = platformStateParam;
+					String relaunchUrlParam = req.getParameter("relaunch_url");
+					if (relaunchUrlParam != null) toolBean.relaunchUrl = relaunchUrlParam;
 
 					String state = req.getParameter("state");
 					String nonce = req.getParameter("nonce");
 
-					String oidc_endpoint = (String) tool.get(LTIService.LTI13_TOOL_ENDPOINT);
+					String oidc_endpoint = toolBean.lti13OidcEndpoint;
 					log.debug("State={} nonce={} oidc_endpoint={}",state, nonce, oidc_endpoint);
 
-					// Sanity check for missing config data
-					if ( ! sanityCheck(req, res, null, tool, rb) ) return;
+					if ( ! sanityCheck(req, res, null, toolBean, rb) ) return;
 
-					if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isNotBlank(oidc_endpoint) &&
-							( StringUtils.isEmpty(state) || StringUtils.isEmpty(state) ) ) {
-						redirectOIDC(req, res, null, tool, oidc_endpoint, rb);
+					if (SakaiLTIUtil.isLTI13(toolBean) && StringUtils.isNotBlank(oidc_endpoint) &&
+							( StringUtils.isEmpty(state) || StringUtils.isEmpty(nonce) ) ) {
+						redirectOIDC(req, res, null, toolBean, oidc_endpoint, rb);
 						return;
 					}
 
-					retval = SakaiLTIUtil.postContentItemSelectionRequest(toolKey, tool, state, nonce, rb, contentReturn, propData);
+					retval = SakaiLTIUtil.postContentItemSelectionRequest(toolKey, toolBean, state, nonce, rb, contentReturn, propData);
 
 				}
 				else if ( refId.startsWith("content:") && refId.length() > 8 )
 				{
-					Map<String,Object> content;
-					Map<String,Object> tool = null;
-
 					String contentStr = refId.substring(8);
 					Long contentKey = LTIUtil.toLongKey(contentStr);
 					if (contentKey < 1 ) {
 						throw new EntityNotDefinedException("Could not load content item");
 					}
 
-					content = ltiService.getContentDao(contentKey,ref.getContext());
-					if (content == null ) {
+					LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, ref.getContext());
+					if (contentBean == null ) {
 						throw new EntityNotDefinedException("Could not load content item");
 					}
 
 					// Check to see if we need launch protection
-					int protect = LTIUtil.toInt(content.get(LTIService.LTI_PROTECT));
-					String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(content);
+					int protect = contentBean.protect != null ? (contentBean.protect ? 1 : 0) : -1;
+					String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(contentBean);
 					Session session = sessionManager.getCurrentSession();
 
 					// SAK-43709 - Prior to Sakai-21 there is no protect field in Content
-					// If there is no protect value, we fall back to the pre-21 description in JSON
 					if ( protect < 0 ) {
-						String content_settings = (String) content.get(LTIService.LTI_SETTINGS);
+						String content_settings = contentBean.settings;
 						JSONObject content_json = org.tsugi.lti.LTIUtil.parseJSONObject(content_settings);
 						protect = LTIUtil.toInt(content_json.get(LTIService.LTI_PROTECT));
 					}
 
 					if ( protect > 0 && ! checkSiteUpdate(ref) ) {
 						String launch_code = (String) session.getAttribute(launch_code_key);
-
-						// We don't remove the token until later because LTI 1.3 pass through this twice
-						if ( launch_code == null || ! SakaiLTIUtil.checkLaunchCode(content, launch_code) ) {
+						if ( launch_code == null || ! SakaiLTIUtil.checkLaunchCode(contentBean, launch_code) ) {
 							throw new EntityPermissionException(sessionManager.getCurrentSessionUserId(), "basiclti", ref.getReference());
 						}
 					}
 
-					String siteId = (String) content.get(LTIService.LTI_SITE_ID);
+					String siteId = contentBean.siteId;
 					if ( siteId == null || ! siteId.equals(ref.getContext()) )
 					{
 						throw new EntityNotDefinedException("Incorrect site");
 					}
 
-					Long toolKey = LTIUtil.toLongKey(content.get(LTIService.LTI_TOOL_ID));
-					if ( toolKey >= 0 ) tool = ltiService.getTool(toolKey, ref.getContext());
+					LtiToolBean toolBean = null;
+					Long toolKey = contentBean.toolId != null ? contentBean.toolId : -1L;
+					if ( toolKey >= 0 ) toolBean = ltiService.getToolAsBean(toolKey, ref.getContext());
 
-					ltiService.filterContent(content, tool);
+					ltiService.filterContent(contentBean, toolBean);
 
 					String splash = null;
-					if ( tool != null ) splash = (String) tool.get("splash");
+					if ( toolBean != null ) splash = toolBean.splash;
 					String splashParm = req.getParameter("splash");
-					siteId = null;
-					if ( tool != null ) siteId = (String) tool.get(LTIService.LTI_SITE_ID);
+					siteId = toolBean != null ? toolBean.siteId : null;
 					if ( splashParm == null && splash != null && splash.trim().length() > 1 )
 					{
-							// XSS Note: Administrator-created tools can put HTML in the splash.
 							if ( siteId != null ) splash = formattedText.escapeHtml(splash,false);
 							doSplash(req, res, splash, rb);
 							return;
@@ -505,24 +499,22 @@ public class LTISecurityServiceImpl implements EntityProducer {
 					String state = req.getParameter("state");
 					String nonce = req.getParameter("nonce");
 
-					if ( tool != null ) {
-						String oidc_endpoint = (String) tool.get(LTIService.LTI13_TOOL_ENDPOINT);
+					if ( toolBean != null ) {
+						String oidc_endpoint = toolBean.lti13OidcEndpoint;
 						log.debug("State={} nonce={} oidc_endpoint={}",state, nonce, oidc_endpoint);
 
-						// Sanity check for missing config data
-						if ( ! sanityCheck(req, res, content, tool, rb) ) return;
+						if ( ! sanityCheck(req, res, contentBean, toolBean, rb) ) return;
 
-						if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isNotBlank(oidc_endpoint) &&
+						if (SakaiLTIUtil.isLTI13(toolBean) && StringUtils.isNotBlank(oidc_endpoint) &&
 								(StringUtils.isEmpty(state) || StringUtils.isEmpty(nonce) ) ) {
-							redirectOIDC(req, res, content, tool, oidc_endpoint, rb);
+							redirectOIDC(req, res, contentBean, toolBean, oidc_endpoint, rb);
 							return;
 						}
 					}
 
-					retval = SakaiLTIUtil.postLaunchHTML(content, tool, state, nonce, ltiService, rb);
+					retval = SakaiLTIUtil.postLaunchHTML(contentBean, toolBean, state, nonce, ltiService, rb);
 
-					// Once we are ready to do the actual launch, remove the assignments protection key
-					session.removeAttribute(launch_code_key);  // You get one try
+					session.removeAttribute(launch_code_key);
 				}
 				else if (refId.startsWith("export:") && refId.length() > 7)
 				{

--- a/lti/lti-oidc/src/java/org/sakaiproject/lti13/OIDCServlet.java
+++ b/lti/lti-oidc/src/java/org/sakaiproject/lti13/OIDCServlet.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.tsugi.lti.LTIUtil;
@@ -274,7 +275,7 @@ public class OIDCServlet extends HttpServlet {
 		// For an LTI 1.1 response, check the signature and if it passes, re-sign and forward
 		// to the new URL
 		ltiService = (LTIService) ComponentManager.get("org.sakaiproject.lti.api.LTIService");
-		Map<String, Object> tool = ltiService.getToolDao(toolKey, null, true);
+		LtiToolBean tool = ltiService.getToolDaoAsBean(toolKey, null, true);
 
 		if ( tool == null ) {
 			LTI13Util.return400(response, "Invalid tool_id");
@@ -291,7 +292,7 @@ public class OIDCServlet extends HttpServlet {
 			return;
 		}
 
-		String oauth_secret = (String) tool.get(LTIService.LTI_SECRET);
+		String oauth_secret = SakaiLTIUtil.getSecret(tool);
 		oauth_secret = SakaiLTIUtil.decryptSecret(oauth_secret);
 
 		String URL = SakaiLTIUtil.getOurServletPath(request);

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -3570,7 +3570,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_tool_system";
 		}
 		Long key = Long.valueOf(id);
-		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentBean(key, getSiteId(state));
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsBean(key, getSiteId(state));
 		if (content == null) {
 			addAlert(state, rb.getString("error.content.not.found"));
 			return "lti_tool_system";
@@ -3632,7 +3632,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_tool_system";
 		}
 		Long key = Long.valueOf(id);
-		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentBean(key, getSiteId(state));
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsBean(key, getSiteId(state));
 		if (content == null) {
 			addAlert(state, rb.getString("error.content.not.found"));
 			return "lti_tool_system";
@@ -3685,7 +3685,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_error";
 		}
 		Long key = Long.valueOf(id);
-		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentBean(key, getSiteId(state));
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsBean(key, getSiteId(state));
 		if (content == null) {
 			addAlert(state, rb.getString("error.content.not.found"));
 			return "lti_error";

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -2157,8 +2157,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return;
 		}
 
-		Map<String, Object> tool = ltiService.getTool(toolKey, getSiteId(state));
-		if (tool == null) {
+		LtiToolBean toolBean = ltiService.getToolAsBean(toolKey, getSiteId(state));
+		if (toolBean == null) {
 			addAlert(state, rb.getString("error.contentitem.missing"));
 			switchPanel(state, errorPanel);
 			return;
@@ -2190,7 +2190,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		if ( isDeepLink ) {
 
 			// Parse and validate the incoming DeepLink
-			String keyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+			String keyset = toolBean.getLti13ToolKeyset();
 			if (keyset == null) {
 				addAlert(state, rb.getString("error.tool.missing.keyset"));
 				switchPanel(state, errorPanel);
@@ -2199,7 +2199,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 
 			DeepLinkResponse dlr;
 			try {
-				dlr = SakaiLTIUtil.getDeepLinkFromToken(tool, id_token);  // Also checks security
+				dlr = SakaiLTIUtil.getDeepLinkFromToken(toolBean, id_token);  // Also checks security
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.deeplink.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2224,7 +2224,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 					return;
 				}
 
-				reqProps = extractLTIDeepLink(item, tool, toolKey);
+				reqProps = extractLTIDeepLink(item, toolBean.asMap(), toolKey);
 				reqProps.setProperty("returnUrl", returnUrl);
 
 				// Create the gradebook column if we need to do so
@@ -2247,7 +2247,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			// Parse and validate the incoming ContentItem
 			ContentItem contentItem;
 			try {
-				contentItem = SakaiLTIUtil.getContentItemFromRequest(tool);
+				contentItem = SakaiLTIUtil.getContentItemFromRequest(toolBean);
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.contentitem.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2279,7 +2279,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 
 				// Prepare data for the next phase
-				reqProps = extractLTIContentItem(item, tool, toolKey);
+				reqProps = extractLTIContentItem(item, toolBean.asMap(), toolKey);
 				reqProps.setProperty("returnUrl", returnUrl);
 
 				// Extract the lineItem material
@@ -2419,8 +2419,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			switchPanel(state, errorPanel);
 			return;
 		}
-		Map<String, Object> tool = ltiService.getTool(toolKey, getSiteId(state));
-		if (tool == null) {
+		LtiToolBean toolBean = ltiService.getToolAsBean(toolKey, getSiteId(state));
+		if (toolBean == null) {
 			addAlert(state, rb.getString("error.contentitem.missing"));
 			switchPanel(state, errorPanel);
 			return;
@@ -2447,7 +2447,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		Long contentKey = null;  // Save for later
 		if ( isDeepLink ) {
 			// Parse and validate the incoming DeepLink
-			String keyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+			String keyset = toolBean.getLti13ToolKeyset();
 			if (keyset == null) {
 				addAlert(state, rb.getString("error.tool.missing.keyset"));
 				switchPanel(state, errorPanel);
@@ -2456,7 +2456,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 
 			DeepLinkResponse dlr;
 			try {
-				dlr = SakaiLTIUtil.getDeepLinkFromToken(tool, id_token);  // Also checks security
+				dlr = SakaiLTIUtil.getDeepLinkFromToken(toolBean, id_token);  // Also checks security
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.deeplink.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2473,7 +2473,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			for (Object obj : links) {
 				if ( ! (obj instanceof JSONObject) ) continue;
 				JSONObject item = (JSONObject) obj;
-				reqProps = extractLTIDeepLink(item, tool, toolKey);
+				reqProps = extractLTIDeepLink(item, toolBean.asMap(), toolKey);
 
 				String type = getString(item, DeepLinkResponse.TYPE);
 				if (!DeepLinkResponse.TYPE_LTILINKITEM.equals(type)) {
@@ -2483,7 +2483,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 
 				// We need to establish resource link ids for the LTILinkItems
-				reqProps = extractLTIContentItem(item, tool, toolKey);
+				reqProps = extractLTIContentItem(item, toolBean.asMap(), toolKey);
 
 				String title = reqProps.getProperty(LTIService.LTI_TITLE);
 				if (title == null) {
@@ -2511,9 +2511,9 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 				contentKey = (Long) retval;
 				String contentUrl = null;
-				Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
-				if (content != null) {
-					contentUrl = ltiService.getContentLaunch(content);
+				LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, getSiteId(state));
+				if (contentBean != null) {
+					contentUrl = ltiService.getContentLaunch(contentBean);
 					if (contentUrl != null && contentUrl.startsWith("/")) {
 						contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
 					}
@@ -2537,7 +2537,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 						if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 							state.setAttribute(STATE_LINE_ITEM, sakaiLineItem);
 						} else {
-							handleLineItem(state, sakaiLineItem, toolKey, content);
+							handleLineItem(state, sakaiLineItem, toolKey, contentBean != null ? contentBean.asMap() : null);
 						}
 					} catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
 						log.warn("Could not parse input as SakaiLineItem {}",lineItemStr);
@@ -2547,8 +2547,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				item.put("content_key", contentKey);
 				item.put("content_newpage", reqProps.getProperty(LTIService.LTI_NEWPAGE));
 				item.put("tool_key", toolKey);
-				item.put("tool_title", (String) tool.get(LTIService.LTI_TITLE));
-				item.put("tool_newpage", LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE)));
+				item.put("tool_title", toolBean.getTitle());
+				item.put("tool_newpage", (toolBean.getNewpage() != null) ? Long.valueOf(toolBean.getNewpage()) : Long.valueOf(0));
 				new_content.add(item);
 				goodcount++;
 			}
@@ -2558,7 +2558,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			// Parse and validate the incoming ContentItem
 			ContentItem contentItem = null;
 			try {
-				contentItem = SakaiLTIUtil.getContentItemFromRequest(tool);
+				contentItem = SakaiLTIUtil.getContentItemFromRequest(toolBean);
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.contentitem.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2581,7 +2581,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 
 				// We need to establish resource link ids for the LTILinkItems
-				reqProps = extractLTIContentItem(item, tool, toolKey);
+				reqProps = extractLTIContentItem(item, toolBean.asMap(), toolKey);
 
 				String title = reqProps.getProperty(LTIService.LTI_TITLE);
 				if (title == null) {
@@ -2609,9 +2609,9 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 				contentKey = (Long) retval;
 				String contentUrl = null;
-				Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
-				if (content != null) {
-					contentUrl = ltiService.getContentLaunch(content);
+				LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, getSiteId(state));
+				if (contentBean != null) {
+					contentUrl = ltiService.getContentLaunch(contentBean);
 					if (contentUrl != null && contentUrl.startsWith("/")) {
 						contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
 					}
@@ -2637,7 +2637,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 						if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 							state.setAttribute(STATE_LINE_ITEM, sakaiLineItem);
 						} else {
-							handleLineItem(state, sakaiLineItem, toolKey, content);
+							handleLineItem(state, sakaiLineItem, toolKey, contentBean != null ? contentBean.asMap() : null);
 						}
 					} catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
 						log.warn("Could not parse input as SakaiLineItem {}",lineItemStr);
@@ -2647,8 +2647,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				item.put("content_key", contentKey);
 				item.put("content_newpage", reqProps.getProperty(LTIService.LTI_NEWPAGE));
 				item.put("tool_key", toolKey);
-				item.put("tool_title", (String) tool.get(LTIService.LTI_TITLE));
-				item.put("tool_newpage", LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE)));
+				item.put("tool_title", toolBean.getTitle());
+				item.put("tool_newpage", (toolBean.getNewpage() != null) ? Long.valueOf(toolBean.getNewpage()) : Long.valueOf(0));
 				new_content.add(item);
 				goodcount++;
 			}
@@ -3429,20 +3429,18 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		}
 
 		String contentUrl = null;
-		Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
+		LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, getSiteId(state));
 
 		// Rare: We just made this a few clicks ago...
-		if (content == null) {
+		if (contentBean == null) {
 			log.error("Unable to load content={}", contentKey);
 			addAlert(state, rb.getString("error.contentitem.content.launch"));
 			return "lti_error";
 		}
 
-		if (content != null) {
-			contentUrl = ltiService.getContentLaunch(content);
-			if (contentUrl != null && contentUrl.startsWith("/")) {
-				contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
-			}
+		contentUrl = ltiService.getContentLaunch(contentBean);
+		if (contentUrl != null && contentUrl.startsWith("/")) {
+			contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
 		}
 
 		if (contentUrl == null) {
@@ -3451,28 +3449,26 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_error";
 		}
 
-		Long key = LTIUtil.toLongNull(content.get(LTIService.LTI_TOOL_ID));
-		Map<String, Object> tool = ltiService.getTool(key, getSiteId(state));
+		Long key = contentBean.getToolId();
+		LtiToolBean toolBean = ltiService.getToolAsBean(key, getSiteId(state));
 
 		JSONArray new_content = new JSONArray();
 
 		JSONObject item = (JSONObject) new JSONObject();
 		item.put(LTIConstants.TYPE, ContentItem.TYPE_LTILINKITEM);
 		item.put("launch", contentUrl);
-		String title = (String) content.get(LTIService.LTI_TITLE);
+		String title = contentBean.getTitle();
 		if (title == null) {
 			title = rb.getString("contentitem.generic.title");
 		}
 		item.put(ContentItem.TITLE, title);
 
-		Long contentNewPage = LTIUtil.toLongNull(content.get(LTIService.LTI_NEWPAGE));
-		if ( contentNewPage == null ) contentNewPage = Long.valueOf(0);
+		Long contentNewPage = (contentBean.getNewpage() != null && contentBean.getNewpage()) ? Long.valueOf(1) : Long.valueOf(0);
 		item.put("content_newpage", contentNewPage);
 
 		Long toolNewPage = Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT);
-		if ( tool != null ) {
-			toolNewPage = LTIUtil.toLongNull(tool.get(LTIService.LTI_NEWPAGE));
-			if ( toolNewPage == null ) toolNewPage = Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT);
+		if ( toolBean != null ) {
+			toolNewPage = (toolBean.getNewpage() != null) ? Long.valueOf(toolBean.getNewpage()) : Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT);
 			item.put("tool_newpage", toolNewPage);
 		}
 
@@ -3484,7 +3480,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 
 		if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 			context.put("contentId",  contentKey);
-			context.put("contentTitle", (String) content.get(LTIService.LTI_TITLE));
+			context.put("contentTitle", contentBean.getTitle());
 			context.put("contentLaunchNewWindow", contentNewPage);
 			context.put("contentToolNewpage", toolNewPage);
 
@@ -3492,10 +3488,10 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			state.removeAttribute(STATE_LINE_ITEM);
 			context.put("lineItem", sakaiLineItem);
 
-			if ( tool != null ) {
-				context.put("toolTitle", (String) tool.get(LTIService.LTI_TITLE));
+			if ( toolBean != null ) {
+				context.put("toolTitle", toolBean.getTitle());
 			} else {
-				context.put("toolTitle", (String) content.get(LTIService.LTI_TITLE));
+				context.put("toolTitle", contentBean.getTitle());
 			}
 			return "lti_assignment_return";
 		} else if ( flow.equals(FLOW_PARAMETER_LESSONS) ) {

--- a/lti/lti-tool/src/webapp/vm/lti_content_delete.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_content_delete.vm
@@ -15,7 +15,7 @@
         <p class="shorttext">
         	$tlang.getString("bl_launch"):
         	#set($tool=false)
-			#set($tool=$ltiService.getToolBean($tool_id_long, $content.siteId))
+			#set($tool=$ltiService.getToolAsBean($tool_id_long, $content.siteId))
 			#if ($!tool)
 				$formattedText.escapeHtml($tool.launch)
 			#end

--- a/lti/lti-tool/src/webapp/vm/lti_tool_site.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_tool_site.vm
@@ -177,10 +177,9 @@ ${includeLatestJQuery}
 				#if ($contentBean.launch)
 					 #set($launch = $formattedText.escapeHtml($contentBean.launch))
 				#else
-					#set($tool=false)
-					#set($tool=$ltiService.getTool($contentBean.toolId, $contentBean.siteId))
-					#if ($!tool)
-						#set($launch = $formattedText.escapeHtml($tool.get("launch")))
+					#set($toolBean = $ltiService.getToolAsBean($contentBean.toolId, $contentBean.siteId))
+					#if ($!toolBean && $!toolBean.launch)
+						#set($launch = $formattedText.escapeHtml($toolBean.launch))
 					#end
 				#end
 				#set($toolUrl = $toolUrlMap.get($contentBean.id))

--- a/lti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/lti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -51,6 +51,7 @@ import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 // lti service
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.sakaiproject.portlet.util.JSPHelper;
 import org.sakaiproject.portlet.util.VelocityHelper;
@@ -314,9 +315,9 @@ public class SakaiIFrame extends GenericPortlet {
 		}
 
 		Long contentKey = (Long) retval;
-		Map<String,Object> newContent = m_ltiService.getContent(contentKey, siteId);
-		String contentUrl = m_ltiService.getContentLaunch(newContent);
-		if ( newContent == null || contentUrl == null ) {
+		LtiContentBean newContentBean = m_ltiService.getContentAsBean(contentKey, siteId);
+		String contentUrl = m_ltiService.getContentLaunch(newContentBean);
+		if ( newContentBean == null || contentUrl == null ) {
 			log.error("Unable to set contentUrl tool={} placement={}",tool_id,placement.getId());
 			placement.getPlacementConfig().setProperty(SOURCE,"");
 			placement.save();
@@ -327,7 +328,7 @@ public class SakaiIFrame extends GenericPortlet {
 
 		log.debug("Patched contentUrl tool={} placement={} url={}",tool_id,placement.getId(),contentUrl);
 
-		return newContent;
+		return newContentBean.asMap();
 	}
 
 	public void doEdit(RenderRequest request, RenderResponse response)
@@ -472,9 +473,9 @@ public class SakaiIFrame extends GenericPortlet {
 					return;
 				} else if ( retval instanceof Long ) {
 					Long contentKey = (Long) retval;
-					Map<String,Object> newContent = m_ltiService.getContent(contentKey, siteId);
-					String contentUrl = m_ltiService.getContentLaunch(newContent);
-					if ( newContent == null || contentUrl == null ) {
+					LtiContentBean newContentBean = m_ltiService.getContentAsBean(contentKey, siteId);
+					String contentUrl = m_ltiService.getContentLaunch(newContentBean);
+					if ( newContentBean == null || contentUrl == null ) {
 						log.error("Unable to set contentUrl tool={} placement={}",toolIdStr,placement.getId());
 						addAlert(request, rb.getString("edit.save.url.fail"));
 						return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative form/field metadata and XML archive import/export added for tools, content, and membership jobs.
* **Refactor**
  * Core LTI surfaces migrated to strongly typed bean models (backward‑compatible map wrappers); improves null safety, LTI 1.3 handling, and launch/archive flows.
* **Tests**
  * Expanded unit tests covering XML serialization/deserialization, archive round‑trips, and bean-based flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->