### PR TITLE
SAK-52539 Assignments / LTI Provide the $ResourceLink.available.startDateTime LTI 1.3 substitution parameter

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2063,15 +2063,16 @@ public class AssignmentAction extends PagedResourceActionII {
                 content_json.put(LTIService.LTI_PROTECT, new Integer(1));
 
                 // Copy assignment specific custom parameter substitutions to pass into SakaiLTIUtil
-                // Normally Sakai does not show, populate nor use visibleDate so we fall bacl to open date
+                // Normally Sakai does not show, populate nor use visibleDate so we fall back to open date
+                content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME, assignmentOpenDate);
+                content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME, assignmentDueDate);
                 if ( ! StringUtils.isBlank(assignmentVisibleDate) ) {
                     content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentVisibleDate);
                 } else {
                     content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentOpenDate);
                 }
-                content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME, assignmentOpenDate);
                 content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME, assignmentCloseDate);
-                content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME, assignmentCloseDate);
+
 
                 // There is no real place for due date in the variables most tools treat close date as due date
                 content_json.put(SakaiLTIUtil.SAKAI_LTI_SUBSTITUTION_DUE_DATE, assignmentDueDate);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2038,8 +2038,6 @@ public class AssignmentAction extends PagedResourceActionII {
                 int protect = LTIUtil.toInt(content.get(LTIService.LTI_PROTECT));
                 String assignmentTitle = StringUtils.trimToEmpty(assignment.getTitle());
                 String assignmentDesc = StringUtils.trimToEmpty(assignment.getInstructions());
-                Instant visibleDate = assignment.getVisibleDate();
-                String assignmentVisibleDate = StringUtils.trimToEmpty(visibleDate == null ? null : visibleDate.toString());
                 Instant openDate = assignment.getOpenDate();
                 String assignmentOpenDate = StringUtils.trimToEmpty(openDate == null ? null : openDate.toString());
                 Instant dueDate = assignment.getDueDate();
@@ -2054,12 +2052,11 @@ public class AssignmentAction extends PagedResourceActionII {
 
                 String content_settings = (String) content.get(LTIService.LTI_SETTINGS);
                 JSONObject content_json = LTIUtil.parseJSONObject(content_settings);
-                String contentVisibleDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME));
                 String contentOpenDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME));
                 String contentDueDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME));
                 String contentCloseDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME));
                 if ( protect < 1 || !assignmentTitle.equals(contentTitle) || !assignmentDesc.equals(contentDesc) ||
-                        ! contentVisibleDate.equals(assignmentVisibleDate) || ! contentOpenDate.equals(assignmentOpenDate) ||
+                        ! contentOpenDate.equals(assignmentOpenDate) ||
                         ! contentDueDate.equals(assignmentDueDate) || ! contentCloseDate.equals(assignmentCloseDate) ||
                         placement_secret == null ) {
                     Map<String, Object> updates = new TreeMap<String, Object>();
@@ -2078,7 +2075,8 @@ public class AssignmentAction extends PagedResourceActionII {
                     content_json.put(LTIService.LTI_PROTECT, new Integer(1));
 
                     // Copy assignment specific custom parameter substitutions to pass into SakaiLTIUtil
-                    content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentVisibleDate);
+                    // visibleDate is deprecated and not used.
+                    content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentOpenDate);
                     content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME, assignmentOpenDate);
                     content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME, assignmentDueDate);
                     content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME, assignmentCloseDate);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2034,30 +2034,62 @@ public class AssignmentAction extends PagedResourceActionII {
                 context.put("height",SakaiLTIUtil.getFrameHeight(tool, content, "1200px"));
                 context.put("browser-feature-allow", serverConfigurationService.getBrowserFeatureAllowString());
 
-                // Copy title, description, and dates from Assignment to content if mis-match
                 int protect = LTIUtil.toInt(content.get(LTIService.LTI_PROTECT));
                 String assignmentTitle = StringUtils.trimToEmpty(assignment.getTitle());
                 String assignmentDesc = StringUtils.trimToEmpty(assignment.getInstructions());
+
+                // Normally Sakai does not show, populate nor use visibleDate
+                Instant visibleDate = assignment.getVisibleDate();
+                String assignmentVisibleDate = StringUtils.trimToEmpty(visibleDate == null ? null : visibleDate.toString());
                 Instant openDate = assignment.getOpenDate();
                 String assignmentOpenDate = StringUtils.trimToEmpty(openDate == null ? null : openDate.toString());
                 Instant dueDate = assignment.getDueDate();
                 String assignmentDueDate = StringUtils.trimToEmpty(dueDate == null ? null : dueDate.toString());
                 Instant closeDate = assignment.getCloseDate();
                 String assignmentCloseDate = StringUtils.trimToEmpty(closeDate == null ? null : closeDate.toString());
+                String assignmentResubmissionAcceptUntil = null;
+                String allowResubmitCloseTime = assignment.getProperties().get(AssignmentConstants.ALLOW_RESUBMIT_CLOSETIME);
+                if (StringUtils.isNotBlank(allowResubmitCloseTime)) {
+                    try {
+                        assignmentResubmissionAcceptUntil = Instant.ofEpochMilli(Long.parseLong(allowResubmitCloseTime)).toString();
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid resubmission close time for assignment {}: {}", assignment.getId(), allowResubmitCloseTime);
+                    }
+                }
 
+                JSONObject content_json = new JSONObject();
+                // SAK-43709 - Prior to Sakai-21 - also copy these in the settings area
+                content_json.put(LTIService.LTI_DESCRIPTION, assignmentDesc);
+                content_json.put(LTIService.LTI_PROTECT, new Integer(1));
+
+                // Copy assignment specific custom parameter substitutions to pass into SakaiLTIUtil
+                // Normally Sakai does not show, populate nor use visibleDate so we fall bacl to open date
+                if ( ! StringUtils.isBlank(assignmentVisibleDate) ) {
+                    content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentVisibleDate);
+                } else {
+                    content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentOpenDate);
+                }
+                content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME, assignmentOpenDate);
+                content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME, assignmentCloseDate);
+                content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME, assignmentCloseDate);
+
+                // There is no real place for due date in the variables most tools treat close date as due date
+                content_json.put(SakaiLTIUtil.SAKAI_LTI_SUBSTITUTION_DUE_DATE, assignmentDueDate);
+                content_json.put(SakaiLTIUtil.SAKAI_LTI_SUBSTITUTION_ACCEPT_UNTIL, assignmentResubmissionAcceptUntil);
+
+                content_json.put(LTICustomVars.COURSEGROUP_ID, courseGroupId);
+                String content_settings = content_json.toString();
+
+                String old_content_settings = (String) content.get(LTIService.LTI_SETTINGS);
+
+                // Copy title, description, and dates from Assignment to content if mis-match
                 String contentTitle = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_TITLE));
                 String contentDesc = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_DESCRIPTION));
 
                 String placement_secret = StringUtils.trimToNull((String) content.get(LTIService.LTI_PLACEMENTSECRET));
 
