### PR TITLE
SAK-48955: Jobs does delete old unread notifications

### DIFF
--- a/jobscheduler/scheduler-component-shared/pom.xml
+++ b/jobscheduler/scheduler-component-shared/pom.xml
@@ -119,6 +119,21 @@
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
         </dependency>
+
+        <!-- needed by mockito to mock SpringRepository -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <version>${sakai.spring.data.commons.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sakaiproject.kernel</groupId>
+            <artifactId>sakai-kernel-impl</artifactId>
+            <version>${sakai.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/NotificationCleanupJob.java
+++ b/jobscheduler/scheduler-component-shared/src/java/org/sakaiproject/component/app/scheduler/jobs/NotificationCleanupJob.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *********************************************************************************/
+
+package org.sakaiproject.component.app.scheduler.jobs;
+
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.sakaiproject.component.api.ServerConfigurationService;
+
+
+import org.sakaiproject.messaging.api.repository.UserNotificationRepository;
+
+import javax.inject.Inject;
+import java.util.*;
+
+/**
+ This job keeps user notifications from growing without limit by removing older notifications once a configurable threshold is exceeded.
+ A global threshold applies to all supported tools by default, and can be overridden per tool if needed.
+ Supported tool types include assignments, Samigo, announcements, and content.
+ If a threshold is set to 0, cleanup is disabled for that tool.
+ If no per-tool value is provided, the global value is used instead.
+
+ notification.cleanup.threshold.per.tool=100
+ notification.cleanup.threshold.per.tool.asn=100
+ notification.cleanup.threshold.per.tool.sam=100
+ notification.cleanup.threshold.per.tool.annc=100
+ notification.cleanup.threshold.per.tool.commons=100
+ notification.cleanup.threshold.per.tool.message=100
+ notification.cleanup.threshold.per.tool.lessonbuilder=100
+ */
+
+@DisallowConcurrentExecution
+@Slf4j
+public class NotificationCleanupJob implements Job {
+
+    private static final String ASSIGNMENT_TOOL_PREFIX      = "asn";
+    private static final String SAMIGO_TOOL_PREFIX          = "sam";
+    private static final String ANNOUNCEMENT_TOOL_PREFIX    = "annc";
+    private static final String COMMONS_TOOL_PREFIX         = "commons";
+    private static final String MESSAGE_TOOL_PREFIX         = "message";
+    private static final String LESSONSBUILDER_TOOL_PREFIX  = "lessonbuilder";
+
+
+    private static final List<String> TOOL_PREFIXES = Arrays.asList(ASSIGNMENT_TOOL_PREFIX, SAMIGO_TOOL_PREFIX, ANNOUNCEMENT_TOOL_PREFIX, COMMONS_TOOL_PREFIX, MESSAGE_TOOL_PREFIX, LESSONSBUILDER_TOOL_PREFIX);
+
+    private static final String THRESHOLD_PROPERTY_NAME_GLOBAL = "notification.cleanup.threshold.per.tool";
+    private static final int DEFAULT_NOTIFICATION_THRESHOLD_PER_TOOL = 100;
+
+
+
+
+    @Inject
+    private ServerConfigurationService serverConfigurationService;
+
+    @Inject
+    private UserNotificationRepository userNotificationRepository;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+
+        try {
+            int globalThreshold = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL, DEFAULT_NOTIFICATION_THRESHOLD_PER_TOOL);
+
+            int thresholdAssignment = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL + "." + ASSIGNMENT_TOOL_PREFIX, globalThreshold);
+            int thresholdSamigo = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL + "." + SAMIGO_TOOL_PREFIX, globalThreshold);
+            int thresholdAnnouncement = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL + "." + ANNOUNCEMENT_TOOL_PREFIX, globalThreshold);
+            int thresholdCommons = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL + "." + COMMONS_TOOL_PREFIX, globalThreshold);
+            int thresholdMessage = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL + "." + MESSAGE_TOOL_PREFIX, globalThreshold);
+            int thresholdLessonbuilder = serverConfigurationService.getInt(
+                    THRESHOLD_PROPERTY_NAME_GLOBAL + "." + LESSONSBUILDER_TOOL_PREFIX, globalThreshold);
+
+
+
+
+
+            Map<String, Integer> thresholds = Map.of(
+                    ASSIGNMENT_TOOL_PREFIX, thresholdAssignment,
+                    SAMIGO_TOOL_PREFIX, thresholdSamigo,
+                    ANNOUNCEMENT_TOOL_PREFIX, thresholdAnnouncement,
+                    COMMONS_TOOL_PREFIX, thresholdCommons,
+                    MESSAGE_TOOL_PREFIX, thresholdMessage,
+                    LESSONSBUILDER_TOOL_PREFIX, thresholdLessonbuilder
+            );
+
+
+            log.info("Starting notification cleanup job with threshold: {} assignment, {} samigo, {} announcement, {} commons, {} message, {} lessonbuilder", thresholdAssignment, thresholdSamigo, thresholdAnnouncement, thresholdCommons, thresholdMessage, thresholdLessonbuilder);
+
+            if (thresholdAssignment <= 0 && thresholdSamigo <= 0 && thresholdAnnouncement <= 0 && thresholdCommons <= 0 && thresholdMessage <= 0 && thresholdLessonbuilder <= 0) {
+                log.info("Notification cleanup skipped due to zero threshold for all tools");
+                return;
+            }
+
+            List<String> usersWithNotifications = getUsersWithNotifications();
+
+            log.info("Found {} users with notifications ... deleting notifications now", usersWithNotifications.size());
+
+            long totalDeletedCountAnnouncement = 0;
+            long totalDeletedCountSamigo = 0;
+            long totalDeletedCountAssignment = 0;
+            long totalDeletedCountCommons = 0;
+            long totalDeletedCountMessage = 0;
+            long totalDeletedCountLessonbuilder = 0;
+
+
+            for (String userId : usersWithNotifications) {
+                for (String toolPrefix : TOOL_PREFIXES) {
+                    if (thresholds.get(toolPrefix) <= 0) {
+                        continue;
+                    }
+
+                    long deletedCount = 0;
+
+                    try {
+                        deletedCount = processNotificationForToolAndUserId(userId, toolPrefix, thresholds.get(toolPrefix));
+                    } catch (Exception e) {
+                        log.error("Error processing notifications for user {} and tool {}", userId, toolPrefix, e);
+                    }
+
+                    switch (toolPrefix) {
+                        case ANNOUNCEMENT_TOOL_PREFIX:
+                            totalDeletedCountAnnouncement += deletedCount;
+                            break;
+                        case SAMIGO_TOOL_PREFIX:
+                            totalDeletedCountSamigo += deletedCount;
+                            break;
+                        case ASSIGNMENT_TOOL_PREFIX:
+                            totalDeletedCountAssignment += deletedCount;
+                            break;
+                        case COMMONS_TOOL_PREFIX:
+                            totalDeletedCountCommons += deletedCount;
+                            break;
+                        case MESSAGE_TOOL_PREFIX:
+                            totalDeletedCountMessage += deletedCount;
+                              break;
+                        case LESSONSBUILDER_TOOL_PREFIX:
+                            totalDeletedCountLessonbuilder += deletedCount;
+                            break;
+                        default:
+                            log.debug("Unknown tool prefix {}", toolPrefix);
+                    }
+                }
+            }
+
+            long totalDeletedCount = totalDeletedCountAnnouncement
+                    + totalDeletedCountSamigo
+                    + totalDeletedCountAssignment
+                    + totalDeletedCountCommons
+                    + totalDeletedCountMessage
+                    + totalDeletedCountLessonbuilder;
+
+            log.info(
+                    "Finished notification cleanup job: total deleted Notifications {} (annc={}, sam={}, asn={}, commons={}, message={}, lessonbuilder={})",
+                    totalDeletedCount,
+                    totalDeletedCountAnnouncement,
+                    totalDeletedCountSamigo,
+                    totalDeletedCountAssignment,
+                    totalDeletedCountCommons,
+                    totalDeletedCountMessage,
+                    totalDeletedCountLessonbuilder
+            );
+
+        } catch (Exception e) {
+            log.error("Error executing notification cleanup job", e);
+        }
+    }
+
+    private List<String> getUsersWithNotifications() {
+        return userNotificationRepository.findAllDistinctToUser();
+    }
+
+
+    private int processNotificationForToolAndUserId(String user, String toolPrefix, int threshold) {
+
+        long countedNotisByUserIdAndTool =  userNotificationRepository.countAllByToUserAndByToolAndNotDeferredOverThreshold(user, toolPrefix, threshold);
+
+        log.debug("User {} has {} notifications over threshold for tool {}", user, countedNotisByUserIdAndTool, toolPrefix);
+
+        int toDeleteCount = calculateDeleteCount(user, countedNotisByUserIdAndTool, threshold);
+
+        log.debug("{} notifications will be deleted for user {} and tool {}", toDeleteCount, user, toolPrefix);
+
+        List<Long> notiIdsToDelete =  userNotificationRepository.getIdsToDeleteByUserIdAndToolPrefix(user, toDeleteCount, toolPrefix);
+
+        return  deleteNotifications(user, notiIdsToDelete, toolPrefix);
+    }
+
+    private int deleteNotifications(String userId, List<Long> notiIdsToDelete, String toolPrefix) {
+        log.debug("Deleting {} notifications for user {} and toolPrefix {}", notiIdsToDelete.size(), userId, toolPrefix);
+        try {
+           return userNotificationRepository.deleteNotificationsInList(notiIdsToDelete);
+        } catch (Exception e) {
+            log.error("Error deleting notifications for user {} and tool {}", userId, toolPrefix, e);
+        }
+        return 0;
+    }
+
+    private int calculateDeleteCount(String userId, long notificationCount, int threshold) {
+        long excess = notificationCount - threshold;
+        if (excess <= 0L) return 0;
+        int toDeleteCount;
+        try {
+            toDeleteCount =  Math.toIntExact(excess);
+        } catch (ArithmeticException e) {
+            log.warn("Excess notifications too large for int for user: {}, excess: {}", userId, excess);
+            toDeleteCount = Integer.MAX_VALUE;
+        }
+        return toDeleteCount;
+    }
+
+
+}

