### PR TITLE
SAK-52459 Assignments keep group submitters in sync after roster moves

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1787,6 +1787,62 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             return;
         }
 
+        reconcileGroupSubmissionSubmittersToRoster(submission, assignmentReference, submissionReference, true);
+    }
+
+    /**
+     * When a submitted group submission is loaded, sync persisted submitter rows to the site's current
+     * group roster if they differ. Fixes stale links after members move teams (e.g. SAK-52459) without
+     * requiring another submission update; uses the same roster rules as post-time reconciliation.
+     */
+    private void maybeReconcileGroupSubmissionSubmittersOnRead(AssignmentSubmission submission) {
+        if (!isGroupSubmittedSubmissionRosterOutOfSync(submission)) {
+            return;
+        }
+        try {
+            Assignment assignment = submission.getAssignment();
+            String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+            String submissionReference = AssignmentReferenceReckoner.reckoner().submission(submission).reckon().getReference();
+            reconcileGroupSubmissionSubmittersToRoster(submission, assignmentReference, submissionReference, false);
+        } catch (PermissionException e) {
+            log.warn("Unexpected permission failure while reconciling group submitters on read for submission {}: {}",
+                    submission.getId(), e.toString());
+        }
+    }
+
+    private boolean isGroupSubmittedSubmissionRosterOutOfSync(AssignmentSubmission submission) {
+        if (submission == null || submission.getAssignment() == null || !submission.getAssignment().getIsGroup()
+                || !Boolean.TRUE.equals(submission.getSubmitted())) {
+            return false;
+        }
+        String groupId = StringUtils.trimToNull(submission.getGroupId());
+        if (groupId == null) {
+            return false;
+        }
+        try {
+            Assignment assignment = submission.getAssignment();
+            Site site = siteService.getSite(assignment.getContext());
+            Group group = site.getGroup(groupId);
+            if (group == null || !assignment.getGroups().contains(group.getReference())) {
+                return false;
+            }
+            Set<String> expected = group.getMembers().stream()
+                    .filter(member -> isSubmitterEligibleForGroup(member, group))
+                    .map(Member::getUserId)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            Set<String> actual = submission.getSubmitters().stream()
+                    .map(AssignmentSubmissionSubmitter::getSubmitter)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            return !expected.equals(actual);
+        } catch (IdUnusedException e) {
+            log.debug("Could not compare group roster for submission {}: {}", submission.getId(), e.toString());
+            return false;
+        }
+    }
+
+    private void reconcileGroupSubmissionSubmittersToRoster(AssignmentSubmission submission, String assignmentReference,
+            String submissionReference, boolean enforceStudentSubmitteeRules) throws PermissionException {
+
         String groupId = StringUtils.trimToNull(submission.getGroupId());
         if (groupId == null) {
             log.warn("Cannot reconcile submitters for group submission {} without a group id", submission.getId());
@@ -1851,9 +1907,24 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 }
             }
 
+            // Read-time reconciliation may leave no submittee when the viewer is not a member;
+            // pick one for display/gradebook consistency. Post/student updates keep prior behavior
+            // (no submittee row required when a grader updates on behalf of the group).
+            if (!enforceStudentSubmitteeRules && submission.getSubmitters().stream().noneMatch(AssignmentSubmissionSubmitter::getSubmittee)
+                    && !submission.getSubmitters().isEmpty()) {
+                Optional<AssignmentSubmissionSubmitter> asCurrent = submission.getSubmitters().stream()
+                        .filter(s -> StringUtils.equals(s.getSubmitter(), currentUserId))
+                        .findFirst();
+                if (asCurrent.isPresent()) {
+                    asCurrent.get().setSubmittee(true);
+                } else {
+                    submission.getSubmitters().iterator().next().setSubmittee(true);
+                }
+            }
+
             // When a student posts, one current group member must resolve as the submittee. A
             // grading user may update on behalf of the group without being one of the submitters.