-                String content_settings = (String) content.get(LTIService.LTI_SETTINGS);
-                JSONObject content_json = LTIUtil.parseJSONObject(content_settings);
-                String contentOpenDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME));
-                String contentDueDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME));
-                String contentCloseDate = StringUtils.trimToEmpty((String) content_json.get(DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME));
                 if ( protect < 1 || !assignmentTitle.equals(contentTitle) || !assignmentDesc.equals(contentDesc) ||
-                        ! contentOpenDate.equals(assignmentOpenDate) ||
-                        ! contentDueDate.equals(assignmentDueDate) || ! contentCloseDate.equals(assignmentCloseDate) ||
+                        ! content_settings.equals(old_content_settings) ||
                         placement_secret == null ) {
                     Map<String, Object> updates = new TreeMap<String, Object>();
                     updates.put(LTIService.LTI_TITLE, assignmentTitle);
@@ -2070,23 +2102,13 @@ public class AssignmentAction extends PagedResourceActionII {
                         content.put(LTIService.LTI_PLACEMENTSECRET, placement_secret);
                     }
 
-                    // SAK-43709 - Prior to Sakai-21 - also copy these in the settings area
-                    content_json.put(LTIService.LTI_DESCRIPTION, assignmentDesc);
-                    content_json.put(LTIService.LTI_PROTECT, new Integer(1));
-
-                    // Copy assignment specific custom parameter substitutions to pass into SakaiLTIUtil
-                    // visibleDate is deprecated and not used.
-                    content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_STARTDATETIME, assignmentOpenDate);
-                    content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME, assignmentOpenDate);
-                    content_json.put(DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME, assignmentDueDate);
-                    content_json.put(DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME, assignmentCloseDate);
-                    content_json.put(LTICustomVars.COURSEGROUP_ID, courseGroupId);
-                    updates.put(LTIService.LTI_SETTINGS, content_json.toString());
+                    updates.put(LTIService.LTI_SETTINGS, content_settings);
 
                     // This uses the Dao access since 99% of the time we are launching as a student
                     // after the instructor updates the assignment, and the student is
