### PR TITLE
SAK-52485 Assignments Change success banner to warning and add notice about draft submission visibility after due date

### DIFF
--- a/assignment/api/src/resources/assignment.properties
+++ b/assignment/api/src/resources/assignment.properties
@@ -740,7 +740,7 @@ nonelec_instruction2=This non-electronic assignment does not accept student subm
 ## on the submission confirmation page
 confirm.savesubmission.title = Saved Assignment Confirmation
 confirm.submission.title=Submission Confirmation
-confirm.savesubmission.success=You have successfully saved your work but NOT submitted yet. To complete submission, you must select the Submit button.
+confirm.savesubmission.success=You have successfully saved your work but NOT submitted yet. To complete submission, you must select the Submit button. Please note that if you do not submit your assignment, your instructor will be able to view your draft submission after the due date.
 confirm.submission.success=You have successfully submitted your work.
 confirm.submission.label.user=User:
 confirm.submission.label.classsite=Class site:

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_submission_confirmation.vm
@@ -10,18 +10,18 @@
             $tlang.getString('confirm.savesubmission.title')
         #end
     </h3>
-    <div class="sak-banner-success">
-        #if ($!submission.Submitted)
+    #if ($!submission.Submitted)
+        <div class="sak-banner-success">
             $tlang.getString('confirm.submission.success')
-        #else
+            #if ($!email_confirmation && $!user_email)
+                $tlang.getString('confirm.submission.email')
+            #end
+        </div>
+    #else
+        <div class="sak-banner-warn">
             $tlang.getString('confirm.savesubmission.success')
-        #end
-	#if ($!email_confirmation && $!submission.Submitted)
-        #if ($!user_email)
-            $tlang.getString('confirm.submission.email')
-        #end
+        </div>
     #end
-    </div>
     #if ($!email_confirmation && $!submission.Submitted)
         #if (!$!user_email)
             ## no email could be sent due to the missing recipent email address


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Clarified submission confirmation text to note instructors can view draft submissions after the due date when a student hasn't submitted.
  * Improved confirmation banners to more clearly distinguish submitted (success) vs. draft-saved (warning) states, and adjusted when email confirmation is shown so it appears appropriately within the submission success notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->