### PR TITLE
SAK-52528 LTI: Prevent overwriting assignment accept until date

### DIFF
--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -495,7 +495,6 @@ public class LineItemUtil {
 			if (endDate != null) {
 				Instant endInstant = endDate.toInstant();
 				asn.setDueDate(endInstant);
-				asn.setCloseDate(endInstant);
 			}
 		}
 	}


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52528

This is only an arguably partial fix to address the Sakai-side Accept Until date. I've an insight and questions re the subsequent revisions happening to TII's due date, elaborated here: https://drive.google.com/file/d/1TaMixGmUdU7rHwDefvIsmabK6iuXWI9d/view?usp=sharing

How should we proceed re this?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined LTI line item synchronization: end dates from external LTI tools now only apply to assignment due dates and no longer overwrite the close date setting in Sakai assignments. This change gives instructors better control over when assignments stop accepting submissions independently from their due dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->