-                    // the first to launch after the change.
+                    // the first to launch after the change.:
                     ltiService.updateContentDao(contentKey, updates);
+                    System.out.println("UPDATED");
                     log.debug("Content Item id={} updated.", contentKey);
                 }
 

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -2108,7 +2108,6 @@ public class AssignmentAction extends PagedResourceActionII {
                     // after the instructor updates the assignment, and the student is
                     // the first to launch after the change.:
                     ltiService.updateContentDao(contentKey, updates);
-                    System.out.println("UPDATED");
                     log.debug("Content Item id={} updated.", contentKey);
                 }
 

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -554,7 +554,8 @@
                                 if ( submission.endDateTime ) {
                                     var tdate = new Date(submission.endDateTime);
                                     tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#duedate").val(tdate);
+                                    $("#closedate").val(tdate);
+                                    $("#duedate").val(tdate);    // LTI treats closedate as due date since there is no real due date
                                 }
                             }
                             if ( item && item.available ) {
@@ -568,6 +569,7 @@
                                     var tdate = new Date(available.endDateTime);
                                     tdate = tdate.toLocaleString([], options).replace(',','');
                                     $("#closedate").val(tdate);
+                                    $("#duedate").val(tdate);   // LTI treats closedate as due date since there is no real due date
                                 }
                             }
                             // Handle new page

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -544,20 +544,7 @@
                             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
                             // https://stackoverflow.com/a/63160519/1994792
                             var options = {year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit'};
-                            if ( item && item.submission ) {
-                                var submission = item.submission;
-                                if ( submission.startDateTime ) {
-                                    var tdate = new Date(submission.startDateTime);
-                                    tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#opendate").val(tdate);
-                                }
-                                if ( submission.endDateTime ) {
-                                    var tdate = new Date(submission.endDateTime);
-                                    tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#closedate").val(tdate);
-                                    $("#duedate").val(tdate);    // LTI treats closedate as due date since there is no real due date
-                                }
-                            }
+
                             if ( item && item.available ) {
                                 var available = item.available;
                                 if ( available.startDateTime ) {
@@ -570,6 +557,20 @@
                                     tdate = tdate.toLocaleString([], options).replace(',','');
                                     $("#closedate").val(tdate);
                                     $("#duedate").val(tdate);   // LTI treats closedate as due date since there is no real due date
+                                }
+                            }
+							if ( item && item.submission ) { 
+                                var submission = item.submission;
+                                if ( submission.startDateTime ) {
+                                    var tdate = new Date(submission.startDateTime);
+                                    tdate = tdate.toLocaleString([], options).replace(',','');
+                                    $("#opendate").val(tdate);
+                                }
+                                if ( submission.endDateTime ) {
+                                    var tdate = new Date(submission.endDateTime);
+                                    tdate = tdate.toLocaleString([], options).replace(',','');
+                                    $("#closedate").val(tdate);
+                                    $("#duedate").val(tdate);    // LTI treats closedate as due date since there is no real due date
                                 }
                             }
                             // Handle new page

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -541,36 +541,32 @@
                                 $("#new_assignment_grade_points").val(item.lineItem.scoreMaximum);
                             }
 
