### PR TITLE
SAK-52431 Samigo SEB allow using file upload questions when permissions are set to allow uploading

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -439,6 +439,7 @@ The configuration has been altered, when the assessment was published.
 seb_exam_keys_recommended=It is recommended to add a config key or exam keys for this type of configuration, because the Safe Exam Browser Configuration can \
 not be validated automatically
 seb_file_upload_error=You can't use "File upload" questions for exams using SEB
+seb_config_unreadable_error=The uploaded SEB configuration could not be read. Please upload a valid, readable .seb configuration file.
 
 # S2U-5
 associate_label_dyn=Create a dynamic rubric to grade this question (always hidden to the student during the assessment)

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -459,10 +459,24 @@ public class ConfirmPublishAssessmentListener
             while (itemFacadeIterator.hasNext()){
                 ItemFacade itemFacade = itemFacadeIterator.next();
                 if (TypeIfc.FILE_UPLOAD.equals(itemFacade.getType().getTypeId())) {
-                    String sebUpload_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "seb_file_upload_error");
-                    context.addMessage(null,new FacesMessage(sebUpload_err));
-                    sebFileUploadError=true;
-                    break;
+                    // Check if the SEB configuration allows file uploads
+                    boolean isUploadModeWithUploadsEnabled = false;
+
+                    // If config mode is UPLOAD, check if the uploaded file has allowUploads enabled
+                    String sebConfigMode = assessmentSettings.getSebConfigMode();
+                    if ("UPLOAD".equals(sebConfigMode)) {
+                        String configUploadId = assessmentSettings.getSebConfigUploadId();
+                        isUploadModeWithUploadsEnabled = SebConfig.isAllowUploadsEnabled(configUploadId);
+                        log.debug("SEB config mode is UPLOAD. Config file allowUploads: {}", isUploadModeWithUploadsEnabled);
+                    }
+
+                    // Only show error if NOT in UPLOAD mode with allowUploads enabled
+                    if (!isUploadModeWithUploadsEnabled) {
+                        String sebUpload_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "seb_file_upload_error");
+                        context.addMessage(null,new FacesMessage(sebUpload_err));
+                        sebFileUploadError=true;
+                        break;
+                    }
                 }
             }
             if (sebFileUploadError) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -467,7 +467,8 @@ public class ConfirmPublishAssessmentListener
                     String sebConfigMode = assessmentSettings.getSebConfigMode();
                     if ("UPLOAD".equals(sebConfigMode)) {
                         String configUploadId = assessmentSettings.getSebConfigUploadId();
-                        SebConfig.AllowUploadsState allowUploadsState = SebConfig.getAllowUploadsState(configUploadId);
+                        SebConfig sebConfig = new SebConfig();
+                        SebConfig.AllowUploadsState allowUploadsState = sebConfig.getAllowUploadsState(configUploadId);
                         isUploadModeWithUploadsEnabled = SebConfig.AllowUploadsState.ENABLED.equals(allowUploadsState);
                         isSebConfigUnreadable = SebConfig.AllowUploadsState.UNREADABLE.equals(allowUploadsState);
                         log.debug("SEB config mode is UPLOAD. Config file allowUploads state: {}", allowUploadsState);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -461,18 +461,22 @@ public class ConfirmPublishAssessmentListener
                 if (TypeIfc.FILE_UPLOAD.equals(itemFacade.getType().getTypeId())) {
                     // Check if the SEB configuration allows file uploads
                     boolean isUploadModeWithUploadsEnabled = false;
+                    boolean isSebConfigUnreadable = false;
 
                     // If config mode is UPLOAD, check if the uploaded file has allowUploads enabled
                     String sebConfigMode = assessmentSettings.getSebConfigMode();
                     if ("UPLOAD".equals(sebConfigMode)) {
                         String configUploadId = assessmentSettings.getSebConfigUploadId();
-                        isUploadModeWithUploadsEnabled = SebConfig.isAllowUploadsEnabled(configUploadId);
-                        log.debug("SEB config mode is UPLOAD. Config file allowUploads: {}", isUploadModeWithUploadsEnabled);
+                        SebConfig.AllowUploadsState allowUploadsState = SebConfig.getAllowUploadsState(configUploadId);
+                        isUploadModeWithUploadsEnabled = SebConfig.AllowUploadsState.ENABLED.equals(allowUploadsState);
+                        isSebConfigUnreadable = SebConfig.AllowUploadsState.UNREADABLE.equals(allowUploadsState);
+                        log.debug("SEB config mode is UPLOAD. Config file allowUploads state: {}", allowUploadsState);
                     }
 
                     // Only show error if NOT in UPLOAD mode with allowUploads enabled
                     if (!isUploadModeWithUploadsEnabled) {
-                        String sebUpload_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , "seb_file_upload_error");
+                        String sebErrorKey = isSebConfigUnreadable ? "seb_config_unreadable_error" : "seb_file_upload_error";
+                        String sebUpload_err= ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages" , sebErrorKey);
                         context.addMessage(null,new FacesMessage(sebUpload_err));
                         sebFileUploadError=true;
                         break;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
@@ -21,13 +21,13 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.configuration2.builder.BasicConfigurationBuilder;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.io.FileHandler;
@@ -35,6 +35,7 @@ import org.apache.commons.configuration2.plist.XMLPropertyListConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.tool.assessment.shared.api.assessment.SecureDeliveryServiceAPI;
 import org.sakaiproject.tool.assessment.util.HashingUtil;
 
@@ -118,6 +119,7 @@ public class SebConfig {
     private static final String SHOW_WIFI_CONTROL_KEY = "allowWlan";
     private static final String USER_CONFIRM_QUIT_KEY = "quitURLConfirm";
     private static final String QUIT_PASSWORD_KEY = "hashedQuitPassword";
+    private static final String ALLOW_UPLOADS_KEY = "allowUploads";
 
     private static final String URL_FILTER_ENABLE = "URLFilterEnable";
     private static final String URL_FILTER_ENABLE_DEFAULT = "false";
@@ -312,6 +314,42 @@ public class SebConfig {
         return map.entrySet().stream()
                 .filter(entry -> entry.getValue() != null)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
+    }
+
+    /**
+     * Reads the allowUploads property from a SEB configuration file uploaded to ContentHostingService.
+     *
+     * @param configResourceId The resource ID of the uploaded SEB configuration file in ContentHostingService
+     * @return true if allowUploads is enabled in the configuration file, false otherwise or if the file cannot be read
+     */
+    public static boolean isAllowUploadsEnabled(String configResourceId) {
+        if (StringUtils.isBlank(configResourceId)) {
+            log.debug("Config resource ID is blank, returning false for allowUploads");
+            return false;
+        }
+
+        try {
+            ContentHostingService contentHostingService = ComponentManager.get(ContentHostingService.class);
+            org.sakaiproject.content.api.ContentResource configResource = contentHostingService.getResource(configResourceId);
+
+            Parameters parameters = new Parameters();
+            FileBasedConfigurationBuilder<XMLPropertyListConfiguration> configBuilder =
+                    new FileBasedConfigurationBuilder<>(XMLPropertyListConfiguration.class)
+                            .configure(parameters.fileBased());
+            XMLPropertyListConfiguration config = configBuilder.getConfiguration();
+            org.apache.commons.configuration2.io.FileHandler fileHandler = new org.apache.commons.configuration2.io.FileHandler(config);
+            fileHandler.setEncoding(CONFIG_ENCODING);
+            fileHandler.load(configResource.streamContent());
+
+            // Read the allowUploads property
+            Boolean allowUploads = config.getBoolean(ALLOW_UPLOADS_KEY, false);
+            log.debug("allowUploads property from SEB config file: {}", allowUploads);
+
+            return allowUploads;
+        } catch (Exception e) {
+            log.error("Error reading allowUploads from SEB config file: {}", e.getMessage(), e);
+            return false;
+        }
     }
 
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
@@ -134,6 +134,7 @@ public class SebConfig {
     public static final String CONFIG_ENCODING = "UTF-8";
 
     public enum ConfigMode { MANUAL, UPLOAD, CLIENT }
+    public enum AllowUploadsState { ENABLED, DISABLED, UNREADABLE }
 
     private ServerConfigurationService serverConfigurationService;
 
@@ -320,12 +321,12 @@ public class SebConfig {
      * Reads the allowUploads property from a SEB configuration file uploaded to ContentHostingService.
      *
      * @param configResourceId The resource ID of the uploaded SEB configuration file in ContentHostingService
-     * @return true if allowUploads is enabled in the configuration file, false otherwise or if the file cannot be read
+     * @return ENABLED if allowUploads is true, DISABLED if false, UNREADABLE if the file cannot be read/parsed
      */
-    public static boolean isAllowUploadsEnabled(String configResourceId) {
+    public static AllowUploadsState getAllowUploadsState(String configResourceId) {
         if (StringUtils.isBlank(configResourceId)) {
-            log.debug("Config resource ID is blank, returning false for allowUploads");
-            return false;
+            log.debug("Config resource ID is blank, returning UNREADABLE for allowUploads");
+            return AllowUploadsState.UNREADABLE;
         }
 
         try {
@@ -341,14 +342,14 @@ public class SebConfig {
             fileHandler.setEncoding(CONFIG_ENCODING);
             fileHandler.load(configResource.streamContent());
 
-            // Read the allowUploads property
+            // Read the allowUploads policy value from a valid and readable config.
             Boolean allowUploads = config.getBoolean(ALLOW_UPLOADS_KEY, false);
             log.debug("allowUploads property from SEB config file: {}", allowUploads);
 
-            return allowUploads;
+            return allowUploads ? AllowUploadsState.ENABLED : AllowUploadsState.DISABLED;
         } catch (Exception e) {
             log.error("Error reading allowUploads from SEB config file: {}", e.getMessage(), e);
-            return false;
+            return AllowUploadsState.UNREADABLE;
         }
     }
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/business/entity/SebConfig.java
@@ -137,9 +137,11 @@ public class SebConfig {
     public enum AllowUploadsState { ENABLED, DISABLED, UNREADABLE }
 
     private ServerConfigurationService serverConfigurationService;
+    private ContentHostingService contentHostingService;
 
     public SebConfig() {
         this.serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
+        this.contentHostingService = ComponentManager.get(ContentHostingService.class);
     }
 
     public static SebConfig of(HashMap<String, String> assessmentMetaDataMap) {
@@ -323,14 +325,13 @@ public class SebConfig {
      * @param configResourceId The resource ID of the uploaded SEB configuration file in ContentHostingService
      * @return ENABLED if allowUploads is true, DISABLED if false, UNREADABLE if the file cannot be read/parsed
      */
-    public static AllowUploadsState getAllowUploadsState(String configResourceId) {
+    public AllowUploadsState getAllowUploadsState(String configResourceId) {
         if (StringUtils.isBlank(configResourceId)) {
             log.debug("Config resource ID is blank, returning UNREADABLE for allowUploads");
             return AllowUploadsState.UNREADABLE;
         }
 
         try {
-            ContentHostingService contentHostingService = ComponentManager.get(ContentHostingService.class);
             org.sakaiproject.content.api.ContentResource configResource = contentHostingService.getResource(configResourceId);
 
             Parameters parameters = new Parameters();
@@ -338,7 +339,7 @@ public class SebConfig {
                     new FileBasedConfigurationBuilder<>(XMLPropertyListConfiguration.class)
                             .configure(parameters.fileBased());
             XMLPropertyListConfiguration config = configBuilder.getConfiguration();
-            org.apache.commons.configuration2.io.FileHandler fileHandler = new org.apache.commons.configuration2.io.FileHandler(config);
+            FileHandler fileHandler = new FileHandler(config);
             fileHandler.setEncoding(CONFIG_ENCODING);
             fileHandler.load(configResource.streamContent());
 
@@ -348,7 +349,7 @@ public class SebConfig {
 
             return allowUploads ? AllowUploadsState.ENABLED : AllowUploadsState.DISABLED;
         } catch (Exception e) {
-            log.error("Error reading allowUploads from SEB config file: {}", e.getMessage(), e);
+            log.error("Error reading allowUploads from SEB config file: {}", e.toString(), e);
             return AllowUploadsState.UNREADABLE;
         }
     }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File upload validation for Secure Exam Browser (SEB) now respects the assessment's SEB configuration, preventing incorrect upload errors.

* **Improvements**
  * Error messages distinguish unreadable SEB configurations from disallowed uploads, guiding users to provide a valid, readable .seb file when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->