### PR TITLE
SAK-52503 Gradebook Grades with decimal comma are not sorted properly

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -780,20 +780,14 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     },
     frozen: true,
     width: GbGradeTable.settings.showPoints ? 220 : 140,
-    sorter: function(a, b) {
-      const a_percent = parseFloat(a[1]);
-      const b_percent = parseFloat(b[1]);
-      const aIsNaN = isNaN(a_percent);
-      const bIsNaN = isNaN(b_percent);
+    sorter: (a, b) => {
+      const parse = (val) => {
+        if (val == null || val === "") return -Infinity;
+        const n = GbGradeTable.localizedStringToNumber(String(val));
+        return isNaN(n) ? -Infinity : n;
+      };
 
-      // treat NaN as less than real numbers
-      if (a_percent > b_percent || (!aIsNaN && bIsNaN)) {
-          return 1;
-      }
-      if (a_percent < b_percent || (aIsNaN && !bIsNaN)) {
-          return -1;
-      }
-      return 0;
+      return parse(a[1]) - parse(b[1]);
     }
   });
 
@@ -1869,6 +1863,15 @@ GbGradeTable.getFilteredColumns = function() {
         formatterParams: { _data_: column },
         titleFormatter: GbGradeTable.headerFormatter(null, column),
         width: 180,
+        sorter: (a, b) => {
+          const parse = (val) => {
+            if (val == null || val === "") return -Infinity;
+            const n = GbGradeTable.localizedStringToNumber(String(val));
+            return isNaN(n) ? -Infinity : n;
+          };
+
+          return parse(a) - parse(b);
+        },
         editor: column.type === 'category' || column.externallyMaintained ? false : "GbGradeTableEditor",
       }))
   );

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -755,6 +755,11 @@ GbGradeTable.renderTable = function (elementId, tableData) {
   GbGradeTable.courseGradeId = tableData.courseGradeId;
   GbGradeTable.gradebookId = tableData.gradebookId;
   GbGradeTable.i18n = tableData.i18n;
+  GbGradeTable.parseGradeValue = (val) => {
+    if (val == null || val === "") return -Infinity;
+    const n = GbGradeTable.localizedStringToNumber(String(val));
+    return isNaN(n) ? -Infinity : n;
+  };
   GbGradeTable._fixedColumns.push({
     titleFormatter: GbGradeTable.headerFormatter('studentHeader'),
     formatter: GbGradeTable.studentCellFormatter,
@@ -780,15 +785,7 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     },
     frozen: true,
     width: GbGradeTable.settings.showPoints ? 220 : 140,
-    sorter: (a, b) => {
-      const parse = (val) => {
-        if (val == null || val === "") return -Infinity;
-        const n = GbGradeTable.localizedStringToNumber(String(val));
-        return isNaN(n) ? -Infinity : n;
-      };
-
-      return parse(a[1]) - parse(b[1]);
-    }
+    sorter: (a, b) => GbGradeTable.parseGradeValue(a[1]) - GbGradeTable.parseGradeValue(b[1])
   });
 
   if (GbGradeTable.settings.isStudentNumberVisible) {
@@ -1863,15 +1860,7 @@ GbGradeTable.getFilteredColumns = function() {
         formatterParams: { _data_: column },
         titleFormatter: GbGradeTable.headerFormatter(null, column),
         width: 180,
-        sorter: (a, b) => {
-          const parse = (val) => {
-            if (val == null || val === "") return -Infinity;
-            const n = GbGradeTable.localizedStringToNumber(String(val));
-            return isNaN(n) ? -Infinity : n;
-          };
-
-          return parse(a) - parse(b);
-        },
+        sorter: (a, b) => GbGradeTable.parseGradeValue(a) - GbGradeTable.parseGradeValue(b),
         editor: column.type === 'category' || column.externallyMaintained ? false : "GbGradeTableEditor",
       }))
   );


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting in the gradebook table: course-grade and grade item columns now use a consistent numeric sort key, handling empty/null and unparseable values predictably for more accurate and stable grade ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->