### PR TITLE
SAK-52404 msgcntr private message reply should generate notification

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/messaging/PrivateMessageUserNotificationHandler.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/messaging/PrivateMessageUserNotificationHandler.java
@@ -49,7 +49,8 @@ public class PrivateMessageUserNotificationHandler extends AbstractUserNotificat
 
     public List<String> getHandledEvents() {
         return Arrays.asList(DiscussionForumService.EVENT_MESSAGES_READ_RECEIPT,
-                DiscussionForumService.EVENT_MESSAGES_ADD);
+                DiscussionForumService.EVENT_MESSAGES_ADD,
+                DiscussionForumService.EVENT_MESSAGES_RESPONSE);
     }
 
     @Override
@@ -74,6 +75,7 @@ public class PrivateMessageUserNotificationHandler extends AbstractUserNotificat
                 case DiscussionForumService.EVENT_MESSAGES_READ_RECEIPT:
                     return Optional.of(handleReadReceipt(from, siteId, pvtMessage.getCreatedBy(), pvtMessage));
                 case DiscussionForumService.EVENT_MESSAGES_ADD:
+                case DiscussionForumService.EVENT_MESSAGES_RESPONSE:
                     return Optional.of(handleAdd(from, siteId, pvtMessage));
                 default:
                     return Optional.empty();


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification handling for message responses to ensure users receive timely notifications when responses are sent, consistent with other message events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->