### PR TITLE
SAK-52505 Assignments LTI don't set submitted if it is already set

### DIFF
--- a/lti/docs/ASSIGNMENTS.md
+++ b/lti/docs/ASSIGNMENTS.md
@@ -91,6 +91,35 @@ To keep behavior predictable and interoperable, Sakai applies this mapping when 
 
 This favors consistency with real-world LTI tool behavior over a strict, spec-only reading that would disagree with common implementations.
 
+## LTI Activity State and Submission Lifecycle
+
+Sakai treats `activityProgress` as a state machine for assignment submission status:
+
+1. **Student submits (submitted/completed state)**
+   - Example states: `ACTIVITY_SUBMITTED`, `ACTIVITY_COMPLETED`
+   - Sakai sets `submitted = true`
+   - If `dateSubmitted` is empty, Sakai sets it to the current time
+
+2. **Instructor requests resubmission (restart/in-progress state)**
+   - Example states: `ACTIVITY_INITIALIZED`, `ACTIVITY_STARTED`, `ACTIVITY_INPROGRESS`
+   - Sakai clears submission state:
+     - `submitted = false`
+     - `dateSubmitted = null`
+
+3. **Student submits again after restart**
+   - State returns to submitted/completed
+   - Because step 2 cleared `dateSubmitted`, Sakai sets a fresh `dateSubmitted` timestamp
+
+4. **Duplicate submitted callbacks without restart**
+   - If a submitted/completed callback is repeated without an intervening restart/in-progress state, Sakai preserves the existing `dateSubmitted`
+   - This avoids timestamp drift from retries
+
+### Practical implication
+
+- Restart/in-progress transitions intentionally clear the submission timestamp.
+- The next real submit records a new submit timestamp.
+- Retries of the same submitted state do not keep moving the timestamp.
+
 ## Sakai LTI Assignments and Gradebook Integration
 
 LTI assignments integrate with the Sakai gradebook **differently** from other assignment types.

--- a/lti/docs/ASSIGNMENTS.md
+++ b/lti/docs/ASSIGNMENTS.md
@@ -95,6 +95,11 @@ This favors consistency with real-world LTI tool behavior over a strict, spec-on
 
 Sakai treats `activityProgress` as a state machine for assignment submission status:
 