-                            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
-                            // https://stackoverflow.com/a/63160519/1994792
-                            var options = {year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit'};
+                            // Use epochMillis so the sakai-date-picker can apply Sakai timezone/formatting logic;
+                            // localized date strings from toLocaleString are ambiguous and not valid iso-date values.
+                            const openDatePicker = document.getElementById("opendate");
+                            const closeDatePicker = document.getElementById("closedate");
+                            const dueDatePicker = document.getElementById("duedate");
 
                             if ( item && item.available ) {
                                 var available = item.available;
                                 if ( available.startDateTime ) {
-                                    var tdate = new Date(available.startDateTime);
-                                    tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#opendate").val(tdate);
+                                    openDatePicker.epochMillis = Date.parse(available.startDateTime);
                                 }
                                 if ( available.endDateTime ) {
-                                    var tdate = new Date(available.endDateTime);
-                                    tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#closedate").val(tdate);
-                                    $("#duedate").val(tdate);   // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
+                                    const epochMillis = Date.parse(available.endDateTime);
+                                    closeDatePicker.epochMillis = epochMillis;
+                                    dueDatePicker.epochMillis = epochMillis;   // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
                                 }
                             }
 							if ( item && item.submission ) { 
                                 var submission = item.submission;
                                 if ( submission.startDateTime ) {
-                                    var tdate = new Date(submission.startDateTime);
-                                    tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#opendate").val(tdate);
+                                    openDatePicker.epochMillis = Date.parse(submission.startDateTime);
                                 }
                                 if ( submission.endDateTime ) {
-                                    var tdate = new Date(submission.endDateTime);
-                                    tdate = tdate.toLocaleString([], options).replace(',','');
-                                    $("#closedate").val(tdate);
-                                    $("#duedate").val(tdate);    // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
+                                    const epochMillis = Date.parse(submission.endDateTime);
+                                    closeDatePicker.epochMillis = epochMillis;
+                                    dueDatePicker.epochMillis = epochMillis;    // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
                                 }
                             }
                             // Handle new page

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -549,24 +549,24 @@
 
                             if ( item && item.available ) {
                                 var available = item.available;
-                                if ( available.startDateTime ) {
+                                if ( available.startDateTime && openDatePicker ) {
                                     openDatePicker.epochMillis = Date.parse(available.startDateTime);
                                 }
                                 if ( available.endDateTime ) {
                                     const epochMillis = Date.parse(available.endDateTime);
-                                    closeDatePicker.epochMillis = epochMillis;
-                                    dueDatePicker.epochMillis = epochMillis;   // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
+                                    if ( closeDatePicker ) closeDatePicker.epochMillis = epochMillis;
+                                    if ( dueDatePicker ) dueDatePicker.epochMillis = epochMillis;   // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
                                 }
                             }
 							if ( item && item.submission ) { 
                                 var submission = item.submission;
-                                if ( submission.startDateTime ) {
+                                if ( submission.startDateTime && openDatePicker ) {
                                     openDatePicker.epochMillis = Date.parse(submission.startDateTime);
                                 }
                                 if ( submission.endDateTime ) {
                                     const epochMillis = Date.parse(submission.endDateTime);
-                                    closeDatePicker.epochMillis = epochMillis;
-                                    dueDatePicker.epochMillis = epochMillis;    // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
+                                    if ( closeDatePicker ) closeDatePicker.epochMillis = epochMillis;
+                                    if ( dueDatePicker ) dueDatePicker.epochMillis = epochMillis;    // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
                                 }
                             }
                             // Handle new page

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -556,7 +556,7 @@
                                     var tdate = new Date(available.endDateTime);
                                     tdate = tdate.toLocaleString([], options).replace(',','');
                                     $("#closedate").val(tdate);
-                                    $("#duedate").val(tdate);   // LTI treats closedate as due date since there is no real due date
+                                    $("#duedate").val(tdate);   // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
                                 }
                             }
 							if ( item && item.submission ) { 
@@ -570,7 +570,7 @@
                                     var tdate = new Date(submission.endDateTime);
                                     tdate = tdate.toLocaleString([], options).replace(',','');
                                     $("#closedate").val(tdate);
-                                    $("#duedate").val(tdate);    // LTI treats closedate as due date since there is no real due date
+                                    $("#duedate").val(tdate);    // Sakai sets both duedate and closedate from the LTI deadline since LTI has no separate soft-deadline
                                 }
                             }
                             // Handle new page

