### PR TITLE
SAK-52534 Samigo scope gradebook removal

### DIFF
--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
@@ -89,7 +89,7 @@ public class GradebookServiceHelperImpl implements GradebookServiceHelper
     */
     public void removeExternalAssessment(String gradebookUId, String publishedAssessmentId, GradingService g)
         throws Exception {
-        g.removeExternalAssignment(null, publishedAssessmentId, getAppName());
+        g.removeExternalAssignment(gradebookUId, publishedAssessmentId, getAppName());
     }
 
   public boolean isAssignmentDefined(String assessmentTitle,

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
@@ -89,7 +89,36 @@ public class GradebookServiceHelperImpl implements GradebookServiceHelper
     */
     public void removeExternalAssessment(String gradebookUId, String publishedAssessmentId, GradingService g)
         throws Exception {
-        g.removeExternalAssignment(gradebookUId, publishedAssessmentId, getAppName());
+        if (gradebookUId == null) {
+            throw new AssessmentNotFoundException("Cannot remove external assessment without a gradebook uid");
+        }
+
+        List<String> gradebookUids = new ArrayList<>(List.of(gradebookUId));
+
+        if (g.isGradebookGroupEnabled(gradebookUId)) {
+            for (String groupGradebookUid : g.getGradebookGroupInstancesIds(gradebookUId)) {
+                if (!gradebookUids.contains(groupGradebookUid)) {
+                    gradebookUids.add(groupGradebookUid);
+                }
+            }
+        }
+
+        AssessmentNotFoundException lastNotFound = null;
+        boolean removed = false;
+
+        for (String uid : gradebookUids) {
+            try {
+                g.removeExternalAssignment(uid, publishedAssessmentId, getAppName());
+                removed = true;
+            } catch (AssessmentNotFoundException e) {
+                lastNotFound = e;
+                log.debug("No external assessment id={} in gradebook uid={}", publishedAssessmentId, uid);
+            }
+        }
+
+        if (!removed && lastNotFound != null) {
+            throw lastNotFound;
+        }
     }
 
   public boolean isAssignmentDefined(String assessmentTitle,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External assessments are now reliably removed from the intended gradebook instance (including group-linked instances when applicable).
  * Improved removal reliability: operations now track successes, log when an assessment isn’t found for a specific gradebook, and only surface an error if no removals succeeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->