### PR TITLE
SAK-52406 msgcntr Use handler provided from user instead of event user

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/messaging/impl/UserMessagingServiceImpl.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/messaging/impl/UserMessagingServiceImpl.java
@@ -384,15 +384,21 @@ public class UserMessagingServiceImpl implements UserMessagingService, Observer 
                 final boolean finalDeferred = deferred;
 
                 String[] pathParts = ref.split("/");
-                String from = e.getUserId();
+                String eventFrom = e.getUserId();
                 try {
                     UserNotificationHandler handler = notificationHandlers.get(event);
                     if (handler != null) {
                         handler.handleEvent(e).ifPresent(notifications ->
                             notifications.forEach(und -> {
 
+                                // Try to use the handler specified from user rather than the event
+                                // supplied one. This may be important in the case of events fired
+                                // by cron jobs where the job is running under the admin user.
+                                String handlerFrom = und.getFrom();
+                                if (StringUtils.isBlank(handlerFrom)) handlerFrom = eventFrom;
+
                                 UserNotificationTransferBean bean
-                                    = UserNotificationTransferBean.of(doInsert(from,
+                                    = UserNotificationTransferBean.of(doInsert(handlerFrom,
                                         und,
                                         event,
                                         ref,

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/messaging/PrivateMessageUserNotificationHandler.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/messaging/PrivateMessageUserNotificationHandler.java
@@ -129,7 +129,7 @@ public class PrivateMessageUserNotificationHandler extends AbstractUserNotificat
             return pvtMessage.getRecipients()
                 .stream()
                 .filter(r -> !StringUtils.equals(r.getUserId(), from))
-                .map(r -> new UserNotificationData(from, r.getUserId(), siteId, title, url, DiscussionForumService.MESSAGES_TOOL_ID, false, null))
+                .map(r -> new UserNotificationData(pvtMessage.getAuthorId(), r.getUserId(), siteId, title, url, DiscussionForumService.MESSAGES_TOOL_ID, false, null))
                 .collect(Collectors.toList());
         } catch (IdUnusedException idEx) {
             log.error("No site for id {}", siteId, idEx);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification sender attribution in the messaging system to correctly display the actual message author or initiator instead of system/admin users when notifications are triggered by automated events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->