--- a/lti/docs/ASSIGNMENTS.md
+++ b/lti/docs/ASSIGNMENTS.md
@@ -1,101 +1,106 @@
+# Sakai LTI Integration in the Assignments Tool
 
-Sakai LTI Integration in the Assignments Tool
-=============================================
+The Sakai Assignments tool supports an **External Tool** / LTI assignment type. This assignment type complements the placement types that have been in Sakai for a long time:
 
-As of Sakai-21, the Sakai Assignments tool has a new feature to support an
-"External Tool" / LTI assignment type.  This assignment type compliments the existing
-placement types that have been in Sakai for a long time:
+- **Lessons** — Learning App and External Tool
+- **Rich Text Editor** placement
+- **Left navigation bar** — Site Manage / Manage External Tools
 
-* Lessons Placement - Learning App and External Tool
-* Rich Text Editor Placement
-* Left navigation bar placement - Site Manage / Manage External Tools
+The Assignments placement is a useful addition because none of these other placements fully support coordinated **open**, **due**, and **accept-until (close)** dates. LTI Advantage Deep Linking can carry availability and submission date ranges as well as maximum points. Maximum points appear in many placements, but only Assignments provides a complete date workflow aligned with how instructors expect assignments to behave.
 
-The Assignments placement is a nice feature because none of these other placements really support
-open and close times, due dates, etc.  LTI Advantage Deep Linking has very nice support that
-allows external tools to specifs open and close datea, and maximum points.  Maximum points are supported
-in many of the placements but only assignments supports any kind of date workflow.
+## Creating an LTI Assignment in Sakai
 
-Creating an LTI Assignment in Sakai
------------------------------------
+1. Install or edit an LTI tool and indicate that it supports the **Assignment** placement.
+2. Open **Assignments** and add a new assignment.
+3. Set **Submission Type** to **External Tool (LTI)**.
+4. Use **Select External Tool (LTI)** to launch the resource picker.
+5. Choose a tool and complete the selection process.
 
-It is pretty simple, install or edit an LTI tool and indicate that it supports the Assignment
-placement.  Two great tools to use are the Tsugi Trophy tool and the Tsugi LMSTest tool because you
-can exercise a lot of features.
+Some tools (for example Tsugi Trophy or LMSTest) may include a configuration step (for example “Configure the LineItem”) as part of the Deep Linking response.
 
