### PR TITLE
SAK-52516 Update Apache Commons IO 2.22.0

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/CSVReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/CSVReader.java
@@ -88,7 +88,12 @@ public class CSVReader extends Reader
 		InputStream stream,
 		ReaderImportRowHandler handler) throws ImportException
 	{
-		BufferedReader bufferedReader = getReader(stream);
+		BufferedReader bufferedReader; 
+		try {
+			bufferedReader = getReader(stream);
+		} catch (IOException e) {
+			throw new ImportException(e);
+		}
 
 		ColumnHeader columnDescriptionArray[] = null;
 

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/OutlookReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/OutlookReader.java
@@ -40,13 +40,11 @@ import org.sakaiproject.calendar.impl.GenericCalendarImporter;
 import org.sakaiproject.exception.ImportException;
 import org.sakaiproject.util.ResourceLoader;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * This class parses a comma (or other separator other than a double-quote) delimited
  * file.
  */
-@Slf4j
+
 public class OutlookReader extends CSVReader
 {
 	private static final ResourceLoader rb = new ResourceLoader("calendar");

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/OutlookReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/OutlookReader.java
@@ -40,10 +40,13 @@ import org.sakaiproject.calendar.impl.GenericCalendarImporter;
 import org.sakaiproject.exception.ImportException;
 import org.sakaiproject.util.ResourceLoader;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * This class parses a comma (or other separator other than a double-quote) delimited
  * file.
  */
+@Slf4j
 public class OutlookReader extends CSVReader
 {
 	private static final ResourceLoader rb = new ResourceLoader("calendar");
@@ -157,14 +160,22 @@ public class OutlookReader extends CSVReader
 	 */
 	protected BufferedReader getReader(InputStream stream) {
 		//Detect and exclude all BOM
-		BOMInputStream bomIn = new BOMInputStream(stream, false, ByteOrderMark.UTF_8,
-				ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
-				ByteOrderMark.UTF_32BE);
+		BOMInputStream bomIn;
+		try {
+			bomIn = new BOMInputStream(stream, false, ByteOrderMark.UTF_8,
+					ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
+					ByteOrderMark.UTF_32BE);
+		
 
 		InputStreamReader inputStream = new InputStreamReader(bomIn);
 		BufferedReader bufferedReader = new BufferedReader(inputStream);
 
 		return bufferedReader;
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return null;
 	}
 
 	/* (non-Javadoc)

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/OutlookReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/OutlookReader.java
@@ -71,7 +71,12 @@ public class OutlookReader extends CSVReader
 		InputStream stream,
 		ReaderImportRowHandler handler) throws ImportException
 	{
-		BufferedReader bufferedReader = getReader(stream);
+		BufferedReader bufferedReader; 
+		try {
+			bufferedReader = getReader(stream);
+		} catch (IOException e) {
+			throw new ImportException(e);
+		}
 
 		ColumnHeader columnDescriptionArray[] = null;
 		
@@ -157,25 +162,23 @@ public class OutlookReader extends CSVReader
 	 * 
 	 * This is because MS Outlook exports in other char set that UTF-8 and it probably   
 	 * depends on the Outlook's language 
+	 * @throws IOException 
 	 */
-	protected BufferedReader getReader(InputStream stream) {
+	protected BufferedReader getReader(InputStream stream) throws IOException {
 		//Detect and exclude all BOM
-		BOMInputStream bomIn;
-		try {
-			bomIn = new BOMInputStream(stream, false, ByteOrderMark.UTF_8,
+		BOMInputStream bomIn =  BOMInputStream.builder()
+					.setInputStream(stream)
+					.setByteOrderMarks(ByteOrderMark.UTF_8,
 					ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE,
-					ByteOrderMark.UTF_32BE);
+					ByteOrderMark.UTF_32BE)
+					.setInclude(false)
+					.get();
 		
 
 		InputStreamReader inputStream = new InputStreamReader(bomIn);
 		BufferedReader bufferedReader = new BufferedReader(inputStream);
 
 		return bufferedReader;
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return null;
 	}
 
 	/* (non-Javadoc)

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/Reader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/Reader.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/Reader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/Reader.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.calendar.impl.readers;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.ZoneId;
@@ -262,8 +263,9 @@ public abstract class Reader
 	/**
 	 * Utility routine to get a BufferedReader
 	 * @param stream
+	 * @throws IOException 
 	 */
-	protected BufferedReader getReader(InputStream stream)
+	protected BufferedReader getReader(InputStream stream) throws IOException
 	{
 		InputStreamReader inStreamReader = new InputStreamReader(stream);
 		BufferedReader bufferedReader = new BufferedReader(inStreamReader);

--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3443,6 +3443,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 					irs = BOMInputStream.builder().setInputStream(risImportStream).get();
 				} catch (IOException e) {
 					log.warn("Unable to construct BOMInputStream for RIS import", e);
+					try { risImportStream.close(); } catch (IOException ignored) { /* best-effort */ }
 					return;
 				}
 		

--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3438,7 +3438,13 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 	      InputStream risImportStream = risImport.getInputStream();
 
 			// Attempt to detect the encoding of the file.
-			BOMInputStream irs = new BOMInputStream(risImportStream);
+			BOMInputStream irs;
+			try {
+				irs = new BOMInputStream(risImportStream);
+			} catch (IOException e) {
+				log.warn(e.getMessage(), e);
+				return;
+			}
 		
 			// below is needed if UTF-8 above is commented out
 			Reader isr = null;

--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3438,13 +3438,13 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 	      InputStream risImportStream = risImport.getInputStream();
 
 			// Attempt to detect the encoding of the file.
-			BOMInputStream irs;
+	      BOMInputStream irs;
 			try {
-				irs = new BOMInputStream(risImportStream);
-			} catch (IOException e) {
-				log.warn(e.getMessage(), e);
-				return;
-			}
+					irs = BOMInputStream.builder().setInputStream(risImportStream).get();
+				} catch (IOException e) {
+					log.warn("Unable to construct BOMInputStream for RIS import", e);
+					return;
+				}
 		
 			// below is needed if UTF-8 above is commented out
 			Reader isr = null;
@@ -3454,7 +3454,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 				 bomCharsetName = irs.getBOMCharsetName();
 				if (bomCharsetName != null)
 				{
-					isr = new InputStreamReader(risImportStream, bomCharsetName);
+					isr = new InputStreamReader(irs, bomCharsetName);
 				}
 			} catch (UnsupportedEncodingException uee)
 			{

--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3446,7 +3446,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 					try {
 					    risImportStream.close();
 					} catch (IOException risIoe) {
-					    log.warn("Attempted to close RIS import, {}", risIoe.toString())
+					    log.warn("Attempted to close RIS import, {}", risIoe.toString());
 					}
 					return;
 				}

--- a/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3443,7 +3443,11 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 					irs = BOMInputStream.builder().setInputStream(risImportStream).get();
 				} catch (IOException e) {
 					log.warn("Unable to construct BOMInputStream for RIS import", e);
-					try { risImportStream.close(); } catch (IOException ignored) { /* best-effort */ }
+					try {
+					    risImportStream.close();
+					} catch (IOException risIoe) {
+					    log.warn("Attempted to close RIS import, {}", risIoe.toString())
+					}
 					return;
 				}
 		

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -17,7 +17,7 @@
     <sakai.version>26-SNAPSHOT</sakai.version>
     <!-- Standard dependency versions -->
     <sakai.commons-httpclient.version>3.1</sakai.commons-httpclient.version>
-    <sakai.commons-io.version>2.21.0</sakai.commons-io.version>
+    <sakai.commons-io.version>2.22.0</sakai.commons-io.version>
     <sakai.commons.lang.version>2.6</sakai.commons.lang.version>
     <sakai.commons.lang3.version>3.20.0</sakai.commons.lang3.version>
     <sakai.commons.fileupload.version>1.6.0</sakai.commons.fileupload.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated managed commons-io version to 2.22.0.

* **Bug Fixes**
  * Improved import robustness in calendar and citation tools: unified BOM/encoding handling, safer reader construction with IO error handling, and explicit conversion of IO errors into controlled import failures with early exit when BOM detection fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->