-            if (submission.getSubmitters().stream().noneMatch(AssignmentSubmissionSubmitter::getSubmittee)
+            if (enforceStudentSubmitteeRules && submission.getSubmitters().stream().noneMatch(AssignmentSubmissionSubmitter::getSubmittee)
                     && !allowGradeSubmission(assignmentReference)) {
                 throw new PermissionException(currentUserId, SECURE_ADD_ASSIGNMENT_SUBMISSION, submissionReference);
             }
@@ -1864,14 +1935,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     private boolean shouldReconcileGroupSubmissionSubmittersOnPost(AssignmentSubmission submission) {
-        if (submission == null || submission.getAssignment() == null || !submission.getAssignment().getIsGroup()
-                || !Boolean.TRUE.equals(submission.getSubmitted())) {
-            return false;
-        }
-
-        Instant dateSubmitted = submission.getDateSubmitted();
-        Instant dateModified = submission.getDateModified();
-        return dateSubmitted == null || dateModified == null || !dateSubmitted.isBefore(dateModified);
+        return submission != null && submission.getAssignment() != null && submission.getAssignment().getIsGroup()
+                && Boolean.TRUE.equals(submission.getSubmitted());
     }
 
     private boolean isSubmitterEligibleForGroup(Member member, Group group) {
@@ -2025,6 +2090,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if (submission != null) {
                 String reference = AssignmentReferenceReckoner.reckoner().submission(submission).reckon().getReference();
                 if (allowGetSubmission(reference)) {
+                    maybeReconcileGroupSubmissionSubmittersOnRead(submission);
                     return submission;
                 } else {
                     throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_ACCESS_ASSIGNMENT_SUBMISSION, reference);
@@ -2068,6 +2134,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if (submission != null) {
                 String reference = AssignmentReferenceReckoner.reckoner().submission(submission).reckon().getReference();
                 if (allowGetSubmission(reference)) {
+                    maybeReconcileGroupSubmissionSubmittersOnRead(submission);
                     return submission;
                 } else {
                     throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_ACCESS_ASSIGNMENT_SUBMISSION, reference);

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1791,9 +1791,11 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     }
 
     /**
-     * When a submitted group submission is loaded, sync persisted submitter rows to the site's current
-     * group roster if they differ. Fixes stale links after members move teams (e.g. SAK-52459) without
-     * requiring another submission update; uses the same roster rules as post-time reconciliation.
+     * When a submitted group submission is loaded, sync persisted submitter rows only if the site's group
+     * roster (active members, excluding graders) no longer matches persisted submitters. Addresses team
+     * membership moves (SAK-52459) without rewriting history on unrelated permission changes: drift detection
+     * deliberately does not use {@link #isSubmitterEligibleForGroup} (asn.submit). Rows are still added or
+     * removed using that eligibility check inside {@link #reconcileGroupSubmissionSubmittersToRoster}.
      */
     private void maybeReconcileGroupSubmissionSubmittersOnRead(AssignmentSubmission submission) {
         if (!isGroupSubmittedSubmissionRosterOutOfSync(submission)) {
@@ -1810,6 +1812,11 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         }
     }
 
+    /**
+     * True when persisted submitters disagree with the current site-group roster used for SAK-52459 read checks.
+     * Compares against active group members who are not graders only — not {@link #isSubmitterEligibleForGroup},
+     * so later asn.submit / asn.grade permission tweaks alone do not count as roster drift.
+     */
     private boolean isGroupSubmittedSubmissionRosterOutOfSync(AssignmentSubmission submission) {
         if (submission == null || submission.getAssignment() == null || !submission.getAssignment().getIsGroup()
                 || !Boolean.TRUE.equals(submission.getSubmitted())) {
@@ -1826,18 +1833,33 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
             if (group == null || !assignment.getGroups().contains(group.getReference())) {
                 return false;
             }
-            Set<String> expected = group.getMembers().stream()
-                    .filter(member -> isSubmitterEligibleForGroup(member, group))
+            Set<String> currentRosterUserIds = group.getMembers().stream()
+                    .filter(member -> countsAsGroupMemberForSubmitterRosterDrift(member, group))
                     .map(Member::getUserId)
+                    .filter(StringUtils::isNotBlank)
                     .collect(Collectors.toCollection(LinkedHashSet::new));
             Set<String> actual = submission.getSubmitters().stream()
                     .map(AssignmentSubmissionSubmitter::getSubmitter)
+                    .filter(StringUtils::isNotBlank)
                     .collect(Collectors.toCollection(LinkedHashSet::new));
-            return !expected.equals(actual);
+            return !currentRosterUserIds.equals(actual);
         } catch (IdUnusedException e) {
             log.debug("Could not compare group roster for submission {}: {}", submission.getId(), e.toString());
             return false;
         }
+    }
+
+    /**
+     * Active site-group participants counted for read-time roster drift (team membership), excluding users
+     * who can grade. Does not require asn.submit, unlike {@link #isSubmitterEligibleForGroup}, so permission-only
+     * submission-right changes do not trigger read reconciliation.
+     */
+    private boolean countsAsGroupMemberForSubmitterRosterDrift(Member member, Group group) {
+        if (member == null || group == null || member.getRole() == null || !member.isActive()) {
+            return false;
+        }
+        return !member.getRole().isAllowed(SECURE_GRADE_ASSIGNMENT_SUBMISSION)
+                && !group.isAllowed(member.getUserId(), SECURE_GRADE_ASSIGNMENT_SUBMISSION);
     }
 
     private void reconcileGroupSubmissionSubmittersToRoster(AssignmentSubmission submission, String assignmentReference,

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1885,6 +1885,15 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 return;
             }
 
+            Optional<String> priorSubmitteeUserId = Optional.empty();
+            if (!enforceStudentSubmitteeRules) {
+                priorSubmitteeUserId = submission.getSubmitters().stream()
+                        .filter(ass -> Boolean.TRUE.equals(ass.getSubmittee()))
+                        .map(AssignmentSubmissionSubmitter::getSubmitter)
+                        .filter(StringUtils::isNotBlank)
+                        .findFirst();
+            }
+
             // The selected group is fixed in the UI, but the persisted submitter rows may still
             // be stale by the time a real post happens. Group submissions can exist as drafts or
             // instructor-created grading records before posting, and membership can change in the
@@ -1929,24 +1938,26 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 }
             }
 
-            // Read-time reconciliation may leave no submittee when the viewer is not a member;
-            // pick one for display/gradebook consistency. Post/student updates keep prior behavior
-            // (no submittee row required when a grader updates on behalf of the group).
-            if (!enforceStudentSubmitteeRules && submission.getSubmitters().stream().noneMatch(AssignmentSubmissionSubmitter::getSubmittee)
+            // Read-time: if no submittee (e.g. instructor opened), restore the historical submittee when
+            // that row still exists after roster sync; otherwise pick a stable default — not the current viewer.
+            if (!enforceStudentSubmitteeRules && submission.getSubmitters().stream().noneMatch(ass -> Boolean.TRUE.equals(ass.getSubmittee()))
                     && !submission.getSubmitters().isEmpty()) {
-                Optional<AssignmentSubmissionSubmitter> asCurrent = submission.getSubmitters().stream()
-                        .filter(s -> StringUtils.equals(s.getSubmitter(), currentUserId))
-                        .findFirst();
-                if (asCurrent.isPresent()) {
-                    asCurrent.get().setSubmittee(true);
+                Optional<AssignmentSubmissionSubmitter> priorRow = priorSubmitteeUserId
+                        .flatMap(uid -> submission.getSubmitters().stream()
+                                .filter(s -> StringUtils.equals(uid, s.getSubmitter()))
+                                .findFirst());
+                if (priorRow.isPresent()) {
+                    priorRow.get().setSubmittee(true);
                 } else {
-                    submission.getSubmitters().iterator().next().setSubmittee(true);
+                    submission.getSubmitters().stream()
+                            .min(Comparator.comparing(AssignmentSubmissionSubmitter::getSubmitter, Comparator.nullsLast(String::compareTo)))
+                            .ifPresent(s -> s.setSubmittee(true));
                 }
             }
 
             // When a student posts, one current group member must resolve as the submittee. A
             // grading user may update on behalf of the group without being one of the submitters.
-            if (enforceStudentSubmitteeRules && submission.getSubmitters().stream().noneMatch(AssignmentSubmissionSubmitter::getSubmittee)
+            if (enforceStudentSubmitteeRules && submission.getSubmitters().stream().noneMatch(ass -> Boolean.TRUE.equals(ass.getSubmittee()))
                     && !allowGradeSubmission(assignmentReference)) {
                 throw new PermissionException(currentUserId, SECURE_ADD_ASSIGNMENT_SUBMISSION, submissionReference);
             }

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -983,6 +983,113 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         }
     }
 
+    /**
+     * SAK-52459: after a group submits and an instructor change makes {@code dateModified} strictly after
+     * {@code dateSubmitted}, roster reconciliation on update was skipped; loading the submission must still
+     * drop users no longer in the group.
+     */
+    @Test
+    public void groupSubmissionReconcilesStaleSubmittersOnReadWhenPostReconcileWasSkippedAfterGrading() {
+        String context = UUID.randomUUID().toString();
+        String groupId = "team-1";
+        String studentA = "student0011";
+        String studentB = "student0012";
+        String instructorId = "instructor001";
+
+        Assignment assignment = createNewAssignment(context);
+        assignment.setTypeOfAccess(Assignment.Access.GROUP);
+        assignment.setIsGroup(true);
+        assignment.setOpenDate(Instant.now().minus(Period.ofDays(1)));
+        assignment.setAuthor(instructorId);
+
+        String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+        String contextReference = AssignmentReferenceReckoner.reckoner().context(context).reckon().getReference();
+        String siteReference = "/site/" + context;
+        String groupReference = siteReference + "/group/" + groupId;
+
+        assignment.getGroups().add(groupReference);
+
+        Site site = mock(Site.class);
+        Group group = mock(Group.class);
+        AuthzGroup authzGroup = mock(AuthzGroup.class);
+
+        Set<Member> bothStudents = new HashSet<>(Arrays.asList(
+                buildGroupMember(studentA),
+                buildGroupMember(studentB)));
+        Set<Member> onlyStudentA = new HashSet<>(Collections.singletonList(buildGroupMember(studentA)));
+
+        when(siteService.siteReference(context)).thenReturn(siteReference);
+        try {
+            when(siteService.getSite(context)).thenReturn(site);
+            when(authzGroupService.getAuthzGroup(groupReference)).thenReturn(authzGroup);
+        } catch (Exception e) {
+            Assert.fail("Could not configure mocks for read-time submitter reconciliation test\n" + e);
+        }
+
+        when(group.getId()).thenReturn(groupId);
+        when(group.getReference()).thenReturn(groupReference);
+        when(group.getProperties()).thenReturn(new BaseResourceProperties());
+        // First two lookups (create + grade reconciliation) see both members; after "move" only A remains on team.
+        when(group.getMembers()).thenReturn(bothStudents, bothStudents, onlyStudentA);
+        when(site.getGroups()).thenReturn(Collections.singleton(group));
+        when(site.getGroup(groupId)).thenReturn(group);
+        when(site.getGroup(groupReference)).thenReturn(group);
+
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, contextReference)).thenReturn(true);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, assignmentReference)).thenReturn(true);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_GRADE_ASSIGNMENT_SUBMISSION, assignmentReference)).thenReturn(true);
+        when(sessionManager.getCurrentSessionUserId()).thenReturn(instructorId);
+
+        try {
+            assignmentService.updateAssignment(assignment);
+        } catch (PermissionException e) {
+            Assert.fail("Could not update assignment\n" + e);
+        }
+
+        AssignmentSubmission submission;
+        try {
+            submission = assignmentService.addSubmission(assignment.getId(), groupId);
+        } catch (Exception e) {
+            Assert.fail("Could not create group submission\n" + e);
+            return;
+        }
+        Assert.assertNotNull(submission);
+
+        Instant submittedAt = Instant.now().minusSeconds(3600);
+        submission.setSubmitted(true);
+        submission.setUserSubmission(true);
+        submission.setDateSubmitted(submittedAt);
+        submission.setDateModified(submittedAt);
+
+        String submissionReference = AssignmentReferenceReckoner.reckoner().submission(submission).reckon().getReference();
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_ACCESS_ASSIGNMENT_SUBMISSION, submissionReference)).thenReturn(true);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT_SUBMISSION, submissionReference)).thenReturn(true);
+
+        try {
+            Optional<AssignmentSubmissionSubmitter> bRow = submission.getSubmitters().stream()
+                    .filter(s -> studentB.equals(s.getSubmitter()))
+                    .findFirst();
+            Assert.assertTrue(bRow.isPresent());
+            bRow.get().setGrade("70");
+            submission.setDateModified(submittedAt.plusSeconds(120));
+            assignmentService.updateSubmission(submission);
+        } catch (Exception e) {
+            Assert.fail("Could not simulate instructor grade after submit\n" + e);
+        }
+
+        Assert.assertTrue(submission.getSubmitters().stream().anyMatch(s -> studentB.equals(s.getSubmitter())));
+
+        try {
+            AssignmentSubmission loaded = assignmentService.getSubmission(submission.getId());
+            Assert.assertNotNull(loaded);
+            Assert.assertFalse("Moved student should be removed from Team 1 submitters on read",
+                    loaded.getSubmitters().stream().anyMatch(s -> studentB.equals(s.getSubmitter())));
+            Assert.assertTrue(loaded.getSubmitters().stream().anyMatch(s -> studentA.equals(s.getSubmitter())));
+        } catch (Exception e) {
+            Assert.fail("Read-time reconciliation failed\n" + e);
+        }
+    }
+
     @Test
     public void ambiguousGroupUserLookupFindsMatchingSubmissionAndCanSubmit() {
         String context = UUID.randomUUID().toString();


### PR DESCRIPTION
(Link): [https://jira.sakaiproject.org/browse/SAK-52459]
reassigned students could stay on the old team submission / gradebook; reconciliation was skipped after grading; now reconcile on every submitted group updateSubmission and on getSubmission when roster ≠ stored submitters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Added read-time reconciliation for group submissions so submitter lists are synced with current group membership when accessed; read-time reconciles without throwing permission errors and will restore a historical submittee if available or assign a deterministic default when none remain.
  - Simplified post-time reconciliation to reconcile reliably for submitted group submissions.

* **Tests**
  - Added a test validating that stale submitters are reconciled on read after grading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->