-Go into Assignments and Add a new Assignment.  Add a new assignment and then scroll
-down to the Submission Type and change it to "External Tool (LTI)".  Then you will see
-a "Select External Tool (LTI)" button.  Pressing the button will launch a resource picker
-similar to the "Install Learning App" in Lessons.  Choose a tool, and go through the selection
-process.  If you are using something like Tsugi's Trophy just before you will be given an option
-to "Configure the LineItem" (<a href="images/assignments/01-Tsugi-LineItem.png" target="_blank">image</a>).
-LineItem is part of the DeepLink response:
+See the IMS Deep Linking specification: [LTI Deep Linking v2.0](http://www.imsglobal.org/spec/lti-dl/v2p0) — search for `lineitem`, `available`, and `submission`.
 
-See http://www.imsglobal.org/spec/lti-dl/v2p0 - search for "lineitem", "available", and "submission".
+Tools may suggest:
 
-This allows the tool to request a different scoreMaximum and available and submission date ranges.
-The Sakai Assignment tool looks for these values when you are placing an assignment.
+- `scoreMaximum`
+- available date range
+- submission date range
 
-Once you pick these values (or your tool picks these values), they are sent back to Sakai.  When
-you come back to the Sakai assignments flow, Sakai parses these values and puts them into the
-Assignments's UI in the appropriate locations.  The instructor can scroll around and change all these
-value before saving the assignment.  Sakai simply sees this as "defaults" or "suggestions" and lets
-the instructor make the final decision within Sakai.
+These values are returned to Sakai and used to **pre-populate** the Assignments UI. Sakai treats them as **defaults**; the instructor can review and change all values before saving.
 
-A tool can find out the actual values set or updated by the instruction
-using the Assignments and Grades Service or by using the following custom
-variable substitution values:
+After save, a tool can read the final values using LTI Advantage services or via substitution variables:
 
-    ResourceLink.available.startDateTime
-    ResourceLink.available.endDateTime
-    ResourceLink.submission.startDateTime
-    ResourceLink.submission.endDateTime
+```
+ResourceLink.available.startDateTime
+ResourceLink.available.endDateTime
+ResourceLink.submission.startDateTime
+ResourceLink.submission.endDateTime
+```
 
-Once you are happy with the assignment, save it.
+Once the assignment is saved, it appears in the gradebook with the correct maximum score.
 
-Once you save the assignment, you should be able to go into the gradebook and see the
-new column with the correct maximum score value.
+## LTI Date Handling in Sakai Assignments
 
-Sakai LTI Assignments and Gradebook Integration
------------------------------------------------
+LTI 1.3 defines two independent date ranges:
 
-LTI Assignments are integrated into the Sakai gradebook differently than
-other assignment types.
+- **`ResourceLink.available.*`** — when the activity is accessible
+- **`ResourceLink.submission.*`** — when submissions are accepted
 
-For non-LTI assignment submission types, when you create an Assignment and
-select "Send Grades to Gradebook" - the Assignments tool creates an externally
-managed Gradebook column that the LTI services cannot use.  The column exists somewhere
-deep inside Assignment but is not available via the grade book API that LTI Assignments
-and Grades Service uses.
+Sakai Assignments uses a three-part model:
 
-When the Assignments tool is creating a grade book column associated with an LTI
-launched assignment - the grade is created in a way that it can be used by LTI
-Services.  It also means that these LTI assignment grades can be overridden
-from within the gradebook (like most other grade book columns).
+**open date → due date → accept-until (close) date**
 
-I debated as to whether to try to implement LTI grades as externally maintained
-in the Assignments tables but it would make complying with all
-of the rules of LTI Advantage very difficult.
+LTI does not explicitly define a separate “due date” (soft deadline). In practice, many LTI tools (including Turnitin) treat **`ResourceLink.submission.endDateTime`** as the assignment due date.
 
-For example, if you have a tool that is used with two placements with one in
-assignments and in lessons, and the tool asks "show me my grade columns" using
-the LTI Advantage Assignments and Grades Services - it is supposed to see both
-the assignments columns and the lessons columns.   A pretty cool feature that
-tools will find quite useful.  This also avoids adding yet another externally
-maintained class of grades that we have to move back into the grade book at some
-point in the future.
+To keep behavior predictable and interoperable, Sakai applies this mapping when processing LTI date values:
 
-This is a fun thing to test by placing the Trophy tool in Assignments, and the
-LMSTest tool in Lessons and retrieving the AGS lineitems - you will see both
-and be able to access either line item from either placement - which is cool.
-For this to work they my be two placements of the same 
-tool (i.e. sakai.tsugicloud.org).  AGS only shows lineitems across placements
-of the same server.
+**If `ResourceLink.submission.endDateTime` is present:**
 
-Another side effect of storing LTI Assignment grades directly in the gradebook
-is that when an assignment is deleted - the grades and grade column are *not*
-deleted.   This give instructors flexibility - it allows a lot of use cases - but also
-it can lead to some "oops" moments - but at least the grades should not be lost
-unless the column is explicitly deleted in the grade book.
+- due date = `submission.endDateTime`
+- close (accept-until) date = `submission.endDateTime`
 
+**Else if `ResourceLink.available.endDateTime` is present:**
 
+- due date = `available.endDateTime`
+- close (accept-until) date = `available.endDateTime`
 
+### Design rules
+
+| Rule | Meaning |
+|------|--------|
+| **`submission.endDateTime` is authoritative** | When present, it defines the assignment deadline and is used for **both** due date and accept-until date. |
+| **`available.endDateTime` is fallback only** | Used only when `submission.endDateTime` is not provided; it must **never** override `submission.endDateTime`. |
+| **Due date and close date may be identical** | LTI does not distinguish a soft due date from a hard cutoff; Sakai may collapse these to one value. |
+
+### Rationale
+
+- Many tools interpret `submission.endDateTime` as the due date.
+- LTI does not standardize a late submission window.
+- Letting `available.endDateTime` override `submission.endDateTime` would produce incorrect deadlines for those tools.
+- A single authoritative rule reduces long-term confusion and support load.
+
+### Practical effect
+
+- `submission.endDateTime` → Sakai **due** date (authoritative)
+- `available.endDateTime` → fallback **due** / **close** date
+- `available.startDateTime` → Sakai **open** date
+
+This favors consistency with real-world LTI tool behavior over a strict, spec-only reading that would disagree with common implementations.
+
+## Sakai LTI Assignments and Gradebook Integration
+
+LTI assignments integrate with the Sakai gradebook **differently** from other assignment types.
+
+**Non-LTI assignments:** Choosing **Send Grades to Gradebook** creates an externally managed column that is **not** exposed through the LTI grade APIs in the same way.
+
+**LTI assignments:**
+
+- Gradebook columns are created in a form compatible with **LTI Advantage** (Assignments and Grades Service, line items).
+- Grades can be updated via LTI.
+- Grades can still be overridden directly in the gradebook.
+
+That lets tools retrieve and manage line items in a consistent way.
+
+**Example:** A tool placed in both Assignments and Lessons can retrieve line items for both contexts; Assignments and Grades Service can return the relevant columns for the tool. This avoids introducing another “externally managed only” grade type that would be hard to reconcile with LTI Advantage expectations. Which line items appear together still depends on tool registration and deployment; in common test setups (for example Trophy in Assignments and LMSTest in Lessons on the same Tsugi host), both placements target the same tool server so AGS can list related line items as expected.
+
+**Side effect:** Deleting an assignment **does not** delete the gradebook column. That preserves historical grades but may require manual column cleanup when an assignment is removed on purpose.

--- a/lti/docs/ASSIGNMENTS.md
+++ b/lti/docs/ASSIGNMENTS.md
@@ -30,7 +30,7 @@ These values are returned to Sakai and used to **pre-populate** the Assignments 
 
 After save, a tool can read the final values using LTI Advantage services or via substitution variables:
 
-```
+```text
 ResourceLink.available.startDateTime
 ResourceLink.available.endDateTime
 ResourceLink.submission.startDateTime
@@ -70,6 +70,7 @@ To keep behavior predictable and interoperable, Sakai applies this mapping when 
 |------|--------|
 | **`submission.endDateTime` is authoritative** | When present, it defines the assignment deadline and is used for **both** due date and accept-until date. |
 | **`available.endDateTime` is fallback only** | Used only when `submission.endDateTime` is not provided; it must **never** override `submission.endDateTime`. |
+| **`submission.startDateTime` overrides `available.startDateTime` for open** | When both are present, the assignment **open** date follows `ResourceLink.submission.startDateTime`; `ResourceLink.available.startDateTime` does not win for open in that case (same precedence idea as end dates). |
 | **Due date and close date may be identical** | LTI does not distinguish a soft due date from a hard cutoff; Sakai may collapse these to one value. |
 
 ### Rationale
@@ -83,7 +84,10 @@ To keep behavior predictable and interoperable, Sakai applies this mapping when 
 
 - `submission.endDateTime` → Sakai **due** date (authoritative)
 - `available.endDateTime` → fallback **due** / **close** date
-- `available.startDateTime` → Sakai **open** date
+- `available.startDateTime` → Sakai **open** date (fallback when `submission.startDateTime` is absent)
+- `submission.startDateTime` → Sakai **open** date when present; **`submission.startDateTime` overrides `available.startDateTime`** when both are present
+
+**Where this is applied in the UI:** In `assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm`, the External Tool deep-link callback `returnContentItem` assigns both `ResourceLink.available.startDateTime` and `ResourceLink.submission.startDateTime` to the assignment open-date input **`#opendate`** in that order, so the submission value wins if both are returned.
 
 This favors consistency with real-world LTI tool behavior over a strict, spec-only reading that would disagree with common implementations.
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -197,6 +197,11 @@ public class SakaiLTIUtil {
 	public static final String MESSAGE_TYPE_PARAMETER_PRIVACY = "privacy";
 	public static final String MESSAGE_TYPE_PARAMETER_CONTENT_REVIEW = "content_review";
 
+	// Sakai custom parameters
+	public static final String SAKAI_LTI_SUBSTITUTION_AVAILABLE_START_DATETIME = "Sakai.assignment.availableStartDateTime";
+	public static final String SAKAI_LTI_SUBSTITUTION_DUE_DATE = "Sakai.assignment.dueDate";
+	public static final String SAKAI_LTI_SUBSTITUTION_ACCEPT_UNTIL = "Sakai.assignment.acceptUntil";
+
 	// Default Outbound Role Mapping - Sakai role to a comma-separated list of LTI Roles
 	// https://www.imsglobal.org/spec/lti/v1p3/#role-vocabularies
 	public static final String LTI_OUTBOUND_ROLE_MAP = "lti.outbound.role.map";
@@ -1190,6 +1195,9 @@ public class SakaiLTIUtil {
 				DeepLinkResponse.RESOURCELINK_AVAILABLE_ENDDATETIME,
 				DeepLinkResponse.RESOURCELINK_SUBMISSION_STARTDATETIME,
 				DeepLinkResponse.RESOURCELINK_SUBMISSION_ENDDATETIME,
+				SAKAI_LTI_SUBSTITUTION_AVAILABLE_START_DATETIME,
+				SAKAI_LTI_SUBSTITUTION_ACCEPT_UNTIL,
+				SAKAI_LTI_SUBSTITUTION_DUE_DATE,
 				LTICustomVars.COURSEGROUP_ID
 			};
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -494,9 +494,13 @@ public class LineItemUtil {
 			Date endDate = LTIUtil.parseIMS8601(lineItem.endDateTime);
 			if (endDate != null) {
 				Instant endInstant = endDate.toInstant();
+				// LTI AGS LineItem has only one endDateTime. In practice tools treat it as
+				// the assignment deadline, so Sakai maps it to both dueDate and closeDate.
 				asn.setDueDate(endInstant);
+				asn.setCloseDate(endInstant);   // It is best for coordinated UIs for these to be locked since LTI 1.3 has no due date
 			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep-link payloads now include explicit scheduling fields (available start, due date, accept‑until) and matching post-launch substitutions; these values pre-populate the assignment editor using native date-picker timestamps. Submission dates now overwrite available dates when both are provided.
  * LTI endDateTime now sets both assignment due and close times.

* **Bug Fixes**
  * Start datetime falls back to open date when visible date is blank.
  * Settings are rewritten only when the full generated settings differ from stored settings.
  * Invalid accept‑until values are detected and logged.

* **Documentation**
  * Assignments docs rewritten with step-by-step deep-link guidance and a new LTI date-handling section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->