--- a/jobscheduler/scheduler-component-shared/src/test/java/org/sakaiproject/component/app/scheduler/NotificationCleanUpJobTest.java
+++ b/jobscheduler/scheduler-component-shared/src/test/java/org/sakaiproject/component/app/scheduler/NotificationCleanUpJobTest.java
@@ -1,0 +1,318 @@
+package org.sakaiproject.component.app.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.quartz.*;
+import org.quartz.impl.DirectSchedulerFactory;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.component.app.scheduler.jobs.NotificationCleanupJob;
+import org.sakaiproject.messaging.api.repository.UserNotificationRepository;
+
+import javax.validation.constraints.NotNull;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+public class NotificationCleanUpJobTest {
+
+
+    private static final String ASSIGNMENT_TOOL_PREFIX      = "asn";
+    private static final String SAMIGO_TOOL_PREFIX          = "sam";
+    private static final String ANNOUNCEMENT_TOOL_PREFIX    = "annc";
+    private static final String COMMONS_TOOL_PREFIX         = "commons";
+    private static final String MESSAGE_TOOL_PREFIX         = "message";
+    private static final String LESSONSBUILDER_TOOL_PREFIX  = "lessonbuilder";
+    private final Integer defaultThreshold = 100;
+
+    private Scheduler scheduler;
+
+
+    @Mock
+    private ServerConfigurationService serverConfigurationService;
+
+    @Mock
+    private UserNotificationRepository userNotificationRepository;
+
+    @InjectMocks
+    private NotificationCleanupJob job;
+
+    private Set<String> allowedTools = Set.of(ASSIGNMENT_TOOL_PREFIX, SAMIGO_TOOL_PREFIX, ANNOUNCEMENT_TOOL_PREFIX, COMMONS_TOOL_PREFIX, MESSAGE_TOOL_PREFIX, LESSONSBUILDER_TOOL_PREFIX);
+
+    private RepoState repoState;
+
+
+    @Before
+    public void setUp() throws Exception {
+        repoState = new RepoState();
+
+        DirectSchedulerFactory schedulerFactory = DirectSchedulerFactory.getInstance();
+        schedulerFactory.createVolatileScheduler(1);
+        scheduler = schedulerFactory.getScheduler();
+        scheduler.start();
+
+
+        scheduler.setJobFactory((bundle, sched) -> {
+            Class<?> jobClass = bundle.getJobDetail().getJobClass();
+            if (jobClass.equals(NotificationCleanupJob.class)) {
+                return job;
+            }
+            try {
+                return (Job) jobClass.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException e) {
+                throw new RuntimeException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        setupServerConfigurationServiceMock(defaultThreshold, null, null, null, null,null,null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdown(true);
+        }
+    }
+
+    @Test
+    public void execute_shouldRunQuartzJob() throws Exception {
+        int threshold = 10;
+        int userCount = 10;
+        int countDown = userCount * allowedTools.size();
+
+        CountDownLatch latch = new CountDownLatch(countDown);
+
+        setupServerConfigurationServiceMock(10, null, null, null, null,null,null);
+
+        setUpRandomRepoState(threshold, userCount);
+
+        when(userNotificationRepository.findAllDistinctToUser()).thenReturn(repoState.usersWithNotifications);
+
+
+        when(userNotificationRepository.countAllByToUserAndByToolAndNotDeferredOverThreshold(anyString(),argThat(allowedTools::contains), eq(threshold)))
+                        .thenAnswer(inv -> {
+                           String user = inv.getArgument(0);
+                            String tool = inv.getArgument(1);
+                            return repoState.countsByTool.get(user).get(tool);
+                        });
+
+        when(userNotificationRepository.getIdsToDeleteByUserIdAndToolPrefix(anyString(), anyInt(), argThat(allowedTools::contains)))
+                .thenAnswer((inv) -> {
+                            int size = inv.getArgument(1);
+                            String user = inv.getArgument(0);
+                            String tool = inv.getArgument(2);
+                            return createRandomListofIds(size);
+                        });
+
+        when(userNotificationRepository.deleteNotificationsInList(anyList())).thenAnswer((invocation) -> {
+            latch.countDown();
+            List<Long> notificationsToDelete = invocation.getArgument(0);
+            return notificationsToDelete.size();
+        });
+
+
+
+        JobDetail job = JobBuilder.newJob(NotificationCleanupJob.class)
+                .withIdentity("testJob", "testGroup")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("testTrigger", "testGroup")
+                .startNow()
+                .forJob(job)
+                .build();
+
+        scheduler.scheduleJob(job, trigger);
+
+
+        boolean completed = latch.await(20, TimeUnit.SECONDS);
+        Assert.assertTrue("Job did not complete in time", completed);
+
+        Assert.assertTrue("Expected at least 1 executed job",
+                scheduler.getMetaData().getNumberOfJobsExecuted() >= 1);
+
+        int numberOfExecutions = repoState.usersWithNotifications.size() * allowedTools.size();
+        verify(userNotificationRepository, times(numberOfExecutions)).countAllByToUserAndByToolAndNotDeferredOverThreshold(anyString(), anyString(), anyInt());
+    }
+
+    @Test
+    public void shouldSkipJob_ifGlobalThresholdIsZero() throws JobExecutionException {
+        setupServerConfigurationServiceMock(0, null, null, null, null,null,null);
+        JobExecutionContext context = mock(JobExecutionContext.class);
+
+        job.execute(context);
+        verify(userNotificationRepository, never()).findAllDistinctToUser();
+    }
+
+    @Test
+    public void shouldSkipJob_ifToolThresholdsAreZero() throws JobExecutionException {
+        setupServerConfigurationServiceMock(null, 0, 0, 0, 0,0,0);
+        JobExecutionContext context = mock(JobExecutionContext.class);
+
+        job.execute(context);
+        verify(userNotificationRepository, never()).findAllDistinctToUser();
+    }
+
+    @Test
+    public void shouldSkipJob_ifToolThresholdsAreZeroAndGlobalIsSet()  throws JobExecutionException {
+        setupServerConfigurationServiceMock(100, 0, 0, 0, 0,0,0);
+        JobExecutionContext context = mock(JobExecutionContext.class);
+
+        job.execute(context);
+        verify(userNotificationRepository, never()).findAllDistinctToUser();
+    }
+
+    @Test
+    public void shouldOnlyProcessNotificationforTool_ifNonZeroPositiveThresholdIsSetForAnnouncement()  throws JobExecutionException {
+        int userCount = 10;
+        setUpRandomRepoState(10, userCount);
+        int thresholdAnnouncement = 10;
+        setupServerConfigurationServiceMock(null, 0, thresholdAnnouncement, 0, 0,0,0);
+
+        when(userNotificationRepository.findAllDistinctToUser()).thenReturn(repoState.usersWithNotifications);
+        when(userNotificationRepository.countAllByToUserAndByToolAndNotDeferredOverThreshold(anyString(), eq("annc"), eq(thresholdAnnouncement)))
+                .thenAnswer(inv -> {
+                    String user = inv.getArgument(0);
+                    String tool = inv.getArgument(1);
+                    return repoState.countsByTool.get(user).get(tool);
+                });
+
+        when(userNotificationRepository.getIdsToDeleteByUserIdAndToolPrefix(anyString(), anyInt(), eq("annc")))
+                .thenAnswer((inv) -> {
+                    int size = inv.getArgument(1);
+                    String user = inv.getArgument(0);
+                    String tool = inv.getArgument(2);
+                    return createRandomListofIds(size);
+                });
+
+        when(userNotificationRepository.deleteNotificationsInList(anyList())).thenAnswer((invocation) -> {
+            List<Long> notificationsToDelete = invocation.getArgument(0);
+            return notificationsToDelete.size();
+        });
+
+
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+
+        job.execute(context);
+
+        verify(userNotificationRepository, times(1)).findAllDistinctToUser();
+
+        int numberOfExecutions = repoState.usersWithNotifications.size();
+        verify(userNotificationRepository, times(numberOfExecutions)).countAllByToUserAndByToolAndNotDeferredOverThreshold(anyString(), anyString(), anyInt());
+
+    }
+
+
+
+
+
+
+
+    private int calcToDelete(int threshold, String user, int size, String tool) throws ArithmeticException {
+        Map<String, Long> countsByUsersForTool =  repoState.countsByTool.get(tool);
+        long countByUserForTool =  countsByUsersForTool.get(user).longValue();
+
+        /*
+         *  attention: countFromDatabase is returned as long and substracting int can result still bigger than MAX_INT
+         *  Math.toIntExact does throw ArithmeticException if that is the case
+         */
+        long toDeleteSize =   countByUserForTool -   threshold;
+        return  Math.toIntExact(toDeleteSize);
+    }
+
+
+    private static class RepoState {
+        private Map<String, Map<String, Long>> countsByTool = new HashMap<>();
+        List<String> usersWithNotifications = new ArrayList<>();
+
+        public void setCountsByTool(String tool, Map<String, Long> counts) {
+            countsByTool.put(tool, counts);
+        }
+
+    }
+
+
+    private List<Long> createRandomListofIds(int size) {
+             return  java.util.concurrent.ThreadLocalRandom.current().longs(size)
+                        .boxed()
+                        .collect(Collectors.toList());
+    }
+
+
+    private void setUpRandomRepoState(int threshold, int userCount) {
+
+        java.util.concurrent.ThreadLocalRandom random = java.util.concurrent.ThreadLocalRandom.current();
+
+        for (int i = 0; i < userCount; i++) {
+            String user;
+            do {
+                user = "user-" + random.nextInt(1000);
+            } while (repoState.usersWithNotifications.contains(user));
+
+
+            Map<String, Long> countsByUserForTool = new HashMap<>();
+            countsByUserForTool.put(ASSIGNMENT_TOOL_PREFIX, randomLongOver2TimesTheThreshold(threshold));
+            countsByUserForTool.put(SAMIGO_TOOL_PREFIX, randomLongOver2TimesTheThreshold(threshold));
+            countsByUserForTool.put(ANNOUNCEMENT_TOOL_PREFIX, randomLongOver2TimesTheThreshold(threshold));
+            countsByUserForTool.put(COMMONS_TOOL_PREFIX, randomLongOver2TimesTheThreshold(threshold));
+            countsByUserForTool.put(MESSAGE_TOOL_PREFIX, randomLongOver2TimesTheThreshold(threshold));
+            countsByUserForTool.put(LESSONSBUILDER_TOOL_PREFIX, randomLongOver2TimesTheThreshold(threshold));
+
+            repoState.setCountsByTool(user, countsByUserForTool);
+            repoState.usersWithNotifications.add(user);
+        }
+    }
+
+    private long randomLongOver2TimesTheThreshold(long max) {
+        return java.util.concurrent.ThreadLocalRandom.current().nextLong(max + 1, (max * 2));
+    }
+
+
+    private void setupServerConfigurationServiceMock(Integer global, Integer samigo, Integer announcement, Integer assignment , Integer commons, Integer message, Integer lessonbuilder) {
+        if (global == null) global = defaultThreshold;
+        when(serverConfigurationService.getInt("notification.cleanup.threshold.per.tool", defaultThreshold)).thenReturn(global.intValue());
+
+        if (samigo == null) samigo = global;
+        when(serverConfigurationService.getInt(("notification.cleanup.threshold.per.tool." + SAMIGO_TOOL_PREFIX), global)).thenReturn(samigo.intValue());
+
+        if (announcement == null) announcement = global;
+       when(serverConfigurationService.getInt(("notification.cleanup.threshold.per.tool." + ANNOUNCEMENT_TOOL_PREFIX), global)).thenReturn(announcement.intValue());
+
+        if (assignment == null) assignment = global;
+        when(serverConfigurationService.getInt(("notification.cleanup.threshold.per.tool." + ASSIGNMENT_TOOL_PREFIX), global)).thenReturn(assignment.intValue());
+
+        if (commons == null)  commons = global;
+        when(serverConfigurationService.getInt(("notification.cleanup.threshold.per.tool." + COMMONS_TOOL_PREFIX), global)).thenReturn(commons.intValue());
+
+        if (message == null)  message = global;
+        when(serverConfigurationService.getInt(("notification.cleanup.threshold.per.tool." + MESSAGE_TOOL_PREFIX), global)).thenReturn(message.intValue());
+
+        if (lessonbuilder == null)  lessonbuilder = global;
+        when(serverConfigurationService.getInt(("notification.cleanup.threshold.per.tool." + LESSONSBUILDER_TOOL_PREFIX), global)).thenReturn(lessonbuilder.intValue());
+    }
+
+
+
+
+
+}

--- a/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
+++ b/jobscheduler/scheduler-component/src/webapp/WEB-INF/components.xml
@@ -404,6 +404,10 @@
                 </bean>
                 <ref bean="org.sakaiproject.api.app.scheduler.BackFillRoleJob"/>
                 <ref bean="org.sakaiproject.api.app.scheduler.BackFillToolJob"/>
+                <bean class="org.sakaiproject.component.app.scheduler.AutowiredJobBeanWrapper">
+                    <constructor-arg value="org.sakaiproject.component.app.scheduler.jobs.NotificationCleanupJob"/>
+                    <constructor-arg value="Cleanup notifications"/>
+                </bean>
             </list>
         </property>
     </bean>

--- a/kernel/api/src/main/java/org/sakaiproject/messaging/api/repository/UserNotificationRepository.java
+++ b/kernel/api/src/main/java/org/sakaiproject/messaging/api/repository/UserNotificationRepository.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.messaging.api.repository;
 
 import java.util.List;
+import java.util.Map;
 
 import org.sakaiproject.messaging.api.model.UserNotification;
 
@@ -31,4 +32,10 @@ public interface UserNotificationRepository extends SpringCrudRepository<UserNot
     int deleteExpiredNotifications();
     int setAllNotificationsViewed(String userId, String siteId, String toolId);
     int setDeferredBySiteId(String siteId, boolean deferred);
+
+
+    int deleteNotificationsInList(List<Long> idsToDelete);
+    List<Long> getIdsToDeleteByUserIdAndToolPrefix(String userId, int toDeleteCount, String toolPrefix);
+    long countAllByToUserAndByToolAndNotDeferredOverThreshold(String toUser, String toolPrefix, int threshold) ;
+    List<String> findAllDistinctToUser();
 }

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/messaging/impl/repository/UserNotificationRepositoryImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/messaging/impl/repository/UserNotificationRepositoryImpl.java
@@ -16,11 +16,18 @@
 package org.sakaiproject.messaging.impl.repository;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+
 import java.util.List;
 import java.time.Instant;
+import java.time.Instant;
+import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
 
+import javax.persistence.Tuple;
+import javax.persistence.criteria.*;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
@@ -36,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import org.apache.commons.lang3.StringUtils;
 
+@Slf4j
 public class UserNotificationRepositoryImpl extends SpringCrudRepositoryImpl<UserNotification, Long> implements UserNotificationRepository {
 
     public List<UserNotification> findByToUser(String userId) {
@@ -151,4 +159,105 @@ public class UserNotificationRepositoryImpl extends SpringCrudRepositoryImpl<Use
         cu.set("deferred", deferred).where(cb.equal(un.get("siteId"), siteId));
         return session.createQuery(cu).executeUpdate();
     }
+
+
+
+
+
+
+
+    @Override
+    @Transactional( readOnly = true)
+    public List<Long> getIdsToDeleteByUserIdAndToolPrefix(String userId, int toDeleteCount, String toolPrefix) {
+
+        Session session = sessionFactory.getCurrentSession();
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Long> idQuery = cb.createQuery(Long.class);
+        Root<UserNotification> un = idQuery.from(UserNotification.class);
+
+        idQuery.select(un.get("id"));
+        idQuery.where(
+                cb.and(
+                    cb.like(un.get("event"), toolPrefix + "%"),
+                    cb.equal(un.get("toUser"), userId),
+                    cb.equal(un.get("deferred"), false)
+                )
+        );
+        idQuery.orderBy(cb.asc(un.get("eventDate")), cb.asc(un.get("id")));
+
+        return session.createQuery(idQuery)
+                .setMaxResults(toDeleteCount)
+                .list();
+    }
+
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countAllByToUserAndByToolAndNotDeferredOverThreshold(String toUser, String toolPrefix, int threshold) {
+        Session session = sessionFactory.getCurrentSession();
+
+
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Tuple> query = cb.createTupleQuery();
+        Root<UserNotification> un = query.from(UserNotification.class);
+
+        Expression<Long> count = cb.count(un);
+
+        query.multiselect(
+                un.get("toUser").alias("userId"),
+                count.alias("count")
+        );
+        query.where(
+                cb.and(
+                    cb.equal(un.get("deferred"), false),
+                    cb.like(un.get("event"), toolPrefix  + "%"),
+                    cb.equal(un.get("toUser"), toUser)
+                )
+        );
+        query.groupBy(un.get("toUser"));
+        query.having(cb.gt(count, threshold));
+
+
+        List<Tuple> rows = session.createQuery(query).getResultList();
+        if (rows.isEmpty()) {
+            return 0L;
+        }
+        return rows.get(0).get("count", Long.class);
+    }
+
+
+    @Override
+    @Transactional
+    public int deleteNotificationsInList(List<Long> idsToDelete) {
+        if (idsToDelete == null || idsToDelete.isEmpty()) return 0;
+
+        Session session = sessionFactory.getCurrentSession();
+
+        CriteriaBuilder db = session.getCriteriaBuilder();
+        CriteriaDelete<UserNotification> delete = db.createCriteriaDelete(UserNotification.class);
+
+        Root<UserNotification> un = delete.from(UserNotification.class);
+        delete.where(un.get("id").in(idsToDelete));
+
+        return session.createQuery(delete).executeUpdate();
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> findAllDistinctToUser() {
+        Session session  = sessionFactory.getCurrentSession();
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<String> query = cb.createQuery(String.class);
+        Root<UserNotification> un = query.from(UserNotification.class);
+        query.select(un.get("toUser"));
+        query.distinct(true);
+        return session.createQuery(query).list();
+    }
+
+
+
+
+
 }


### PR DESCRIPTION
 This job keeps user notifications from growing without limit by removing older notifications once a configurable threshold is exceeded.
 A global threshold applies to all supported tools by default, and can be overridden per tool if needed.
 Supported tool types include assignments, Samigo, announcements, and content.
 If a threshold is set to 0, cleanup is disabled for that tool.
 If no per-tool value is provided, the global value is used instead.

 notification.cleanup.threshold.per.tool=100
 notification.cleanup.threshold.per.tool.asn=100
 notification.cleanup.threshold.per.tool.sam=100
 notification.cleanup.threshold.per.tool.annc=100
 notification.cleanup.threshold.per.tool.commons=100
 notification.cleanup.threshold.per.tool.message=100
 notification.cleanup.threshold.per.tool.lessonbuilder=100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated scheduled job to clean up and remove old user notifications based on configurable retention thresholds, with support for per-tool settings and global fallback configuration.

* **Tests**
  * Added comprehensive test coverage for notification cleanup job execution, threshold configuration validation, and per-tool processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->