### PR TITLE
SAK-52495 LTI Handle LTI Assignment PUT requests

### DIFF
--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/Assignment.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/Assignment.java
@@ -102,6 +102,11 @@ public class Assignment implements Serializable, Comparable<Assignment> {
     private String externalData;
 
     /**
+     * Metadata associated with an LTI line item, or null if none.
+     */
+    private String lineItemMetadata;
+
+    /**
      * true if the assignment has been released for view to students
      */
     @JsonProperty(value = "released")

--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/model/GradebookAssignment.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/model/GradebookAssignment.java
@@ -107,6 +107,10 @@ public class GradebookAssignment extends GradableObject implements PersistableEn
     @Lob
     private String externalData;
 
+    @Column(name = "LINEITEM_METADATA")
+    @Lob
+    private String lineItemMetadata;
+
     @Column(name = "RELEASED")
     private Boolean released = Boolean.FALSE;
 

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -329,6 +329,7 @@ public class GradingServiceImpl implements GradingService {
         assignmentDefinition.setExternalAppName(internalAssignment.getExternalAppName());
         assignmentDefinition.setExternalId(internalAssignment.getExternalId());
         assignmentDefinition.setExternalData(internalAssignment.getExternalData());
+        assignmentDefinition.setLineItemMetadata(internalAssignment.getLineItemMetadata());
         assignmentDefinition.setReleased(internalAssignment.getReleased());
         assignmentDefinition.setId(internalAssignment.getId());
         assignmentDefinition.setExtraCredit(internalAssignment.getExtraCredit());
@@ -407,6 +408,7 @@ public class GradingServiceImpl implements GradingService {
             asn.setExternallyMaintained(assignmentDefinition.getExternallyMaintained());
             asn.setExternalId(assignmentDefinition.getExternalId());
             asn.setExternalAppName(assignmentDefinition.getExternalAppName());
+            asn.setLineItemMetadata(assignmentDefinition.getLineItemMetadata());
         }
 
         return asn;
@@ -700,8 +702,9 @@ public class GradingServiceImpl implements GradingService {
 			if (!copyOnlySettings) {
 				// create the assignment for the current category
 				try {
+					Assignment transferAssignment = buildTransferAssignmentDefinition(a);
 					Long newId = createAssignmentForCategory(gradebook.getId(), categoriesCreated.get(c.getName()), taskName, a.getPoints(),
-										 a.getDueDate(), !a.getCounted(), a.getReleased(), a.getExtraCredit(), a.getCategorizedSortOrder(), null);
+										 a.getDueDate(), !a.getCounted(), a.getReleased(), a.getExtraCredit(), a.getCategorizedSortOrder(), transferAssignment);
 					transversalMap.put("gb/"+a.getId(),"gb/"+newId);
 				} catch (final ConflictingAssignmentNameException e) {
 					// assignment already exists. Could be from a merge.
@@ -755,7 +758,8 @@ public class GradingServiceImpl implements GradingService {
 					: a.getName();
 
 				try {
-					Long newId = createAssignment(gradebook.getId(), taskName, a.getPoints(), a.getDueDate(), !a.getCounted(), a.getReleased(), a.getExtraCredit(), a.getSortOrder(), null);
+					Assignment transferAssignment = buildTransferAssignmentDefinition(a);
+					Long newId = createAssignment(gradebook.getId(), taskName, a.getPoints(), a.getDueDate(), !a.getCounted(), a.getReleased(), a.getExtraCredit(), a.getSortOrder(), transferAssignment);
 					transversalMap.put("gb/"+a.getId(),"gb/"+newId);
 				} catch (final ConflictingAssignmentNameException e) {
 					// assignment already exists. Could be from a merge.
@@ -800,6 +804,12 @@ public class GradingServiceImpl implements GradingService {
         }
 
         return transversalMap;
+    }
+
+    private Assignment buildTransferAssignmentDefinition(final Assignment sourceAssignment) {
+        Assignment transferAssignment = new Assignment();
+        transferAssignment.setLineItemMetadata(sourceAssignment.getLineItemMetadata());
+        return transferAssignment;
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -916,6 +926,7 @@ public class GradingServiceImpl implements GradingService {
         assignment.setExternallyMaintained(assignmentDefinition.getExternallyMaintained());
         assignment.setExternalId(assignmentDefinition.getExternalId());
         assignment.setExternalData(assignmentDefinition.getExternalData());
+        assignment.setLineItemMetadata(assignmentDefinition.getLineItemMetadata());
 
         assignment.setLineItem(assignmentDefinition.getLineItem());
 

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -926,7 +926,10 @@ public class GradingServiceImpl implements GradingService {
         assignment.setExternallyMaintained(assignmentDefinition.getExternallyMaintained());
         assignment.setExternalId(assignmentDefinition.getExternalId());
         assignment.setExternalData(assignmentDefinition.getExternalData());
-        assignment.setLineItemMetadata(assignmentDefinition.getLineItemMetadata());
+        // Only overwrite when the definition carries a value; null means omitted so we keep persisted LTI line-item metadata.
+        if (assignmentDefinition.getLineItemMetadata() != null) {
+            assignment.setLineItemMetadata(assignmentDefinition.getLineItemMetadata());
+        }
 
         assignment.setLineItem(assignmentDefinition.getLineItem());
 

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2435,7 +2435,7 @@ public class LTI13Servlet extends HttpServlet {
 		if ( ! results ) {
 			SakaiLineItem item = LineItemUtil.getLineItemForToolColumn(signed_placement, context_id, sat.tool_id, a);
 			if (item == null) {
-				LTI13Util.return404(response, "Could not load column");
+				LTI13Util.return404(response, "Line item not exposed for this tool");
 				log.error("Line item not exposed for this tool; column_id={} context_id={} tool_id={}",
 						lineitem_key, context_id, sat.tool_id);
 				return;

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -73,6 +73,7 @@ import static org.sakaiproject.lti.util.SakaiLTIUtil.getOurServerUrl;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti13.LineItemUtil;
 
@@ -1095,10 +1096,12 @@ public class LTI13Servlet extends HttpServlet {
 
 		}
 
-		log.debug("tool={} content={} userId={}",
-			tool != null ? tool.getId() : null,
-			content != null ? content.getId() : null,
-			userId);
+		if (log.isDebugEnabled()) {
+			log.debug("tool={} content={} userId={}",
+					tool != null ? tool.getId() : null,
+					content != null ? content.getId() : null,
+					userId);
+		}
 
 		userId = SakaiLTIUtil.parseSubject(userId);
 		if (!checkUserInSite(site, userId)) {
@@ -1112,7 +1115,9 @@ public class LTI13Servlet extends HttpServlet {
 		// When lineitem_key is null we are the "default" lineitem associated with the content object
 		// if the content item is associated with an assignment, we talk to the assignment API,
 		// if the content item is not associated with an assignment, we talk to the gradebook API
-log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+content);
+		if (log.isDebugEnabled()) {
+			log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content={}", content);
+		}
 		Object retval = SakaiLTIUtil.handleGradebookLTI13(site, sat.tool_id, content, userId, lineitem_key, scoreObj);
 		log.debug("handleGradebookLTI13 retval={}",retval);
 		if ( retval instanceof String ) {
@@ -2171,7 +2176,10 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 
 		Assignment retval;
 		try {
-			log.debug("Updating site={} tool_id={} column_id={} lineItem={}",site.getId(), sat.tool_id, lineitem_key, JacksonUtil.prettyPrint(item));
+			if (log.isDebugEnabled()) {
+				log.debug("Updating site={} tool_id={} column_id={} lineItem={}", site.getId(), sat.tool_id, lineitem_key,
+						JacksonUtil.prettyPrint(item));
+			}
 			retval = LineItemUtil.updateLineItem(site, sat.tool_id, lineitem_key, item);
 			if (retval == null) {
 				log.error("Could not update lineitem, column not found or not owned by tool. site={} tool_id={} column_id={}",
@@ -2179,21 +2187,36 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 				LTI13Util.return404(response, "Could not load column");
 				return;
 			}
-			log.debug("Updated retval={}",JacksonUtil.prettyPrint(retval));
+			if (log.isDebugEnabled()) {
+				log.debug("Updated retval={}", JacksonUtil.prettyPrint(retval));
+			}
+		} catch (PermissionException e) {
+			log.warn("Permission denied updating line item: {}", e.getMessage(), e);
+			LTI13Util.return400(response, StringUtils.defaultIfBlank(e.getMessage(), "Could not update lineitem"));
+			return;
+		} catch (RuntimeException e) {
+			log.error(e.getMessage(), e);
+			LTI13Util.return400(response, StringUtils.defaultIfBlank(e.getMessage(), "Could not update lineitem"));
+			return;
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
-			LTI13Util.return400(response, "Could not update lineitem: "+e.getMessage());
+			LTI13Util.return400(response, StringUtils.defaultIfBlank(e.getMessage(), "Could not update lineitem"));
 			return;
 		}
 
 		// Return the line item as we would list it (assignment-backed fields from Assignments when applicable)
 		SakaiLineItem responseItem = LineItemUtil.getLineItemForToolColumn(signed_placement, site.getId(), sat.tool_id, retval);
 		if (responseItem == null) {
-			responseItem = LineItemUtil.getLineItem(signed_placement, retval);
+			log.error("getLineItemForToolColumn returned null after updateLineItem; site={} tool_id={} column_id={}",
+					site.getId(), sat.tool_id, lineitem_key);
+			LTI13Util.return400(response, "Could not build line item response");
+			return;
 		}
 		responseItem.id = getOurServerUrl() + LTI13_PATH + "lineitems/" + signed_placement + "/" + retval.getId();
 
-		log.debug("Lineitem responseItem={}", JacksonUtil.prettyPrint(responseItem));
+		if (log.isDebugEnabled()) {
+			log.debug("Lineitem responseItem={}", JacksonUtil.prettyPrint(responseItem));
+		}
 		response.setContentType(SakaiLineItem.CONTENT_TYPE);
 
 		PrintWriter out = response.getWriter();
@@ -2275,7 +2298,9 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 			if ( content != null ) {
 				response.setContentType(SakaiLineItem.CONTENT_TYPE);
 				SakaiLineItem item = LineItemUtil.getDefaultLineItem(site, content);
-				log.debug("single line item = {}", JacksonUtil.prettyPrint(item));
+				if (log.isDebugEnabled()) {
+					log.debug("single line item = {}", JacksonUtil.prettyPrint(item));
+				}
 				PrintWriter out = response.getWriter();
 				out.print(JacksonUtil.prettyPrint(item));
 				return;
@@ -2286,7 +2311,9 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 		}
 
 		// Find the line items created for this tool
-		log.debug("filter={}", JacksonUtil.prettyPrint(filter));
+		if (log.isDebugEnabled()) {
+			log.debug("filter={}", JacksonUtil.prettyPrint(filter));
+		}
 		List<SakaiLineItem> toolItems = LineItemUtil.getLineItemsForTool(signed_placement, site, sat.tool_id, filter);
 
 		response.setContentType(SakaiLineItem.CONTENT_TYPE_CONTAINER);
@@ -2297,7 +2324,9 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 		for (SakaiLineItem item : toolItems) {
 			out.println(first ? "" : ",");
 			first = false;
-			log.debug("line item = {}", JacksonUtil.prettyPrint(item));
+			if (log.isDebugEnabled()) {
+				log.debug("line item = {}", JacksonUtil.prettyPrint(item));
+			}
 			out.print(JacksonUtil.prettyPrint(item));
 		}
 		out.println("");
@@ -2406,7 +2435,10 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 		if ( ! results ) {
 			SakaiLineItem item = LineItemUtil.getLineItemForToolColumn(signed_placement, context_id, sat.tool_id, a);
 			if (item == null) {
-				item = LineItemUtil.getLineItem(signed_placement, a);
+				LTI13Util.return404(response, "Could not load column");
+				log.error("Line item not exposed for this tool; column_id={} context_id={} tool_id={}",
+						lineitem_key, context_id, sat.tool_id);
+				return;
 			}
 
 			String json_out = JacksonUtil.prettyPrint(item);

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2163,8 +2163,7 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 			}
 
 			if ( ! checkToolHasPlacements(sat.tool_id, signed_placement, response) ) {
-				log.error("Tool={} does not have placements for site={}", sat.tool_id, signed_placement);
-				LTI13Util.return400(response, "Tool does not have placements for site");
+				// checkToolHasPlacements() already logs and writes the 400 response.
 				return;
 			}
 
@@ -2174,6 +2173,12 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 		try {
 			log.debug("Updating site={} tool_id={} column_id={} lineItem={}",site.getId(), sat.tool_id, lineitem_key, JacksonUtil.prettyPrint(item));
 			retval = LineItemUtil.updateLineItem(site, sat.tool_id, lineitem_key, item);
+			if (retval == null) {
+				log.error("Could not update lineitem, column not found or not owned by tool. site={} tool_id={} column_id={}",
+					site.getId(), sat.tool_id, lineitem_key);
+				LTI13Util.return404(response, "Could not load column");
+				return;
+			}
 			log.debug("Updated retval={}",JacksonUtil.prettyPrint(retval));
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
@@ -2181,14 +2186,18 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 			return;
 		}
 
-		// Add the link to this lineitem
-		item.id = getOurServerUrl() + LTI13_PATH + "lineitems/" + signed_placement + "/" + retval.getId();
+		// Return the line item as we would list it (assignment-backed fields from Assignments when applicable)
+		SakaiLineItem responseItem = LineItemUtil.getLineItemForToolColumn(signed_placement, site.getId(), sat.tool_id, retval);
+		if (responseItem == null) {
+			responseItem = LineItemUtil.getLineItem(signed_placement, retval);
+		}
+		responseItem.id = getOurServerUrl() + LTI13_PATH + "lineitems/" + signed_placement + "/" + retval.getId();
 
-		log.debug("Lineitem item={}",JacksonUtil.prettyPrint(item));
+		log.debug("Lineitem responseItem={}", JacksonUtil.prettyPrint(responseItem));
 		response.setContentType(SakaiLineItem.CONTENT_TYPE);
 
 		PrintWriter out = response.getWriter();
-		out.print(JacksonUtil.prettyPrint(item));
+		out.print(JacksonUtil.prettyPrint(responseItem));
 	}
 
 	/**
@@ -2393,9 +2402,12 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 			return;
 		}
 
-		// Return the line item metadata
+		// Return the line item metadata (same source as list: assignment-backed fields from Assignments when applicable)
 		if ( ! results ) {
-			SakaiLineItem item = LineItemUtil.getLineItem(signed_placement, a);
+			SakaiLineItem item = LineItemUtil.getLineItemForToolColumn(signed_placement, context_id, sat.tool_id, a);
+			if (item == null) {
+				item = LineItemUtil.getLineItem(signed_placement, a);
+			}
 
 			String json_out = JacksonUtil.prettyPrint(item);
 			log.debug("Returning {}", json_out);

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2162,13 +2162,19 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 				return;
 			}
 
-			if ( ! checkToolHasPlacements(sat.tool_id, signed_placement, response) ) return;
+			if ( ! checkToolHasPlacements(sat.tool_id, signed_placement, response) ) {
+				log.error("Tool={} does not have placements for site={}", sat.tool_id, signed_placement);
+				LTI13Util.return400(response, "Tool does not have placements for site");
+				return;
+			}
 
 		}
 
 		Assignment retval;
 		try {
+			log.debug("Updating site={} tool_id={} column_id={} lineItem={}",site.getId(), sat.tool_id, lineitem_key, JacksonUtil.prettyPrint(item));
 			retval = LineItemUtil.updateLineItem(site, sat.tool_id, lineitem_key, item);
+			log.debug("Updated retval={}",JacksonUtil.prettyPrint(retval));
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			LTI13Util.return400(response, "Could not update lineitem: "+e.getMessage());
@@ -2178,7 +2184,7 @@ log.debug("calling SakaiLTIUtil.handleGradebookLTI13 bean version content="+cont
 		// Add the link to this lineitem
 		item.id = getOurServerUrl() + LTI13_PATH + "lineitems/" + signed_placement + "/" + retval.getId();
 
-		log.debug("Lineitem item={}",item);
+		log.debug("Lineitem item={}",JacksonUtil.prettyPrint(item));
 		response.setContentType(SakaiLineItem.CONTENT_TYPE);
 
 		PrintWriter out = response.getWriter();

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2191,8 +2191,8 @@ public class LTI13Servlet extends HttpServlet {
 				log.debug("Updated retval={}", JacksonUtil.prettyPrint(retval));
 			}
 		} catch (PermissionException e) {
-			log.warn("Permission denied updating line item: {}", e.getMessage(), e);
-			LTI13Util.return400(response, StringUtils.defaultIfBlank(e.getMessage(), "Could not update lineitem"));
+			log.warn("Permission denied updating line item", e);
+			LTI13Util.return403(response, "Permission denied updating lineitem");
 			return;
 		} catch (RuntimeException e) {
 			log.error(e.getMessage(), e);

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2195,12 +2195,8 @@ public class LTI13Servlet extends HttpServlet {
 			LTI13Util.return403(response, "Permission denied updating lineitem");
 			return;
 		} catch (RuntimeException e) {
-			log.error(e.getMessage(), e);
-			LTI13Util.return400(response, StringUtils.defaultIfBlank(e.getMessage(), "Could not update lineitem"));
-			return;
-		} catch (Exception e) {
-			log.error(e.getMessage(), e);
-			LTI13Util.return400(response, StringUtils.defaultIfBlank(e.getMessage(), "Could not update lineitem"));
+			log.error("Could not update lineitem", e);
+			LTI13Util.return400(response, "Could not update lineitem");
 			return;
 		}
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -147,11 +147,37 @@ public class LineItemUtil {
 		return retval;
 	}
 
-	private static Long deriveContentIdFromGradebookExternalId(String external_id) {
-		if (external_id == null) {
+	private static boolean hasValidExternalIdFormat(String externalId) {
+		if (StringUtils.isBlank(externalId)) {
+			return false;
+		}
+		String[] parts = externalId.split(ID_SEPARATOR_REGEX, -1);
+		if (parts == null || parts.length < 2) {
+			return false;
+		}
+		return StringUtils.isNumeric(parts[0]) && StringUtils.isNumeric(parts[1]);
+	}
+
+	private static String getPreferredExternalId(Assignment gradebookColumn) {
+		if (gradebookColumn == null) {
 			return null;
 		}
-		String[] parts = StringUtils.split(external_id, ID_SEPARATOR_REGEX);
+
+		String externalData = StringUtils.trimToNull(gradebookColumn.getExternalData());
+		if (hasValidExternalIdFormat(externalData)) {
+			return externalData;
+		}
+
+		String externalId = StringUtils.trimToNull(gradebookColumn.getExternalId());
+		return hasValidExternalIdFormat(externalId) ? externalId : null;
+	}
+
+	private static Long deriveContentIdFromGradebookExternalId(Assignment gradebookColumn) {
+		String externalId = getPreferredExternalId(gradebookColumn);
+		if (externalId == null) {
+			return null;
+		}
+		String[] parts = StringUtils.split(externalId, ID_SEPARATOR_REGEX);
 		return (parts == null || parts.length < 2) ? null : Long.valueOf(parts[1]);
 	}
 
@@ -212,7 +238,7 @@ public class LineItemUtil {
 			}
 			// We are using the actual grade and points possible in the GB
 			gradebookColumn.setExternallyMaintained(false);
-			gradebookColumn.setExternalId(external_id);
+			gradebookColumn.setExternalData(external_id);
 			gradebookColumn.setExternalAppName(GB_EXTERNAL_APP_NAME);
 			gradebookColumn.setName(lineItem.label);
 			Boolean releaseToStudent = lineItem.releaseToStudent == null ? Boolean.TRUE : lineItem.releaseToStudent; // Default to true
@@ -254,9 +280,9 @@ public class LineItemUtil {
 	}
 
 	public static Assignment updateLineItem(Site site, Long tool_id, Long column_id, SakaiLineItem lineItem) {
+		log.debug("updateLineItem site={} tool_id={} column_id={} lineItem={}", site.getId(), tool_id, column_id, lineItem);
 		GradingService gradingService = (GradingService) ComponentManager
 				.get("org.sakaiproject.grading.api.GradingService");
-
 		String context_id = site.getId();
 
 		if ( column_id == null ) {
@@ -278,18 +304,19 @@ public class LineItemUtil {
 			  "resourceId": "string"
 			}
 		*/
+		log.debug("gradebookColumn={}", gradebookColumn);
 
 		if ( lineItem.scoreMaximum != null ) {
 			gradebookColumn.setPoints(Double.valueOf(lineItem.scoreMaximum));
 		}
 
-		Long content_id = deriveContentIdFromGradebookExternalId(gradebookColumn.getExternalId());
+		Long content_id = deriveContentIdFromGradebookExternalId(gradebookColumn);
 		String external_id = (content_id != null) ? constructExternalIdImpl(tool_id, content_id, lineItem) : constructExternalId(tool_id, null, lineItem);
 
 		log.debug("gb item id={}; gb item title={}; external_id={}; prior external_id={}; derived content id={}", gradebookColumn.getId(),
 			  gradebookColumn.getName(), external_id, gradebookColumn.getExternalId(), content_id);
 
-		gradebookColumn.setExternalId(external_id);
+		gradebookColumn.setExternalData(external_id);
 		if ( lineItem.label != null ) {
 			gradebookColumn.setName(lineItem.label);
 		}
@@ -364,14 +391,15 @@ public class LineItemUtil {
 			List<Assignment> gradebookColumns = gradingService.getAssignments(context_id, context_id, SortType.SORT_BY_NONE);
 			for (Iterator i = gradebookColumns.iterator(); i.hasNext();) {
 				Assignment gbColumn = (Assignment) i.next();
-				String external_id = gbColumn.getExternalId();
+				String external_id = getPreferredExternalId(gbColumn);
+				String assignmentExternalId = StringUtils.trimToNull(gbColumn.getExternalId());
 				if ( isGradebookColumnLTI(gbColumn) ) {
 					// We are good to go
-				} else if ( isAssignmentColumn(external_id) ) {
+				} else if ( isAssignmentColumn(assignmentExternalId) ) {
 					if ( externalIds == null ) {
 						externalIds = getExternalIdsForToolAssignments(context_id);
 					}
-					external_id = externalIds.get(external_id);
+					external_id = externalIds.get(assignmentExternalId);
 					if ( external_id == null ) continue;
 				}
 
@@ -537,15 +565,16 @@ public class LineItemUtil {
 			List gradebookColumns = gradingService.getAssignments(context_id, context_id, SortType.SORT_BY_NONE);
 			for (Iterator i = gradebookColumns.iterator(); i.hasNext();) {
 				Assignment gbColumn = (Assignment) i.next();
-				String external_id = gbColumn.getExternalId();
+				String external_id = getPreferredExternalId(gbColumn);
+				String assignmentExternalId = StringUtils.trimToNull(gbColumn.getExternalId());
 				log.debug("gbColumn: {} {}", gbColumn.getName(), external_id);
 				if ( isGradebookColumnLTI(gbColumn) ) {
 					// We are good to go
-				} else if ( StringUtils.isNotEmpty(external_id) && isAssignmentColumn(external_id) ) {
+				} else if ( StringUtils.isNotEmpty(assignmentExternalId) && isAssignmentColumn(assignmentExternalId) ) {
 					if ( externalIds == null ) {
 						externalIds = getExternalIdsForToolAssignments(context_id);
 					}
-					external_id = externalIds.get(external_id);
+					external_id = externalIds.get(assignmentExternalId);
 					log.debug("derived assignment based on external_id: {} {}", external_id, externalIds);
 					if ( external_id == null ) continue;
 				}
@@ -592,7 +621,7 @@ public class LineItemUtil {
 
 		// Parse the external_id
 		// tool_id|content_id|resourceLink|tag|
-		String external_id = assignment.getExternalId();
+		String external_id = getPreferredExternalId(assignment);
 		if ( external_id != null && external_id.length() > 0 ) {
 			String[] parts = external_id.split(ID_SEPARATOR_REGEX);
 			li.resourceLinkId = (parts.length > 1 && parts[1].trim().length() > 1) ? parts[1].trim() : null;

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -21,11 +21,13 @@ package org.sakaiproject.lti13;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Date;
 import java.util.HashMap;
+import java.time.Instant;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,6 +38,7 @@ import org.tsugi.lti13.DeepLinkResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
+import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.cover.SecurityService;
 import static org.sakaiproject.lti.util.SakaiLTIUtil.LTI13_PATH;
@@ -50,6 +53,8 @@ import org.sakaiproject.component.cover.ServerConfigurationService;
 
 import org.sakaiproject.grading.api.GradingService;
 import org.sakaiproject.grading.api.ConflictingAssignmentNameException;
+import org.sakaiproject.grading.api.AssessmentNotFoundException;
+import org.sakaiproject.grading.api.AssignmentHasIllegalPointsException;
 import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.grading.api.SortType;
 import org.sakaiproject.lti13.util.SakaiLineItem;
@@ -64,9 +69,12 @@ import org.tsugi.lti13.LTI13Util;
 @SuppressWarnings("deprecation")
 @Slf4j
 public class LineItemUtil {
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	public static final String GB_EXTERNAL_APP_NAME = "IMS-AGS";
 	public static final String ASSIGNMENTS_EXTERNAL_APP_NAME = "Assignments"; // Avoid circular references
+	/** Tool id stored in {@code GB_GRADABLE_OBJECT_T.EXTERNAL_APP_NAME} for gradebook columns owned by Assignments. */
+	public static final String ASSIGNMENT_GRADES_TOOL_ID = "sakai.assignment.grades";
 	public static final String ASSIGNMENT_REFERENCE_PREFIX = "/assignment/a";
 
 	public final static String ID_SEPARATOR = "|";
@@ -77,6 +85,65 @@ public class LineItemUtil {
 	public static final String LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_TRUE = "true";
 	public static final String LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_FALSE = "false";
 	public static final String LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_DEFAULT = LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_TRUE;
+
+	/**
+	 * Result of classifying a gradebook column for LTI Advantage line items: whether it is a primary
+	 * LTI line item row, a legacy assignment-ref row discoverable via the site assignment→LTI map,
+	 * tool ownership, the resolved {@code tool_id|content_id} key, and (when loaded) the Sakai Assignment.
+	 */
+	public static final class LtiLineItemRowResolution {
+		private final boolean primaryLtiLineItemRow;
+		private final boolean fallbackAssignmentRefRow;
+		private final boolean ownedByTool;
+		private final String toolContentKey;
+		private final org.sakaiproject.assignment.api.model.Assignment sakaiAssignment;
+
+		private LtiLineItemRowResolution(boolean primaryLtiLineItemRow, boolean fallbackAssignmentRefRow,
+				boolean ownedByTool, String toolContentKey,
+				org.sakaiproject.assignment.api.model.Assignment sakaiAssignment) {
+			this.primaryLtiLineItemRow = primaryLtiLineItemRow;
+			this.fallbackAssignmentRefRow = fallbackAssignmentRefRow;
+			this.ownedByTool = ownedByTool;
+			this.toolContentKey = toolContentKey;
+			this.sakaiAssignment = sakaiAssignment;
+		}
+
+		private static LtiLineItemRowResolution none() {
+			return new LtiLineItemRowResolution(false, false, false, null, null);
+		}
+
+		public boolean isPrimaryLtiLineItemRow() {
+			return primaryLtiLineItemRow;
+		}
+
+		public boolean isFallbackAssignmentRefRow() {
+			return fallbackAssignmentRefRow;
+		}
+
+		public boolean isOwnedByTool() {
+			return ownedByTool;
+		}
+
+		public String getToolContentKey() {
+			return toolContentKey;
+		}
+
+		/**
+		 * Present when {@link #isPrimaryLtiLineItemRow()} is true and the row is backed by Assignments
+		 * (external-tool submission). Callers may use this to avoid a second assignment load.
+		 */
+		public org.sakaiproject.assignment.api.model.Assignment getSakaiAssignment() {
+			return sakaiAssignment;
+		}
+
+		/**
+		 * Whether this row should appear in AGS line item listings for the requested tool (matches prior
+		 * combinations of {@code isGradebookColumnLTI} / assignment-ref fallback / tool id match).
+		 */
+		public boolean isIncludedInToolLineItemList() {
+			return ownedByTool && (primaryLtiLineItemRow || fallbackAssignmentRefRow);
+		}
+	}
 
 	public static String URLEncode(String inp) {
 		if ( inp == null ) return null;
@@ -158,26 +225,131 @@ public class LineItemUtil {
 		return StringUtils.isNumeric(parts[0]) && StringUtils.isNumeric(parts[1]);
 	}
 
-	private static String getPreferredExternalId(Assignment gradebookColumn) {
+	/**
+	 * Stable key for LTI line items: {@code tool_id|content_id}. Stored in {@code EXTERNAL_ID}
+	 * and not modified on line item updates (only {@code LINEITEM_METADATA} changes).
+	 */
+	private static String constructToolContentExternalId(Long toolId, Long contentId) {
+		return toolId + ID_SEPARATOR + ((contentId == null) ? "0" : contentId.toString());
+	}
+
+	private static String constructLineItemMetadata(SakaiLineItem lineItem) {
+		Map<String, String> metadata = new LinkedHashMap<>();
+		metadata.put("resourceId", StringUtils.trimToNull(lineItem.resourceId));
+		metadata.put("tag", StringUtils.trimToNull(lineItem.tag));
+		try {
+			return OBJECT_MAPPER.writeValueAsString(metadata);
+		} catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+			throw new RuntimeException("Could not serialize line item metadata", e);
+		}
+	}
+
+	private static boolean hasValidExternalDataFormat(String externalData) {
+		if (StringUtils.isBlank(externalData)) {
+			return false;
+		}
+		String[] parts = externalData.split(ID_SEPARATOR_REGEX, -1);
+		if (parts == null || parts.length < 2) {
+			return false;
+		}
+		return StringUtils.isNumeric(parts[0]) && StringUtils.isNumeric(parts[1]);
+	}
+
+	/**
+	 * Ownership / filtering key: {@code tool_id|content_id}. Prefer {@code EXTERNAL_ID}; fall back to
+	 * legacy {@code EXTERNAL_DATA} from interim deployments.
+	 */
+	private static String getPreferredToolContentKey(Assignment gradebookColumn) {
 		if (gradebookColumn == null) {
 			return null;
 		}
 
+		String externalId = StringUtils.trimToNull(gradebookColumn.getExternalId());
+		if (hasValidExternalIdFormat(externalId)) {
+			String[] parts = externalId.split(ID_SEPARATOR_REGEX, -1);
+			return parts[0] + ID_SEPARATOR + parts[1];
+		}
+
 		String externalData = StringUtils.trimToNull(gradebookColumn.getExternalData());
-		if (hasValidExternalIdFormat(externalData)) {
+		if (hasValidExternalDataFormat(externalData)) {
 			return externalData;
 		}
 
+		return null;
+	}
+
+	private static Map<String, String> parseLineItemMetadata(String lineItemMetadata) {
+		if (StringUtils.isBlank(lineItemMetadata)) {
+			return null;
+		}
+		try {
+			Map<?, ?> raw = OBJECT_MAPPER.readValue(lineItemMetadata, Map.class);
+			Map<String, String> parsed = new HashMap<>();
+			Object resourceId = raw.get("resourceId");
+			Object tag = raw.get("tag");
+			if (resourceId instanceof String) {
+				parsed.put("resourceId", StringUtils.trimToNull((String) resourceId));
+			}
+			if (tag instanceof String) {
+				parsed.put("tag", StringUtils.trimToNull((String) tag));
+			}
+			return parsed;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private static Map<String, String> getPreferredLineItemMetadata(Assignment gradebookColumn) {
+		if (gradebookColumn == null) {
+			return null;
+		}
+
+		Map<String, String> parsedMetadata = parseLineItemMetadata(gradebookColumn.getLineItemMetadata());
+		if (parsedMetadata != null) {
+			return parsedMetadata;
+		}
+
+		String legacyExternalId = StringUtils.trimToNull(gradebookColumn.getExternalId());
+		if (!hasValidExternalIdFormat(legacyExternalId)) {
+			return null;
+		}
+		String[] parts = legacyExternalId.split(ID_SEPARATOR_REGEX, -1);
+		Map<String, String> legacy = new HashMap<>();
+		legacy.put("resourceId", (parts.length > 2) ? StringUtils.trimToNull(parts[2]) : null);
+		legacy.put("tag", (parts.length > 3) ? StringUtils.trimToNull(parts[3]) : null);
+		return legacy;
+	}
+
+	private static boolean shouldMigrateLegacyOnUpdate(Assignment gradebookColumn) {
+		if (gradebookColumn == null) {
+			return false;
+		}
+		if (StringUtils.isNotBlank(gradebookColumn.getLineItemMetadata())) {
+			return false;
+		}
+		// Interim rows: tool|content only in EXTERNAL_DATA
+		if (hasValidExternalDataFormat(StringUtils.trimToNull(gradebookColumn.getExternalData()))) {
+			return true;
+		}
 		String externalId = StringUtils.trimToNull(gradebookColumn.getExternalId());
-		return hasValidExternalIdFormat(externalId) ? externalId : null;
+		if (!hasValidExternalIdFormat(externalId)) {
+			return false;
+		}
+		String[] parts = externalId.split(ID_SEPARATOR_REGEX, -1);
+		// Legacy full line: tool|content|resourceId|tag|...
+		return parts.length > 2;
+	}
+
+	static boolean shouldMigrateLegacyExternalId(Assignment gradebookColumn) {
+		return shouldMigrateLegacyOnUpdate(gradebookColumn);
 	}
 
 	private static Long deriveContentIdFromGradebookExternalId(Assignment gradebookColumn) {
-		String externalId = getPreferredExternalId(gradebookColumn);
-		if (externalId == null) {
+		String toolContentKey = getPreferredToolContentKey(gradebookColumn);
+		if (toolContentKey == null) {
 			return null;
 		}
-		String[] parts = StringUtils.split(externalId, ID_SEPARATOR_REGEX);
+		String[] parts = StringUtils.split(toolContentKey, ID_SEPARATOR_REGEX);
 		return (parts == null || parts.length < 2) ? null : Long.valueOf(parts[1]);
 	}
 
@@ -203,7 +375,9 @@ public class LineItemUtil {
 			throw new RuntimeException("tool_id is required");
 		}
 
-		String external_id = constructExternalId(tool_id, content, lineItem);
+		Long content_id = (content == null) ? null : LTIUtil.toLongNull(content.get(LTIService.LTI_ID));
+		String stableExternalId = constructToolContentExternalId(tool_id, content_id);
+		String lineitem_metadata = constructLineItemMetadata(lineItem);
 
 		Assignment gradebookColumn = null;
 		Long gradebookColumnId = null;
@@ -238,7 +412,8 @@ public class LineItemUtil {
 			}
 			// We are using the actual grade and points possible in the GB
 			gradebookColumn.setExternallyMaintained(false);
-			gradebookColumn.setExternalData(external_id);
+			gradebookColumn.setExternalId(stableExternalId);
+			gradebookColumn.setLineItemMetadata(lineitem_metadata);
 			gradebookColumn.setExternalAppName(GB_EXTERNAL_APP_NAME);
 			gradebookColumn.setName(lineItem.label);
 			Boolean releaseToStudent = lineItem.releaseToStudent == null ? Boolean.TRUE : lineItem.releaseToStudent; // Default to true
@@ -279,10 +454,97 @@ public class LineItemUtil {
 		return gradebookColumn;
 	}
 
+	/**
+	 * Applies LTI line item fields to a Sakai Assignments activity (points use the assignment scale factor).
+	 * {@code startDateTime} maps to {@link org.sakaiproject.assignment.api.model.Assignment#getOpenDate() openDate}.
+	 * {@code endDateTime} maps to both {@link org.sakaiproject.assignment.api.model.Assignment#getDueDate() due date}
+	 * and {@link org.sakaiproject.assignment.api.model.Assignment#getCloseDate() close date} (accept until).
+	 */
+	private static void applyLineItemToSakaiAssignment(SakaiLineItem lineItem,
+			org.sakaiproject.assignment.api.model.Assignment asn,
+			org.sakaiproject.assignment.api.AssignmentService assignmentService) {
+		if (lineItem == null || asn == null || assignmentService == null) {
+			return;
+		}
+		if (lineItem.label != null) {
+			asn.setTitle(lineItem.label.trim());
+		}
+		if (lineItem.scoreMaximum != null
+				&& asn.getTypeOfGrade() == org.sakaiproject.assignment.api.model.Assignment.GradeType.SCORE_GRADE_TYPE) {
+			int scaleFactor = asn.getScaleFactor() != null ? asn.getScaleFactor() : assignmentService.getScaleFactor();
+			int maxGradePoint = (int) Math.round(lineItem.scoreMaximum * scaleFactor);
+			asn.setMaxGradePoint(maxGradePoint);
+		}
+		if (lineItem.startDateTime != null) {
+			Date startDate = LTIUtil.parseIMS8601(lineItem.startDateTime);
+			if (startDate != null) {
+				asn.setOpenDate(startDate.toInstant());
+			}
+		}
+		if (lineItem.endDateTime != null) {
+			Date endDate = LTIUtil.parseIMS8601(lineItem.endDateTime);
+			if (endDate != null) {
+				Instant endInstant = endDate.toInstant();
+				asn.setDueDate(endInstant);
+				asn.setCloseDate(endInstant);
+			}
+		}
+	}
+
+	/**
+	 * Copies title and due date from a Sakai assignment onto the linked gradebook column.
+	 * Score maximum is applied separately so the gradebook row and assignment both receive explicit updates
+	 * from the line item (see {@link #updateLineItem}).
+	 */
+	private static void syncGradebookColumnTitleAndDueFromSakaiAssignment(Assignment gbColumn,
+			org.sakaiproject.assignment.api.model.Assignment asn) {
+		if (gbColumn == null || asn == null) {
+			return;
+		}
+		gbColumn.setName(asn.getTitle());
+		if (asn.getDueDate() != null) {
+			gbColumn.setDueDate(Date.from(asn.getDueDate()));
+		}
+	}
+
+	/**
+	 * Persists title, points, and due date for externally maintained gradebook columns.
+	 * {@link GradingService#updateAssignment} does not apply those fields when
+	 * {@link Assignment#getExternallyMaintained()} is true; {@link GradingService#updateExternalAssessment}
+	 * must be used (same pattern as {@code AssignmentToolUtils#integrateGradebook} for {@code update}).
+	 */
+	private static void syncExternalAssessmentDefinition(GradingService gradingService, String gradebookUid,
+			Assignment gradebookColumn) {
+		if (gradingService == null || gradebookUid == null || gradebookColumn == null) {
+			return;
+		}
+		if (!Boolean.TRUE.equals(gradebookColumn.getExternallyMaintained())) {
+			return;
+		}
+		String externalId = StringUtils.trimToNull(gradebookColumn.getExternalId());
+		if (externalId == null) {
+			return;
+		}
+		String title = StringUtils.trimToNull(gradebookColumn.getName());
+		if (title == null) {
+			return;
+		}
+		try {
+			gradingService.updateExternalAssessment(gradebookUid, externalId, null, gradebookColumn.getExternalData(),
+					title, null, gradebookColumn.getPoints(), gradebookColumn.getDueDate(),
+					gradebookColumn.getUngraded());
+		} catch (AssessmentNotFoundException | ConflictingAssignmentNameException
+				| AssignmentHasIllegalPointsException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	public static Assignment updateLineItem(Site site, Long tool_id, Long column_id, SakaiLineItem lineItem) {
 		log.debug("updateLineItem site={} tool_id={} column_id={} lineItem={}", site.getId(), tool_id, column_id, lineItem);
 		GradingService gradingService = (GradingService) ComponentManager
 				.get("org.sakaiproject.grading.api.GradingService");
+		org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager
+				.get(org.sakaiproject.assignment.api.AssignmentService.class);
 		String context_id = site.getId();
 
 		if ( column_id == null ) {
@@ -306,31 +568,73 @@ public class LineItemUtil {
 		*/
 		log.debug("gradebookColumn={}", gradebookColumn);
 
-		if ( lineItem.scoreMaximum != null ) {
-			gradebookColumn.setPoints(Double.valueOf(lineItem.scoreMaximum));
+		boolean shouldMigrateLegacy = shouldMigrateLegacyOnUpdate(gradebookColumn);
+		if (shouldMigrateLegacy) {
+			String interimData = StringUtils.trimToNull(gradebookColumn.getExternalData());
+			if (hasValidExternalDataFormat(interimData)) {
+				gradebookColumn.setExternalId(interimData);
+				gradebookColumn.setExternalData(null);
+			} else {
+				String legacyExternalId = StringUtils.trimToNull(gradebookColumn.getExternalId());
+				String[] parts = legacyExternalId.split(ID_SEPARATOR_REGEX, -1);
+				gradebookColumn.setExternalId(parts[0] + ID_SEPARATOR + parts[1]);
+				Map<String, String> legacyMetadata = new HashMap<>();
+				legacyMetadata.put("resourceId", (parts.length > 2) ? StringUtils.trimToNull(parts[2]) : null);
+				legacyMetadata.put("tag", (parts.length > 3) ? StringUtils.trimToNull(parts[3]) : null);
+				try {
+					gradebookColumn.setLineItemMetadata(OBJECT_MAPPER.writeValueAsString(legacyMetadata));
+				} catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+					throw new RuntimeException("Could not serialize legacy line item metadata", e);
+				}
+			}
 		}
 
-		Long content_id = deriveContentIdFromGradebookExternalId(gradebookColumn);
-		String external_id = (content_id != null) ? constructExternalIdImpl(tool_id, content_id, lineItem) : constructExternalId(tool_id, null, lineItem);
+		String lineitem_metadata = constructLineItemMetadata(lineItem);
 
-		log.debug("gb item id={}; gb item title={}; external_id={}; prior external_id={}; derived content id={}", gradebookColumn.getId(),
-			  gradebookColumn.getName(), external_id, gradebookColumn.getExternalId(), content_id);
+		log.debug("gb item id={}; gb item title={}; lineitem_metadata={}; external_id={}", gradebookColumn.getId(),
+			  gradebookColumn.getName(), lineitem_metadata, gradebookColumn.getExternalId());
 
-		gradebookColumn.setExternalData(external_id);
-		if ( lineItem.label != null ) {
-			gradebookColumn.setName(lineItem.label);
-		}
+		// Do not modify EXTERNAL_ID after create; only LINEITEM_METADATA (and normal GB fields) change here.
+		gradebookColumn.setLineItemMetadata(lineitem_metadata);
 
 		Boolean releaseToStudent = lineItem.releaseToStudent == null ? Boolean.TRUE : lineItem.releaseToStudent; // Default to true
 		Boolean includeInComputation = lineItem.includeInComputation == null ? Boolean.TRUE : lineItem.includeInComputation; // Default true
 		gradebookColumn.setReleased(releaseToStudent); // default true
 		gradebookColumn.setCounted(includeInComputation); // default true
 		gradebookColumn.setUngraded(false);
-		Date dueDate = LTIUtil.parseIMS8601(lineItem.endDateTime);
-		if ( dueDate != null ) gradebookColumn.setDueDate(dueDate);
+
+		Map<String, String> assignmentRefToToolKey = getExternalIdsForToolAssignments(context_id);
+		LtiLineItemRowResolution resolution = resolveLtiLineItemRow(context_id, gradebookColumn, tool_id, assignmentRefToToolKey);
+		org.sakaiproject.assignment.api.model.Assignment sakaiAsn = resolution.getSakaiAssignment();
 
 		pushAdvisor();
 		try {
+			if (sakaiAsn != null && resolution.isPrimaryLtiLineItemRow() && assignmentService != null) {
+				try {
+					applyLineItemToSakaiAssignment(lineItem, sakaiAsn, assignmentService);
+					assignmentService.updateAssignment(sakaiAsn);
+					syncGradebookColumnTitleAndDueFromSakaiAssignment(gradebookColumn, sakaiAsn);
+					// scoreMaximum is stored on the assignment (scaled maxGradePoint) and on the gradebook row (points)
+					if (lineItem.scoreMaximum != null) {
+						gradebookColumn.setPoints(Double.valueOf(lineItem.scoreMaximum));
+					}
+				} catch (PermissionException e) {
+					log.warn("Could not update linked Sakai assignment from LTI line item: {}", e.toString());
+					return null;
+				}
+			} else {
+				if ( lineItem.scoreMaximum != null ) {
+					gradebookColumn.setPoints(Double.valueOf(lineItem.scoreMaximum));
+				}
+				if ( lineItem.label != null ) {
+					gradebookColumn.setName(lineItem.label);
+				}
+				Date dueDate = LTIUtil.parseIMS8601(lineItem.endDateTime);
+				if ( dueDate != null ) {
+					gradebookColumn.setDueDate(dueDate);
+				}
+			}
+			syncExternalAssessmentDefinition(gradingService, context_id, gradebookColumn);
 			gradingService.updateAssignment(context_id, context_id, column_id, gradebookColumn);
 		} finally {
 			popAdvisor();
@@ -374,6 +678,151 @@ public class LineItemUtil {
 		return retval;
 	}
 
+	private static boolean toolIdMatchesKey(Long toolId, String toolContentKey) {
+		if (toolId == null || StringUtils.isBlank(toolContentKey)) {
+			return false;
+		}
+		String[] parts = toolContentKey.split(ID_SEPARATOR_REGEX);
+		return parts.length >= 1 && toolId.toString().equals(parts[0]);
+	}
+
+	private static org.sakaiproject.assignment.api.model.Assignment loadSakaiAssignment(String assignmentRef) {
+		if (!isAssignmentColumn(assignmentRef)) {
+			return null;
+		}
+		org.sakaiproject.assignment.api.AssignmentService assignmentService = null;
+		try {
+			assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
+		} catch (Throwable t) {
+			log.debug("AssignmentService not available: {}", t.toString());
+			return null;
+		}
+		if (assignmentService == null) {
+			return null;
+		}
+		try {
+			String assignmentId = org.sakaiproject.assignment.api.AssignmentReferenceReckoner.reckoner()
+					.reference(assignmentRef).reckon().getId();
+			if (StringUtils.isBlank(assignmentId)) {
+				assignmentId = assignmentRef;
+			}
+			return assignmentService.getAssignment(assignmentId);
+		} catch (Exception e) {
+			log.debug("Could not load assignment: {}", assignmentRef, e);
+			return null;
+		}
+	}
+
+	private static String constructToolKeyFromAssignmentContent(String contextId,
+			org.sakaiproject.assignment.api.model.Assignment asn) {
+		if (asn == null || asn.getContentId() == null || StringUtils.isBlank(contextId)) {
+			return null;
+		}
+		try {
+			LTIService ltiService = ComponentManager.get(LTIService.class);
+			if (ltiService == null) {
+				return null;
+			}
+			Map<String, Object> content = ltiService.getContent(asn.getContentId().longValue(), contextId);
+			if (content == null) {
+				return null;
+			}
+			return constructExternalId(content, null);
+		} catch (Throwable t) {
+			log.debug("Could not build tool key from assignment content: {}", t.toString());
+			return null;
+		}
+	}
+
+	/**
+	 * Single classification pass for a gradebook column: primary LTI line item vs legacy assignment-ref
+	 * row, tool ownership, resolved {@code tool_id|content_id} key, and (for external-tool assignments)
+	 * the loaded {@link org.sakaiproject.assignment.api.model.Assignment} so callers do not fetch twice.
+	 *
+	 * @param contextId site / gradebook uid
+	 * @param gbColumn gradebook column
+	 * @param toolId requesting LTI tool id; if null, ownership is not evaluated (always passes)
+	 * @param assignmentRefToToolKey map from assignment reference to {@code tool_id|content_id}; if null,
+	 *        a map is loaded when needed (prefer passing a pre-built map when iterating all columns)
+	 */
+	public static LtiLineItemRowResolution resolveLtiLineItemRow(String contextId, Assignment gbColumn, Long toolId,
+			Map<String, String> assignmentRefToToolKey) {
+		if (gbColumn == null) {
+			return LtiLineItemRowResolution.none();
+		}
+
+		String appName = gbColumn.getExternalAppName();
+		String assignmentExternalId = StringUtils.trimToNull(gbColumn.getExternalId());
+		Map<String, String> refMap = assignmentRefToToolKey;
+
+		if (GB_EXTERNAL_APP_NAME.equals(appName)) {
+			String key = getPreferredToolContentKey(gbColumn);
+			if (StringUtils.isBlank(key) && isAssignmentColumn(assignmentExternalId)) {
+				if (refMap == null) {
+					refMap = getExternalIdsForToolAssignments(contextId);
+				}
+				key = refMap != null ? refMap.get(assignmentExternalId) : null;
+			}
+			boolean owned = toolId == null || toolIdMatchesKey(toolId, key);
+			return new LtiLineItemRowResolution(true, false, owned, key, null);
+		}
+
+		boolean assignmentApp = ASSIGNMENTS_EXTERNAL_APP_NAME.equals(appName)
+				|| ASSIGNMENT_GRADES_TOOL_ID.equals(appName);
+
+		if (assignmentApp) {
+			String assignmentRef = assignmentExternalId;
+			if (assignmentRef == null) {
+				assignmentRef = StringUtils.trimToNull(gbColumn.getReference());
+			}
+			if (!isAssignmentColumn(assignmentRef)) {
+				return LtiLineItemRowResolution.none();
+			}
+			org.sakaiproject.assignment.api.model.Assignment asn = loadSakaiAssignment(assignmentRef);
+			if (asn == null) {
+				return LtiLineItemRowResolution.none();
+			}
+			if (contextId != null && asn.getContext() != null && !contextId.equals(asn.getContext())) {
+				return LtiLineItemRowResolution.none();
+			}
+			if (org.sakaiproject.assignment.api.model.Assignment.SubmissionType.EXTERNAL_TOOL_SUBMISSION
+					.equals(asn.getTypeOfSubmission())) {
+				String key = null;
+				if (refMap != null) {
+					key = refMap.get(assignmentRef);
+				}
+				if (StringUtils.isBlank(key)) {
+					key = constructToolKeyFromAssignmentContent(contextId, asn);
+				}
+				boolean owned = toolId == null || toolIdMatchesKey(toolId, key);
+				return new LtiLineItemRowResolution(true, false, owned, key, asn);
+			}
+			if (refMap == null) {
+				refMap = getExternalIdsForToolAssignments(contextId);
+			}
+			String key = refMap != null ? refMap.get(assignmentRef) : null;
+			if (StringUtils.isBlank(key)) {
+				return LtiLineItemRowResolution.none();
+			}
+			boolean owned = toolId == null || toolIdMatchesKey(toolId, key);
+			return new LtiLineItemRowResolution(false, true, owned, key, null);
+		}
+
+		if (isAssignmentColumn(assignmentExternalId)) {
+			if (refMap == null) {
+				refMap = getExternalIdsForToolAssignments(contextId);
+			}
+			String key = refMap != null ? refMap.get(assignmentExternalId) : null;
+			if (StringUtils.isBlank(key)) {
+				return LtiLineItemRowResolution.none();
+			}
+			boolean owned = toolId == null || toolIdMatchesKey(toolId, key);
+			return new LtiLineItemRowResolution(false, true, owned, key, null);
+		}
+
+		return LtiLineItemRowResolution.none();
+	}
+
 	/**
 	 * Return a list of assignments associated with this tool in a site
 	 * @param context_id - The site id
@@ -384,33 +833,17 @@ public class LineItemUtil {
 		List<Assignment> retval = new ArrayList<>();
 		GradingService gradingService = (GradingService) ComponentManager
 				.get("org.sakaiproject.grading.api.GradingService");
-		Map<String, String> externalIds = null;
 
 		pushAdvisor();
 		try {
+			Map<String, String> assignmentRefToToolKey = getExternalIdsForToolAssignments(context_id);
 			List<Assignment> gradebookColumns = gradingService.getAssignments(context_id, context_id, SortType.SORT_BY_NONE);
 			for (Iterator i = gradebookColumns.iterator(); i.hasNext();) {
 				Assignment gbColumn = (Assignment) i.next();
-				String external_id = getPreferredExternalId(gbColumn);
-				String assignmentExternalId = StringUtils.trimToNull(gbColumn.getExternalId());
-				if ( isGradebookColumnLTI(gbColumn) ) {
-					// We are good to go
-				} else if ( isAssignmentColumn(assignmentExternalId) ) {
-					if ( externalIds == null ) {
-						externalIds = getExternalIdsForToolAssignments(context_id);
-					}
-					external_id = externalIds.get(assignmentExternalId);
-					if ( external_id == null ) continue;
+				LtiLineItemRowResolution r = resolveLtiLineItemRow(context_id, gbColumn, tool_id, assignmentRefToToolKey);
+				if (r.isIncludedInToolLineItemList()) {
+					retval.add(gbColumn);
 				}
-
-				// Parse the external_id
-				// tool_id|content_id|resourceLink|tag|
-				if ( external_id == null || external_id.length() < 1 ) continue;
-
-				String[] parts = external_id.split(ID_SEPARATOR_REGEX);
-				if ( parts.length < 1 || ! parts[0].equals(tool_id.toString()) ) continue;
-
-				retval.add(gbColumn);
 			}
 		} catch (Throwable e) {
 			log.error("Unexpected Throwable", e.toString());
@@ -478,11 +911,14 @@ public class LineItemUtil {
 
 		pushAdvisor();
 		try {
+			Map<String, String> assignmentRefToToolKey = getExternalIdsForToolAssignments(context_id);
 			List gradebookColumns = gradingService.getAssignments(context_id, context_id, SortType.SORT_BY_NONE);
 			for (Iterator i = gradebookColumns.iterator(); i.hasNext();) {
 				Assignment gbColumn = (Assignment) i.next();
-				if ( ! isGradebookColumnLTI(gbColumn) ) continue;
-
+				LtiLineItemRowResolution r = resolveLtiLineItemRow(context_id, gbColumn, tool_id, assignmentRefToToolKey);
+				if (!r.isIncludedInToolLineItemList()) {
+					continue;
+				}
 				if (column_label.equals(gbColumn.getName())) {
 					retval = gbColumn;
 					break;
@@ -525,13 +961,27 @@ public class LineItemUtil {
 	}
 
 	/**
-	 * Determine if a grade book column is relevant to LTI
+	 * Determine if a grade book column is relevant to LTI Advantage line items / AGS.
+	 * <p>
+	 * IMS-AGS columns are always treated as LTI. Columns owned by the Assignments tool
+	 * ({@link #ASSIGNMENT_GRADES_TOOL_ID} or legacy {@link #ASSIGNMENTS_EXTERNAL_APP_NAME})
+	 * are LTI only when the linked Sakai assignment uses external (LTI) submission.
+	 * </p>
+	 *
+	 * @param contextId site id (gradebook uid); used to verify the assignment belongs to the site. May be null.
+	 * @param gradebookColumn gradebook assignment row
+	 * @see #resolveLtiLineItemRow(String, Assignment, Long, java.util.Map) for tool ownership and loaded assignment
 	 */
+	public static boolean isGradebookColumnLTI(String contextId, Assignment gradebookColumn) {
+		return resolveLtiLineItemRow(contextId, gradebookColumn, null, null).isPrimaryLtiLineItemRow();
+	}
+
+	/**
+	 * @deprecated use {@link #isGradebookColumnLTI(String, Assignment)}
+	 */
+	@Deprecated
 	public static boolean isGradebookColumnLTI(Assignment gradebookColumn) {
-		// if (gradebookColumn.isExternallyMaintained()) return false;
-		if ( GB_EXTERNAL_APP_NAME.equals(gradebookColumn.getExternalAppName()) ) return true;
-		if ( ASSIGNMENTS_EXTERNAL_APP_NAME.equals(gradebookColumn.getExternalAppName())) return true;
-		return false;
+		return isGradebookColumnLTI(null, gradebookColumn);
 	}
 
 	public static boolean isAssignmentColumn(String external_id) {
@@ -557,38 +1007,27 @@ public class LineItemUtil {
 				.get("org.sakaiproject.grading.api.GradingService");
 
 		List<SakaiLineItem> retval = new ArrayList<>();
-		Map<String, String> externalIds = null;
 
 		pushAdvisor();
 		try {
-
+			Map<String, String> assignmentRefToToolKey = getExternalIdsForToolAssignments(context_id);
 			List gradebookColumns = gradingService.getAssignments(context_id, context_id, SortType.SORT_BY_NONE);
 			for (Iterator i = gradebookColumns.iterator(); i.hasNext();) {
 				Assignment gbColumn = (Assignment) i.next();
-				String external_id = getPreferredExternalId(gbColumn);
-				String assignmentExternalId = StringUtils.trimToNull(gbColumn.getExternalId());
-				log.debug("gbColumn: {} {}", gbColumn.getName(), external_id);
-				if ( isGradebookColumnLTI(gbColumn) ) {
-					// We are good to go
-				} else if ( StringUtils.isNotEmpty(assignmentExternalId) && isAssignmentColumn(assignmentExternalId) ) {
-					if ( externalIds == null ) {
-						externalIds = getExternalIdsForToolAssignments(context_id);
-					}
-					external_id = externalIds.get(assignmentExternalId);
-					log.debug("derived assignment based on external_id: {} {}", external_id, externalIds);
-					if ( external_id == null ) continue;
+				LtiLineItemRowResolution r = resolveLtiLineItemRow(context_id, gbColumn, tool_id, assignmentRefToToolKey);
+				if (!r.isIncludedInToolLineItemList()) {
+					continue;
 				}
-
-				// Parse the external_id
-				// tool_id|content_id|resourceLink|tag|assignmentRef (optional)
+				String external_id = r.getToolContentKey();
+				log.debug("gbColumn: {} resolved key={}", gbColumn.getName(), external_id);
 				if ( external_id == null || external_id.length() < 1 ) continue;
 
 				log.debug("gb column id={}; title={}; external_id={}", gbColumn.getId(), gbColumn.getName(), external_id);
 
 				String[] parts = external_id.split(ID_SEPARATOR_REGEX);
-				if ( parts.length < 1 || ! parts[0].equals(tool_id.toString()) ) continue;
 
-				SakaiLineItem item = getLineItem(signed_placement, gbColumn);
+				org.sakaiproject.assignment.api.model.Assignment sakaiAsn = r.getSakaiAssignment();
+				SakaiLineItem item = getLineItem(signed_placement, gbColumn, sakaiAsn);
 				if ( parts.length > 1 && ! StringUtils.equals("0", parts[1]) ) {
 					item.resourceLinkId = "content:" + parts[1];
 				}
@@ -610,29 +1049,93 @@ public class LineItemUtil {
 		return retval;
 	}
 
-	public static SakaiLineItem getLineItem(String signed_placement, Assignment assignment) {
+	public static SakaiLineItem getLineItem(String signed_placement, Assignment gbColumn) {
+		return getLineItem(signed_placement, gbColumn, null);
+	}
+
+	/**
+	 * Build a line item for AGS. When {@code sakaiAssignment} is non-null (external-tool assignment row),
+	 * label, score cap, dates follow the Assignments object; resourceId/tag still come from the
+	 * gradebook column metadata. {@code startDateTime} reflects {@code openDate}; {@code endDateTime}
+	 * reflects due date (or accept-until if due is unset).
+	 */
+	public static SakaiLineItem getLineItem(String signed_placement, Assignment gbColumn,
+			org.sakaiproject.assignment.api.model.Assignment sakaiAssignment) {
 		SakaiLineItem li = new SakaiLineItem();
-		li.label = assignment.getName();
-		li.scoreMaximum = assignment.getPoints();
-		Date dueDate = assignment.getDueDate();
-		if ( dueDate != null ) {
-			li.endDateTime = org.tsugi.lti.LTIUtil.getISO8601(dueDate);
+		if (sakaiAssignment != null) {
+			li.label = sakaiAssignment.getTitle();
+			if (sakaiAssignment.getTypeOfGrade() == org.sakaiproject.assignment.api.model.Assignment.GradeType.SCORE_GRADE_TYPE
+					&& sakaiAssignment.getMaxGradePoint() != null) {
+				int scaleFactor = sakaiAssignment.getScaleFactor() != null ? sakaiAssignment.getScaleFactor() : 100;
+				li.scoreMaximum = sakaiAssignment.getMaxGradePoint() / (double) scaleFactor;
+			} else if (gbColumn.getPoints() != null) {
+				li.scoreMaximum = gbColumn.getPoints();
+			}
+			Instant openInstant = sakaiAssignment.getOpenDate();
+			if (openInstant != null) {
+				li.startDateTime = org.tsugi.lti.LTIUtil.getISO8601(Date.from(openInstant));
+			}
+			Instant endInstant = sakaiAssignment.getDueDate();
+			if (endInstant == null) {
+				endInstant = sakaiAssignment.getCloseDate();
+			}
+			if (endInstant != null) {
+				li.endDateTime = org.tsugi.lti.LTIUtil.getISO8601(Date.from(endInstant));
+			} else if (gbColumn.getDueDate() != null) {
+				li.endDateTime = org.tsugi.lti.LTIUtil.getISO8601(gbColumn.getDueDate());
+			}
+		} else {
+			li.label = gbColumn.getName();
+			li.scoreMaximum = gbColumn.getPoints();
+			Date dueDate = gbColumn.getDueDate();
+			if (dueDate != null) {
+				li.endDateTime = org.tsugi.lti.LTIUtil.getISO8601(dueDate);
+			}
 		}
 
-		// Parse the external_id
-		// tool_id|content_id|resourceLink|tag|
-		String external_id = getPreferredExternalId(assignment);
-		if ( external_id != null && external_id.length() > 0 ) {
-			String[] parts = external_id.split(ID_SEPARATOR_REGEX);
+		// EXTERNAL_ID holds tool_id|content_id (stable); LINEITEM_METADATA JSON holds resourceId/tag.
+		String toolContentKey = getPreferredToolContentKey(gbColumn);
+		if (toolContentKey != null && toolContentKey.length() > 0) {
+			String[] parts = toolContentKey.split(ID_SEPARATOR_REGEX);
 			li.resourceLinkId = (parts.length > 1 && parts[1].trim().length() > 1) ? parts[1].trim() : null;
-			li.resourceId  = (parts.length > 2 && parts[2].trim().length() > 1) ? parts[2].trim() : null;
-			li.tag = (parts.length > 3 && parts[3].trim().length() > 1) ? parts[3].trim() : null;
 		}
 
-		if ( signed_placement != null ) {
-			li.id = getOurServerUrl() + LTI13_PATH + "lineitems/" + signed_placement + "/" + assignment.getId();
+		Map<String, String> metadata = getPreferredLineItemMetadata(gbColumn);
+		if (metadata != null) {
+			li.resourceId = metadata.get("resourceId");
+			li.tag = metadata.get("tag");
 		}
 
+		if (signed_placement != null) {
+			li.id = getOurServerUrl() + LTI13_PATH + "lineitems/" + signed_placement + "/" + gbColumn.getId();
+		}
+
+		return li;
+	}
+
+	/**
+	 * Builds the {@link SakaiLineItem} for one gradebook column the same way as {@link #getLineItemsForTool}
+	 * (assignment-sourced label/points/due when applicable, resourceId/tag from gradebook metadata, resourceLinkId
+	 * from the resolved tool key).
+	 */
+	public static SakaiLineItem getLineItemForToolColumn(String signed_placement, String contextId, Long toolId,
+			Assignment gbColumn) {
+		if (gbColumn == null) {
+			return null;
+		}
+		Map<String, String> assignmentRefToToolKey = getExternalIdsForToolAssignments(contextId);
+		LtiLineItemRowResolution r = resolveLtiLineItemRow(contextId, gbColumn, toolId, assignmentRefToToolKey);
+		if (!r.isIncludedInToolLineItemList()) {
+			return getLineItem(signed_placement, gbColumn, null);
+		}
+		String external_id = r.getToolContentKey();
+		SakaiLineItem li = getLineItem(signed_placement, gbColumn, r.getSakaiAssignment());
+		if (StringUtils.isNotBlank(external_id)) {
+			String[] parts = external_id.split(ID_SEPARATOR_REGEX);
+			if (parts.length > 1 && !StringUtils.equals("0", parts[1])) {
+				li.resourceLinkId = "content:" + parts[1];
+			}
+		}
 		return li;
 	}
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -278,7 +278,7 @@ public class LineItemUtil {
 		return null;
 	}
 
-	private static Map<String, String> parseLineItemMetadata(String lineItemMetadata) {
+	private static Map<String, String> parseLineItemMetadata(String lineItemMetadata, Assignment gradebookColumn) {
 		if (StringUtils.isBlank(lineItemMetadata)) {
 			return null;
 		}
@@ -295,6 +295,15 @@ public class LineItemUtil {
 			}
 			return parsed;
 		} catch (Exception e) {
+			log.warn(
+					"Failed to parse LINEITEM_METADATA as JSON; gradebookAssignmentId={} name={} externalId={} reference={} gradebookUid={}; rawLineItemMetadata={}",
+					gradebookColumn != null ? gradebookColumn.getId() : null,
+					gradebookColumn != null ? gradebookColumn.getName() : null,
+					gradebookColumn != null ? gradebookColumn.getExternalId() : null,
+					gradebookColumn != null ? gradebookColumn.getReference() : null,
+					gradebookColumn != null ? gradebookColumn.getGradebookUid() : null,
+					lineItemMetadata,
+					e);
 			return null;
 		}
 	}
@@ -304,7 +313,7 @@ public class LineItemUtil {
 			return null;
 		}
 
-		Map<String, String> parsedMetadata = parseLineItemMetadata(gradebookColumn.getLineItemMetadata());
+		Map<String, String> parsedMetadata = parseLineItemMetadata(gradebookColumn.getLineItemMetadata(), gradebookColumn);
 		if (parsedMetadata != null) {
 			return parsedMetadata;
 		}

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -539,7 +539,8 @@ public class LineItemUtil {
 		}
 	}
 
-	public static Assignment updateLineItem(Site site, Long tool_id, Long column_id, SakaiLineItem lineItem) {
+	public static Assignment updateLineItem(Site site, Long tool_id, Long column_id, SakaiLineItem lineItem)
+			throws PermissionException {
 		log.debug("updateLineItem site={} tool_id={} column_id={} lineItem={}", site.getId(), tool_id, column_id, lineItem);
 		GradingService gradingService = (GradingService) ComponentManager
 				.get("org.sakaiproject.grading.api.GradingService");
@@ -620,7 +621,7 @@ public class LineItemUtil {
 					}
 				} catch (PermissionException e) {
 					log.warn("Could not update linked Sakai assignment from LTI line item: {}", e.toString());
-					return null;
+					throw e;
 				}
 			} else {
 				if ( lineItem.scoreMaximum != null ) {
@@ -1117,6 +1118,9 @@ public class LineItemUtil {
 	 * Builds the {@link SakaiLineItem} for one gradebook column the same way as {@link #getLineItemsForTool}
 	 * (assignment-sourced label/points/due when applicable, resourceId/tag from gradebook metadata, resourceLinkId
 	 * from the resolved tool key).
+	 *
+	 * @return the line item for this tool, or {@code null} if the column is not included for this tool (same
+	 *         {@link LtiLineItemRowResolution#isIncludedInToolLineItemList()} gate as {@link #getLineItemsForTool})
 	 */
 	public static SakaiLineItem getLineItemForToolColumn(String signed_placement, String contextId, Long toolId,
 			Assignment gbColumn) {
@@ -1126,7 +1130,7 @@ public class LineItemUtil {
 		Map<String, String> assignmentRefToToolKey = getExternalIdsForToolAssignments(contextId);
 		LtiLineItemRowResolution r = resolveLtiLineItemRow(contextId, gbColumn, toolId, assignmentRefToToolKey);
 		if (!r.isIncludedInToolLineItemList()) {
-			return getLineItem(signed_placement, gbColumn, null);
+			return null;
 		}
 		String external_id = r.getToolContentKey();
 		SakaiLineItem li = getLineItem(signed_placement, gbColumn, r.getSakaiAssignment());

--- a/lti/lti-common/src/test/org/sakaiproject/lti13/LineItemUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti13/LineItemUtilTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.lti13.util.SakaiLineItem;
 import org.sakaiproject.lti13.LineItemUtil;
 
@@ -87,6 +88,79 @@ public class LineItemUtilTest {
 		assertEquals("Bean and map should have same tool_id", contentMap.get("tool_id"), contentAsMap.get("tool_id"));
 		assertEquals("Bean and map should have same title", contentMap.get("title"), contentAsMap.get("title"));
 		assertEquals("Bean and map should have same SITE_ID", contentMap.get("SITE_ID"), contentAsMap.get("SITE_ID"));
+	}
+
+	@Test
+	public void testGetLineItemUsesExternalIdAndMetadataJson() {
+		Assignment assignment = new Assignment();
+		assignment.setName("Test");
+		assignment.setPoints(100.0);
+		assignment.setExternalId("123|456");
+		assignment.setLineItemMetadata("{\"resourceId\":\"metadataResource\",\"tag\":\"metadataTag\"}");
+
+		SakaiLineItem lineItem = LineItemUtil.getLineItem(null, assignment);
+		assertEquals("456", lineItem.resourceLinkId);
+		assertEquals("metadataResource", lineItem.resourceId);
+		assertEquals("metadataTag", lineItem.tag);
+	}
+
+	@Test
+	public void testGetLineItemFallsBackToExternalDataForToolContentKey() {
+		Assignment assignment = new Assignment();
+		assignment.setName("Test");
+		assignment.setPoints(100.0);
+		assignment.setExternalId(null);
+		assignment.setExternalData("123|456");
+		assignment.setLineItemMetadata("{\"resourceId\":\"r1\",\"tag\":\"t1\"}");
+
+		SakaiLineItem lineItem = LineItemUtil.getLineItem(null, assignment);
+		assertEquals("456", lineItem.resourceLinkId);
+		assertEquals("r1", lineItem.resourceId);
+		assertEquals("t1", lineItem.tag);
+	}
+
+	@Test
+	public void testShouldMigrateLegacyExternalIdWhenNewFieldsMissing() {
+		Assignment assignment = new Assignment();
+		assignment.setExternalData(null);
+		assignment.setLineItemMetadata(null);
+		assignment.setExternalId("123|456|legacyResource|legacyTag|");
+
+		assertTrue(LineItemUtil.shouldMigrateLegacyExternalId(assignment));
+	}
+
+	@Test
+	public void testShouldNotMigrateLegacyExternalIdWhenMetadataPresent() {
+		Assignment assignment = new Assignment();
+		assignment.setExternalData(null);
+		assignment.setLineItemMetadata("{\"resourceId\":\"metadataResource\",\"tag\":\"metadataTag\"}");
+		assignment.setExternalId("123|456|legacyResource|legacyTag|");
+
+		assertFalse(LineItemUtil.shouldMigrateLegacyExternalId(assignment));
+	}
+
+	@Test
+	public void testShouldNotMigrateLegacyExternalIdWhenLegacyInvalid() {
+		Assignment assignment = new Assignment();
+		assignment.setExternalData(null);
+		assignment.setLineItemMetadata(null);
+		assignment.setExternalId("not-valid");
+
+		assertFalse(LineItemUtil.shouldMigrateLegacyExternalId(assignment));
+	}
+
+	@Test
+	public void testIsGradebookColumnLTI_ImsAgsIsTrue() {
+		Assignment a = new Assignment();
+		a.setExternalAppName(LineItemUtil.GB_EXTERNAL_APP_NAME);
+		assertTrue(LineItemUtil.isGradebookColumnLTI("site1", a));
+	}
+
+	@Test
+	public void testIsGradebookColumnLTI_AssignmentToolWithoutReferenceIsFalse() {
+		Assignment a = new Assignment();
+		a.setExternalAppName(LineItemUtil.ASSIGNMENT_GRADES_TOOL_ID);
+		assertFalse(LineItemUtil.isGradebookColumnLTI("site1", a));
 	}
 
 }


### PR DESCRIPTION
@hornersa This is a draft and not complete.  I think this will keep the PUT to the line item to not break the association between the grade book column and the assignment.  There are other shortcomings in the PUT code that need to be addressed before this is done - but this might make grade and status flow to start working so testing can move further.  I will continue to work on making PUT work better for LTI assignments.  The external id will not be smashed  -the little LTI data is now stashed in externalData.  Thanks for the diagnosis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable external IDs and explicit line‑item metadata persisted on assignments and preserved during transfers for reliable LTI gradebook linking and resolution.
  * Line‑item updates now return rebuilt, authoritative responses.

* **Bug Fixes**
  * Clearer 400/403/404 responses, permission-aware handling, safer response construction, and reduced noisy debug logging.

* **Tests**
  * Expanded tests for line‑item resolution, metadata parsing, legacy migration, and ownership/visibility logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->