+0. **Tool omits `activityProgress`**
+   - Sakai defaults missing `activityProgress` to completed/submitted behavior
+   - This is intentional compatibility behavior for grade pushes without lifecycle state
+   - Tools that need/implement precise lifecycle control must send `activityProgress` on every update
+
 1. **Student submits (submitted/completed state)**
    - Example states: `ACTIVITY_SUBMITTED`, `ACTIVITY_COMPLETED`
    - Sakai sets `submitted = true`

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -2837,6 +2837,8 @@ public class SakaiLTIUtil {
 		UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
 		org.sakaiproject.site.api.SiteService siteService = ComponentManager.get(org.sakaiproject.site.api.SiteService.class);
 
+		// Design rule: if a tool omits activityProgress, treat it as completed/submitted.
+		// Tools that manage lifecycle transitions must send activityProgress on every update.
 		String activityProgress = scoreObj.activityProgress != null ? scoreObj.activityProgress : Score.ACTIVITY_COMPLETED ;
 		String gradingProgress = scoreObj.gradingProgress != null ? scoreObj.gradingProgress : Score.GRADING_FULLYGRADED;
 		log.debug("activityProgress: {} gradingProgress: {}", activityProgress, gradingProgress);
@@ -2948,9 +2950,10 @@ public class SakaiLTIUtil {
 			}
 
 			Instant previousDateSubmitted = submission.getDateSubmitted();
-			boolean isInProgressState = activityProgress.equals(Score.ACTIVITY_INITIALIZED)
-					|| activityProgress.equals(Score.ACTIVITY_STARTED)
-					|| activityProgress.equals(Score.ACTIVITY_INPROGRESS);
+			boolean isInProgressState = StringUtils.equalsAny(activityProgress,
+					Score.ACTIVITY_INITIALIZED,
+					Score.ACTIVITY_STARTED,
+					Score.ACTIVITY_INPROGRESS);
 
 			/*
 			 * Submission lifecycle (step by step):
@@ -2978,7 +2981,8 @@ public class SakaiLTIUtil {
 				submission.setDateSubmitted(null);
 			} else {
 				submission.setSubmitted(true);
-				// Preserve existing submit time on repeated submit/restart callbacks.
+				// Non-in-progress branch (explicit submitted/completed OR missing-state default):
+				// initial submit sets now; duplicate submit preserves existing timestamp.
 				if (previousDateSubmitted == null) {
 					submission.setDateSubmitted(now);
 				} else {

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -2947,20 +2947,51 @@ public class SakaiLTIUtil {
 				submission.setGraded(true);
 			}
 
-			if ( activityProgress.equals(Score.ACTIVITY_INITIALIZED) || activityProgress.equals(Score.ACTIVITY_STARTED) ||
-					 activityProgress.equals(Score.ACTIVITY_INPROGRESS) ) {
+			Instant previousDateSubmitted = submission.getDateSubmitted();
+			boolean isInProgressState = activityProgress.equals(Score.ACTIVITY_INITIALIZED)
+					|| activityProgress.equals(Score.ACTIVITY_STARTED)
+					|| activityProgress.equals(Score.ACTIVITY_INPROGRESS);
+
+			/*
+			 * Submission lifecycle (step by step):
+			 *
+			 * 1) Student submits:
+			 *    - activityProgress is submitted/completed.
+			 *    - We set submitted=true.
+			 *    - If dateSubmitted is null, we set it to "now".
+			 *
+			 * 2) Instructor requests resubmission (tool sends restart/in-progress):
+			 *    - activityProgress is initialized/started/inprogress.
+			 *    - We clear submission state (submitted=false, dateSubmitted=null).
+			 *
+			 * 3) Student submits again:
+			 *    - activityProgress returns to submitted/completed.
+			 *    - dateSubmitted was cleared in step 2, so we set a new submit time.
+			 *
+			 * 4) Duplicate submitted callbacks without a restart:
+			 *    - Keep the existing dateSubmitted to avoid timestamp drift from retries.
+			 */
+			log.debug("submission transition input: assignmentId={} userId={} activityProgress={} gradingProgress={} isInProgressState={} wasSubmitted={} previousDateSubmitted={} now={}",
+					a.getId(), userId, activityProgress, gradingProgress, isInProgressState, submission.getSubmitted(), previousDateSubmitted, now);
+			if (isInProgressState) {
 				submission.setSubmitted(false);
 				submission.setDateSubmitted(null);
 			} else {
 				submission.setSubmitted(true);
-				submission.setDateSubmitted(now);
+				// Preserve existing submit time on repeated submit/restart callbacks.
+				if (previousDateSubmitted == null) {
+					submission.setDateSubmitted(now);
+				} else {
+					submission.setDateSubmitted(previousDateSubmitted);
+				}
 			}
 
 			submission.getProperties().put(getNextSubmissionLogKey(submission), logEntry.toString());
 
 			 try {
 				assignmentService.updateSubmission(submission);
-				log.debug("Submitted submission={} userId={} log={}", submission.getId(), userId, logEntry.toString());
+				log.debug("Submitted submission={} userId={} submitted={} dateSubmitted={} log={}",
+						submission.getId(), userId, submission.getSubmitted(), submission.getDateSubmitted(), logEntry.toString());
 			} catch (org.sakaiproject.exception.PermissionException e) {
 				log.warn("Could not update submission: {}, {}", submission.getId(), e);
 				return "Could not update submission="+submission.getId()+" "+e;


### PR DESCRIPTION
This PR supersedes #14573 and builds on work by @hornersa.
   
I reworked the implementation enough that it seemed cleaner to open a new PR rather than revise the original one.
    
Co-authored-by: Sean Horner <hornersa@plu.edu>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assignment submission state handling: now preserves prior submitted status and timestamps, prevents incorrect toggles when an activity is in-progress, and adds clearer transition logging for diagnostics and troubleshooting.

* **Documentation**
  * Added "LTI Activity State and Submission Lifecycle" guide explaining lifecycle steps, state transitions, timestamp handling, and retry considerations for integrators and admins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->