### PR TITLE
SAK-52514 SCORM Xerte file not passing correct values to the results page and nothing to the Gradebook in Firefox

### DIFF
--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormLaunchServiceImpl.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormLaunchServiceImpl.java
@@ -278,13 +278,13 @@ public class ScormLaunchServiceImpl implements ScormLaunchService
 
         if (StringUtils.isNotBlank(hintScore))
         {
-            log.debug("applyScoreHints: score={} completion={} success={}", hintScore, hintCompletion, hintSuccess);
             scormApplicationService.setValue("cmi.score.scaled", hintScore, sessionBean, scoBean);
         }
 
-        if ("completed".equals(hintCompletion))
+        // "passed" and "failed" are both terminal success_status values (quiz was submitted); "unknown" means mid-session
+        if ("completed".equals(hintCompletion) || "passed".equals(hintSuccess) || "failed".equals(hintSuccess))
         {
-            scormApplicationService.setValue("cmi.completion_status", hintCompletion, sessionBean, scoBean);
+            scormApplicationService.setValue("cmi.completion_status", "completed", sessionBean, scoBean);
         }
 
         if ("passed".equals(hintSuccess) || "failed".equals(hintSuccess))

--- a/scormplayer/scorm-tool/src/webapp/scripts/scorm-rest-launcher.js
+++ b/scormplayer/scorm-tool/src/webapp/scripts/scorm-rest-launcher.js
@@ -656,6 +656,20 @@
         adjustFrameHeight();
         window.addEventListener('resize', adjustFrameHeight, { passive: true });
 
+        // Firefox suppresses beforeunload on non-localhost popup close, so invoke the SCO's
+        // unload handler explicitly to ensure score/completion are submitted before the window goes.
+        window.addEventListener('pagehide', function(event) {
+            if (event.persisted) return;
+            if (state.sessionId && state.activeScoId) {
+                const iframeWin = frame?.contentWindow;
+                try {
+                    if (typeof iframeWin?.finishTracking === 'function') iframeWin.finishTracking();
+                    else if (typeof iframeWin?.onbeforeunload === 'function') iframeWin.onbeforeunload();
+                } catch (_) {} // SCO may throw on pagehide — window is closing anyway, ignore
+            }
+            if (window.opener && !window.opener.closed) window.opener.location.reload();
+        });
+
         launchers.push({ root, state, adjustFrameHeight });
     }
 
@@ -671,12 +685,4 @@
         bootstrap,
         active: launchers,
     };
-
-    // Refresh parent window when this popup closes (handles both normal exit and force-close)
-    // Using pagehide event with persisted check to avoid triggering on bfcache navigations
-    window.addEventListener('pagehide', function(event) {
-        if (!event.persisted && window.opener && !window.opener.closed) {
-            window.opener.location.reload();
-        }
-    });
 })();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Popup closes now ignore bfcache restores and explicitly trigger content unload/completion before refreshing the parent window to ensure proper session tracking.
  * Completion logic now treats successful or failed outcome hints as completed so additional success scenarios are correctly recognized.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14569)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->