### PR TITLE
SAK-52471 Lessons Add Layout Button Modal Focus Incorrect After Tabbing Past Cancel Button

### DIFF
--- a/lessonbuilder/tool/src/webapp/js/show-page.js
+++ b/lessonbuilder/tool/src/webapp/js/show-page.js
@@ -108,7 +108,46 @@ var blankRubricRow;
 // Note from Chuck S. - Is there a strong reason to do this before ready()?
 // $(function () {
 $(document).ready(function () {
-  
+  const layoutDialog = document.getElementById('layout-dialog');
+  if (layoutDialog) {
+    const sectionLayoutPane = document.getElementById('sectionlayout');
+    const pageLayoutPane = document.getElementById('pagelayout');
+    const syncLayoutDialogTabInert = function (targetSel) {
+      if (!sectionLayoutPane || !pageLayoutPane) {
+        return;
+      }
+      const pageActive = targetSel === '#pagelayout';
+      pageLayoutPane.toggleAttribute('inert', !pageActive);
+      sectionLayoutPane.toggleAttribute('inert', pageActive);
+    };
+    layoutDialog.addEventListener('shown.bs.tab', function (e) {
+      const target = e.target.getAttribute('data-bs-target');
+      if (target === '#sectionlayout' || target === '#pagelayout') {
+        syncLayoutDialogTabInert(target);
+      }
+    });
+    layoutDialog.addEventListener('shown.bs.modal', function () {
+      const activeTab = layoutDialog.querySelector('[data-bs-toggle="tab"].nav-link.active');
+      const targetSel = activeTab && activeTab.getAttribute('data-bs-target');
+      syncLayoutDialogTabInert(targetSel || '#sectionlayout');
+    });
+    layoutDialog.addEventListener('keydown', function (e) {
+      if (e.key !== 'Tab' || e.shiftKey) {
+        return;
+      }
+      const el = document.activeElement;
+      if (!el || !layoutDialog.contains(el) || !el.closest('[data-lb-layout-cancel]')) {
+        return;
+      }
+      const closeBtn = layoutDialog.querySelector('.modal-header .btn-close');
+      if (!closeBtn) {
+        return;
+      }
+      e.preventDefault();
+      closeBtn.focus();
+    }, true);
+  }
+
   maxFileUploadSize = $("#mm-max-file-upload-size").text();
   accumulatedFileSize = 0;
   // if we're in morpheus, move breadcrums into top bar, and generate an H2 with the title

--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -2194,11 +2194,11 @@
                   <hr />
                   <p class="act">
                     <input type="submit" rsf:id="layout-submit" class="btn btn-primary" />
-                    <input type="button" rsf:id="layout-cancel" class="btn btn-link" data-bs-dismiss="modal"/>
+                    <input type="button" rsf:id="layout-cancel" class="btn btn-link" data-bs-dismiss="modal" data-lb-layout-cancel="" />
                   </p>
                 </form>
               </div>
-              <div id="pagelayout" class="tab-pane fade">
+              <div id="pagelayout" class="tab-pane fade" inert="inert">
                 <form action="#" rsf:id="page-form" class="controlsPanel form">
                   <input type="hidden" rsf:id="page-csrf28" />
                   <div rsf:id="msg=simplepage.layout.page.directions"></div>
@@ -2282,7 +2282,7 @@
                   <hr />
                   <p class="act">
                     <input type="submit" rsf:id="page-submit" class="btn btn-primary" />
-                    <input type="button" rsf:id="page-cancel" class="btn btn-link" data-bs-dismiss="modal" />
+                    <input type="button" rsf:id="page-cancel" class="btn btn-link" data-bs-dismiss="modal" data-lb-layout-cancel="" />
                   </p>
                 </form>
               </div>


### PR DESCRIPTION
Fixed tab focus to move from the cancel button to the header close button so that the focus stays in the right order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in layout dialogs for Tab and Shift+Tab handling.
  * Enhanced focus management for better dialog accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->