### PR TITLE
SAK-52359 LTI Convert most calls to LTIService to return and use beans instead of maps

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -91,6 +91,8 @@ import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.tsugi.lti.LTIUtil;
 import org.sakaiproject.user.api.UserNotDefinedException;
@@ -708,9 +710,9 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                 Integer contentKey = assignment.getContentId();
                 if (StringUtils.isNotBlank(submitterId) && contentKey != null) {
                     String siteId = assignment.getContext();
-                    Map<String, Object> content = ltiService.getContent(contentKey.longValue(), siteId);
+                    LtiContentBean content = ltiService.getContentAsBean(contentKey.longValue(), siteId);
                     if (content != null) {
-                        String contentItem = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_CONTENTITEM));
+                        String contentItem = StringUtils.trimToEmpty(content.getContentitem());
                         boolean submissionReviewAvailable = contentItem.indexOf("\"submissionReview\"") > 0;
                         
                         String ltiSubmissionLaunch = "/access/lti/site/" + siteId + "/content:" + contentKey;
@@ -1102,12 +1104,12 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
             // Default assignment-wide launch to tool if there is not a SubmissionReview launch in a submission
             simpleAssignment.ltiGradableLaunch = "/access/lti/site/" + siteId + "/content:" + contentKey;
 
-            Map<String, Object> content = ltiService.getContent(contentKey.longValue(), site.getId());
+            LtiContentBean content = ltiService.getContentAsBean(contentKey.longValue(), site.getId());
             if (content != null) {
-                Long toolKey = LTIUtil.toLongNull(content.get(LTIService.LTI_TOOL_ID));
-                Map<String, Object> tool = (toolKey != null) ? ltiService.getTool(toolKey, site.getId()) : null;
+                Long toolKey = content.getToolId();
+                LtiToolBean tool = (toolKey != null) ? ltiService.getToolAsBean(toolKey, site.getId()) : null;
                 simpleAssignment.ltiFrameHeight = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
-                String contentItem = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_CONTENTITEM));
+                String contentItem = StringUtils.trimToEmpty(content.getContentitem());
 
                 for (Map<String, Object> submission : submissionMaps) {
                     if (!submission.containsKey("userSubmission")) continue;

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -227,6 +227,8 @@ import org.sakaiproject.util.comparator.AlphaNumericComparator;
 import org.sakaiproject.util.comparator.SakaiCollators;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -2003,7 +2005,7 @@ public class AssignmentAction extends PagedResourceActionII {
             try {
                 Long contentKey = assignment.getContentId().longValue();
                 Site site = siteService.getSite((String) state.getAttribute(STATE_CONTEXT_STRING));
-                Map<String, Object> content = ltiService.getContent(contentKey, site.getId());
+                LtiContentBean content = ltiService.getContentAsBean(contentKey, site.getId());
                 String content_launch = ltiService.getContentLaunch(content);
                 context.put("value_ContentLaunchURL", content_launch);
                 context.put("placement", "assignment_launch_"+contentKey);
@@ -2017,10 +2019,10 @@ public class AssignmentAction extends PagedResourceActionII {
                 } catch(PermissionException e) {
                     courseGroupId = null;
                 }
-                Long toolKey = LTIUtil.toLongNull(content.get(LTIService.LTI_TOOL_ID));
-                Map<String, Object> tool = null;
+                LtiToolBean tool = null;
+                Long toolKey = content.getToolId();
                 if (toolKey != null) {
-                    tool = ltiService.getTool(toolKey, site.getId());
+                    tool = ltiService.getToolAsBean(toolKey, site.getId());
                 }
 
                 // Ignore the Content Item - use the value in the assignment if tool allows
@@ -2028,7 +2030,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 context.put("height",SakaiLTIUtil.getFrameHeight(tool, content, "1200px"));
                 context.put("browser-feature-allow", serverConfigurationService.getBrowserFeatureAllowString());
 
-                int protect = LTIUtil.toInt(content.get(LTIService.LTI_PROTECT));
+                int protect = Boolean.TRUE.equals(content.getProtect()) ? 1 : 0;
                 String assignmentTitle = StringUtils.trimToEmpty(assignment.getTitle());
                 String assignmentDesc = StringUtils.trimToEmpty(assignment.getInstructions());
 
@@ -2102,13 +2104,13 @@ public class AssignmentAction extends PagedResourceActionII {
                 content_json.put(LTICustomVars.COURSEGROUP_ID, courseGroupId);
                 String content_settings = content_json.toString();
 
-                String old_content_settings = (String) content.get(LTIService.LTI_SETTINGS);
+                String old_content_settings = StringUtils.trimToEmpty(content.getSettings());
 
                 // Copy title, description, and dates from Assignment to content if mis-match
-                String contentTitle = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_TITLE));
-                String contentDesc = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_DESCRIPTION));
+                String contentTitle = StringUtils.trimToEmpty(content.getTitle());
+                String contentDesc = StringUtils.trimToEmpty(content.getDescription());
 
-                String placement_secret = StringUtils.trimToNull((String) content.get(LTIService.LTI_PLACEMENTSECRET));
+                String placement_secret = StringUtils.trimToNull(content.getPlacementsecret());
 
                 if ( protect < 1 || !assignmentTitle.equals(contentTitle) || !assignmentDesc.equals(contentDesc) ||
                         ! content_settings.equals(old_content_settings) ||
@@ -2121,7 +2123,7 @@ public class AssignmentAction extends PagedResourceActionII {
                         placement_secret = UUID.randomUUID().toString();
                         updates.put(LTIService.LTI_PLACEMENTSECRET, placement_secret);
                         // Need to update for the protection key computation to work
-                        content.put(LTIService.LTI_PLACEMENTSECRET, placement_secret);
+                        content.setPlacementsecret(placement_secret);
                     }
 
                     updates.put(LTIService.LTI_SETTINGS, content_settings);
@@ -3208,13 +3210,13 @@ public class AssignmentAction extends PagedResourceActionII {
     public boolean isContentToolIdValid(Integer contentKey, Site site) {
         if ( contentKey == null ) return true;
         Long contentLong = contentKey.longValue();
-        Map<String, Object> content = ltiService.getContent(contentLong, site.getId());
+        LtiContentBean content = ltiService.getContentAsBean(contentLong, site.getId());
         if ( content == null ) return false;
 
-        Long toolKey = LTIUtil.toLongNull(content.get(LTIService.LTI_TOOL_ID));
+        Long toolKey = content.getToolId();
         if ( toolKey == null ) return false;
 
-        Map<String, Object> tool = ltiService.getTool(toolKey, site.getId());
+        LtiToolBean tool = ltiService.getToolAsBean(toolKey, site.getId());
         if ( tool == null ) return false;
 
         return true;
@@ -5657,7 +5659,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 log.warn("contentId not set {} ", assignment);
                 return false;
             }
-            Map<String, Object> content = ltiService.getContent(contentKey, site.getId());
+            LtiContentBean content = ltiService.getContentAsBean(contentKey, site.getId());
             if ( content == null ) {
                 log.warn("contentId not loaded {} ", contentKey);
                 return false;
@@ -5666,15 +5668,14 @@ public class AssignmentAction extends PagedResourceActionII {
             String content_launch = ltiService.getContentLaunch(content);
             context.put("value_ContentLaunchURL", content_launch);
 
-            Long toolKey = LTIUtil.toLongNull(content.get(LTIService.LTI_TOOL_ID));
+            Long toolKey = content.getToolId();
             if (toolKey != null) {
-                Map<String, Object> tool = ltiService.getTool(toolKey, site.getId());
+                LtiToolBean tool = ltiService.getToolAsBean(toolKey, site.getId());
                 if ( tool == null ) {
                     log.warn("tool not loaded {} ", toolKey);
                     return false;
                 }
-                String toolTitle = (String) tool.get(LTIService.LTI_TITLE);
-                context.put("value_ContentTitle", toolTitle);
+                context.put("value_ContentTitle", tool.getTitle());
             }
             return true;
         } catch(org.sakaiproject.exception.IdUnusedException e ) {
@@ -10723,19 +10724,25 @@ public class AssignmentAction extends PagedResourceActionII {
                    try {
                         Site site = siteService.getSite((String) state.getAttribute(STATE_CONTEXT_STRING));
                         Long contentKey = a.getContentId().longValue();
-                        Map<String, Object> content = ltiService.getContent(contentKey, site.getId());
-                        Long toolKey = new Long(content.get(LTIService.LTI_TOOL_ID).toString());
-                        if (toolKey != null) {
-                            Map<String, Object> tool = ltiService.getTool(toolKey, site.getId());
-                            if ( tool == null ) {
-                                state.setAttribute(NEW_ASSIGNMENT_CONTENT_TITLE, null);
-                                state.setAttribute(NEW_ASSIGNMENT_CONTENT_DELETED, Boolean.TRUE);
-                                addAlert(state, rb.getString("contentitem.tool.deleted"));
-                            } else {
-                                String toolTitle = (String) tool.get(LTIService.LTI_TITLE);
-                                state.setAttribute(NEW_ASSIGNMENT_CONTENT_TITLE, toolTitle);
-                                Long toolNewpage = LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE));
-                                state.setAttribute(NEW_ASSIGNMENT_CONTENT_TOOL_NEWPAGE, toolNewpage);
+                        LtiContentBean content = ltiService.getContentAsBean(contentKey, site.getId());
+                        if (content == null) {
+                            state.setAttribute(NEW_ASSIGNMENT_CONTENT_TITLE, null);
+                            state.setAttribute(NEW_ASSIGNMENT_CONTENT_DELETED, Boolean.TRUE);
+                            addAlert(state, rb.getString("contentitem.tool.deleted"));
+                        } else {
+                            Long toolKey = content.getToolId();
+                            if (toolKey != null) {
+                                LtiToolBean tool = ltiService.getToolAsBean(toolKey, site.getId());
+                                if ( tool == null ) {
+                                    state.setAttribute(NEW_ASSIGNMENT_CONTENT_TITLE, null);
+                                    state.setAttribute(NEW_ASSIGNMENT_CONTENT_DELETED, Boolean.TRUE);
+                                    addAlert(state, rb.getString("contentitem.tool.deleted"));
+                                } else {
+                                    state.setAttribute(NEW_ASSIGNMENT_CONTENT_TITLE, tool.getTitle());
+                                    Integer toolNewpage = tool.getNewpage();
+                                    state.setAttribute(NEW_ASSIGNMENT_CONTENT_TOOL_NEWPAGE,
+                                            toolNewpage != null ? Long.valueOf(toolNewpage.longValue()) : null);
+                                }
                             }
                         }
                     } catch(org.sakaiproject.exception.IdUnusedException e ) {

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -999,34 +999,29 @@ public interface LTIService extends LTISubstitutionsFilter {
         if (trimmedSite.isEmpty()) {
             return null;
         }
-        List<Map<String, Object>> rows = getToolSitesByToolId(String.valueOf(toolKey), trimmedSite);
-        if (rows == null) {
+        List<LtiToolSiteBean> rows = getToolSitesByToolIdAsBeans(String.valueOf(toolKey), trimmedSite);
+        if (rows == null || rows.isEmpty()) {
             return null;
         }
-        Map<String, Object> bestRow = null;
+        LtiToolSiteBean bestRow = null;
         java.util.Date bestUpdated = null;
-        for (Map<String, Object> row : rows) {
-            Object siteObj = row.get(LTI_SITE_ID);
-            if (siteObj == null) {
+        for (LtiToolSiteBean row : rows) {
+            if (row.siteId == null) {
                 continue;
             }
-            if (!trimmedSite.equals(siteObj.toString().trim())) {
+            if (!trimmedSite.equals(row.siteId.trim())) {
                 continue;
             }
-            java.util.Date updated = toolSiteRowUpdatedAt(row.get(LTI_UPDATED_AT));
+            java.util.Date updated = row.updatedAt;
             if (bestRow == null || isNewerToolSiteRow(updated, bestUpdated)) {
                 bestRow = row;
                 bestUpdated = updated;
             }
         }
-        if (bestRow == null) {
+        if (bestRow == null || bestRow.deploymentGroup == null) {
             return null;
         }
-        Object dg = bestRow.get(LTI_DEPLOYMENT_GROUP);
-        if (dg == null) {
-            return null;
-        }
-        String s = dg.toString().trim();
+        String s = bestRow.deploymentGroup.trim();
         return s.isEmpty() ? null : s;
     }
 

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -21,10 +21,17 @@
 
 package org.sakaiproject.lti.api;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiMembershipsJobBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
+import org.sakaiproject.lti.beans.LtiToolSiteBean;
+import org.sakaiproject.site.api.Site;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -558,6 +565,11 @@ public interface LTIService extends LTISubstitutionsFilter {
 
     void filterContent(Map<String, Object> content, Map<String, Object> tool);
 
+    /**
+     * Bean overload: filter content using tool/content beans (delegates to Map version).
+     * Obtains content map, filters in place, then persists filtered values back to the bean.
+     */
+    void filterContent(LtiContentBean content, LtiToolBean tool);
 
     // These can be static and moved to the tool, or at least split off into a Foorm UI
 
@@ -582,6 +594,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param filter The filter to remove.
      */
     void removePropertiesFilter(LTISubstitutionsFilter filter);
+
+    /**
+     * Bean overload: filter custom substitutions using tool bean (delegates to Map version).
+     */
+    void filterCustomSubstitutions(Properties properties, LtiToolBean tool, Site site);
 
     List<Map<String, Object>> getToolSitesByToolId(String toolId, String siteId);
 
@@ -709,20 +726,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiToolBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiToolBean getToolAsBean(Long key, String siteId) {
+    default LtiToolBean getToolAsBean(Long key, String siteId) {
         Map<String, Object> toolMap = getTool(key, siteId);
-        return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
-    }
-
-    /**
-     * Get a single LTI tool as a Bean (alias for getToolAsBean)
-     * @param key The tool ID
-     * @param siteId The site ID
-     * @return LtiToolBean or null if not found
-     */
-    default org.sakaiproject.lti.beans.LtiToolBean getToolBean(Long key, String siteId) {
-        Map<String, Object> toolMap = getTool(key, siteId);
-        return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+        return toolMap != null ? LtiToolBean.of(toolMap) : null;
     }
 
     /**
@@ -732,9 +738,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param isAdminRole Whether to bypass security checks
      * @return LtiToolBean instance or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiToolBean getToolDaoAsBean(Long key, String siteId, boolean isAdminRole) {
+    default LtiToolBean getToolDaoAsBean(Long key, String siteId, boolean isAdminRole) {
         Map<String, Object> toolMap = getToolDao(key, siteId, isAdminRole);
-        return toolMap != null ? org.sakaiproject.lti.beans.LtiToolBean.of(toolMap) : null;
+        return toolMap != null ? LtiToolBean.of(toolMap) : null;
     }
 
     // ------------------------------------------------------------------------------------
@@ -752,29 +758,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId) {
+    default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
-        return toolMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolBean::of)
-                .collect(java.util.stream.Collectors.toList());
-    }
-
-    /**
-     * Get a list of LTI tools as Beans (alias for getToolsAsBeans)
-     * @param search Search criteria
-     * @param order Sort order
-     * @param first First result index
-     * @param last Last result index
-     * @param siteId The site ID
-     * @return List of LtiToolBean objects
-     */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId) {
-        List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+        if (toolMaps == null) {
+            return Collections.emptyList();
         }
-        return toolBeans;
+        return toolMaps.stream()
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -787,30 +778,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param includeStealthed Whether to include stealthed tools
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
+    default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
-        return toolMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolBean::of)
-                .collect(java.util.stream.Collectors.toList());
-    }
-
-    /**
-     * Get a list of LTI tools as Beans with stealthed option (alias for getToolsAsBeans)
-     * @param search Search criteria
-     * @param order Sort order
-     * @param first First result index
-     * @param last Last result index
-     * @param siteId The site ID
-     * @param includeStealthed Whether to include stealthed tools
-     * @return List of LtiToolBean objects
-     */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed) {
-        List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+        if (toolMaps == null) {
+            return Collections.emptyList();
         }
-        return toolBeans;
+        return toolMaps.stream()
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -824,13 +799,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param includeLaunchable Whether to include only launchable tools
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
+    default List<LtiToolBean> getToolsAsBeans(String search, String order, int first, int last, String siteId, boolean includeStealthed, boolean includeLaunchable) {
         List<Map<String, Object>> toolMaps = getTools(search, order, first, last, siteId, includeStealthed, includeLaunchable);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+        if (toolMaps == null) {
+            return Collections.emptyList();
         }
-        return toolBeans;
+        return toolMaps.stream()
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -838,11 +814,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsLaunchAsBeans(String siteId) {
+    default List<LtiToolBean> getToolsLaunchAsBeans(String siteId) {
         List<Map<String, Object>> toolMaps = getToolsLaunch(siteId);
+        if (toolMaps == null) {
+            return Collections.emptyList();
+        }
         return toolMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -850,13 +829,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolBean> getToolsImportItemBeans(String siteId) {
+    default List<LtiToolBean> getToolsImportItemAsBeans(String siteId) {
         List<Map<String, Object>> toolMaps = getToolsImportItem(siteId);
-        List<org.sakaiproject.lti.beans.LtiToolBean> toolBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> toolMap : toolMaps) {
-            toolBeans.add(org.sakaiproject.lti.beans.LtiToolBean.of(toolMap));
+        if (toolMaps == null) {
+            return Collections.emptyList();
         }
-        return toolBeans;
+        return toolMaps.stream()
+                .map(LtiToolBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -871,20 +851,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiContentBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiContentBean getContentAsBean(Long key, String siteId) {
+    default LtiContentBean getContentAsBean(Long key, String siteId) {
         Map<String, Object> contentMap = getContent(key, siteId);
-        return contentMap != null ? org.sakaiproject.lti.beans.LtiContentBean.of(contentMap) : null;
-    }
-
-    /**
-     * Get a single LTI content item as a Bean (alias for getContentAsBean)
-     * @param key The content ID
-     * @param siteId The site ID
-     * @return LtiContentBean or null if not found
-     */
-    default org.sakaiproject.lti.beans.LtiContentBean getContentBean(Long key, String siteId) {
-        Map<String, Object> contentMap = getContent(key, siteId);
-        return contentMap != null ? org.sakaiproject.lti.beans.LtiContentBean.of(contentMap) : null;
+        return contentMap != null ? LtiContentBean.of(contentMap) : null;
     }
 
     // ------------------------------------------------------------------------------------
@@ -902,15 +871,18 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiContentBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiContentBean> getContentsAsBeans(String search, String order, int first, int last, String siteId) {
+    default List<LtiContentBean> getContentsAsBeans(String search, String order, int first, int last, String siteId) {
         List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
+        if (contentMaps == null) {
+            return Collections.emptyList();
+        }
         return contentMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiContentBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiContentBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
-     * Get a list of LTI content items as Beans (alias for getContentsAsBeans)
+     * Get a list of LTI content items as Beans (DAO access, bypasses security).
      * @param search Search criteria
      * @param order Sort order
      * @param first First result index
@@ -918,13 +890,34 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiContentBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiContentBean> getContentBeans(String search, String order, int first, int last, String siteId) {
-        List<Map<String, Object>> contentMaps = getContents(search, order, first, last, siteId);
-        List<org.sakaiproject.lti.beans.LtiContentBean> contentBeans = new java.util.ArrayList<>();
-        for (Map<String, Object> contentMap : contentMaps) {
-            contentBeans.add(org.sakaiproject.lti.beans.LtiContentBean.of(contentMap));
+    default List<LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId) {
+        List<Map<String, Object>> contentMaps = getContentsDao(search, order, first, last, siteId);
+        if (contentMaps == null) {
+            return Collections.emptyList();
         }
-        return contentBeans;
+        return contentMaps.stream()
+                .map(LtiContentBean::of)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get a list of LTI content items as Beans (DAO access, bypasses security).
+     * @param search Search criteria
+     * @param order Sort order
+     * @param first First result index
+     * @param last Last result index
+     * @param siteId The site ID
+     * @param isAdminRole Whether to bypass security checks
+     * @return List of LtiContentBean objects
+     */
+    default List<LtiContentBean> getContentsDaoAsBeans(String search, String order, int first, int last, String siteId, boolean isAdminRole) {
+        List<Map<String, Object>> contentMaps = getContentsDao(search, order, first, last, siteId, isAdminRole);
+        if (contentMaps == null) {
+            return Collections.emptyList();
+        }
+        return contentMaps.stream()
+                .map(LtiContentBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -939,9 +932,9 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiToolSiteBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiToolSiteBean getToolSiteAsBean(Long key, String siteId) {
+    default LtiToolSiteBean getToolSiteAsBean(Long key, String siteId) {
         Map<String, Object> toolSiteMap = getToolSiteById(key, siteId);
-        return toolSiteMap != null ? org.sakaiproject.lti.beans.LtiToolSiteBean.of(toolSiteMap) : null;
+        return toolSiteMap != null ? LtiToolSiteBean.of(toolSiteMap) : null;
     }
 
     /**
@@ -950,11 +943,14 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return List of LtiToolSiteBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiToolSiteBean> getToolSitesByToolIdAsBeans(String toolId, String siteId) {
+    default List<LtiToolSiteBean> getToolSitesByToolIdAsBeans(String toolId, String siteId) {
         List<Map<String, Object>> toolSiteMaps = getToolSitesByToolId(toolId, siteId);
+        if (toolSiteMaps == null) {
+            return Collections.emptyList();
+        }
         return toolSiteMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiToolSiteBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiToolSiteBean::of)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -1045,20 +1041,23 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return LtiMembershipsJobBean or null if not found
      */
-    default org.sakaiproject.lti.beans.LtiMembershipsJobBean getMembershipsJobAsBean(String siteId) {
+    default LtiMembershipsJobBean getMembershipsJobAsBean(String siteId) {
         Map<String, Object> jobMap = getMembershipsJob(siteId);
-        return jobMap != null ? org.sakaiproject.lti.beans.LtiMembershipsJobBean.of(jobMap) : null;
+        return jobMap != null ? LtiMembershipsJobBean.of(jobMap) : null;
     }
 
     /**
      * Get all LTI memberships jobs as Beans
      * @return List of LtiMembershipsJobBean objects
      */
-    default List<org.sakaiproject.lti.beans.LtiMembershipsJobBean> getMembershipsJobsAsBeans() {
+    default List<LtiMembershipsJobBean> getMembershipsJobsAsBeans() {
         List<Map<String, Object>> jobMaps = getMembershipsJobs();
+        if (jobMaps == null) {
+            return Collections.emptyList();
+        }
         return jobMaps.stream()
-                .map(org.sakaiproject.lti.beans.LtiMembershipsJobBean::of)
-                .collect(java.util.stream.Collectors.toList());
+                .map(LtiMembershipsJobBean::of)
+                .collect(Collectors.toList());
     }
 
     // ------------------------------------------------------------------------------------
@@ -1073,8 +1072,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The ID of the inserted tool
      */
-    default Object insertTool(org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
-        return insertTool(toolBean != null ? toolBean.asMap() : null, siteId);
+    default Object insertTool(LtiToolBean toolBean, String siteId) {
+        if (toolBean == null) {
+            throw new IllegalArgumentException("toolBean must not be null");
+        }
+        return insertTool(toolBean.asMap(), siteId);
     }
 
     /**
@@ -1083,8 +1085,11 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The ID of the inserted content
      */
-    default Object insertContent(org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
-        return insertContent(contentBean != null ? contentBean.asMap() : null, siteId);
+    default Object insertContent(LtiContentBean contentBean, String siteId) {
+        if (contentBean == null) {
+            throw new IllegalArgumentException("contentBean must not be null");
+        }
+        return insertContent(contentBean.asMap(), siteId);
     }
 
     /**
@@ -1094,7 +1099,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The result of the update operation
      */
-    default Object updateTool(Long key, org.sakaiproject.lti.beans.LtiToolBean toolBean, String siteId) {
+    default Object updateTool(Long key, LtiToolBean toolBean, String siteId) {
         return updateTool(key, toolBean != null ? toolBean.asMap() : null, siteId);
     }
 
@@ -1105,7 +1110,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId the site id
      * @return the result
      */
-    default Object updateToolDao(Long key, org.sakaiproject.lti.beans.LtiToolBean tool, String siteId) {
+    default Object updateToolDao(Long key, LtiToolBean tool, String siteId) {
         return updateToolDao(key, tool != null ? tool.asMap() : null, siteId);
     }
 
@@ -1116,7 +1121,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param siteId The site ID
      * @return The result of the update operation
      */
-    default Object updateContent(Long key, org.sakaiproject.lti.beans.LtiContentBean contentBean, String siteId) {
+    default Object updateContent(Long key, LtiContentBean contentBean, String siteId) {
         return updateContent(key, contentBean != null ? contentBean.asMap() : null, siteId);
     }
 
@@ -1130,7 +1135,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param contentBean The content data as Bean
      * @return The launch URL
      */
-    default String getContentLaunch(org.sakaiproject.lti.beans.LtiContentBean contentBean) {
+    default String getContentLaunch(LtiContentBean contentBean) {
         return getContentLaunch(contentBean != null ? contentBean.asMap() : null);
     }
 
@@ -1147,7 +1152,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String fieldinfo) {
+    default String formOutput(LtiToolBean toolBean, String fieldinfo) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formOutput(toolMap, fieldinfo);
     }
@@ -1158,7 +1163,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String[] formDefinition) {
+    default String formOutput(LtiToolBean toolBean, String[] formDefinition) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formOutput(toolMap, formDefinition);
     }
@@ -1169,7 +1174,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String fieldinfo) {
+    default String formOutput(LtiContentBean contentBean, String fieldinfo) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formOutput(contentMap, fieldinfo);
     }
@@ -1180,7 +1185,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String[] formDefinition) {
+    default String formOutput(LtiContentBean contentBean, String[] formDefinition) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formOutput(contentMap, formDefinition);
     }
@@ -1191,7 +1196,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String fieldinfo) {
+    default String formOutput(LtiToolSiteBean toolSiteBean, String fieldinfo) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formOutput(toolSiteMap, fieldinfo);
     }
@@ -1202,7 +1207,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted output
      */
-    default String formOutput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String[] formDefinition) {
+    default String formOutput(LtiToolSiteBean toolSiteBean, String[] formDefinition) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formOutput(toolSiteMap, formDefinition);
     }
@@ -1220,7 +1225,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String fieldinfo) {
+    default String formInput(LtiToolBean toolBean, String fieldinfo) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formInput(toolMap, fieldinfo);
     }
@@ -1231,7 +1236,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolBean toolBean, String[] formDefinition) {
+    default String formInput(LtiToolBean toolBean, String[] formDefinition) {
         Map<String, Object> toolMap = (toolBean != null) ? toolBean.asMap() : null;
         return formInput(toolMap, formDefinition);
     }
@@ -1242,7 +1247,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String fieldinfo) {
+    default String formInput(LtiContentBean contentBean, String fieldinfo) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formInput(contentMap, fieldinfo);
     }
@@ -1253,7 +1258,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiContentBean contentBean, String[] formDefinition) {
+    default String formInput(LtiContentBean contentBean, String[] formDefinition) {
         Map<String, Object> contentMap = (contentBean != null) ? contentBean.asMap() : null;
         return formInput(contentMap, formDefinition);
     }
@@ -1264,7 +1269,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param fieldinfo The field information
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String fieldinfo) {
+    default String formInput(LtiToolSiteBean toolSiteBean, String fieldinfo) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formInput(toolSiteMap, fieldinfo);
     }
@@ -1275,7 +1280,7 @@ public interface LTIService extends LTISubstitutionsFilter {
      * @param formDefinition The form definition array
      * @return The formatted input
      */
-    default String formInput(org.sakaiproject.lti.beans.LtiToolSiteBean toolSiteBean, String[] formDefinition) {
+    default String formInput(LtiToolSiteBean toolSiteBean, String[] formDefinition) {
         Map<String, Object> toolSiteMap = (toolSiteBean != null) ? toolSiteBean.asMap() : null;
         return formInput(toolSiteMap, formDefinition);
     }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -856,6 +856,39 @@ public interface LTIService extends LTISubstitutionsFilter {
         return contentMap != null ? LtiContentBean.of(contentMap) : null;
     }
 
+    /**
+     * Get a single LTI content item as a Bean, bypassing security checks (DAO method).
+     * @param key The content ID
+     * @return LtiContentBean or null if not found
+     */
+    default LtiContentBean getContentDaoAsBean(Long key) {
+        Map<String, Object> contentMap = getContentDao(key);
+        return contentMap != null ? LtiContentBean.of(contentMap) : null;
+    }
+
+    /**
+     * Get a single LTI content item as a Bean, bypassing security checks (DAO method).
+     * @param key The content ID
+     * @param siteId The site ID
+     * @return LtiContentBean or null if not found
+     */
+    default LtiContentBean getContentDaoAsBean(Long key, String siteId) {
+        Map<String, Object> contentMap = getContentDao(key, siteId);
+        return contentMap != null ? LtiContentBean.of(contentMap) : null;
+    }
+
+    /**
+     * Get a single LTI content item as a Bean (DAO method).
+     * @param key The content ID
+     * @param siteId The site ID
+     * @param isAdminRole Whether to bypass site-scoped security filters
+     * @return LtiContentBean or null if not found
+     */
+    default LtiContentBean getContentDaoAsBean(Long key, String siteId, boolean isAdminRole) {
+        Map<String, Object> contentMap = getContentDao(key, siteId, isAdminRole);
+        return contentMap != null ? LtiContentBean.of(contentMap) : null;
+    }
+
     // ------------------------------------------------------------------------------------
     // CONTENT BEAN METHODS - Multiple Content Retrieval
     // ------------------------------------------------------------------------------------

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiContentBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiContentBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -30,6 +34,10 @@ import lombok.ToString;
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Stack;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import org.sakaiproject.lti.api.LTIService;
 
@@ -43,42 +51,62 @@ import org.sakaiproject.lti.api.LTIService;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
 @ToString(exclude = {"placementsecret", "oldplacementsecret"})
-public class LtiContentBean extends LTIBaseBean {
+public class LtiContentBean extends FoormBaseBean {
 
-    // Core fields from CONTENT_MODEL
-    public Long id;                    // CONTENT_MODEL: "id:key:archive=true"
-    public Long toolId;                // CONTENT_MODEL: "tool_id:integer:hidden=true"
-    public String siteId;              // CONTENT_MODEL: "SITE_ID:text:label=bl_content_site_id:required=true:maxlength=99:role=admin"
-    public String title;               // CONTENT_MODEL: "title:text:label=bl_title:required=true:maxlength=1024:archive=true"
-    public String description;         // CONTENT_MODEL: "description:textarea:label=bl_description:maxlength=4096:archive=true"
-    public Integer frameheight;        // CONTENT_MODEL: "frameheight:integer:label=bl_frameheight:archive=true"
-    public Boolean newpage;            // CONTENT_MODEL: "newpage:checkbox:label=bl_newpage:archive=true"
-    public Boolean protect;            // CONTENT_MODEL: "protect:checkbox:label=bl_protect:role=admin"
-    public Boolean debug;              // CONTENT_MODEL: "debug:checkbox:label=bl_debug"
-    // LTI fields from CONTENT_MODEL
-    public String custom;              // CONTENT_MODEL: "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384:archive=true"
-    public String launch;              // CONTENT_MODEL: "launch:url:label=bl_launch:hidden=true:maxlength=1024:archive=true"
-    public String xmlimport;           // CONTENT_MODEL: "xmlimport:text:hidden=true:maxlength=1M"
-    public String settings;            // CONTENT_MODEL: "settings:text:hidden=true:maxlength=1M"
-    public String contentitem;         // CONTENT_MODEL: "contentitem:text:label=bl_contentitem:rows=5:cols=25:maxlength=1M:hidden=true:archive=true"
-    public String placement;           // CONTENT_MODEL: "placement:text:hidden=true:maxlength=256"
-    public String placementsecret;     // CONTENT_MODEL: "placementsecret:text:hidden=true:maxlength=512"
-    public String oldplacementsecret;  // CONTENT_MODEL: "oldplacementsecret:text:hidden=true:maxlength=512"
-    // Timestamps from CONTENT_MODEL
-    public Date createdAt;             // CONTENT_MODEL: "created_at:autodate"
-    public Date updatedAt;             // CONTENT_MODEL: "updated_at:autodate"
-
-    // Extra fields that can be populated from joins (CONTENT_EXTRA_FIELDS)
-    public String siteTitle;           // CONTENT_EXTRA_FIELDS: "SITE_TITLE:text:table=SAKAI_SITE:realname=TITLE"
-    public String siteContactName;     // CONTENT_EXTRA_FIELDS: "SITE_CONTACT_NAME:text:table=ssp1:realname=VALUE"
-    public String siteContactEmail;    // CONTENT_EXTRA_FIELDS: "SITE_CONTACT_EMAIL:text:table=ssp2:realname=VALUE"
-    public String attribution;         // CONTENT_EXTRA_FIELDS: "ATTRIBUTION:text:table=ssp3:realname=VALUE"
-    public String url;                 // CONTENT_EXTRA_FIELDS: "URL:text:table=ssp4:realname=VALUE"
-    public String searchUrl;           // CONTENT_EXTRA_FIELDS: "searchURL:text:table=ssp5:realname=VALUE"
+    @FoormField(value = "id", type = FoormType.KEY, archive = true)
+    public Long id;
+    @FoormField(value = "tool_id", type = FoormType.INTEGER, hidden = true)
+    public Long toolId;
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, label = "bl_content_site_id", required = true, maxlength = 99, role = "admin")
+    public String siteId;
+    @FoormField(value = "title", type = FoormType.TEXT, label = "bl_title", required = true, maxlength = 1024, archive = true)
+    public String title;
+    @FoormField(value = "description", type = FoormType.TEXTAREA, label = "bl_description", maxlength = 4096, archive = true)
+    public String description;
+    @FoormField(value = "frameheight", type = FoormType.INTEGER, label = "bl_frameheight", archive = true)
+    public Integer frameheight;
+    @FoormField(value = "newpage", type = FoormType.CHECKBOX, label = "bl_newpage", archive = true)
+    public Boolean newpage;
+    @FoormField(value = "protect", type = FoormType.CHECKBOX, label = "bl_protect", role = "admin")
+    public Boolean protect;
+    @FoormField(value = "debug", type = FoormType.CHECKBOX, label = "bl_debug")
+    public Boolean debug;
+    @FoormField(value = "custom", type = FoormType.TEXTAREA, label = "bl_custom", rows = 5, cols = 25, maxlength = 16384, archive = true)
+    public String custom;
+    @FoormField(value = "launch", type = FoormType.URL, label = "bl_launch", hidden = true, maxlength = 1024, archive = true)
+    public String launch;
+    @FoormField(value = "xmlimport", type = FoormType.TEXT, hidden = true)
+    public String xmlimport;
+    @FoormField(value = "settings", type = FoormType.TEXT, hidden = true)
+    public String settings;
+    @FoormField(value = "contentitem", type = FoormType.TEXTAREA, label = "bl_contentitem", rows = 5, cols = 25, hidden = true, archive = true)
+    public String contentitem;
+    @FoormField(value = "placement", type = FoormType.TEXT, hidden = true, maxlength = 256)
+    public String placement;
+    @FoormField(value = "placementsecret", type = FoormType.TEXT, hidden = true, maxlength = 512)
+    public String placementsecret;
+    @FoormField(value = "oldplacementsecret", type = FoormType.TEXT, hidden = true, maxlength = 512)
+    public String oldplacementsecret;
+    @FoormField(value = "created_at", type = FoormType.AUTODATE)
+    public Date createdAt;
+    @FoormField(value = "updated_at", type = FoormType.AUTODATE)
+    public Date updatedAt;
+    @FoormField(value = "SITE_TITLE", type = FoormType.TEXT)
+    public String siteTitle;
+    @FoormField(value = "SITE_CONTACT_NAME", type = FoormType.TEXT)
+    public String siteContactName;
+    @FoormField(value = "SITE_CONTACT_EMAIL", type = FoormType.TEXT)
+    public String siteContactEmail;
+    @FoormField(value = "ATTRIBUTION", type = FoormType.TEXT)
+    public String attribution;
+    @FoormField(value = "URL", type = FoormType.TEXT)
+    public String url;
+    @FoormField(value = "searchURL", type = FoormType.TEXT)
+    public String searchUrl;
 
     /**
      * Creates an LtiContentBean instance from a Map<String, Object>.
-     * 
+     *
      * @param map The map containing LTI content data
      * @return LtiContentBean instance populated from the map
      */
@@ -86,44 +114,46 @@ public class LtiContentBean extends LTIBaseBean {
         if (map == null) {
             return null;
         }
-        
         LtiContentBean content = new LtiContentBean();
-        
-        // Core fields
-        content.setId(getLongValue(map, LTIService.LTI_ID));
-        content.setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
-        content.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
-        content.setTitle(getStringValue(map, LTIService.LTI_TITLE));
-        content.setDescription(getStringValue(map, LTIService.LTI_DESCRIPTION));
-        content.setFrameheight(getIntegerValue(map, LTIService.LTI_FRAMEHEIGHT));
-        content.setNewpage(getBooleanValue(map, LTIService.LTI_NEWPAGE));
-        content.setProtect(getBooleanValue(map, LTIService.LTI_PROTECT));
-        content.setDebug(getBooleanValue(map, LTIService.LTI_DEBUG));
-        
-        // LTI fields
-        content.setCustom(getStringValue(map, LTIService.LTI_CUSTOM));
-        content.setLaunch(getStringValue(map, LTIService.LTI_LAUNCH));
-        content.setXmlimport(getStringValue(map, LTIService.LTI_XMLIMPORT));
-        content.setSettings(getStringValue(map, LTIService.LTI_SETTINGS));
-        content.setContentitem(getStringValue(map, "contentitem"));
-        content.setPlacement(getStringValue(map, "placement"));
-        content.setPlacementsecret(getStringValue(map, LTIService.LTI_PLACEMENTSECRET));
-        content.setOldplacementsecret(getStringValue(map, LTIService.LTI_OLDPLACEMENTSECRET));
-        
-        
-        // Timestamps
-        content.setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
-        content.setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
-        
-        // Extra fields from joins
-        content.setSiteTitle(getStringValue(map, "SITE_TITLE"));
-        content.setSiteContactName(getStringValue(map, "SITE_CONTACT_NAME"));
-        content.setSiteContactEmail(getStringValue(map, "SITE_CONTACT_EMAIL"));
-        content.setAttribution(getStringValue(map, "ATTRIBUTION"));
-        content.setUrl(getStringValue(map, "URL"));
-        content.setSearchUrl(getStringValue(map, "searchURL"));
-        
+        content.applyFromMap(map);
         return content;
+    }
+
+    /**
+     * Applies map values to this bean's fields. Used to persist filtered or
+     * mutated map data back into the bean (e.g. after filterContent).
+     *
+     * @param map The map containing LTI content data (null is a no-op)
+     */
+    public void applyFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return;
+        }
+        setId(getLongValue(map, LTIService.LTI_ID));
+        setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
+        setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
+        setTitle(getStringValue(map, LTIService.LTI_TITLE));
+        setDescription(getStringValue(map, LTIService.LTI_DESCRIPTION));
+        setFrameheight(getIntegerValue(map, LTIService.LTI_FRAMEHEIGHT));
+        setNewpage(getBooleanValue(map, LTIService.LTI_NEWPAGE));
+        setProtect(getBooleanValue(map, LTIService.LTI_PROTECT));
+        setDebug(getBooleanValue(map, LTIService.LTI_DEBUG));
+        setCustom(getStringValue(map, LTIService.LTI_CUSTOM));
+        setLaunch(getStringValue(map, LTIService.LTI_LAUNCH));
+        setXmlimport(getStringValue(map, LTIService.LTI_XMLIMPORT));
+        setSettings(getStringValue(map, LTIService.LTI_SETTINGS));
+        setContentitem(getStringValue(map, "contentitem"));
+        setPlacement(getStringValue(map, "placement"));
+        setPlacementsecret(getStringValue(map, LTIService.LTI_PLACEMENTSECRET));
+        setOldplacementsecret(getStringValue(map, LTIService.LTI_OLDPLACEMENTSECRET));
+        setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
+        setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
+        setSiteTitle(getStringValue(map, "SITE_TITLE"));
+        setSiteContactName(getStringValue(map, "SITE_CONTACT_NAME"));
+        setSiteContactEmail(getStringValue(map, "SITE_CONTACT_EMAIL"));
+        setAttribution(getStringValue(map, "ATTRIBUTION"));
+        setUrl(getStringValue(map, "URL"));
+        setSearchUrl(getStringValue(map, "searchURL"));
     }
 
     /**
@@ -169,6 +199,52 @@ public class LtiContentBean extends LTIBaseBean {
         putIfNotNull(map, "searchURL", searchUrl);
         
         return map;
+    }
+
+    /**
+     * Creates an LtiContentBean from an archive XML element.
+     * Uses the same format as {@link #toXml} (child elements per archivable field).
+     * For use in archive/import flows.
+     *
+     * @param element the sakai-lti-content element (or equivalent)
+     * @return new bean populated from the element, or null if element is null
+     */
+    public static LtiContentBean fromXml(Element element) {
+        if (element == null) {
+            return null;
+        }
+        LtiContentBean bean = new LtiContentBean();
+        bean.populateFromArchiveElement(element);
+        return bean;
+    }
+
+    /**
+     * Serializes this bean to an XML element in archive format.
+     * Uses the same structure as the existing archive process (child elements per archivable field).
+     * For use in archive/export flows.
+     *
+     * @param doc   the document to create elements in
+     * @param stack parent stack; if null or empty, the element is appended to doc; otherwise to stack.peek()
+     * @return the created element, or null if doc is null
+     */
+    public Element toXml(Document doc, Stack<Element> stack) {
+        if (doc == null) {
+            return null;
+        }
+        Element el = toArchiveElement(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG);
+        if (el == null) {
+            return null;
+        }
+        if (stack == null || stack.isEmpty()) {
+            doc.appendChild(el);
+        } else {
+            stack.peek().appendChild(el);
+        }
+        if (stack != null) {
+            stack.push(el);
+            stack.pop();
+        }
+        return el;
     }
 
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiMembershipsJobBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiMembershipsJobBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -42,14 +46,18 @@ import org.sakaiproject.lti.api.LTIService;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
 @ToString
-public class LtiMembershipsJobBean extends LTIBaseBean {
+public class LtiMembershipsJobBean extends FoormBaseBean {
 
-    // Fields from MEMBERSHIPS_JOBS_MODEL
-    public String siteId;              // MEMBERSHIPS_JOBS_MODEL: "SITE_ID:text:maxlength=99:required=true"
-    public String membershipsId;       // MEMBERSHIPS_JOBS_MODEL: "memberships_id:text:maxlength=256:required=true"
-    public String membershipsUrl;      // MEMBERSHIPS_JOBS_MODEL: "memberships_url:text:maxlength=4000:required=true"
-    public String consumerkey;         // MEMBERSHIPS_JOBS_MODEL: "consumerkey:text:label=bl_consumerkey:maxlength=1024"
-    public String ltiVersion;          // MEMBERSHIPS_JOBS_MODEL: "lti_version:text:maxlength=32:required=true"
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, maxlength = 99, required = true)
+    public String siteId;
+    @FoormField(value = "memberships_id", type = FoormType.TEXT, maxlength = 256, required = true)
+    public String membershipsId;
+    @FoormField(value = "memberships_url", type = FoormType.TEXT, maxlength = 4000, required = true)
+    public String membershipsUrl;
+    @FoormField(value = "consumerkey", type = FoormType.TEXT, label = "bl_consumerkey", maxlength = 1024)
+    public String consumerkey;
+    @FoormField(value = "lti_version", type = FoormType.TEXT, maxlength = 32, required = true)
+    public String ltiVersion;
 
     /**
      * Creates an LtiMembershipsJobBean instance from a Map<String, Object>.

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
@@ -30,94 +34,187 @@ import lombok.ToString;
 import java.util.Date;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.Stack;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import org.sakaiproject.lti.api.LTIService;
 
 /**
  * Transfer object for LTI Tools.
  * Based on the TOOL_MODEL from LTIService.
+ * <p>
+ * Includes <em>non-persisted</em> fields that round-trip between bean and map in
+ * {@link #of(java.util.Map)} and {@link #asMap()} but are never stored: launch-flow fields
+ * ({@link #toolState}, {@link #platformState}, {@link #relaunchUrl}, {@link #origSiteIdNull}) and
+ * archive-only {@link #sakaiToolChecksum}.
+ * </p>
  */
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
-@ToString(exclude = {"secret", "lti13AutoToken"})
-public class LtiToolBean extends LTIBaseBean {
+@ToString(exclude = {"secret", "lti13AutoToken", "toolState", "platformState", "relaunchUrl", "origSiteIdNull", "sakaiToolChecksum"})
+public class LtiToolBean extends FoormBaseBean {
 
-    // Core fields from TOOL_MODEL
-    public Long id;                    // TOOL_MODEL: "id:key:archive=true"
-    public String siteId;              // TOOL_MODEL: "SITE_ID:text:maxlength=99:role=admin"
-    public String title;               // TOOL_MODEL: "title:text:label=bl_title:required=true:maxlength=1024:archive=true"
-    public String description;         // TOOL_MODEL: "description:textarea:label=bl_description:maxlength=4096:archive=true"
-    public String status;              // TOOL_MODEL: "status:radio:label=bl_status:choices=enable,disable"
-    public String visible;             // TOOL_MODEL: "visible:radio:label=bl_visible:choices=visible,stealth:role=admin"
-    public String deploymentId;        // TOOL_MODEL: "deployment_id:text:label=bl_deployment_id:maxlength=255:role=admin:archive=true"
-    public String launch;              // TOOL_MODEL: "launch:url:label=bl_launch:maxlength=1024:required=true:archive=true"
-    public Integer newpage;            // TOOL_MODEL: "newpage:radio:label=bl_newpage:choices=off,on,content:archive=true"
-    public Integer frameheight;        // TOOL_MODEL: "frameheight:integer:label=bl_frameheight:archive=true"
-    public String faIcon;              // TOOL_MODEL: "fa_icon:text:label=bl_fa_icon:maxlength=1024:archive=true"
+    @Override
+    protected Set<String> getExcludedArchiveFieldNames() {
+        return Set.of(LTIService.SAKAI_TOOL_CHECKSUM);
+    }
+
+    @FoormField(value = "id", type = FoormType.KEY, archive = true)
+    public Long id;
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, maxlength = 99, role = "admin")
+    public String siteId;
+    @FoormField(value = "title", type = FoormType.TEXT, label = "bl_title", required = true, maxlength = 1024, archive = true)
+    public String title;
+    @FoormField(value = "description", type = FoormType.TEXTAREA, label = "bl_description", maxlength = 4096, archive = true)
+    public String description;
+    @FoormField(value = "status", type = FoormType.RADIO, label = "bl_status", choices = {"enable", "disable"})
+    public String status;
+    @FoormField(value = "visible", type = FoormType.RADIO, label = "bl_visible", choices = {"visible", "stealth"}, role = "admin")
+    public String visible;
+    @FoormField(value = "deployment_id", type = FoormType.TEXT, label = "bl_deployment_id", maxlength = 255, role = "admin", archive = true)
+    public String deploymentId;
+    @FoormField(value = "launch", type = FoormType.URL, label = "bl_launch", maxlength = 1024, required = true, archive = true)
+    public String launch;
+    @FoormField(value = "newpage", type = FoormType.RADIO, label = "bl_newpage", choices = {"off", "on", "content"}, archive = true)
+    public Integer newpage;
+    @FoormField(value = "frameheight", type = FoormType.INTEGER, label = "bl_frameheight", archive = true)
+    public Integer frameheight;
+    @FoormField(value = "fa_icon", type = FoormType.TEXT, label = "bl_fa_icon", maxlength = 1024, archive = true)
+    public String faIcon;
     
-    // Message Types (pl_ prefix for backwards compatibility) from TOOL_MODEL
-    public Boolean plLaunch;           // TOOL_MODEL: "pl_launch:checkbox:label=bl_pl_launch:archive=true"
-    public Boolean plLinkselection;    // TOOL_MODEL: "pl_linkselection:checkbox:label=bl_pl_linkselection:archive=true"
-    public Boolean plContextlaunch;    // TOOL_MODEL: "pl_contextlaunch:checkbox:label=bl_pl_contextlaunch:hidden=true"
+    @FoormField(value = "pl_launch", type = FoormType.CHECKBOX, label = "bl_pl_launch", archive = true)
+    public Boolean plLaunch;
+    @FoormField(value = "pl_linkselection", type = FoormType.CHECKBOX, label = "bl_pl_linkselection", archive = true)
+    public Boolean plLinkselection;
+    @FoormField(value = "pl_contextlaunch", type = FoormType.CHECKBOX, label = "bl_pl_contextlaunch", hidden = true)
+    public Boolean plContextlaunch;
+
+    @FoormField(value = "pl_lessonsselection", type = FoormType.CHECKBOX, label = "bl_pl_lessonsselection", archive = true)
+    public Boolean plLessonsselection;
+    @FoormField(value = "pl_contenteditor", type = FoormType.CHECKBOX, label = "bl_pl_contenteditor", archive = true)
+    public Boolean plContenteditor;
+    @FoormField(value = "pl_assessmentselection", type = FoormType.CHECKBOX, label = "bl_pl_assessmentselection", archive = true)
+    public Boolean plAssessmentselection;
+    @FoormField(value = "pl_coursenav", type = FoormType.CHECKBOX, label = "bl_pl_coursenav", archive = true)
+    public Boolean plCoursenav;
+    @FoormField(value = "pl_importitem", type = FoormType.CHECKBOX, label = "bl_pl_importitem", role = "admin", archive = true)
+    public Boolean plImportitem;
+    @FoormField(value = "pl_fileitem", type = FoormType.CHECKBOX, label = "bl_pl_fileitem", role = "admin", hidden = true, archive = true)
+    public Boolean plFileitem;
     
-    // Placements from TOOL_MODEL
-    public Boolean plLessonsselection;     // TOOL_MODEL: "pl_lessonsselection:checkbox:label=bl_pl_lessonsselection:archive=true"
-    public Boolean plContenteditor;        // TOOL_MODEL: "pl_contenteditor:checkbox:label=bl_pl_contenteditor:archive=true"
-    public Boolean plAssessmentselection;  // TOOL_MODEL: "pl_assessmentselection:checkbox:label=bl_pl_assessmentselection:archive=true"
-    public Boolean plCoursenav;            // TOOL_MODEL: "pl_coursenav:checkbox:label=bl_pl_coursenav:archive=true"
-    public Boolean plImportitem;           // TOOL_MODEL: "pl_importitem:checkbox:label=bl_pl_importitem:role=admin:archive=true"
-    public Boolean plFileitem;             // TOOL_MODEL: "pl_fileitem:checkbox:label=bl_pl_fileitem:role=admin:hidden=true:archive=true"
+    @FoormField(value = "sendname", type = FoormType.CHECKBOX, label = "bl_sendname", archive = true)
+    public Boolean sendname;
+    @FoormField(value = "sendemailaddr", type = FoormType.CHECKBOX, label = "bl_sendemailaddr", archive = true)
+    public Boolean sendemailaddr;
+    @FoormField(value = "pl_privacy", type = FoormType.CHECKBOX, label = "bl_pl_privacy", role = "admin")
+    public Boolean plPrivacy;
+
+    @FoormField(value = "allowoutcomes", type = FoormType.CHECKBOX, label = "bl_allowoutcomes", archive = true)
+    public Boolean allowoutcomes;
+    @FoormField(value = "allowlineitems", type = FoormType.CHECKBOX, label = "bl_allowlineitems", archive = true)
+    public Boolean allowlineitems;
+    @FoormField(value = "allowgradebookreadonly", type = FoormType.CHECKBOX, label = "bl_allowgradebookreadonly", archive = true)
+    public Boolean allowgradebookreadonly;
+    @FoormField(value = "allowroster", type = FoormType.CHECKBOX, label = "bl_allowroster", archive = true)
+    public Boolean allowroster;
     
-    // Privacy from TOOL_MODEL
-    public Boolean sendname;           // TOOL_MODEL: "sendname:checkbox:label=bl_sendname:archive=true"
-    public Boolean sendemailaddr;      // TOOL_MODEL: "sendemailaddr:checkbox:label=bl_sendemailaddr:archive=true"
-    public Boolean plPrivacy;          // TOOL_MODEL: "pl_privacy:checkbox:label=bl_pl_privacy:role=admin"
+    @FoormField(value = "debug", type = FoormType.RADIO, label = "bl_debug", choices = {"off", "on", "content"})
+    public Integer debug;
+    @FoormField(value = "siteinfoconfig", type = FoormType.RADIO, label = "bl_siteinfoconfig", advanced = true, choices = {"bypass", "config"})
+    public String siteinfoconfig;
+    @FoormField(value = "splash", type = FoormType.TEXTAREA, label = "bl_splash", rows = 5, cols = 25, maxlength = 16384)
+    public String splash;
+    @FoormField(value = "custom", type = FoormType.TEXTAREA, label = "bl_custom", rows = 5, cols = 25, maxlength = 16384, archive = true)
+    public String custom;
+    @FoormField(value = "rolemap", type = FoormType.TEXTAREA, label = "bl_rolemap", rows = 5, cols = 25, maxlength = 16384, role = "admin", archive = true)
+    public String rolemap;
+    @FoormField(value = "lti13", type = FoormType.RADIO, label = "bl_lti13", choices = {"off", "on", "both"}, role = "admin", archive = true)
+    public Integer lti13;
     
-    // Services from TOOL_MODEL
-    public Boolean allowoutcomes;      // TOOL_MODEL: "allowoutcomes:checkbox:label=bl_allowoutcomes:archive=true"
-    public Boolean allowlineitems;     // TOOL_MODEL: "allowlineitems:checkbox:label=bl_allowlineitems:archive=true"
-    public Boolean allowgradebookreadonly; // TOOL_MODEL: "allowgradebookreadonly:checkbox:label=bl_allowgradebookreadonly:archive=true"
-    public Boolean allowroster;        // TOOL_MODEL: "allowroster:checkbox:label=bl_allowroster:archive=true"
+    @FoormField(value = "lti13_tool_keyset", type = FoormType.TEXT, label = "bl_lti13_tool_keyset", maxlength = 1024, role = "admin")
+    public String lti13ToolKeyset;
+    @FoormField(value = "lti13_oidc_endpoint", type = FoormType.TEXT, label = "bl_lti13_oidc_endpoint", maxlength = 1024, role = "admin")
+    public String lti13OidcEndpoint;
+    @FoormField(value = "lti13_oidc_redirect", type = FoormType.TEXT, label = "bl_lti13_oidc_redirect", maxlength = 1024, role = "admin")
+    public String lti13OidcRedirect;
+
+    @FoormField(value = "lti13_lms_issuer", type = FoormType.TEXT, label = "bl_lti13_lms_issuer", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsIssuer;
+    @FoormField(value = "lti13_client_id", type = FoormType.TEXT, label = "bl_lti13_client_id", readonly = true, maxlength = 1024, role = "admin")
+    public String lti13ClientId;
+    @FoormField(value = "lti13_lms_deployment_id", type = FoormType.TEXT, label = "bl_lti13_lms_deployment_id", readonly = true, maxlength = 1024, role = "admin")
+    public String lti13LmsDeploymentId;
+    @FoormField(value = "lti13_lms_keyset", type = FoormType.TEXT, label = "bl_lti13_lms_keyset", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsKeyset;
+    @FoormField(value = "lti13_lms_endpoint", type = FoormType.TEXT, label = "bl_lti13_lms_endpoint", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsEndpoint;
+    @FoormField(value = "lti13_lms_token", type = FoormType.TEXT, label = "bl_lti13_lms_token", readonly = true, persist = false, maxlength = 1024, role = "admin")
+    public String lti13LmsToken;
     
-    // Configuration fields from TOOL_MODEL
-    public Integer debug;              // TOOL_MODEL: "debug:radio:label=bl_debug:choices=off,on,content"
-    public String siteinfoconfig;      // TOOL_MODEL: "siteinfoconfig:radio:label=bl_siteinfoconfig:advanced:choices=bypass,config"
-    public String splash;              // TOOL_MODEL: "splash:textarea:label=bl_splash:rows=5:cols=25:maxlength=16384"
-    public String custom;              // TOOL_MODEL: "custom:textarea:label=bl_custom:rows=5:cols=25:maxlength=16384:archive=true"
-    public String rolemap;             // TOOL_MODEL: "rolemap:textarea:label=bl_rolemap:rows=5:cols=25:maxlength=16384:role=admin:archive=true"
-    public Integer lti13;              // TOOL_MODEL: "lti13:radio:label=bl_lti13:choices=off,on,both:role=admin:archive=true"
-    
-    // LTI 1.3 security values from the tool from TOOL_MODEL
-    public String lti13ToolKeyset;     // TOOL_MODEL: "lti13_tool_keyset:text:label=bl_lti13_tool_keyset:maxlength=1024:role=admin"
-    public String lti13OidcEndpoint;   // TOOL_MODEL: "lti13_oidc_endpoint:text:label=bl_lti13_oidc_endpoint:maxlength=1024:role=admin"
-    public String lti13OidcRedirect;   // TOOL_MODEL: "lti13_oidc_redirect:text:label=bl_lti13_oidc_redirect:maxlength=1024:role=admin"
-    
-    // LTI 1.3 security values from the LMS from TOOL_MODEL
-    public String lti13LmsIssuer;      // TOOL_MODEL: "lti13_lms_issuer:text:label=bl_lti13_lms_issuer:readonly=true:persist=false:maxlength=1024:role=admin"
-    public String lti13ClientId;       // TOOL_MODEL: "lti13_client_id:text:label=bl_lti13_client_id:readonly=true:maxlength=1024:role=admin"
-    public String lti13LmsKeyset;      // TOOL_MODEL: "lti13_lms_keyset:text:label=bl_lti13_lms_keyset:readonly=true:persist=false:maxlength=1024:role=admin"
-    public String lti13LmsEndpoint;    // TOOL_MODEL: "lti13_lms_endpoint:text:label=bl_lti13_lms_endpoint:readonly=true:persist=false:maxlength=1024:role=admin"
-    public String lti13LmsToken;       // TOOL_MODEL: "lti13_lms_token:text:label=bl_lti13_lms_token:readonly=true:persist=false:maxlength=1024:role=admin"
-    
-    // LTI 1.1 security arrangement from TOOL_MODEL
-    public String consumerkey;         // TOOL_MODEL: "consumerkey:text:label=bl_consumerkey:maxlength=1024"
-    public String secret;              // TOOL_MODEL: "secret:text:label=bl_secret:maxlength=1024"
-    public String xmlimport;           // TOOL_MODEL: "xmlimport:textarea:hidden=true:maxlength=1M"
-    public String lti13AutoToken;      // TOOL_MODEL: "lti13_auto_token:text:hidden=true:maxlength=1024"
-    public Integer lti13AutoState;     // TOOL_MODEL: "lti13_auto_state:integer:hidden=true"
-    public String lti13AutoRegistration; // TOOL_MODEL: "lti13_auto_registration:textarea:hidden=true:maxlength=1M"
-    public String sakaiToolChecksum;   // TOOL_MODEL: "sakai_tool_checksum:text:maxlength=99:hidden=true:persist=false:archive=true"
-    
-    // Timestamps from TOOL_MODEL
-    public Date createdAt;             // TOOL_MODEL: "created_at:autodate"
-    public Date updatedAt;             // TOOL_MODEL: "updated_at:autodate"
-    
-    // Live attributes - computed fields that may be present in Map data
-    public Long ltiContentCount;       // Live attribute: "lti_content_count" from database joins
-    public Long ltiSiteCount;          // Live attribute: "lti_site_count" from database joins
+    @FoormField(value = "consumerkey", type = FoormType.TEXT, label = "bl_consumerkey", maxlength = 1024)
+    public String consumerkey;
+    @FoormField(value = "secret", type = FoormType.TEXT, label = "bl_secret", maxlength = 1024)
+    public String secret;
+    @FoormField(value = "xmlimport", type = FoormType.TEXTAREA, hidden = true)
+    public String xmlimport;
+    @FoormField(value = "lti13_auto_token", type = FoormType.TEXT, hidden = true, maxlength = 1024)
+    public String lti13AutoToken;
+    @FoormField(value = "lti13_auto_state", type = FoormType.INTEGER, hidden = true)
+    public Integer lti13AutoState;
+    @FoormField(value = "lti13_auto_registration", type = FoormType.TEXTAREA, hidden = true)
+    public String lti13AutoRegistration;
+
+    @FoormField(value = "created_at", type = FoormType.AUTODATE)
+    public Date createdAt;
+    @FoormField(value = "updated_at", type = FoormType.AUTODATE)
+    public Date updatedAt;
+
+    @FoormField(value = "lti_content_count", type = FoormType.INTEGER)
+    public Long ltiContentCount;
+    @FoormField(value = "lti_site_count", type = FoormType.INTEGER)
+    public Long ltiSiteCount;
+
+    /**
+     * Launch-flow only fields.
+     * <p>
+     * These fields are <strong>not persisted</strong> to the tool record. They round-trip between
+     * bean and map in {@link #of(java.util.Map)} and {@link #asMap()}, but are never stored in the
+     * database. They are used only during the launch request/response flow. The platform may
+     * receive them as request parameters (e.g. when building a Content Item or LTI 1.1 launch URL)
+     * and should pass them through so they can be sent back to the tool in the launch payload,
+     * allowing the tool to restore context or continue a flow.
+     * </p>
+     * <ul>
+     *   <li><strong>toolState</strong> – Opaque value set by the tool (e.g. in a Content Item
+     *       request) and returned in the launch so the tool can resume state.</li>
+     *   <li><strong>platformState</strong> – Opaque value set by the platform and returned in the
+     *       launch for platform-specific state.</li>
+     *   <li><strong>relaunchUrl</strong> – URL the platform may use for a "relaunch" or "open in new
+     *       window" action; returned in the launch so the tool can offer a consistent relaunch
+     *       link.</li>
+     *   <li><strong>origSiteIdNull</strong> – Internal: set to {@code "true"} when the tool’s
+     *       stored site id was null before the launch context was applied; used by the LTI 1.3
+     *       OIDC redirect flow.</li>
+     *   <li><strong>sakaiToolChecksum</strong> – Computed checksum for tool import/export archives;
+     *       round-trips in {@link #asMap()} and {@link #of(java.util.Map)} but is never stored.</li>
+     * </ul>
+     */
+    @FoormField(value = "tool_state", type = FoormType.TEXT, persist = false)
+    public String toolState;
+    @FoormField(value = "platform_state", type = FoormType.TEXT, persist = false)
+    public String platformState;
+    @FoormField(value = "relaunch_url", type = FoormType.TEXT, persist = false)
+    public String relaunchUrl;
+    @FoormField(value = "orig_site_id_null", type = FoormType.TEXT, persist = false)
+    public String origSiteIdNull;
+    @FoormField(value = "sakai_tool_checksum", type = FoormType.TEXT, maxlength = 99, hidden = true, persist = false, archive = true)
+    public String sakaiToolChecksum;
 
     /**
      * Creates an LtiToolBean instance from a Map<String, Object>.
@@ -185,6 +282,7 @@ public class LtiToolBean extends LTIBaseBean {
         // LTI 1.3 security values from the LMS
         tool.setLti13LmsIssuer(getStringValue(map, "lti13_lms_issuer"));
         tool.setLti13ClientId(getStringValue(map, "lti13_client_id"));
+        tool.setLti13LmsDeploymentId(getStringValue(map, "lti13_lms_deployment_id"));
         tool.setLti13LmsKeyset(getStringValue(map, "lti13_lms_keyset"));
         tool.setLti13LmsEndpoint(getStringValue(map, "lti13_lms_endpoint"));
         tool.setLti13LmsToken(getStringValue(map, "lti13_lms_token"));
@@ -205,6 +303,12 @@ public class LtiToolBean extends LTIBaseBean {
         // Live attributes - computed fields that may be present in Map data
         tool.setLtiContentCount(getLongValue(map, "lti_content_count"));
         tool.setLtiSiteCount(getLongValue(map, "lti_site_count"));
+        
+        // Launch-flow only (not persisted)
+        tool.setToolState(getStringValue(map, "tool_state"));
+        tool.setPlatformState(getStringValue(map, "platform_state"));
+        tool.setRelaunchUrl(getStringValue(map, "relaunch_url"));
+        tool.setOrigSiteIdNull(getStringValue(map, "orig_site_id_null"));
         
         return tool;
     }
@@ -270,6 +374,7 @@ public class LtiToolBean extends LTIBaseBean {
         // LTI 1.3 security values from the LMS
         putIfNotNull(map, "lti13_lms_issuer", lti13LmsIssuer);
         putIfNotNull(map, "lti13_client_id", lti13ClientId);
+        putIfNotNull(map, "lti13_lms_deployment_id", lti13LmsDeploymentId);
         putIfNotNull(map, "lti13_lms_keyset", lti13LmsKeyset);
         putIfNotNull(map, "lti13_lms_endpoint", lti13LmsEndpoint);
         putIfNotNull(map, "lti13_lms_token", lti13LmsToken);
@@ -281,7 +386,6 @@ public class LtiToolBean extends LTIBaseBean {
         putIfNotNull(map, "lti13_auto_token", lti13AutoToken);
         putIfNotNull(map, "lti13_auto_state", lti13AutoState);
         putIfNotNull(map, "lti13_auto_registration", lti13AutoRegistration);
-        putIfNotNull(map, "sakai_tool_checksum", sakaiToolChecksum);
         
         // Timestamps
         putIfNotNull(map, LTIService.LTI_CREATED_AT, createdAt);
@@ -291,7 +395,61 @@ public class LtiToolBean extends LTIBaseBean {
         putIfNotNull(map, "lti_content_count", ltiContentCount);
         putIfNotNull(map, "lti_site_count", ltiSiteCount);
         
+        // Non-persisted
+        putIfNotNull(map, "tool_state", toolState);
+        putIfNotNull(map, "platform_state", platformState);
+        putIfNotNull(map, "relaunch_url", relaunchUrl);
+        putIfNotNull(map, "orig_site_id_null", origSiteIdNull);
+        putIfNotNull(map, "sakai_tool_checksum", sakaiToolChecksum);
+        
         return map;
+    }
+
+    /**
+     * Creates an LtiToolBean from an archive XML element.
+     * Uses the same format as {@link #toXml} (child elements per archivable field).
+     * For use in archive/import flows.
+     *
+     * @param element the sakai-lti-tool element (or equivalent)
+     * @return new bean populated from the element, or null if element is null
+     */
+    public static LtiToolBean fromXml(Element element) {
+        if (element == null) {
+            return null;
+        }
+        LtiToolBean bean = new LtiToolBean();
+        bean.populateFromArchiveElement(element);
+        return bean;
+    }
+
+    /**
+     * Serializes this bean to an XML element in archive format.
+     * Uses the same structure as the existing archive process (child elements per archivable field).
+     * For use in archive/export flows. The checksum is not included; add it separately if needed
+     * (e.g. via SakaiLTIUtil.archiveToolBean).
+     *
+     * @param doc   the document to create elements in
+     * @param stack parent stack; if null or empty, the element is appended to doc; otherwise to stack.peek()
+     * @return the created element, or null if doc is null
+     */
+    public Element toXml(Document doc, Stack<Element> stack) {
+        if (doc == null) {
+            return null;
+        }
+        Element el = toArchiveElement(doc, LTIService.ARCHIVE_LTI_TOOL_TAG);
+        if (el == null) {
+            return null;
+        }
+        if (stack == null || stack.isEmpty()) {
+            doc.appendChild(el);
+        } else {
+            stack.peek().appendChild(el);
+        }
+        if (stack != null) {
+            stack.push(el);
+            stack.pop();
+        }
+        return el;
     }
 
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
@@ -20,6 +20,10 @@
 
 package org.sakaiproject.lti.beans;
 
+import org.sakaiproject.lti.foorm.FoormBaseBean;
+import org.sakaiproject.lti.foorm.FoormField;
+import org.sakaiproject.lti.foorm.FoormType;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -39,16 +43,22 @@ import org.sakaiproject.lti.api.LTIService;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper=false)
-public class LtiToolSiteBean extends LTIBaseBean {
+public class LtiToolSiteBean extends FoormBaseBean {
 
-    // Fields from TOOL_SITE_MODEL
-    public Long id;                    // TOOL_SITE_MODEL: "id:key"
-    public Long toolId;                // TOOL_SITE_MODEL: "tool_id:integer:hidden=true"
-    public String siteId;              // TOOL_SITE_MODEL: "SITE_ID:text:label=bl_tool_site_SITE_ID:required=true:maxlength=99:role=admin"
-    public String notes;               // TOOL_SITE_MODEL: "notes:text:label=bl_tool_site_notes:maxlength=1024"
-    public String deploymentGroup;     // TOOL_SITE_MODEL: "deployment_group:text:label=bl_deployment_group:maxlength=128:alphanumeric=true"
-    public Date createdAt;             // TOOL_SITE_MODEL: "created_at:autodate"
-    public Date updatedAt;             // TOOL_SITE_MODEL: "updated_at:autodate"
+    @FoormField(value = "id", type = FoormType.KEY)
+    public Long id;
+    @FoormField(value = "tool_id", type = FoormType.INTEGER, hidden = true)
+    public Long toolId;
+    @FoormField(value = "SITE_ID", type = FoormType.TEXT, label = "bl_tool_site_SITE_ID", required = true, maxlength = 99, role = "admin")
+    public String siteId;
+    @FoormField(value = "notes", type = FoormType.TEXT, label = "bl_tool_site_notes", maxlength = 1024)
+    public String notes;
+    @FoormField(value = "deployment_group", type = FoormType.TEXT, label = "bl_deployment_group", maxlength = 128)
+    public String deploymentGroup;
+    @FoormField(value = "created_at", type = FoormType.AUTODATE)
+    public Date createdAt;
+    @FoormField(value = "updated_at", type = FoormType.AUTODATE)
+    public Date updatedAt;
 
     /**
      * Creates an LtiToolSiteBean instance from a Map<String, Object>.

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormBaseBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormBaseBean.java
@@ -18,24 +18,33 @@
  * permissions and limitations under the License.
  */
 
-package org.sakaiproject.lti.beans;
+package org.sakaiproject.lti.foorm;
 
+import java.lang.reflect.Field;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Base class providing common type conversion utilities for LTI Beans.
- * These methods handle the robust conversion of Object types from database results
- * to strongly-typed Bean fields, similar to the LTIUtil conversion methods.
- *
- * Implementation assistance provided by Claude AI for comprehensive type conversion
- * and robust database number handling across SQLite, Oracle, and MySQL systems.
+ * Base class for beans with {@link FoormField} annotations and type conversion utilities.
+ * Provides robust conversion of Object types from database results to strongly-typed fields,
+ * and reflection-based access by canonical field name for Foorm-annotated subclasses.
+ * <p>
+ * Named in homage to the someday long-gone Foorm code.
  */
 @Slf4j
-public abstract class LTIBaseBean {
+public abstract class FoormBaseBean {
 
     /**
      * Safely converts a map value to a String.
@@ -308,5 +317,203 @@ public abstract class LTIBaseBean {
         if (value != null) {
             map.put(key, value ? Integer.valueOf(1) : Integer.valueOf(0));
         }
+    }
+
+    // --- FoormField reflection (for archive, etc.) ---
+
+    private static final Map<Class<?>, Map<String, Field>> FIELDS_CACHE = new ConcurrentHashMap<>();
+
+    protected static Map<String, Field> getFieldsForClass(Class<?> clazz) {
+        return FIELDS_CACHE.computeIfAbsent(clazz, c -> {
+            Map<String, Field> map = new ConcurrentHashMap<>();
+            for (Field f : c.getDeclaredFields()) {
+                FoormField ann = f.getAnnotation(FoormField.class);
+                if (ann != null) {
+                    f.setAccessible(true);
+                    map.put(ann.value(), f);
+                }
+            }
+            return map;
+        });
+    }
+
+    /**
+     * Returns the value of the property identified by its canonical field name.
+     *
+     * @param fieldName Canonical name from {@link FoormField} (e.g. {@code deployment_id}, {@code SITE_ID})
+     * @return The property value, or null if the field is unknown or its value is null
+     */
+    public Object getValueByFieldName(String fieldName) {
+        Field f = getFieldsForClass(getClass()).get(fieldName);
+        if (f == null) {
+            return null;
+        }
+        try {
+            return f.get(this);
+        } catch (IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the {@link FoormField} annotation for a field name, or null if unknown.
+     */
+    public FoormField getFoormFieldByFieldName(String fieldName) {
+        Field f = getFieldsForClass(getClass()).get(fieldName);
+        return f != null ? f.getAnnotation(FoormField.class) : null;
+    }
+
+    /**
+     * Field names to omit from archive output. Override in subclasses (e.g. to exclude
+     * computed fields like checksum that are appended separately).
+     */
+    protected Set<String> getExcludedArchiveFieldNames() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Produces an archive XML element for this bean. Iterates over fields with
+     * {@link FoormField#archive()}{@code == true}, excluding any in
+     * {@link #getExcludedArchiveFieldNames()}, and appends child elements.
+     *
+     * @param doc     The document to create elements in
+     * @param tagName Root element tag name (e.g. {@code sakai-lti-tool})
+     * @return The root element with archivable fields as children, or null if doc is null
+     */
+    public Element toArchiveElement(Document doc, String tagName) {
+        if (doc == null) {
+            return null;
+        }
+        Set<String> excluded = getExcludedArchiveFieldNames();
+        Element root = doc.createElement(tagName);
+        for (Field f : getClass().getDeclaredFields()) {
+            FoormField ann = f.getAnnotation(FoormField.class);
+            if (ann == null || !ann.archive() || excluded.contains(ann.value())) {
+                continue;
+            }
+            String field = ann.value();
+            Object o = getValueByFieldName(field);
+            if (o == null) {
+                continue;
+            }
+            String text = formatArchiveValue(o, ann.type());
+            if (text == null) {
+                continue;
+            }
+            Element child;
+            try {
+                child = doc.createElement(field);
+            } catch (DOMException | IllegalArgumentException e) {
+                log.error("Skipping archive field '{}' due to invalid XML element name in {}: {}",
+                        field, getClass().getName(), e.getMessage(), e);
+                continue;
+            }
+            child.setTextContent(text);
+            root.appendChild(child);
+        }
+        return root;
+    }
+
+    /**
+     * Formats a value for archive XML based on its FoormType.
+     */
+    protected static String formatArchiveValue(Object o, FoormType type) {
+        if (o == null) {
+            return null;
+        }
+        if (type == FoormType.CHECKBOX
+                || type == FoormType.RADIO
+                || type == FoormType.INTEGER
+                || type == FoormType.KEY) {
+            if (o instanceof Boolean) {
+                return Boolean.TRUE.equals(o) ? "1" : "0";
+            }
+        }
+        if (o instanceof Date) {
+            return String.valueOf(((Date) o).getTime());
+        }
+        return o.toString();
+    }
+
+    /**
+     * Populates this bean from an archive XML element. Iterates over child elements,
+     * and for each tag name matching an archivable {@link FoormField}, parses the
+     * text content and sets the corresponding field. Skips fields in
+     * {@link #getExcludedArchiveFieldNames()} (same filter as export) and children
+     * that are not archivable (e.g. nested {@code sakai-lti-tool}).
+     *
+     * @param element The archive element (e.g. {@code sakai-lti-tool}) containing children
+     */
+    public void populateFromArchiveElement(Element element) {
+        if (element == null) {
+            return;
+        }
+        Map<String, Field> fieldsByName = getFieldsForClass(getClass());
+        NodeList children = element.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = children.item(i);
+            if (n.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element child = (Element) n;
+            String tagName = child.getTagName();
+            Field f = fieldsByName.get(tagName);
+            if (f == null) {
+                continue;
+            }
+            FoormField ann = f.getAnnotation(FoormField.class);
+            if (ann == null || !ann.archive()) {
+                continue;
+            }
+            if (getExcludedArchiveFieldNames().contains(tagName)) {
+                continue;
+            }
+            String text = child.getTextContent();
+            if (text == null || text.isEmpty()) {
+                continue;
+            }
+            Object value = parseArchiveValue(text.trim(), f);
+            if (value == null) {
+                continue;
+            }
+            try {
+                f.set(this, value);
+            } catch (IllegalAccessException e) {
+                log.debug("Could not set field {}: {}", tagName, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Parses archive XML text content into the correct type for the given field.
+     */
+    protected static Object parseArchiveValue(String text, Field f) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        Class<?> type = f.getType();
+        try {
+            if (type == Boolean.class || type == boolean.class) {
+                return "1".equals(text) || "true".equalsIgnoreCase(text) || "yes".equalsIgnoreCase(text);
+            }
+            if (type == Integer.class || type == int.class) {
+                if (text.contains(".")) {
+                    return Integer.valueOf((int) Double.parseDouble(text));
+                }
+                return Integer.valueOf(text);
+            }
+            if (type == Long.class || type == long.class) {
+                if (text.contains(".")) {
+                    return Long.valueOf((long) Double.parseDouble(text));
+                }
+                return Long.valueOf(text);
+            }
+            if (type == Date.class) {
+                return new Date(Long.parseLong(text));
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        return text;
     }
 }

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormField.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormField.java
@@ -1,0 +1,82 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.lti.foorm;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declarative field metadata for form generation, validation, archive, and persistence.
+ * <p>
+ * Replaces the Foorm model string format with strongly typed attributes.
+ * Multi-valued attributes like {@link #choices()} and {@link #fields()} use arrays to preserve order.
+ * </p>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FoormField {
+	/** Canonical field name (archive XML element, DB column). */
+	String value();
+
+	/** Field type. */
+	FoormType type() default FoormType.TEXT;
+
+	/** Label key for UI. */
+	String label() default "";
+
+	/** Whether the field is required. */
+	boolean required() default false;
+
+	/** Max length (0 = no limit). */
+	int maxlength() default 0;
+
+	/** Whether the field is included in archive XML. */
+	boolean archive() default false;
+
+	/** Whether the field is hidden in forms. */
+	boolean hidden() default false;
+
+	/** Role required to edit (e.g. "admin"). */
+	String role() default "";
+
+	/** Whether the field is read-only. */
+	boolean readonly() default false;
+
+	/** Whether the field is persisted (false for computed/transient). */
+	boolean persist() default true;
+
+	/** For radio: ordered choices. */
+	String[] choices() default {};
+
+	/** For header: ordered child field names. */
+	String[] fields() default {};
+
+	/** For textarea: rows. */
+	int rows() default 0;
+
+	/** For textarea: cols. */
+	int cols() default 0;
+
+	/** Whether shown in advanced section. */
+	boolean advanced() default false;
+}

--- a/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormType.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/foorm/FoormType.java
@@ -1,0 +1,36 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.lti.foorm;
+
+/**
+ * Foorm field type for form generation, validation, archive, and persistence.
+ */
+public enum FoormType {
+	KEY,
+	TEXT,
+	TEXTAREA,
+	CHECKBOX,
+	RADIO,
+	INTEGER,
+	URL,
+	AUTODATE,
+	HEADER
+}

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiToolBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/beans/LtiToolBeanTest.java
@@ -28,7 +28,15 @@ import org.junit.Before;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Stack;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.beans.LtiToolBean;
 
 /**
@@ -677,5 +685,132 @@ public class LtiToolBeanTest {
         assertEquals("Only id and title should be in map", 2, convertedMap.size());
         assertEquals(Long.valueOf(999L), convertedMap.get("id"));
         assertEquals("Test Tool with Missing Booleans", convertedMap.get("title"));
+    }
+
+    @Test
+    public void testFromXmlNullInput() throws ParserConfigurationException {
+        assertNull(LtiToolBean.fromXml(null));
+    }
+
+    @Test
+    public void testFromXmlEmptyElement() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element el = doc.createElement(LTIService.ARCHIVE_LTI_TOOL_TAG);
+        LtiToolBean tool = LtiToolBean.fromXml(el);
+        assertNotNull(tool);
+        assertNull(tool.getId());
+        assertNull(tool.getTitle());
+    }
+
+    @Test
+    public void testFromXmlPopulatesArchivableFields() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element el = doc.createElement(LTIService.ARCHIVE_LTI_TOOL_TAG);
+        appendChild(el, "id", "42");
+        appendChild(el, "title", "XML Tool Title");
+        appendChild(el, "description", "XML description");
+        appendChild(el, "launch", "https://xml.example.com/launch");
+        appendChild(el, "frameheight", "600");
+        appendChild(el, "newpage", "1");
+        appendChild(el, "lti13", "1");
+
+        LtiToolBean tool = LtiToolBean.fromXml(el);
+        assertNotNull(tool);
+        assertEquals(Long.valueOf(42L), tool.getId());
+        assertEquals("XML Tool Title", tool.getTitle());
+        assertEquals("XML description", tool.getDescription());
+        assertEquals("https://xml.example.com/launch", tool.getLaunch());
+        assertEquals(Integer.valueOf(600), tool.getFrameheight());
+        assertEquals(Integer.valueOf(1), tool.getNewpage());
+        assertEquals(Integer.valueOf(1), tool.getLti13());
+    }
+
+    @Test
+    public void testToXmlAppendsToDocumentWhenStackEmpty() throws ParserConfigurationException {
+        LtiToolBean tool = new LtiToolBean();
+        tool.setId(99L);
+        tool.setTitle("Stack Empty Tool");
+        tool.setLaunch("https://empty.example/launch");
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Stack<Element> stack = new Stack<>();
+        Element el = tool.toXml(doc, stack);
+
+        assertNotNull(el);
+        assertEquals(LTIService.ARCHIVE_LTI_TOOL_TAG, el.getTagName());
+        assertNotNull(doc.getFirstChild());
+        assertEquals(el, doc.getFirstChild());
+        assertTrue(stack.isEmpty());
+    }
+
+    @Test
+    public void testToXmlAppendsToStackPeekWhenStackNonEmpty() throws ParserConfigurationException {
+        LtiToolBean tool = new LtiToolBean();
+        tool.setId(88L);
+        tool.setTitle("Stack Peek Tool");
+        tool.setLaunch("https://peek.example/launch");
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("root");
+        doc.appendChild(root);
+        Stack<Element> stack = new Stack<>();
+        stack.push(root);
+
+        Element el = tool.toXml(doc, stack);
+
+        assertNotNull(el);
+        assertEquals(LTIService.ARCHIVE_LTI_TOOL_TAG, el.getTagName());
+        assertEquals(el, root.getFirstChild());
+        assertEquals(root, stack.peek());
+    }
+
+    @Test
+    public void testToXmlWithNullStack() throws ParserConfigurationException {
+        LtiToolBean tool = new LtiToolBean();
+        tool.setId(77L);
+        tool.setTitle("Null Stack Tool");
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element el = tool.toXml(doc, null);
+
+        assertNotNull(el);
+        assertEquals(LTIService.ARCHIVE_LTI_TOOL_TAG, el.getTagName());
+        assertNotNull(doc.getFirstChild());
+    }
+
+    @Test
+    public void testToXmlReturnsNullWhenDocumentNull() {
+        LtiToolBean tool = new LtiToolBean();
+        tool.setTitle("No Doc Tool");
+        assertNull(tool.toXml(null, new Stack<>()));
+    }
+
+    @Test
+    public void testToXmlFromXmlRoundTrip() throws ParserConfigurationException {
+        LtiToolBean original = LtiToolBean.of(testMap);
+        assertNotNull(original);
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element el = original.toXml(doc, new Stack<>());
+        assertNotNull(el);
+
+        LtiToolBean restored = LtiToolBean.fromXml(el);
+        assertNotNull(restored);
+
+        // Archivable fields should round-trip (only fields with archive=true)
+        assertEquals(original.getId(), restored.getId());
+        assertEquals(original.getTitle(), restored.getTitle());
+        assertEquals(original.getDescription(), restored.getDescription());
+        assertEquals(original.getLaunch(), restored.getLaunch());
+        assertEquals(original.getFrameheight(), restored.getFrameheight());
+        assertEquals(original.getNewpage(), restored.getNewpage());
+        assertEquals(original.getLti13(), restored.getLti13());
+    }
+
+    private static void appendChild(Element parent, String tagName, String textContent) {
+        Document doc = parent.getOwnerDocument();
+        Element child = doc.createElement(tagName);
+        child.setTextContent(textContent);
+        parent.appendChild(child);
     }
 }

--- a/lti/lti-api/src/test/java/org/sakaiproject/lti/foorm/FoormBaseBeanTest.java
+++ b/lti/lti-api/src/test/java/org/sakaiproject/lti/foorm/FoormBaseBeanTest.java
@@ -1,0 +1,358 @@
+/*
+ *
+ * $URL$
+ * $Id$
+ *
+ * Copyright (c) 2025 Charles R. Severance
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.lti.foorm;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Unit tests for FoormBaseBean reflection, archive, and type handling.
+ */
+public class FoormBaseBeanTest {
+
+    private Date testDate;
+
+    /**
+     * Minimal FoormBaseBean subclass for testing reflection and archive behavior.
+     */
+    public static class MinimalFoormBean extends FoormBaseBean {
+        @FoormField(value = "id", type = FoormType.KEY, archive = true)
+        public Long id;
+        @FoormField(value = "title", type = FoormType.TEXT, archive = true)
+        public String title;
+        @FoormField(value = "count", type = FoormType.INTEGER, archive = true)
+        public Integer count;
+        @FoormField(value = "active", type = FoormType.CHECKBOX, archive = true)
+        public Boolean active;
+        @FoormField(value = "state", type = FoormType.RADIO, archive = true)
+        public Integer state;
+        @FoormField(value = "created", type = FoormType.AUTODATE, archive = true)
+        public Date created;
+        @FoormField(value = "notes", type = FoormType.TEXT)
+        public String notes;
+    }
+
+    /**
+     * Bean that overrides getExcludedArchiveFieldNames to exclude a field.
+     */
+    public static class BeanWithExclusion extends FoormBaseBean {
+        @FoormField(value = "id", type = FoormType.KEY, archive = true)
+        public Long id;
+        @FoormField(value = "secret", type = FoormType.TEXT, archive = true)
+        public String secret;
+
+        @Override
+        protected Set<String> getExcludedArchiveFieldNames() {
+            return Set.of("secret");
+        }
+    }
+
+    @Before
+    public void setUp() {
+        testDate = new Date();
+    }
+
+    // --- getValueByFieldName / getFoormFieldByFieldName ---
+
+    @Test
+    public void testGetValueByFieldName() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 42L;
+        bean.title = "Test Title";
+        bean.count = 99;
+        bean.active = true;
+        bean.notes = "not archived";
+
+        assertEquals(Long.valueOf(42L), bean.getValueByFieldName("id"));
+        assertEquals("Test Title", bean.getValueByFieldName("title"));
+        assertEquals(Integer.valueOf(99), bean.getValueByFieldName("count"));
+        assertEquals(Boolean.TRUE, bean.getValueByFieldName("active"));
+        assertEquals("not archived", bean.getValueByFieldName("notes"));
+    }
+
+    @Test
+    public void testGetValueByFieldNameUnknownField() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        assertNull(bean.getValueByFieldName("unknown_field"));
+    }
+
+    @Test
+    public void testGetValueByFieldNameNullValue() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        assertNull(bean.getValueByFieldName("id"));
+        assertNull(bean.getValueByFieldName("title"));
+    }
+
+    @Test
+    public void testGetFoormFieldByFieldName() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        FoormField idField = bean.getFoormFieldByFieldName("id");
+        assertNotNull(idField);
+        assertEquals("id", idField.value());
+        assertEquals(FoormType.KEY, idField.type());
+        assertTrue(idField.archive());
+
+        FoormField notesField = bean.getFoormFieldByFieldName("notes");
+        assertNotNull(notesField);
+        assertEquals("notes", notesField.value());
+        assertFalse(notesField.archive());
+    }
+
+    @Test
+    public void testGetFoormFieldByFieldNameUnknown() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        assertNull(bean.getFoormFieldByFieldName("nonexistent"));
+    }
+
+    // --- toArchiveElement ---
+
+    @Test
+    public void testToArchiveElementNullDocument() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        bean.title = "x";
+        assertNull(bean.toArchiveElement(null, "root"));
+    }
+
+    @Test
+    public void testToArchiveElementOnlyArchivableFields() throws ParserConfigurationException {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 123L;
+        bean.title = "Archive Me";
+        bean.count = 7;
+        bean.active = true;
+        bean.state = 1;
+        bean.created = testDate;
+        bean.notes = "should not appear";
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = bean.toArchiveElement(doc, "test-bean");
+
+        assertNotNull(root);
+        assertEquals("test-bean", root.getTagName());
+
+        Map<String, String> children = getChildElementsAsMap(root);
+        assertTrue(children.containsKey("id"));
+        assertTrue(children.containsKey("title"));
+        assertTrue(children.containsKey("count"));
+        assertTrue(children.containsKey("active"));
+        assertTrue(children.containsKey("state"));
+        assertTrue(children.containsKey("created"));
+        assertFalse(children.containsKey("notes"));
+
+        assertEquals("123", children.get("id"));
+        assertEquals("Archive Me", children.get("title"));
+        assertEquals("7", children.get("count"));
+        assertEquals("1", children.get("active"));
+        assertEquals("1", children.get("state"));
+        assertEquals(String.valueOf(testDate.getTime()), children.get("created"));
+    }
+
+    @Test
+    public void testToArchiveElementSkipsNullFields() throws ParserConfigurationException {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        bean.title = null;
+        bean.count = null;
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = bean.toArchiveElement(doc, "test-bean");
+
+        Map<String, String> children = getChildElementsAsMap(root);
+        assertEquals(1, children.size());
+        assertEquals("1", children.get("id"));
+    }
+
+    @Test
+    public void testToArchiveElementRespectsExcludedFields() throws ParserConfigurationException {
+        BeanWithExclusion bean = new BeanWithExclusion();
+        bean.id = 999L;
+        bean.secret = "super-secret";
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = bean.toArchiveElement(doc, "bean-with-exclusion");
+
+        Map<String, String> children = getChildElementsAsMap(root);
+        assertTrue(children.containsKey("id"));
+        assertFalse(children.containsKey("secret"));
+        assertEquals("999", children.get("id"));
+    }
+
+    // --- populateFromArchiveElement ---
+
+    @Test
+    public void testPopulateFromArchiveElementNullInput() {
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.id = 1L;
+        bean.populateFromArchiveElement(null);
+        assertEquals(Long.valueOf(1L), bean.id);
+    }
+
+    @Test
+    public void testPopulateFromArchiveElement() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "456");
+        appendChild(root, "title", "Populated Title");
+        appendChild(root, "count", "21");
+        appendChild(root, "active", "1");
+        appendChild(root, "state", "2");
+        appendChild(root, "created", String.valueOf(testDate.getTime()));
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(456L), bean.id);
+        assertEquals("Populated Title", bean.title);
+        assertEquals(Integer.valueOf(21), bean.count);
+        assertTrue(bean.active);
+        assertEquals(Integer.valueOf(2), bean.state);
+        assertEquals(testDate, bean.created);
+    }
+
+    @Test
+    public void testPopulateFromArchiveElementIgnoresNonArchivable() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "1");
+        appendChild(root, "notes", "should be ignored");  // notes has archive=false
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(1L), bean.id);
+        assertNull(bean.notes);  // notes not archivable, so not parsed
+    }
+
+    @Test
+    public void testPopulateFromArchiveElementIgnoresUnknownTags() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "1");
+        appendChild(root, "unknown_tag", "value");
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(1L), bean.id);
+    }
+
+    // --- Archive round-trip ---
+
+    @Test
+    public void testArchiveRoundTrip() throws ParserConfigurationException {
+        MinimalFoormBean original = new MinimalFoormBean();
+        original.id = 777L;
+        original.title = "Round Trip Test";
+        original.count = 42;
+        original.active = false;
+        original.state = 0;
+        original.created = testDate;
+
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element el = original.toArchiveElement(doc, "minimal");
+        doc.appendChild(el);
+
+        MinimalFoormBean restored = new MinimalFoormBean();
+        restored.populateFromArchiveElement(el);
+
+        assertEquals(original.id, restored.id);
+        assertEquals(original.title, restored.title);
+        assertEquals(original.count, restored.count);
+        assertEquals(original.active, restored.active);
+        assertEquals(original.state, restored.state);
+        assertEquals(original.created, restored.created);
+    }
+
+    @Test
+    public void testParseArchiveValueBooleanVariants() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "1");
+        appendChild(root, "active", "true");
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+        assertTrue(bean.active);
+
+        root.getElementsByTagName("active").item(0).setTextContent("1");
+        MinimalFoormBean bean2 = new MinimalFoormBean();
+        bean2.populateFromArchiveElement(root);
+        assertTrue(bean2.active);
+
+        root.getElementsByTagName("active").item(0).setTextContent("yes");
+        MinimalFoormBean bean3 = new MinimalFoormBean();
+        bean3.populateFromArchiveElement(root);
+        assertTrue(bean3.active);
+    }
+
+    @Test
+    public void testParseArchiveValueDecimalTruncation() throws ParserConfigurationException {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("test-bean");
+        appendChild(root, "id", "123.99");
+        appendChild(root, "count", "456.7");
+
+        MinimalFoormBean bean = new MinimalFoormBean();
+        bean.populateFromArchiveElement(root);
+
+        assertEquals(Long.valueOf(123L), bean.id);
+        assertEquals(Integer.valueOf(456), bean.count);
+    }
+
+    // --- Helpers ---
+
+    private static Map<String, String> getChildElementsAsMap(Element parent) {
+        Map<String, String> map = new HashMap<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = children.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE) {
+                Element e = (Element) n;
+                map.put(e.getTagName(), e.getTextContent());
+            }
+        }
+        return map;
+    }
+
+    private static void appendChild(Element parent, String tagName, String textContent) {
+        Document doc = parent.getOwnerDocument();
+        Element child = doc.createElement(tagName);
+        child.setTextContent(textContent);
+        parent.appendChild(child);
+    }
+}

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -1399,7 +1399,7 @@ public class LTI13Servlet extends HttpServlet {
 		int paging = NumberUtils.toInt(pagingstr, -1);
 		if ( paging > 0 && ( limit < 0 || limit > paging ) ) limit = paging;
 
-		// int allowOutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
+		// int allowOutcomes = (tool.allowoutcomes != null && Boolean.TRUE.equals(tool.allowoutcomes)) ? 1 : 0;
 
 		/* SAK-47261 - Scope NRPS to Context, not Resource Link
 		String assignment_name = (String) content.title;

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -1245,7 +1245,7 @@ public class LTI13Servlet extends HttpServlet {
 		if ( toolConfigurationObj instanceof JSONObject ) {
 			JSONObject toolConfiguration = (JSONObject) toolConfigurationObj;
 			// No site context during dynamic registration; resolve from the tool record.
-			String deployment_id = SakaiLTIUtil.getToolDeploymentId(null, tool.asMap());
+			String deployment_id = SakaiLTIUtil.getToolDeploymentId(null, tool);
 			toolConfiguration.put(LTIService.LTI_DEPLOYMENT_ID, deployment_id);
 		}
 

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -1778,6 +1778,21 @@ public class SakaiLTIUtil {
 		 */
 		public static String resolveLaunchDeploymentId(Site site, String launchSiteId, Long toolKey,
 				Map<String, Object> tool, LTIService ltiService) {
+			return resolveLaunchDeploymentId(site, launchSiteId, toolKey, LtiToolBean.of(tool), ltiService);
+		}
+
+		public static String resolveLaunchDeploymentId(Site site, String launchSiteId, Long toolKey,
+				LtiToolBean tool, LTIService ltiService) {
+			Long effectiveToolKey = toolKey;
+			if (effectiveToolKey == null && tool != null) {
+				effectiveToolKey = tool.id;
+			}
+			String toolDeploymentId = tool == null ? null : StringUtils.trimToNull(tool.deploymentId);
+			return resolveLaunchDeploymentId(site, launchSiteId, effectiveToolKey, toolDeploymentId, ltiService);
+		}
+
+		private static String resolveLaunchDeploymentId(Site site, String launchSiteId, Long toolKey,
+				String toolDeploymentId, LTIService ltiService) {
 			String normalized;
 			if (site != null) {
 				String explicit = StringUtils.trimToNull(site.getProperties().getProperty(LTI13_DEPLOYMENT_ID));
@@ -1809,13 +1824,9 @@ public class SakaiLTIUtil {
 					}
 				}
 			}
-			if (tool != null) {
-				Object deploymentId = tool.get(LTIService.LTI_DEPLOYMENT_ID);
-				String toolDeploymentId = deploymentId == null ? null : StringUtils.trimToNull(deploymentId.toString());
-				normalized = normalizeLtiDeploymentIdForLaunch(toolDeploymentId);
-				if (normalized != null) {
-					return normalized;
-				}
+			normalized = normalizeLtiDeploymentIdForLaunch(toolDeploymentId);
+			if (normalized != null) {
+				return normalized;
 			}
 			String serverDefault = ServerConfigurationService.getString(LTI13_DEPLOYMENT_ID, LTI13_DEPLOYMENT_ID_DEFAULT);
 			normalized = normalizeLtiDeploymentIdForLaunch(serverDefault);
@@ -1826,8 +1837,12 @@ public class SakaiLTIUtil {
 		 * Resolves {@code deployment_id} when no launch site or {@link LTIService} context is available
 		 * (same as {@link #resolveLaunchDeploymentId} with null launch site id, tool key, and service).
 		 */
+		public static String getToolDeploymentId(Site site, LtiToolBean tool) {
+			return resolveLaunchDeploymentId(site, null, tool == null ? null : tool.id, tool, null);
+		}
+
 		public static String getToolDeploymentId(Site site, Map<String, Object> tool) {
-			return resolveLaunchDeploymentId(site, null, null, tool, null);
+			return getToolDeploymentId(site, LtiToolBean.of(tool));
 		}
 
 		// LTI 1.3 / OIDC: the iss (issuer) claim is a stable per-platform identifier.
@@ -1972,7 +1987,7 @@ public class SakaiLTIUtil {
 			lj.expires = lj.issued + 3600L;
 			String launchSiteId = StringUtils.trimToNull(ltiProps.getProperty(LTIConstants.CONTEXT_ID));
 			Long toolKeyJwt = tool.id;
-			lj.deployment_id = resolveLaunchDeploymentId(site, launchSiteId, toolKeyJwt, tool.asMap(), ltiService);
+			lj.deployment_id = resolveLaunchDeploymentId(site, launchSiteId, toolKeyJwt, tool, ltiService);
 
 			String lti1_roles = fixLegacyRoles(ltiProps.getProperty("roles"));
 			if (lti1_roles != null ) {
@@ -4011,33 +4026,33 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static String computeToolCheckSum(Map<String, Object> tool) {
-		if ( tool == null ) return null;
-		if ( StringUtils.isEmpty((String) tool.get(LTIService.LTI_LAUNCH)) ) return null;
-		if ( StringUtils.isNotEmpty((String) tool.get(LTIService.LTI_CONSUMERKEY)) &&
-			StringUtils.isNotEmpty((String) tool.get(LTIService.LTI_SECRET)) ) {
+	public static String computeToolCheckSum(LtiToolBean tool) {
+		if (tool == null) {
+			return null;
+		}
+		if (StringUtils.isEmpty(tool.launch)) {
+			return null;
+		}
+		if (StringUtils.isNotEmpty(tool.consumerkey) && StringUtils.isNotEmpty(tool.secret)) {
 			// Enough
-		} else if ( StringUtils.isNotEmpty((String) tool.get(LTIService.LTI13_CLIENT_ID)) &&
-			StringUtils.isNotEmpty((String) tool.get(LTIService.LTI13_TOOL_KEYSET)) ) {
+		} else if (StringUtils.isNotEmpty(tool.lti13ClientId) && StringUtils.isNotEmpty(tool.lti13ToolKeyset)) {
 			// Enough
 		} else {
 			return null;
 		}
 
 		StringBuffer sb = new StringBuffer();
-		String secret = (String) tool.get(LTIService.LTI_SECRET);
-		sb.append(secret != null ? secret : "");
-		String consumerkey = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-		sb.append(consumerkey != null ? consumerkey : "");
-		String lti13ClientId = (String) tool.get(LTIService.LTI13_CLIENT_ID);
-		sb.append(lti13ClientId != null ? lti13ClientId : "");
-		String lti13ToolKeyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
-		sb.append(lti13ToolKeyset != null ? lti13ToolKeyset : "");
-		String launch = (String) tool.get(LTIService.LTI_LAUNCH);
-		sb.append(launch != null ? launch : "");
+		sb.append(tool.secret != null ? tool.secret : "");
+		sb.append(tool.consumerkey != null ? tool.consumerkey : "");
+		sb.append(tool.lti13ClientId != null ? tool.lti13ClientId : "");
+		sb.append(tool.lti13ToolKeyset != null ? tool.lti13ToolKeyset : "");
+		sb.append(tool.launch != null ? tool.launch : "");
 
-		String retval = LTI13Util.sha256(sb.toString());
-		return retval;
+		return LTI13Util.sha256(sb.toString());
+	}
+
+	public static String computeToolCheckSum(Map<String, Object> tool) {
+		return computeToolCheckSum(LtiToolBean.of(tool));
 	}
 
 	// /access/lti/site/22153323-3037-480f-b979-c630e3e2b3cf/content:1

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -78,6 +79,8 @@ import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.grading.api.model.Gradebook;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.portal.util.CSSUtils;
 import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.assignment.api.AssignmentConstants;
@@ -300,7 +303,7 @@ public class SakaiLTIUtil {
 
 		// Look at a Placement and come up with the launch urls, and
 		// other launch parameters to drive the launch.
-		public static boolean loadFromPlacement(Properties info, Properties launch, Placement placement) {
+		private static boolean loadFromPlacement(Properties info, Properties launch, Placement placement) {
 			Properties config = placement.getConfig();
 			log.debug("Sakai properties={}", config);
 			String launch_url = StringUtils.trimToNull(getCorrectProperty(config, LTIService.LTI_LAUNCH, placement));
@@ -336,7 +339,7 @@ public class SakaiLTIUtil {
 			return false;
 		}
 
-		public static void parseCustom(Properties info, String customstr) {
+		private static void parseCustom(Properties info, String customstr) {
 			if (customstr != null) {
 				String splitChar = "\n";
 				if (customstr.trim().indexOf("\n") == -1) {
@@ -504,7 +507,7 @@ public class SakaiLTIUtil {
 		}
 
 
-	public static void addSiteInfo(Properties props, Properties lti13subst, Site site) {
+	private static void addSiteInfo(Properties props, Properties lti13subst, Site site) {
 		if (site != null) {
 			String context_type = site.getType();
 			if (context_type != null && context_type.toLowerCase().contains("course")) {
@@ -575,9 +578,9 @@ public class SakaiLTIUtil {
 		setProperty(props, LTIConstants.LAUNCH_PRESENTATION_RETURN_URL, returnUrl);
 	}
 
-	public static void addUserInfo(Properties ltiProps, Properties lti13subst, User user, Map<String, Object> tool) {
-		int releasename = LTIUtil.toInt(tool.get(LTIService.LTI_SENDNAME));
-		int releaseemail = LTIUtil.toInt(tool.get(LTIService.LTI_SENDEMAILADDR));
+	private static void addUserInfo(Properties ltiProps, Properties lti13subst, User user, LtiToolBean tool) {
+		int releasename = (tool != null && Boolean.TRUE.equals(tool.sendname)) ? 1 : 0;
+		int releaseemail = (tool != null && Boolean.TRUE.equals(tool.sendemailaddr)) ? 1 : 0;
 		if (user != null) {
 			setProperty(ltiProps, LTIConstants.USER_ID, user.getId());
 			setProperty(lti13subst, LTICustomVars.USER_ID, user.getId());
@@ -616,7 +619,7 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static String getCurrentUserSakaiRole(User user, String context) {
+	private static String getCurrentUserSakaiRole(User user, String context) {
 		if (user == null) return null;
 
 		String realmId = SiteService.siteReference(context);
@@ -644,7 +647,7 @@ public class SakaiLTIUtil {
 		return null;
 	}
 
-	public static String getFallBackRole(String context) {
+	private static String getFallBackRole(String context) {
 		if (SecurityService.isSuperUser()) {
 			return LTI13ConstantsUtil.ROLE_INSTRUCTOR + ","
 				+ LTI13ConstantsUtil.ROLE_CONTEXT_ADMIN + ","
@@ -655,7 +658,8 @@ public class SakaiLTIUtil {
 		return LTI13ConstantsUtil.ROLE_LEARNER;
 	}
 
-	public static void addRoleInfo(Properties props, Properties lti13subst, User user, String context, String roleMapProp) {
+	private static void addRoleInfo(Properties props, Properties lti13subst, User user, String context, LtiToolBean tool) {
+		String roleMapProp = (tool != null && tool.rolemap != null) ? tool.rolemap : null;
 
 		String sakaiRole = SecurityService.isSuperUser() ? "admin" : getCurrentUserSakaiRole(user, context);
 
@@ -851,7 +855,9 @@ public class SakaiLTIUtil {
 		ToolConfiguration placement = SiteService.findTool(placementId);
 		Properties config = placement.getConfig();
 		String roleMapProp = StringUtils.trimToNull(getCorrectProperty(config, LTIService.LTI_ROLEMAP, placement));
-		addRoleInfo(props, null, user, context, roleMapProp);
+		// Deliberately minimal/ephemeral bean used only to supply tool.rolemap to addRoleInfo (LtiToolBean.of, roleMapProp, LTIService.LTI_ROLEMAP)
+		LtiToolBean minimalToolWithRoleMap = LtiToolBean.of(roleMapProp != null ? Collections.singletonMap(LTIService.LTI_ROLEMAP, roleMapProp) : null);
+		addRoleInfo(props, null, user, context, minimalToolWithRoleMap);
 		addSiteInfo(props, null, site);
 
 		// Add Placement Information
@@ -859,7 +865,7 @@ public class SakaiLTIUtil {
 		return true;
 	}
 
-	public static void addPlacementInfo(Properties props, String placementId) {
+	private static void addPlacementInfo(Properties props, String placementId) {
 
 		// Get the placement to see if we are to release information
 		ToolConfiguration placement = SiteService.findTool(placementId);
@@ -974,7 +980,7 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static void addConsumerData(Properties props, Properties custom) {
+	private static void addConsumerData(Properties props, Properties custom) {
 		final String defaultName =  ServerConfigurationService.getString("serverName",
 			ServerConfigurationService.getString("serverUrl","localhost.sakailms"));
 
@@ -1011,7 +1017,7 @@ public class SakaiLTIUtil {
 	// Custom variable substitutions extensions follow the form of
 	// $com.example.Foo.bar
 	// http://www.imsglobal.org/spec/lti/v1p3/#custom-variables
-	public static void addPropertyExtensionData(Properties props, Properties custom) {
+	private static void addPropertyExtensionData(Properties props, Properties custom) {
 		org.sakaiproject.component.api.ServerConfigurationService serverConfigurationService =
 			(org.sakaiproject.component.api.ServerConfigurationService) ComponentManager.get("org.sakaiproject.component.api.ServerConfigurationService");
 		if ( serverConfigurationService == null ) return;
@@ -1032,7 +1038,7 @@ public class SakaiLTIUtil {
 		}
 	}
 
-	public static void addGlobalData(Site site, Properties props, Properties custom, ResourceLoader rb) {
+	private static void addGlobalData(Site site, Properties props, Properties custom, ResourceLoader rb) {
 		if (rb != null) {
 			String locale = rb.getLocale().toString();
 			setProperty(props, LTIConstants.LAUNCH_PRESENTATION_LOCALE, locale);
@@ -1077,7 +1083,7 @@ public class SakaiLTIUtil {
 
 		// This must return an HTML message as the [0] in the array
 		// If things are successful - the launch URL is in [1]
-		public static String[] postLaunchHTML(Map<String, Object> content, Map<String, Object> tool,
+		public static String[] postLaunchHTML(LtiContentBean content, LtiToolBean tool,
 				String state, String nonce, LTIService ltiService, ResourceLoader rb) {
 
 			log.debug("state={} nonce={}", state, nonce);
@@ -1088,21 +1094,20 @@ public class SakaiLTIUtil {
 				return postError("<p>" + getRB(rb, "error.tool.missing", "Tool item is missing or improperly configured.") + "</p>");
 			}
 
-			int status = LTIUtil.toInt(tool.get(LTIService.LTI_STATUS));
-			if (status == 1) {
+			if ("disable".equals(tool.status)) {
 				return postError("<p>" + getRB(rb, "tool.disabled", "Tool is currently disabled") + "</p>");
 			}
 
 			// Go with the content url first
-			String launch_url = (String) content.get(LTIService.LTI_LAUNCH);
+			String launch_url = content.launch;
 			if (launch_url == null) {
-				launch_url = (String) tool.get(LTIService.LTI_LAUNCH);
+				launch_url = tool.launch;
 			}
 			if (launch_url == null) {
 				return postError("<p>" + getRB(rb, "error.nolaunch", "This tool is not yet configured.") + "</p>");
 			}
 
-			String context = (String) content.get(LTIService.LTI_SITE_ID);
+			String context = content.siteId;
 			Site site;
 			try {
 				site = SiteService.getSite(context);
@@ -1117,8 +1122,8 @@ public class SakaiLTIUtil {
 			gradingService.initializeGradebooksForSite(context);
 
 			// See if there are the necessary items
-			String secret = getSecret(tool, content);
-			String key = getKey(tool, content);
+			String secret = getSecret(tool);
+			String key = getKey(tool);
 
 			if (LTIService.LTI_SECRET_INCOMPLETE.equals(key) && LTIService.LTI_SECRET_INCOMPLETE.equals(secret)) {
 				return postError("<p>" + getRB(rb, "error.tool.partial", "Tool item is incomplete, missing a key and secret.") + "</p>");
@@ -1137,7 +1142,7 @@ public class SakaiLTIUtil {
 			setProperty(ltiProps, LTIConstants.LTI_VERSION, LTIConstants.LTI_VERSION_1);
 			addGlobalData(site, ltiProps, lti13subst, rb);
 			addSiteInfo(ltiProps, lti13subst, site);
-			addRoleInfo(ltiProps, lti13subst, user, context, (String) tool.get(LTIService.LTI_ROLEMAP));
+			addRoleInfo(ltiProps, lti13subst, user, context, tool);
 			addUserInfo(ltiProps, lti13subst, user, tool);
 
 			String resource_link_id = getResourceLinkId(content);
@@ -1150,15 +1155,15 @@ public class SakaiLTIUtil {
 			setProperty(toolProps, LTIService.LTI_SECRET, secret);
 			setProperty(toolProps, LTI_PORTLET_KEY, key);
 
-			int debug = LTIUtil.toInt(tool.get(LTIService.LTI_DEBUG));
+			int debug = (tool.debug != null) ? tool.debug : 0;
 			if (debug == 2) {
-				debug = LTIUtil.toInt(content.get(LTIService.LTI_DEBUG));
+				debug = (content.debug != null && content.debug) ? 1 : 0;
 			}
 			setProperty(toolProps, LTIService.LTI_DEBUG, debug + "");
 
-			int frameheight = LTIUtil.toInt(content.get(LTIService.LTI_FRAMEHEIGHT));
+			int frameheight = (content.frameheight != null && content.frameheight > 0) ? content.frameheight : 0;
 			if (frameheight < 1) {
-				frameheight = LTIUtil.toInt(tool.get(LTIService.LTI_FRAMEHEIGHT));
+				frameheight = (tool.frameheight != null && tool.frameheight > 0) ? tool.frameheight : 0;
 			}
 
 			setProperty(toolProps, LTIService.LTI_FRAMEHEIGHT, frameheight + "");
@@ -1166,10 +1171,10 @@ public class SakaiLTIUtil {
 
 			int newpage = getNewpage(tool, content, true) ? 1 : 0;
 			String title = getToolTitle(tool, content, "");
-			String description = (String) content.get(LTIService.LTI_DESCRIPTION);
+			String description = content.description;
 
 			// SAK-40044 - If there is no description, we fall back to the pre-21 description in JSON
-			String content_settings = (String) content.get(LTIService.LTI_SETTINGS);
+			String content_settings = content.settings;
 			JSONObject content_json = org.tsugi.lti.LTIUtil.parseJSONObject(content_settings);
 			if (StringUtils.isBlank(description) ) {
 				description = (String) content_json.get(LTIService.LTI_DESCRIPTION);
@@ -1217,9 +1222,9 @@ public class SakaiLTIUtil {
 				setProperty(lti13subst, subKey, value);
 			}
 
-			int allowoutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
-			int allowroster = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWROSTER));
-			String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+			int allowoutcomes = (tool.allowoutcomes != null && tool.allowoutcomes) ? 1 : 0;
+			int allowroster = (tool.allowroster != null && tool.allowroster) ? 1 : 0;
+			String placement_secret = content.placementsecret;
 
 			String result_sourcedid = getSourceDID(user, resource_link_id, placement_secret);
 			log.debug("allowoutcomes={} allowroster={} result_sourcedid={}",
@@ -1258,15 +1263,14 @@ public class SakaiLTIUtil {
 			// Construct the ultimate custom values for Launch
 			Properties custom = new Properties();
 
-			String contentCustom = (String) content.get(LTIService.LTI_CUSTOM);
+			String contentCustom = content.custom;
 			contentCustom = adjustCustom(contentCustom);
 			mergeLTI1Custom(custom, contentCustom);
 
-			String toolCustom = (String) tool.get(LTIService.LTI_CUSTOM);
+			String toolCustom = tool.custom;
 			toolCustom = adjustCustom(toolCustom);
 			mergeLTI1Custom(custom, toolCustom);
 
-			// See if there are any locally deployed substitutions
 			ltiService.filterCustomSubstitutions(lti13subst, tool, site);
 
 			log.debug("lti13subst={}", lti13subst);
@@ -1284,6 +1288,11 @@ public class SakaiLTIUtil {
 				return postLaunchJWT(toolProps, ltiProps, site, tool, content, ltiService, rb);
 			}
 			return postLaunchHTML(toolProps, ltiProps, rb);
+		}
+
+		public static String[] postLaunchHTML(Map<String, Object> content, Map<String, Object> tool,
+				String state, String nonce, LTIService ltiService, ResourceLoader rb) {
+			return postLaunchHTML(LtiContentBean.of(content), LtiToolBean.of(tool), state, nonce, ltiService, rb);
 		}
 
 		/**
@@ -1304,12 +1313,15 @@ public class SakaiLTIUtil {
 		/**
 		 * Create a ContentItem from the current request (may throw runtime)
 		 */
-		public static ContentItem getContentItemFromRequest(Map<String, Object> tool) {
+		public static ContentItem getContentItemFromRequest(LtiToolBean tool) {
+			if (tool == null) {
+				throw new RuntimeException("Tool is null");
+			}
 
 			Placement placement = ToolManager.getCurrentPlacement();
 			String siteId = placement.getContext();
 
-			String toolSiteId = (String) tool.get(LTIService.LTI_SITE_ID);
+			String toolSiteId = tool.siteId;
 			if (toolSiteId != null && !toolSiteId.equals(siteId)) {
 				throw new RuntimeException("Incorrect site id");
 			}
@@ -1328,7 +1340,7 @@ public class SakaiLTIUtil {
 			ContentItem contentItem = new ContentItem(req);
 
 			String oauth_consumer_key = req.getParameter("oauth_consumer_key");
-			String oauth_secret = (String) tool.get(LTIService.LTI_SECRET);
+			String oauth_secret = getSecret(tool);
 			oauth_secret = decryptSecret(oauth_secret);
 
 			String URL = getOurServletPath(req);
@@ -1343,60 +1355,50 @@ public class SakaiLTIUtil {
 			return contentItem;
 		}
 
+		public static ContentItem getContentItemFromRequest(Map<String, Object> tool) {
+			return getContentItemFromRequest(LtiToolBean.of(tool));
+		}
+
 		/**
-		 * getPublicKey - Get the appropriate public key for use for an incoming request
+		 * getPublicKey - Get the appropriate public key for use for an incoming request (bean overload)
 		 */
-		public static Key getPublicKey(Map<String, Object> tool, String id_token)
-		{
+		public static Key getPublicKey(LtiToolBean tool, String id_token) {
+			if (tool == null) {
+				throw new RuntimeException("Tool is null");
+			}
 			JSONObject jsonHeader = LTI13JwtUtil.jsonJwtHeader(id_token);
 			if (jsonHeader == null) {
 				throw new RuntimeException("Could not parse Jwt Header in client_assertion");
 			}
 			String incoming_kid = (String) jsonHeader.get("kid");
 
-			String tool_keyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+			String tool_keyset = tool.lti13ToolKeyset;
 			if (tool_keyset == null) {
 				throw new RuntimeException("Could not find tool keyset url");
 			}
 
-			Key publicKey = null;
-			if ( tool_keyset != null ) {
-				log.debug("Retrieving kid="+incoming_kid+" from "+tool_keyset);
-
-				// TODO: Read from Earle's super-cluster-cache one day - SAK-43700
-				try {
-					publicKey = LTI13KeySetUtil.getKeyFromKeySet(incoming_kid, tool_keyset);
-				} catch (Exception e) {
-					log.error(e.toString(), e);
-					log.debug("Stacktrace:", e);
-					// Sorry - too many exceptions to explain here - lets keep it simple after logging it
-					throw new RuntimeException("Unable to retrieve kid="+incoming_kid+" from "+tool_keyset+" detail="+e.toString());
-				}
-				// TODO: Store in Earle's super-cluster-cache one day - SAK-43700
-
+			log.debug("Retrieving kid={} from {}", incoming_kid, tool_keyset);
+			try {
+				return LTI13KeySetUtil.getKeyFromKeySet(incoming_kid, tool_keyset);
+			} catch (Exception e) {
+				log.error(e.toString(), e);
+				log.debug("Stacktrace:", e);
+				throw new RuntimeException("Unable to retrieve kid=" + incoming_kid + " from " + tool_keyset + " detail=" + e.toString());
 			}
-			return publicKey;
 		}
 
 		/**
-		 * getPublicKey - Get the appropriate public key for use for an incoming request
-		 * @param tool the tool bean
-		 * @param id_token the id token
-		 * @return the public key
+		 * Create a DeepLinkResponse from the current request (may throw runtime). Bean overload.
 		 */
-	public static Key getPublicKey(org.sakaiproject.lti.beans.LtiToolBean tool, String id_token) {
-		return getPublicKey(tool != null ? tool.asMap() : null, id_token);
-	}
-
-		/**
-		 * Create a ContentItem from the current request (may throw runtime)
-		 */
-		public static DeepLinkResponse getDeepLinkFromToken(Map<String, Object> tool, String id_token) {
+		public static DeepLinkResponse getDeepLinkFromToken(LtiToolBean tool, String id_token) {
+			if (tool == null) {
+				throw new RuntimeException("Tool is null");
+			}
 
 			Placement placement = ToolManager.getCurrentPlacement();
 			String siteId = placement.getContext();
 
-			String toolSiteId = (String) tool.get(LTIService.LTI_SITE_ID);
+			String toolSiteId = tool.siteId;
 			if (toolSiteId != null && !toolSiteId.equals(siteId)) {
 				throw new RuntimeException("Incorrect site id");
 			}
@@ -1412,10 +1414,8 @@ public class SakaiLTIUtil {
 				log.warn(lti_errorlog);
 			}
 
-			// May throw a RunTimeException on our behalf :)
 			Key publicKey = SakaiLTIUtil.getPublicKey(tool, id_token);
 
-			// Fill up the object, validate and return
 			DeepLinkResponse dlr = new DeepLinkResponse(id_token);
 			if ( ! dlr.validate(publicKey) ) {
 				throw new RuntimeException("Could not verify signature");
@@ -1424,27 +1424,26 @@ public class SakaiLTIUtil {
 			return dlr;
 		}
 
+		public static DeepLinkResponse getDeepLinkFromToken(Map<String, Object> tool, String id_token) {
+			return getDeepLinkFromToken(LtiToolBean.of(tool), id_token);
+		}
+
 		/**
-		 * An LTI ContentItemSelectionRequest launch
-		 *
-		 * This must return an HTML message as the [0] in the array If things are
-		 * successful - the launch URL is in [1]
+		 * An LTI ContentItemSelectionRequest launch. Bean overload.
 		 */
-		public static String[] postContentItemSelectionRequest(Long toolKey, Map<String, Object> tool,
+		public static String[] postContentItemSelectionRequest(Long toolKey, LtiToolBean tool,
 				String state, String nonce, ResourceLoader rb, String contentReturn, Properties dataProps) {
 			if (tool == null) {
 				return postError("<p>" + getRB(rb, "error.tool.missing", "Tool is missing or improperly configured.") + "</p>");
 			}
 
-			String launch_url = (String) tool.get("launch");
+			String launch_url = tool.launch;
 			if (launch_url == null) {
 				return postError("<p>" + getRB(rb, "error.tool.noreg", "This tool is has no launch url.") + "</p>");
 			}
 
-			String consumerkey = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-			String secret = (String) tool.get(LTIService.LTI_SECRET);
-
-			// If secret is encrypted, decrypt it
+			String consumerkey = tool.consumerkey;
+			String secret = getSecret(tool);
 			secret = decryptSecret(secret);
 
 			boolean isLTI13 = isLTI13(tool);
@@ -1516,7 +1515,7 @@ public class SakaiLTIUtil {
 			setProperty(ltiProps, LTIConstants.CONTENT_ITEM_RETURN_URL, contentReturn);
 
 			// This must always be there
-			String context = (String) tool.get(LTIService.LTI_SITE_ID);
+			String context = tool.siteId;
 			Site site;
 			try {
 				site = SiteService.getSite(context);
@@ -1535,10 +1534,8 @@ public class SakaiLTIUtil {
 			Properties lti13subst = new Properties();
 			addGlobalData(site, ltiProps, lti13subst, rb);
 			addSiteInfo(ltiProps, lti13subst, site);
-			addRoleInfo(ltiProps, lti13subst, user, context, (String) tool.get(LTIService.LTI_ROLEMAP));
+			addRoleInfo(ltiProps, lti13subst, user, context, tool);
 
-			int releasename = LTIUtil.toInt(tool.get(LTIService.LTI_SENDNAME));
-			int releaseemail = LTIUtil.toInt(tool.get(LTIService.LTI_SENDEMAILADDR));
 			addUserInfo(ltiProps, lti13subst, user, tool);
 
 			// Don't sent the normal return URL when we are doing ContentItem launch
@@ -1548,16 +1545,15 @@ public class SakaiLTIUtil {
 				ltiProps.remove(LTIConstants.LAUNCH_PRESENTATION_RETURN_URL);
 			}
 
-			boolean dodebug = LTIUtil.toInt(tool.get(LTIService.LTI_DEBUG)) == 1;
+			boolean dodebug = (tool.debug != null && tool.debug == 1);
 
 			// Merge all the sources of custom vaues and run the substitution
 			Properties custom = new Properties();
 
-			String toolCustom = (String) tool.get(LTIService.LTI_CUSTOM);
+			String toolCustom = tool.custom;
 			toolCustom = adjustCustom(toolCustom);
 			mergeLTI1Custom(custom, toolCustom);
 
-			// See if there are any locally deployed substitutions
 			LTIService ltiService = (LTIService) ComponentManager.get("org.sakaiproject.lti.api.LTIService");
 			ltiService.filterCustomSubstitutions(lti13subst, tool, site);
 
@@ -1579,17 +1575,13 @@ public class SakaiLTIUtil {
 				setProperty(toolProps, "nonce", nonce);  // So far LTI 1.3 only
 				toolProps.put(LTIService.LTI_DEBUG, dodebug ? "1" : "0");
 
-				Map<String, Object> content = null;
-				return postLaunchJWT(toolProps, ltiProps, site, tool, content, ltiService, rb);
+				return postLaunchJWT(toolProps, ltiProps, site, tool, null, ltiService, rb);
 			}
 
 			// LTI 1.1.2
-			String tool_state = (String) tool.get("tool_state");
-			if ( StringUtils.isNotEmpty(tool_state) ) setProperty(ltiProps, "tool_state", tool_state);
-			String platform_state = (String) tool.get("platform_state");
-			if ( StringUtils.isNotEmpty(platform_state) ) setProperty(ltiProps, "platform_state", platform_state);
-			String relaunch_url = (String) tool.get("relaunch_url");
-			if ( StringUtils.isNotEmpty(relaunch_url) ) setProperty(ltiProps, "relaunch_url", relaunch_url);
+			if ( StringUtils.isNotEmpty(tool.toolState) ) setProperty(ltiProps, "tool_state", tool.toolState);
+			if ( StringUtils.isNotEmpty(tool.platformState) ) setProperty(ltiProps, "platform_state", tool.platformState);
+			if ( StringUtils.isNotEmpty(tool.relaunchUrl) ) setProperty(ltiProps, "relaunch_url", tool.relaunchUrl);
 
 			String submit_form_id = java.util.UUID.randomUUID().toString() + "";
 			boolean autosubmit = !dodebug;
@@ -1609,6 +1601,11 @@ public class SakaiLTIUtil {
 
 			String[] retval = {postData, launch_url};
 			return retval;
+		}
+
+		public static String[] postContentItemSelectionRequest(Long toolKey, Map<String, Object> tool,
+				String state, String nonce, ResourceLoader rb, String contentReturn, Properties dataProps) {
+			return postContentItemSelectionRequest(toolKey, LtiToolBean.of(tool), state, nonce, rb, contentReturn, dataProps);
 		}
 
 		// This must return an HTML message as the [0] in the array
@@ -1862,7 +1859,15 @@ public class SakaiLTIUtil {
 
 		public static String[] postLaunchJWT(Properties toolProps, Properties ltiProps,
 				Site site, Map<String, Object> tool, Map<String, Object> content, LTIService ltiService, ResourceLoader rb) {
+			return postLaunchJWT(toolProps, ltiProps, site, LtiToolBean.of(tool), LtiContentBean.of(content), ltiService, rb);
+		}
+
+		public static String[] postLaunchJWT(Properties toolProps, Properties ltiProps,
+				Site site, LtiToolBean tool, LtiContentBean content, LTIService ltiService, ResourceLoader rb) {
 			log.debug("postLaunchJWT LTI 1.3");
+			if (tool == null) {
+				return postError("<p>" + getRB(rb, "error.missing", "Not configured") + "</p>");
+			}
 			String launch_url = toolProps.getProperty("secure_launch_url");
 			if (launch_url == null) {
 				launch_url = toolProps.getProperty("launch_url");
@@ -1873,16 +1878,16 @@ public class SakaiLTIUtil {
 
 			HttpServletRequest req = ToolUtils.getRequestFromThreadLocal();
 
-			String orig_site_id_null = (String) tool.get("orig_site_id_null");
+			String orig_site_id_null = tool.origSiteIdNull;
 			String site_id = null;
 			if ( ! "true".equals(orig_site_id_null) ) {
-				site_id = (String) tool.get(LTIService.LTI_SITE_ID);
+				site_id = tool.siteId;
 			}
 
-			String client_id = (String) tool.get(LTIService.LTI13_CLIENT_ID);
+			String client_id = tool.lti13ClientId;
 			String placement_secret = null;
 			if (content != null) {
-				placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+				placement_secret = content.placementsecret;
 			}
 
 		/*
@@ -1934,7 +1939,7 @@ public class SakaiLTIUtil {
 
 			SakaiLineItem sakaiLineItem = null;
 			if ( content != null ) {
-				String lineItemStr = (String) content.get(LTIService.LTI_LINEITEM);
+				String lineItemStr = content.contentitem;
 				sakaiLineItem = LineItemUtil.parseLineItem(lineItemStr);
 			}
 
@@ -1966,8 +1971,8 @@ public class SakaiLTIUtil {
 			lj.issued = Long.valueOf(System.currentTimeMillis() / 1000L);
 			lj.expires = lj.issued + 3600L;
 			String launchSiteId = StringUtils.trimToNull(ltiProps.getProperty(LTIConstants.CONTEXT_ID));
-			Long toolKeyJwt = LTIUtil.toLongNull(tool.get(LTIService.LTI_ID));
-			lj.deployment_id = resolveLaunchDeploymentId(site, launchSiteId, toolKeyJwt, tool, ltiService);
+			Long toolKeyJwt = tool.id;
+			lj.deployment_id = resolveLaunchDeploymentId(site, launchSiteId, toolKeyJwt, tool.asMap(), ltiService);
 
 			String lti1_roles = fixLegacyRoles(ltiProps.getProperty("roles"));
 			if (lti1_roles != null ) {
@@ -1988,8 +1993,8 @@ public class SakaiLTIUtil {
 
 			// Construct the LTI 1.1 -> LTIAdvantage transition claim
 			// https://www.imsglobal.org/spec/lti/v1p3/migr#lti-1-1-migration-claim
-			String oauth_consumer_key = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-			String oauth_secret = (String) tool.get(LTIService.LTI_SECRET);
+			String oauth_consumer_key = tool.consumerkey;
+			String oauth_secret = getSecret(tool);
 			oauth_secret = decryptSecret(oauth_secret);
 			if ( oauth_consumer_key != null && oauth_secret != null ) {
 				lj.lti11_transition = new LTI11Transition();
@@ -2046,9 +2051,9 @@ public class SakaiLTIUtil {
 				lj.custom.put(custom_key, custom_val);
 			}
 
-			int allowOutcomes = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWOUTCOMES));
-			int allowRoster = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWROSTER));
-			int allowLineItems = LTIUtil.toInt(tool.get(LTIService.LTI_ALLOWLINEITEMS));
+			int allowOutcomes = (tool.allowoutcomes != null && Boolean.TRUE.equals(tool.allowoutcomes)) ? 1 : 0;
+			int allowRoster = (tool.allowroster != null && Boolean.TRUE.equals(tool.allowroster)) ? 1 : 0;
+			int allowLineItems = (tool.allowlineitems != null && Boolean.TRUE.equals(tool.allowlineitems)) ? 1 : 0;
 
 			String sourcedid = ltiProps.getProperty("lis_result_sourcedid");
 
@@ -2226,7 +2231,7 @@ public class SakaiLTIUtil {
 			state = StringUtils.trimToNull(state);
 
 			// This is a comma separated list of valid redirect URLs - lame as heck
-			String lti13_tool_redirect = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_TOOL_REDIRECT));
+			String lti13_tool_redirect = StringUtils.trimToNull(tool.lti13OidcRedirect);
 
 			// If we have been told to send this to a redirect_uri instead of a launch...
 			String redirect_uri = req.getParameter("redirect_uri");
@@ -2303,11 +2308,15 @@ public class SakaiLTIUtil {
 		}
 
 		/*
-		 * get a signed placement from a content item
+		 * get a signed placement from a content item. Bean overload.
 		 */
+		public static String getResourceLinkId(LtiContentBean content) {
+			if (content == null || content.id == null) return null;
+			return "content:" + content.id;
+		}
+
 		public static String getResourceLinkId(Map<String, Object> content) {
-			String resource_link_id = "content:" + content.get(LTIService.LTI_ID);
-			return resource_link_id;
+			return getResourceLinkId(LtiContentBean.of(content));
 		}
 
 		public static String getSignedPlacement(String context_id, String resource_link_id, String placementSecret) {
@@ -2321,22 +2330,22 @@ public class SakaiLTIUtil {
 		}
 
 		/*
-		 * get a signed placement from a content item
+		 * get a signed placement from a content item. Bean overload.
 		 */
-		public static String getSignedPlacement(Map<String, Object> content) {
-			String context_id = (String) content.get(LTIService.LTI_SITE_ID);
-			String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
+		public static String getSignedPlacement(LtiContentBean content) {
+			if (content == null) return null;
+			String context_id = content.getSiteId();
+			String placement_secret = content.getPlacementsecret();
 			String resource_link_id = getResourceLinkId(content);
-			String signed_placement = null;
-			if ( placement_secret != null ) {
-				signed_placement = getSignedPlacement(context_id, resource_link_id, placement_secret);
-			}
-			return signed_placement;
+			if (placement_secret == null) return null;
+			return getSignedPlacement(context_id, resource_link_id, placement_secret);
+		}
+
+		public static String getSignedPlacement(Map<String, Object> content) {
+			return getSignedPlacement(LtiContentBean.of(content));
 		}
 
 		public static String trackResourceLinkID(Map<String, Object> oldContent) {
-			boolean retval = false;
-
 			String old_settings = (String) oldContent.get(LTIService.LTI_SETTINGS);
 			JSONObject old_json = LTIUtil.parseJSONObject(old_settings);
 			String old_id_history = (String) old_json.get(LTIService.LTI_ID_HISTORY);
@@ -2368,7 +2377,7 @@ public class SakaiLTIUtil {
 			return true;
 		}
 
-		public static String[] postError(String str) {
+		private static String[] postError(String str) {
 			String[] retval = {str};
 			return retval;
 		}
@@ -2381,7 +2390,7 @@ public class SakaiLTIUtil {
 		}
 
 		// To make absolutely sure we never send an XSS, we clean these values
-		public static void setProperty(Properties props, String key, String value) {
+		private static void setProperty(Properties props, String key, String value) {
 			if (value == null) {
 				return;
 			}
@@ -2710,14 +2719,19 @@ public class SakaiLTIUtil {
 	 * If the scoreGiven is null, we are clearing out the grade value.
 	 * Note that scoreObj.userId is subject, not userId (naming inconsistency in IMS specs but we have to follow here).
 	 */
-	public static Object handleGradebookLTI13(Site site,  Long tool_id, Map<String, Object> content, String userId,
+	public static Object handleGradebookLTI13(Site site, Long tool_id, Map<String, Object> content, String userId,
+			Long lineitem_key, Score scoreObj) {
+		return handleGradebookLTI13(site, tool_id, LtiContentBean.of(content), userId, lineitem_key, scoreObj);
+	}
+
+	public static Object handleGradebookLTI13(Site site, Long tool_id, LtiContentBean content, String userId,
 			Long lineitem_key, Score scoreObj) {
 
 		Object retval;
 		String title;
 
-		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}", 
-			site.getId(), tool_id, (content == null ? "null" : content.get(LTIService.LTI_ID)), lineitem_key, userId, scoreObj);
+		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}",
+			site.getId(), tool_id, (content == null ? "null" : content.id), lineitem_key, userId, scoreObj);
 
 		// An empty / null score given means to delete the score
 		SakaiLineItem lineItem = new SakaiLineItem();
@@ -2750,16 +2764,16 @@ public class SakaiLTIUtil {
 			} finally {
 				popAdvisor(); // Remove security advisor
 			}
-			title = (String) content.get(LTIService.LTI_TITLE);
+			title = content.title;
 			if (title == null || title.length() < 1) {
-				log.error("Could not determine content title {}", content.get(LTIService.LTI_ID));
-				return "Could not determine content title key="+content.get(LTIService.LTI_ID);
+				log.error("Could not determine content title {}", content.id);
+				return "Could not determine content title key=" + content.id;
 			}
 			gradebookColumn = getGradebookColumn(site, userId, title, lineItem, tool_id, content);
 		} else {
 			gradebookColumn = LineItemUtil.getColumnByKeyDAO(siteId, tool_id, lineitem_key);
 			if ( gradebookColumn == null || gradebookColumn.getName() == null ) {
-				log.error("Could not determine assignment_name title {}", content.get(LTIService.LTI_ID));
+				log.error("Could not determine assignment_name title {}", (content != null ? content.id : null));
 				return "Unable to load column for lineitem_key="+lineitem_key;
 			}
 
@@ -2882,14 +2896,12 @@ public class SakaiLTIUtil {
 	 * @param scoreObj the score object
 	 * @return the result
 	 */
-	public static Object handleGradebookLTI13(Site site, Long tool_id, org.sakaiproject.lti.beans.LtiContentBean content, String userId, Long lineitem_key, Score scoreObj) {
-		log.debug("siteid: {} tool_id: {} content: {} lineitem_key: {} userId: {} scoreObj: {}", site.getId(), tool_id, (content == null ? "null" : content.id), lineitem_key, userId, scoreObj);
-		return handleGradebookLTI13(site, tool_id, (content == null ? null : content.asMap()), userId, lineitem_key, scoreObj);
+	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, Map<String, Object> content) {
+		return getAssignment(site, LtiContentBean.of(content));
 	}
 
-	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, Map<String, Object> content) {
-
-		Long contentId = LTIUtil.toLongNull(content.get(LTIService.LTI_ID));
+	public static org.sakaiproject.assignment.api.model.Assignment getAssignment(Site site, LtiContentBean content) {
+		Long contentId = (content != null) ? content.getId() : null;
 		if ( contentId == null ) return null;
 
 		pushAdvisor();
@@ -2901,7 +2913,7 @@ public class SakaiLTIUtil {
 			for (org.sakaiproject.assignment.api.model.Assignment a : assignments) {
 				Integer assignmentContentId = a.getContentId();
 				if ( assignmentContentId == null ) continue;
-				if ( ! assignmentContentId.equals(contentId.intValue()) ) continue;
+				if ( contentId.longValue() != assignmentContentId.longValue() ) continue;
 				return a;
 			}
 			return null;
@@ -3211,6 +3223,10 @@ public class SakaiLTIUtil {
 	}
 
 	public static org.sakaiproject.grading.api.Assignment getGradebookColumn(Site site, String userId, String title, SakaiLineItem lineItem, Long tool_id, Map<String, Object> content) {
+		return getGradebookColumn(site, userId, title, lineItem, tool_id, LtiContentBean.of(content));
+	}
+
+	public static org.sakaiproject.grading.api.Assignment getGradebookColumn(Site site, String userId, String title, SakaiLineItem lineItem, Long tool_id, LtiContentBean content) {
 		// Look up the gradebook columns so we can find the max points
 		GradingService gradingService = (GradingService) ComponentManager.get("org.sakaiproject.grading.api.GradingService");
 
@@ -3255,7 +3271,7 @@ public class SakaiLTIUtil {
 				returnColumn.setExternallyMaintained(false);
 				returnColumn.setName(title);
 				if ( tool_id != null && content != null ) {
-					String external_id = LineItemUtil.constructExternalId(tool_id, content, lineItem);
+					String external_id = LineItemUtil.constructExternalId(content, lineItem);
 					returnColumn.setExternalAppName(LineItemUtil.GB_EXTERNAL_APP_NAME);
 					returnColumn.setExternalId(external_id);
 				}
@@ -3467,52 +3483,45 @@ public class SakaiLTIUtil {
 	/**
 	 * getLaunchCodeKey - Return the launch code key for a content item
 	 */
-	public static String getLaunchCodeKey(org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getLaunchCodeKey(content != null ? content.asMap() : null);
+	public static String getLaunchCodeKey(LtiContentBean content) {
+		if (content == null) return SESSION_LAUNCH_CODE + "0";
+		String id = (content.getId() != null) ? content.getId().toString() : "0";
+		return SESSION_LAUNCH_CODE + id;
 	}
 
 	public static String getLaunchCodeKey(Map<String, Object> content) {
-		if (content == null) return SESSION_LAUNCH_CODE + "0";
-		int id = LTIUtil.toInt(content.get(LTIService.LTI_ID));
-		return SESSION_LAUNCH_CODE + id;
+		return getLaunchCodeKey(LtiContentBean.of(content));
 	}
 
 	/**
 	 * getLaunchCode - Return the launch code for a content item
 	 */
-	public static String getLaunchCode(org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getLaunchCode(content != null ? content.asMap() : null);
+	public static String getLaunchCode(LtiContentBean content) {
+		if (content == null) return LTI13Util.timeStampSign("0", null);
+		String content_id = (content.getId() != null) ? content.getId().toString() : "0";
+		String placement_secret = content.getPlacementsecret();
+		return LTI13Util.timeStampSign(content_id, placement_secret);
 	}
 
 	public static String getLaunchCode(Map<String, Object> content) {
-		if (content == null) {
-			return LTI13Util.timeStampSign("0", null);
-		}
-		/*
-		long now = (new java.util.Date()).getTime();
-		int id = LTIUtil.toInt(content.get(LTIService.LTI_ID));
-		String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
-		String base_string = id + ":" + now + ":" + placement_secret;
-		String signature = LegacyShaUtil.sha256Hash(base_string);
-		String retval = id + ":" + now + ":" + signature;
-		*/
-		String content_id = content.get(LTIService.LTI_ID).toString();
-		String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
-		String retval = LTI13Util.timeStampSign(content_id, placement_secret);
-		return retval;
+		return getLaunchCode(LtiContentBean.of(content));
 	}
 
 	/**
-	 * checkLaunchCode - check to see if a launch code is properly signed and not expired
+	 * checkLaunchCode - check to see if a launch code is properly signed and not expired. Bean overload.
 	 */
+	public static boolean checkLaunchCode(LtiContentBean content, String launch_code) {
+		if (content == null) return false;
+		if (launch_code == null || launch_code.trim().isEmpty()) return false;
+		String content_id = (content.getId() != null) ? content.getId().toString() : "0";
+		if (!launch_code.contains(":" + content_id + ":")) return false;
+		String placement_secret = content.getPlacementsecret();
+		int delta = 5 * 60; // Five minutes
+		return LTI13Util.timeStampCheckSign(launch_code, placement_secret, delta);
+	}
+
 	public static boolean checkLaunchCode(Map<String, Object> content, String launch_code) {
-		String content_id = content.get(LTIService.LTI_ID).toString();
-		// Make sure that the token belongs to this content item
-		if ( ! launch_code.contains(":"+content_id+":") ) return false;
-		String placement_secret = (String) content.get(LTIService.LTI_PLACEMENTSECRET);
-		int delta = 5*60*60; // Five minutes
-		boolean retval = LTI13Util.timeStampCheckSign(launch_code, placement_secret, delta);
-		return retval;
+		return checkLaunchCode(LtiContentBean.of(content), launch_code);
 	}
 
 	/**
@@ -3598,6 +3607,9 @@ public class SakaiLTIUtil {
 
 	public static Map<String, Object> findBestToolMatch(boolean global, String launchUrl, String importCheckSum, List<Map<String,Object>> tools)
 	{
+		if (tools == null) {
+			return null;
+		}
 		boolean local = ! global;  // Makes it easier to read :)
 
 		// Next we look for a tool with a checksum match
@@ -3682,6 +3694,9 @@ public class SakaiLTIUtil {
 
 	public static Map<String, Object> findBestToolMatch(String launchUrl, String toolCheckSum, List<Map<String,Object>> tools)
 	{
+		if (tools == null) {
+			return null;
+		}
 		// Example launch URL:
 		// https://www.py4e.com/mod/gift/?quiz=02-Python.txt
 
@@ -3692,28 +3707,6 @@ public class SakaiLTIUtil {
 
 		retval = findBestToolMatch(global, launchUrl, toolCheckSum, tools);
 		return retval;
-	}
-
-	/**
-	 * Bean overload for findBestToolMatch
-	 */
-	public static org.sakaiproject.lti.beans.LtiToolBean findBestToolMatchBean(String launchUrl, String toolCheckSum, List<org.sakaiproject.lti.beans.LtiToolBean> tools)
-	{
-		// Guard against null tools parameter
-		if (tools == null) {
-			return null;
-		}
-		
-		// Convert Beans to maps for the existing logic
-		List<Map<String,Object>> toolMaps = new ArrayList<>();
-		for (org.sakaiproject.lti.beans.LtiToolBean tool : tools) {
-			if (tool != null) {
-				toolMaps.add(tool.asMap());
-			}
-		}
-
-		Map<String,Object> result = findBestToolMatch(launchUrl, toolCheckSum, toolMaps);
-		return result != null ? org.sakaiproject.lti.beans.LtiToolBean.of(result) : null;
 	}
 
 	public static String getStringNull(Object value) {
@@ -3827,173 +3820,149 @@ public class SakaiLTIUtil {
 	}
 
 	/**
-	 *  Check if we are an LTI 1.1 launch or not
+	 *  Check if we are an LTI 1.1 launch or not. Bean overload.
 	 */
-	public static boolean isLTI11(Map<String, Object> tool) {
-		if ( tool == null ) return false;
-		Long toolLTI13 = LTIUtil.toLong(tool.get(LTIService.LTI13));
-		if ( toolLTI13.equals(LTIService.LTI13_LTI11) ) return true;
-		if ( toolLTI13.equals(LTIService.LTI13_LTI13) ) return false;
-		if ( toolLTI13.equals(LTIService.LTI13_BOTH) ) return true;
+	public static boolean isLTI11(LtiToolBean tool) {
+		if (tool == null) return false;
+		Integer lti13 = tool.getLti13();
+		if (lti13 == null) return true;
+		int v = lti13.intValue();
+		if (v == LTIService.LTI13_LTI11.intValue()) return true;
+		if (v == LTIService.LTI13_LTI13.intValue()) return false;
+		if (v == LTIService.LTI13_BOTH.intValue()) return true;
 		return true;
 	}
 
+	/**
+	 *  Check if we are an LTI 1.1 launch or not
+	 */
+	public static boolean isLTI11(Map<String, Object> tool) {
+		return isLTI11(LtiToolBean.of(tool));
+	}
+
+
+	/**
+	 *  Check if we are an LTI 1.3 launch or not. Bean overload.
+	 */
+	public static boolean isLTI13(LtiToolBean tool) {
+		if (tool == null) return false;
+		Integer lti13 = tool.getLti13();
+		if (lti13 == null) return false;
+		int v = lti13.intValue();
+		if (v == LTIService.LTI13_LTI11.intValue()) return false;
+		if (v == LTIService.LTI13_LTI13.intValue()) return true;
+		if (v == LTIService.LTI13_BOTH.intValue()) return true;
+		return false;
+	}
 
 	/**
 	 *  Check if we are an LTI 1.3 launch or not
 	 */
 	public static boolean isLTI13(Map<String, Object> tool) {
-		if ( tool == null ) return false;
-		Long toolLTI13 = LTIUtil.toLong(tool.get(LTIService.LTI13));
-		if ( toolLTI13.equals(LTIService.LTI13_LTI11) ) return false;
-		if ( toolLTI13.equals(LTIService.LTI13_LTI13) ) return true;
-		if ( toolLTI13.equals(LTIService.LTI13_BOTH) ) return true;
-		return false;  // Default of null or other funky value is LTI 1.1
+		return isLTI13(LtiToolBean.of(tool));
 	}
 
 	/**
-	 * Get the secret based on inheritance rules
+	 * Get the secret for the tool. Content does not have secret; only tool is used.
 	 */
-	public static String getSecret(Map<String, Object> tool, Map<String, Object> content) {
-		String secret = null;
-		if ( content != null ) {
-			secret = (String) content.get(LTIService.LTI_SECRET);
-		}
-		if (secret == null) {
-			secret = (String) tool.get(LTIService.LTI_SECRET);
-		}
-		return secret;
+	public static String getSecret(LtiToolBean tool) {
+		return (tool != null) ? tool.getSecret() : null;
 	}
 
 	/**
-	 * Get the consumer key based on inheritance rules
+	 * Get the consumer key for the tool. Content does not have consumerkey; only tool is used.
 	 */
-	public static String getKey(Map<String, Object> tool, Map<String, Object> content) {
-		String key = null;
-		if ( content != null ) {
-			key = (String) content.get(LTIService.LTI_CONSUMERKEY);
-		}
-		if (key == null) {
-			key = (String) tool.get(LTIService.LTI_CONSUMERKEY);
-		}
-		return key;
+	public static String getKey(LtiToolBean tool) {
+		return (tool != null) ? tool.getConsumerkey() : null;
 	}
 
 	/**
 	 * Get the correct frameheight for a content / combination based on inheritance rules
 	 */
-	public static String getFrameHeight(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, String defaultValue) {
-		return getFrameHeight(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
-	}
-
-	public static String getFrameHeight(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
+	public static String getFrameHeight(LtiToolBean tool, LtiContentBean content, String defaultValue) {
 		String height = defaultValue;
 
 		// Check tool first (default behavior)
-		if ( tool != null ) {
-			Long toolFrameHeight = LTIUtil.toLong(tool.get(LTIService.LTI_FRAMEHEIGHT), -1L);
-			if ( toolFrameHeight > 0 )  height = toolFrameHeight + "px";
+		if (tool != null && tool.getFrameheight() != null && tool.getFrameheight() > 0) {
+			height = tool.getFrameheight() + "px";
 		}
 
 		// Check content second (content overrides tool if not null)
-		if (content != null) {
-			Long contentFrameHeight = LTIUtil.toLong(content.get(LTIService.LTI_FRAMEHEIGHT));
-			if ( contentFrameHeight > 0 ) height = contentFrameHeight + "px";
+		if (content != null && content.getFrameheight() != null && content.getFrameheight() > 0) {
+			height = content.getFrameheight() + "px";
 		}
 
 		return height;
 	}
 
+	public static String getFrameHeight(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
+		return getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
+	}
+
 	/**
 	 * Get the new page setting for a content / combination based on inheritance rules
 	 */
-	public static boolean getNewpage(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, boolean defaultValue) {
-		return getNewpage(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
-	}
-
-	public static boolean getNewpage(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+	public static boolean getNewpage(LtiToolBean tool, LtiContentBean content, boolean defaultValue) {
 		boolean newpage = defaultValue;
 
 		// Check content first (lower priority)
-		if (content != null ) {
-			Object contentNewpageObj = content.get(LTIService.LTI_NEWPAGE);
-			if ( contentNewpageObj != null ) {
-				if (contentNewpageObj instanceof Boolean) {
-					newpage = (Boolean) contentNewpageObj;
-				} else {
-					Long contentNewpage = LTIUtil.toLongNull(contentNewpageObj);
-					if ( contentNewpage != null ) newpage = (contentNewpage != 0);
-				}
-			}
+		if (content != null && content.getNewpage() != null) {
+			newpage = content.getNewpage();
 		}
 
 		// Check tool second (higher priority - overrides content)
-		if ( tool != null ) {
-			Long toolNewpage = LTIUtil.toLongNull(tool.get(LTIService.LTI_NEWPAGE));
-
-			if ( toolNewpage != null ) {
-				// Leave this alone for LTIService.LTI_TOOL_NEWPAGE_CONTENT
-				if ( toolNewpage == LTIService.LTI_TOOL_NEWPAGE_OFF ) newpage = false;
-				if ( toolNewpage == LTIService.LTI_TOOL_NEWPAGE_ON ) newpage = true;
-			}
+		if (tool != null && tool.getNewpage() != null) {
+			if (tool.getNewpage() == LTIService.LTI_TOOL_NEWPAGE_OFF) newpage = false;
+			if (tool.getNewpage() == LTIService.LTI_TOOL_NEWPAGE_ON) newpage = true;
 		}
 		return newpage;
+	}
+
+	public static boolean getNewpage(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+		return getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
 	}
 
 	/**
 	 * Get the debug setting for a content / tool combination based on inheritance rules
 	 */
-	public static boolean getDebug(org.sakaiproject.lti.beans.LtiToolBean tool, org.sakaiproject.lti.beans.LtiContentBean content, boolean defaultValue) {
-		return getDebug(tool != null ? tool.asMap() : null, content != null ? content.asMap() : null, defaultValue);
-	}
-
-	public static boolean getDebug(Map<String, Object> tool, Map<String, Object> content, boolean defaultValue) {
+	public static boolean getDebug(LtiToolBean tool, LtiContentBean content, boolean defaultValue) {
 		boolean debug = defaultValue;
 
 		// Check content first (lower priority)
-		if (content != null ) {
-			Object contentDebugObj = content.get(LTIService.LTI_DEBUG);
-			if ( contentDebugObj != null ) {
-				if (contentDebugObj instanceof Boolean) {
-					debug = (Boolean) contentDebugObj;
-				} else {
-					Long contentDebug = LTIUtil.toLongNull(contentDebugObj);
-					if ( contentDebug != null ) debug = (contentDebug != 0);
-				}
-			}
+		if (content != null && content.getDebug() != null) {
+			debug = content.getDebug();
 		}
 
 		// Check tool second (higher priority - overrides content)
-		if ( tool != null ) {
-			Long toolDebug = LTIUtil.toLongNull(tool.get(LTIService.LTI_DEBUG));
-
-			if ( toolDebug != null ) {
-				// Leave this alone for LTIService.LTI_TOOL_DEBUG_CONTENT
-				if ( toolDebug == LTIService.LTI_TOOL_DEBUG_OFF ) debug = false;
-				if ( toolDebug == LTIService.LTI_TOOL_DEBUG_ON ) debug = true;
-				// toolDebug == 2 (CONTENT) - leave content value as-is
-			}
+		if (tool != null && tool.getDebug() != null) {
+			if (tool.getDebug() == LTIService.LTI_TOOL_DEBUG_OFF) debug = false;
+			if (tool.getDebug() == LTIService.LTI_TOOL_DEBUG_ON) debug = true;
 		}
 		return debug;
+	}
+
+	/**
+	 * Get the title for a content / tool combination based on inheritance rules. Bean overload.
+	 */
+	public static String getToolTitle(LtiToolBean tool, LtiContentBean content, String defaultValue) {
+		String title = defaultValue;
+
+		if (tool != null && StringUtils.isNotEmpty(tool.getTitle())) {
+			title = tool.getTitle();
+		}
+
+		if (content != null && StringUtils.isNotEmpty(content.getTitle())) {
+			title = content.getTitle();
+		}
+
+		return title;
 	}
 
 	/**
 	 * Get the title for a content / combination based on inheritance rules
 	 */
 	public static String getToolTitle(Map<String, Object> tool, Map<String, Object> content, String defaultValue) {
-		String title = defaultValue;
-
-		if ( tool != null ) {
-			String toolTitle = (String) tool.get(LTIService.LTI_TITLE);
-			if ( StringUtils.isNotEmpty(toolTitle) ) title = toolTitle;
-		}
-
-		if (content != null ) {
-			String contentTitle = (String) content.get(LTIService.LTI_TITLE);
-			if ( StringUtils.isNotEmpty(contentTitle) ) title = contentTitle;
-		}
-
-		return title;
+		return getToolTitle(LtiToolBean.of(tool), LtiContentBean.of(content), defaultValue);
 	}
 
 	public static Element archiveTool(Document doc, Map<String, Object> tool) {
@@ -4023,6 +3992,9 @@ public class SakaiLTIUtil {
 
 	public static void mergeTool(Element element, Map<String, Object> tool) {
 		Foorm.mergeThing(element, LTIService.TOOL_MODEL, tool);
+		if (tool != null) {
+			tool.remove(LTIService.SAKAI_TOOL_CHECKSUM);
+		}
 	}
 
 	public static void mergeContent(Element element, Map<String, Object> content, Map<String, Object> tool) {
@@ -4053,11 +4025,16 @@ public class SakaiLTIUtil {
 		}
 
 		StringBuffer sb = new StringBuffer();
-		sb.append((String) tool.get(LTIService.LTI_SECRET));
-		sb.append((String) tool.get(LTIService.LTI_CONSUMERKEY));
-		sb.append((String) tool.get(LTIService.LTI13_CLIENT_ID));
-		sb.append((String) tool.get(LTIService.LTI13_TOOL_KEYSET));
-		sb.append((String) tool.get(LTIService.LTI_LAUNCH));
+		String secret = (String) tool.get(LTIService.LTI_SECRET);
+		sb.append(secret != null ? secret : "");
+		String consumerkey = (String) tool.get(LTIService.LTI_CONSUMERKEY);
+		sb.append(consumerkey != null ? consumerkey : "");
+		String lti13ClientId = (String) tool.get(LTIService.LTI13_CLIENT_ID);
+		sb.append(lti13ClientId != null ? lti13ClientId : "");
+		String lti13ToolKeyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+		sb.append(lti13ToolKeyset != null ? lti13ToolKeyset : "");
+		String launch = (String) tool.get(LTIService.LTI_LAUNCH);
+		sb.append(launch != null ? launch : "");
 
 		String retval = LTI13Util.sha256(sb.toString());
 		return retval;
@@ -4082,22 +4059,29 @@ public class SakaiLTIUtil {
 		return -1L;
 	}
 
-	public static String getContentLaunch(Map<String, Object> content) {
-		if ( content == null ) return null;
-		int key = LTIUtil.toInt(content.get(LTIService.LTI_ID));
-		String siteId = (String) content.get(LTIService.LTI_SITE_ID);
-		if (key < 0 || siteId == null)
-			return null;
+	public static String getContentLaunch(LtiContentBean content) {
+		if (content == null) return null;
+		Long id = content.getId();
+		long key = (id != null) ? id.longValue() : -1L;
+		String siteId = content.getSiteId();
+		if (key < 0 || siteId == null) return null;
 		return LTIService.LAUNCH_PREFIX + siteId + "/content:" + key;
 	}
 
-	public static String getToolLaunch(Map<String, Object> tool, String siteId) {
-		if ( tool == null ) return null;
-		if ( siteId == null ) return null;
-		int key = LTIUtil.toInt(tool.get(LTIService.LTI_ID));
-		if (key < 0 || siteId == null)
-			return null;
+	public static String getContentLaunch(Map<String, Object> content) {
+		return getContentLaunch(LtiContentBean.of(content));
+	}
+
+	public static String getToolLaunch(LtiToolBean tool, String siteId) {
+		if (tool == null || siteId == null) return null;
+		Long id = tool.getId();
+		long key = (id != null) ? id.longValue() : -1L;
+		if (key < 0) return null;
 		return LTIService.LAUNCH_PREFIX + siteId + "/tool:" + key;
+	}
+
+	public static String getToolLaunch(Map<String, Object> tool, String siteId) {
+		return getToolLaunch(LtiToolBean.of(tool), siteId);
 	}
 
 	public static String getExportUrl(String siteId, String filterId, ExportType exportType) {

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -749,7 +749,7 @@ public class LineItemUtil {
 			if (ltiService == null) {
 				return null;
 			}
-			Map<String, Object> content = ltiService.getContent(asn.getContentId().longValue(), contextId);
+			LtiContentBean content = ltiService.getContentAsBean(asn.getContentId().longValue(), contextId);
 			if (content == null) {
 				return null;
 			}

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -50,6 +50,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.util.foorm.Foorm;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 
 import org.sakaiproject.grading.api.GradingService;
@@ -155,6 +156,19 @@ public class LineItemUtil {
 		}
 	}
 	// tool_id|content_id|resourceId|tag|
+	/**
+	 * Construct the GB_EXTERNAL_ID for LTI AGS entries
+	 * @param content - The content item (can be null)
+	 * @param lineItem - The lineItem to insert
+	 * @return The properly formatted external id, or null if content is null or has no tool id
+	 */
+	public static String constructExternalId(LtiContentBean content, SakaiLineItem lineItem) {
+		if (content == null) return null;
+		Long toolId = content.getToolId();
+		if (toolId == null) return null;
+		return constructExternalIdImpl(toolId, content.getId(), lineItem);
+	}
+
 	/**
 	 * Construct the GB_EXTERNAL_ID for LTI AGS entries
 	 * @param content - The content item cannot be null
@@ -679,7 +693,7 @@ public class LineItemUtil {
 				String assignmentReference = org.sakaiproject.assignment.api.AssignmentReferenceReckoner.reckoner().assignment(a).reckon().getReference();
 				Integer assignmentContentId = a.getContentId();
 				if ( assignmentContentId == null ) continue;
-				Map<String, Object> content = ltiService.getContent(assignmentContentId.longValue(), context_id);
+				LtiContentBean content = ltiService.getContentAsBean(assignmentContentId.longValue(), context_id);
 				if ( content == null ) continue;
 				retval.put(assignmentReference, constructExternalId(content, null));
 			}
@@ -1321,6 +1335,23 @@ public class LineItemUtil {
 
 	/*
 	 * This is the statically constructed line item for a content item - if this is used, it will create
+	 * a line item when a score is first received. Bean overload using bean-based SakaiLTIUtil methods.
+	 */
+	public static SakaiLineItem constructLineItem(LtiContentBean content) {
+		if (content == null) return null;
+		String signed_placement = SakaiLTIUtil.getSignedPlacement(content);
+		SakaiLineItem li = new SakaiLineItem();
+		li.label = content.getTitle();
+		li.resourceLinkId = SakaiLTIUtil.getResourceLinkId(content);
+		if ( signed_placement != null ) {
+			li.id = getOurServerUrl() + LTI13_PATH + "lineitem/" + signed_placement;
+		}
+		li.scoreMaximum = 100.0;
+		return li;
+	}
+
+	/*
+	 * This is the statically constructed line item for a content item - if this is used, it will create
 	 * a line item when a score is first received
 	 */
 	public static SakaiLineItem constructLineItem(Map<String, Object> content) {
@@ -1362,13 +1393,29 @@ public class LineItemUtil {
 	}
 
 	/**
-	 * Gets the default lineItem for a content launch with content bean
+	 * Gets the default lineItem for a content launch with content bean. Uses bean-based SakaiLTIUtil methods.
 	 * @param site the site
 	 * @param content the content bean
 	 * @return the default line item
 	 */
-	public static SakaiLineItem getDefaultLineItem(Site site, org.sakaiproject.lti.beans.LtiContentBean content) {
-		return getDefaultLineItem(site, content != null ? content.asMap() : null);
+	public static SakaiLineItem getDefaultLineItem(Site site, LtiContentBean content) {
+		if (content == null) return null;
+		String signed_placement = SakaiLTIUtil.getSignedPlacement(content);
+		Long tool_id = content.getToolId();
+		log.debug("signed_placement={}; site id={}; tool_id={}", signed_placement, site.getId(), tool_id);
+		List<SakaiLineItem> toolItems = LineItemUtil.getLineItemsForTool(signed_placement, site, tool_id, null /* filter */);
+		String title = content.getTitle();
+		for (SakaiLineItem item : toolItems) {
+			if ( item.label == null) continue;
+			if ( item.label.equals(title) ) {
+				return item;
+			}
+		}
+		String autoConstruct = ServerConfigurationService.getString(LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM, LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_DEFAULT);
+		if ( LTI_ADVANTAGE_CONSTRUCT_LINE_ITEM_TRUE.equals(autoConstruct) ) {
+			return constructLineItem(content);
+		}
+		return null;
 	}
 
 	/**

--- a/lti/lti-common/src/test/org/sakaiproject/lti/beans/LTIBeanIntegrationTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/beans/LTIBeanIntegrationTest.java
@@ -104,7 +104,7 @@ public class LTIBeanIntegrationTest {
         // 3. Create new content bean
         // 4. Insert content
         
-        // Create a list of tool beans (simulating what would come from ltiService.getToolBeans())
+        // Create a list of tool beans (simulating what would come from ltiService.getToolsAsBeans())
         List<LtiToolBean> tools = new ArrayList<>();
         
         LtiToolBean tool1 = new LtiToolBean();

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -38,11 +38,15 @@ import java.util.stream.Collectors;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import org.json.simple.JSONObject;
 
 import org.sakaiproject.util.Xml;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.tsugi.lti.LTIUtil;
 import org.tsugi.lti.LTIConstants;
@@ -178,20 +182,23 @@ public class SakaiLTIUtilTest {
 		Map<String, Object> content = new TreeMap<String, Object>();
 		content.put(LTIService.LTI_ID, "42");
 		content.put(LTIService.LTI_PLACEMENTSECRET, "xyzzy");
+		LtiContentBean contentBean = LtiContentBean.of(content);
 
-		String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(content);
+		String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(contentBean);
 		assertEquals(launch_code_key,"launch_code:42");
 
-		String launch_code = SakaiLTIUtil.getLaunchCode(content);
-		assertTrue(SakaiLTIUtil.checkLaunchCode(content, launch_code));
+		String launch_code = SakaiLTIUtil.getLaunchCode(contentBean);
+		assertTrue(SakaiLTIUtil.checkLaunchCode(contentBean, launch_code));
 
 		content.put(LTIService.LTI_PLACEMENTSECRET, "wrong");
-		assertFalse(SakaiLTIUtil.checkLaunchCode(content, launch_code));
+		contentBean = LtiContentBean.of(content);
+		assertFalse(SakaiLTIUtil.checkLaunchCode(contentBean, launch_code));
 
 		// Correct password different id
 		content.put(LTIService.LTI_ID, "43");
 		content.put(LTIService.LTI_PLACEMENTSECRET, "xyzzy");
-		assertFalse(SakaiLTIUtil.checkLaunchCode(content, launch_code));
+		contentBean = LtiContentBean.of(content);
+		assertFalse(SakaiLTIUtil.checkLaunchCode(contentBean, launch_code));
 	}
 
 	@Test
@@ -776,41 +783,41 @@ public class SakaiLTIUtilTest {
 		Map<String, Object> tool = new HashMap();
 		Map<String, Object> content = new HashMap();
 
-		// Run default tests
-		boolean retval = SakaiLTIUtil.getNewpage((Map<String, Object>) null, (Map<String, Object>) null, true);
+		// Run default tests (bean overload with null)
+		boolean retval = SakaiLTIUtil.getNewpage((LtiToolBean) null, (LtiContentBean) null, true);
 		assertEquals(retval, true);
-		retval = SakaiLTIUtil.getNewpage((Map<String, Object>) null, (Map<String, Object>) null, false);
+		retval = SakaiLTIUtil.getNewpage((LtiToolBean) null, (LtiContentBean) null, false);
 		assertEquals(retval, false);
 
 		// No data means default comes through
-		retval = SakaiLTIUtil.getNewpage(tool, content, true);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), true);
 		assertEquals(retval, true);
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, false);
 
 		// Only content
 		content.put(LTIService.LTI_NEWPAGE, 0L);
-		retval = SakaiLTIUtil.getNewpage(tool, content, true);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), true);
 		assertEquals(retval, false);
 		content.put(LTIService.LTI_NEWPAGE, 1L);
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, true);
 
 		// Tool wins
 		tool.put(LTIService.LTI_NEWPAGE, LTIService.LTI_TOOL_NEWPAGE_OFF);
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, false);
 
 		tool.put(LTIService.LTI_NEWPAGE, Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_ON));
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, true);
 
 		// Let content win
 		tool.put(LTIService.LTI_NEWPAGE, Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT));
-		retval = SakaiLTIUtil.getNewpage(tool, content, false);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), false);
 		assertEquals(retval, true);
 		content.put(LTIService.LTI_NEWPAGE, 0L);
-		retval = SakaiLTIUtil.getNewpage(tool, content, true);
+		retval = SakaiLTIUtil.getNewpage(LtiToolBean.of(tool), LtiContentBean.of(content), true);
 		assertEquals(retval, false);
 	}
 
@@ -818,33 +825,33 @@ public class SakaiLTIUtilTest {
 	public void testGetFrameHeight() {
 		Map<String, Object> tool = new HashMap();
 		Map<String, Object> content = new HashMap();
-		String retval = SakaiLTIUtil.getFrameHeight((Map<String, Object>) null, (Map<String, Object>) null, "1200px");
+		String retval = SakaiLTIUtil.getFrameHeight((LtiToolBean) null, (LtiContentBean) null, "1200px");
 		assertEquals(retval, "1200px");
 
 		// Both are empty
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "1200px");
 
 		content.put(LTIService.LTI_FRAMEHEIGHT, Long.valueOf(42));
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "42px");
 
 		// Tool is empty
 		content.put(LTIService.LTI_FRAMEHEIGHT, Long.valueOf(42));
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "42px");
 
 		// Strings work as well - just in case
 		content.put(LTIService.LTI_FRAMEHEIGHT, "44");
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "44px");
 
 		tool.put(LTIService.LTI_FRAMEHEIGHT, Long.valueOf(100));
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "44px");
 
 		// Content takes precedence over tool
-		retval = SakaiLTIUtil.getFrameHeight(tool, content, "1200px");
+		retval = SakaiLTIUtil.getFrameHeight(LtiToolBean.of(tool), LtiContentBean.of(content), "1200px");
 		assertEquals(retval, "44px");
 	}
 
@@ -864,14 +871,23 @@ public class SakaiLTIUtilTest {
 
 		Element element = SakaiLTIUtil.archiveContent(doc, content, null);
 		root.appendChild(element);
-		String xmlOut = Xml.writeDocumentToString(doc);
-		assertEquals(xmlOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><sakai-lti-content><title>An LTI title</title><description>An LTI DESCRIPTION</description><frameheight>42</frameheight><newpage>1</newpage><launch>http://localhost:a-launch?x=42</launch></sakai-lti-content></root>");
+		Map<String, String> expectedContent = new HashMap<>();
+		expectedContent.put("title", "An LTI title");
+		expectedContent.put("description", "An LTI DESCRIPTION");
+		expectedContent.put("frameheight", "42");
+		expectedContent.put("newpage", "1");
+		expectedContent.put("launch", "http://localhost:a-launch?x=42");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG, expectedContent, LTIService.ARCHIVE_LTI_TOOL_TAG);
 
 		Map<String, Object> content2  = new HashMap();
 		SakaiLTIUtil.mergeContent(element, content2, null);
-		assertNotEquals(content, content2);
-		content.remove(LTIService.LTI_TOOL_ID);
-		assertEquals(content, content2);
+		Map<String, Object> expectedContentMap = new HashMap();
+		expectedContentMap.put(LTIService.LTI_FRAMEHEIGHT, 42L);
+		expectedContentMap.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedContentMap.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedContentMap.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedContentMap.put(LTIService.LTI_NEWPAGE, 1L);
+		assertEquals(expectedContentMap, content2);
 	}
 
 	@Test
@@ -888,28 +904,116 @@ public class SakaiLTIUtilTest {
 		tool.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
 		tool.put(LTIService.LTI_NEWPAGE, 1L);
 
-		tool.put(LTIService.LTI_SENDNAME, "please");  // Wil export (bad data) will not import
+		tool.put(LTIService.LTI_SENDNAME, "please");  // Map/Foorm path preserves raw value
 		tool.put(LTIService.LTI_SECRET, "verysecure");  // Should not come back - Not archived
 		tool.put(LTIService.LTI_CONSUMERKEY, "key12345");  // Should not come back - Not archived
 
 		Element element = SakaiLTIUtil.archiveTool(doc, tool);
 		root.appendChild(element);
-		String xmlOut = Xml.writeDocumentToString(doc);
-		assertEquals(xmlOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><sakai-lti-tool><title>An LTI title</title><description>An LTI DESCRIPTION</description><launch>http://localhost:a-launch?x=42</launch><newpage>1</newpage><frameheight>42</frameheight><sendname>please</sendname><lti13>1</lti13><sakai_tool_checksum>85RP91sSzHqtxBIkTrknaShQlL52r0JLOfKvaLJT4Gc=</sakai_tool_checksum></sakai-lti-tool></root>");
+		Map<String, String> expectedToolElements = new HashMap<>();
+		expectedToolElements.put("title", "An LTI title");
+		expectedToolElements.put("description", "An LTI DESCRIPTION");
+		expectedToolElements.put("launch", "http://localhost:a-launch?x=42");
+		expectedToolElements.put("newpage", "1");
+		expectedToolElements.put("frameheight", "42");
+		expectedToolElements.put("sendname", "please");  // Map/Foorm path preserves raw value
+		expectedToolElements.put("lti13", "1");
+		expectedToolElements.put("sakai_tool_checksum", "Jon1MG0AtWlH0fcbHrOJ9L/PNb+mti8syZ2b6OGf0Rw=");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedToolElements, null);
 
 		Map<String, Object> tool2 = new HashMap();
 		SakaiLTIUtil.mergeTool(element, tool2);
 		assertNotEquals(tool, tool2);
-		assertEquals((String) (tool2.get(LTIService.SAKAI_TOOL_CHECKSUM)), "85RP91sSzHqtxBIkTrknaShQlL52r0JLOfKvaLJT4Gc=");
+		assertNull("Checksum is excluded from rehydration (getExcludedArchiveFieldNames)", tool2.get(LTIService.SAKAI_TOOL_CHECKSUM));
 		tool.remove(LTIService.LTI_SECRET);
 		assertNotEquals(tool, tool2);
 		tool.remove(LTIService.LTI_CONSUMERKEY);
 		assertNotEquals(tool, tool2);
 		tool.remove(LTIService.LTI_SENDNAME);
-		assertNotEquals(tool, tool2);
 		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
-		assertTrue(tool.equals(tool2));
-		assertEquals(tool, tool2);
+		tool2.remove(LTIService.LTI_SENDNAME);  // Exclude for equivalence (archived value may vary)
+		Map<String, Object> expectedTool = new HashMap();
+		expectedTool.put(LTIService.LTI_FRAMEHEIGHT, 42L);
+		expectedTool.put(LTIService.LTI13, 1L);
+		expectedTool.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedTool.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedTool.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedTool.put(LTIService.LTI_NEWPAGE, 1L);
+		assertEquals(expectedTool, tool2);
+	}
+
+	@Test
+	public void testArchiveMergeToolBean() {
+		Document doc = Xml.createDocument();
+		Element root = doc.createElement("root");
+		doc.appendChild(root);
+
+		Map<String, Object> tool = new HashMap();
+		tool.put(LTIService.LTI_FRAMEHEIGHT, 42);
+		tool.put(LTIService.LTI13, LTIService.LTI13_LTI13);
+		tool.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		tool.put(LTIService.LTI_TITLE, "An LTI title");
+		tool.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		tool.put(LTIService.LTI_NEWPAGE, 1);
+		tool.put(LTIService.LTI_SENDNAME, 0);
+		tool.put(LTIService.LTI_SECRET, "verysecure");
+		tool.put(LTIService.LTI_CONSUMERKEY, "key12345");
+
+		Element element = SakaiLTIUtil.archiveTool(doc, tool);
+		root.appendChild(element);
+		Map<String, String> expectedToolElements = new HashMap<>();
+		expectedToolElements.put("title", "An LTI title");
+		expectedToolElements.put("description", "An LTI DESCRIPTION");
+		expectedToolElements.put("launch", "http://localhost:a-launch?x=42");
+		expectedToolElements.put("newpage", "1");
+		expectedToolElements.put("frameheight", "42");
+		expectedToolElements.put("sendname", "0");
+		expectedToolElements.put("lti13", "1");
+		expectedToolElements.put("sakai_tool_checksum", "Jon1MG0AtWlH0fcbHrOJ9L/PNb+mti8syZ2b6OGf0Rw=");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedToolElements, null);
+
+		// Round-trip: merge XML back into a map and verify we get the same tool data.
+		// mergeTool parses the sakai-lti-tool element and populates tool2 with element values.
+		// Checksum is excluded from rehydration (getExcludedArchiveFieldNames), so we assert it is null.
+		Map<String, Object> tool2 = new HashMap();
+		SakaiLTIUtil.mergeTool(element, tool2);
+		assertNull("Checksum is excluded from rehydration", tool2.get(LTIService.SAKAI_TOOL_CHECKSUM));
+		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
+		Map<String, Object> expected = new HashMap();
+		expected.put(LTIService.LTI_TITLE, "An LTI title");
+		expected.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expected.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expected.put(LTIService.LTI_NEWPAGE, 1L);
+		expected.put(LTIService.LTI_FRAMEHEIGHT, 42L);
+		expected.put(LTIService.LTI_SENDNAME, 0L);
+		expected.put(LTIService.LTI13, 1L);
+		assertEquals(expected, tool2);
+	}
+
+	/**
+	 * Asserts that the first element with the given tag in doc has child elements equivalent
+	 * to expected (same tag names and text content, ignoring order). Optionally excludes
+	 * a nested child tag when building the map (e.g. exclude sakai-lti-tool when checking
+	 * content element's direct fields).
+	 */
+	private void assertElementXmlEquivalent(Document doc, String tagName, Map<String, String> expected, String excludeChildTag) {
+		NodeList nodes = doc.getElementsByTagName(tagName);
+		assertNotNull(tagName + " element should exist", nodes);
+		assertTrue(tagName + " element should exist", nodes.getLength() >= 1);
+		Element el = (Element) nodes.item(0);
+		Map<String, String> actual = new HashMap<>();
+		NodeList children = el.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node n = children.item(i);
+			if (n.getNodeType() == Node.ELEMENT_NODE) {
+				Element e = (Element) n;
+				if (excludeChildTag != null && excludeChildTag.equals(e.getTagName())) {
+					continue;
+				}
+				actual.put(e.getTagName(), e.getTextContent());
+			}
+		}
+		assertEquals(tagName + " XML elements should be equivalent (order-independent)", expected, actual);
 	}
 
 	public void mapDump(String header, Map<String, Object> dump)
@@ -946,23 +1050,47 @@ public class SakaiLTIUtilTest {
 
 		Element element = SakaiLTIUtil.archiveContent(doc, content, tool);
 		root.appendChild(element);
-		String xmlOut = Xml.writeDocumentToString(doc);
-		assertEquals(xmlOut, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><sakai-lti-content><title>An LTI title</title><description>An LTI DESCRIPTION</description><frameheight>42</frameheight><newpage>1</newpage><launch>http://localhost:a-launch?x=42</launch><sakai-lti-tool><title>An LTI title</title><description>An LTI DESCRIPTION</description><launch>http://localhost:a-launch?x=42</launch><newpage>1</newpage><frameheight>42</frameheight><lti13>1</lti13><sakai_tool_checksum>ASRHSVgrhBjDbhkLEZpWa/IueI9FwFwTxSjnU5uNCB0=</sakai_tool_checksum></sakai-lti-tool></sakai-lti-content></root>");
+		Map<String, String> expectedContent = new HashMap<>();
+		expectedContent.put("title", "An LTI title");
+		expectedContent.put("description", "An LTI DESCRIPTION");
+		expectedContent.put("frameheight", "42");
+		expectedContent.put("newpage", "1");
+		expectedContent.put("launch", "http://localhost:a-launch?x=42");
+		Map<String, String> expectedTool = new HashMap<>();
+		expectedTool.put("title", "An LTI title");
+		expectedTool.put("description", "An LTI DESCRIPTION");
+		expectedTool.put("launch", "http://localhost:a-launch?x=42");
+		expectedTool.put("newpage", "1");
+		expectedTool.put("frameheight", "42");
+		expectedTool.put("lti13", "1");
+		expectedTool.put("sakai_tool_checksum", "BF6JwVmB1Y1kgPxP4WnAS30BnWzJP46IpmKKrKCSfaw=");
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_CONTENT_TAG, expectedContent, LTIService.ARCHIVE_LTI_TOOL_TAG);
+		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedTool, null);
 
 		Map<String, Object> content2  = new HashMap();
 		Map<String, Object> tool2  = new HashMap();
 		SakaiLTIUtil.mergeContent(element, content2, tool2);
-		assertEquals(content, content2);
-		assertNotEquals(tool, tool2);
-		tool.remove(LTIService.LTI_CONSUMERKEY);
-		tool.remove(LTIService.LTI_SECRET);
+		Map<String, Object> expectedContentMap = new HashMap();
+		expectedContentMap.put(LTIService.LTI_FRAMEHEIGHT, 42L);
+		expectedContentMap.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedContentMap.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedContentMap.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedContentMap.put(LTIService.LTI_NEWPAGE, 1L);
+		assertEquals(expectedContentMap, content2);
 		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
-		assertEquals(tool, tool2);
+		Map<String, Object> expectedToolMap = new HashMap();
+		expectedToolMap.put(LTIService.LTI_FRAMEHEIGHT, 42L);
+		expectedToolMap.put(LTIService.LTI13, 1L);
+		expectedToolMap.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
+		expectedToolMap.put(LTIService.LTI_TITLE, "An LTI title");
+		expectedToolMap.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
+		expectedToolMap.put(LTIService.LTI_NEWPAGE, 1L);
+		assertEquals(expectedToolMap, tool2);
 	}
 
 	@Test
 	public void testToolCheckSum() {
-		String test = SakaiLTIUtil.computeToolCheckSum(null);
+		String test = SakaiLTIUtil.computeToolCheckSum((Map<String, Object>) null);
 		assertEquals(test, null);
 
 		Map<String, Object> tool = new HashMap();
@@ -980,29 +1108,29 @@ public class SakaiLTIUtilTest {
 		tool.put(LTIService.LTI_CONSUMERKEY, "key12345");
 
 		test = SakaiLTIUtil.computeToolCheckSum(tool);
-		assertEquals(test, "ASRHSVgrhBjDbhkLEZpWa/IueI9FwFwTxSjnU5uNCB0=");
+		assertEquals(test, "BF6JwVmB1Y1kgPxP4WnAS30BnWzJP46IpmKKrKCSfaw=");
 	}
 
 	@Test
 	public void testLTIUrls() {
-		String launchUrl = SakaiLTIUtil.getContentLaunch(null);
+		String launchUrl = SakaiLTIUtil.getContentLaunch((LtiContentBean) null);
 		assertEquals(launchUrl, null);
-		launchUrl = SakaiLTIUtil.getToolLaunch(null, null);
+		launchUrl = SakaiLTIUtil.getToolLaunch((LtiToolBean) null, null);
 		assertEquals(launchUrl, null);
-		launchUrl = SakaiLTIUtil.getToolLaunch(null, "siteid-was-here");
+		launchUrl = SakaiLTIUtil.getToolLaunch((LtiToolBean) null, "siteid-was-here");
 		assertEquals(launchUrl, null);
 
 		Map<String, Object> tool = new HashMap();
 		tool.put(LTIService.LTI_ID, Long.valueOf(42));
-		launchUrl = SakaiLTIUtil.getToolLaunch(tool, "siteid-was-here");
+		launchUrl = SakaiLTIUtil.getToolLaunch(LtiToolBean.of(tool), "siteid-was-here");
 		assertEquals(launchUrl, "/access/lti/site/siteid-was-here/tool:42");
 
 		Map<String, Object> content = new HashMap();
 		content.put(LTIService.LTI_ID, Long.valueOf(43));
-		launchUrl = SakaiLTIUtil.getContentLaunch(content);
+		launchUrl = SakaiLTIUtil.getContentLaunch(LtiContentBean.of(content));
 		assertEquals(launchUrl, null);
 		content.put(LTIService.LTI_SITE_ID, "siteid-was-here");
-		launchUrl = SakaiLTIUtil.getContentLaunch(content);
+		launchUrl = SakaiLTIUtil.getContentLaunch(LtiContentBean.of(content));
 		assertEquals(launchUrl, "/access/lti/site/siteid-was-here/content:43");
 
 		Long contentKey = SakaiLTIUtil.getContentKeyFromLaunch(launchUrl);
@@ -1091,47 +1219,27 @@ public class SakaiLTIUtilTest {
 		// We'll test with a null keyset to avoid making real HTTP requests
 
 		// Create a test tool bean with null keyset
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.lti13ToolKeyset = null; // This should cause a RuntimeException
 
-		// Create equivalent map for comparison
-		Map<String, Object> toolMap = new HashMap<>();
-		toolMap.put(LTIService.LTI13_TOOL_KEYSET, null);
-
-		// Test that both methods fail with the same exception for null keyset
+		// Test that bean method fails with exception for null keyset (Map-based impl is now private)
 		String idToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2lkIn0.eyJpc3MiOiJ0ZXN0Iiwic3ViIjoidGVzdCIsImF1ZCI6InRlc3QiLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMzYwMH0.test";
-
-		Exception pojoException = null;
-		Exception mapException = null;
 
 		try {
 			SakaiLTIUtil.getPublicKey(tool, idToken);
 			fail("Expected RuntimeException for null keyset");
-		} catch (Exception e) {
-			pojoException = e;
+		} catch (RuntimeException e) {
+			assertNotNull("Bean method should throw exception", e);
 		}
-
-		try {
-			SakaiLTIUtil.getPublicKey(toolMap, idToken);
-			fail("Expected RuntimeException for null keyset");
-		} catch (Exception e) {
-			mapException = e;
-		}
-
-		// Both should fail with the same type of exception
-		assertNotNull("Bean method should throw exception", pojoException);
-		assertNotNull("Map method should throw exception", mapException);
-		assertEquals("Both methods should throw the same type of exception",
-					mapException.getClass(), pojoException.getClass());
 	}
 
 	@Test
 	public void testGetNewpageOverload() {
 		// Test the Bean overload of getNewpage method
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.newpage = 1; // LTI_TOOL_NEWPAGE_ON
 
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.newpage = false; // Boolean for content
 
 		// Test with tool setting (should override default)
@@ -1162,17 +1270,17 @@ public class SakaiLTIUtilTest {
 		assertFalse("Tool newpage=2 should allow content newpage=false to take precedence", result);
 
 		// Test with null parameters
-		result = SakaiLTIUtil.getNewpage((org.sakaiproject.lti.beans.LtiToolBean) null, (org.sakaiproject.lti.beans.LtiContentBean) null, false);
+		result = SakaiLTIUtil.getNewpage((LtiToolBean) null, (LtiContentBean) null, false);
 		assertFalse("Default should be used when both parameters are null", result);
 	}
 
 	@Test
 	public void testGetDebugOverload() {
 		// Test the Bean overload of getDebug method
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.debug = 1; // LTI_TOOL_DEBUG_ON
 
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.debug = false; // Boolean for content
 
 		// Test with tool setting (should override default)
@@ -1203,17 +1311,17 @@ public class SakaiLTIUtilTest {
 		assertFalse("Tool debug=2 should allow content debug=false to take precedence", result);
 
 		// Test with null parameters
-		result = SakaiLTIUtil.getDebug((org.sakaiproject.lti.beans.LtiToolBean) null, (org.sakaiproject.lti.beans.LtiContentBean) null, false);
+		result = SakaiLTIUtil.getDebug((LtiToolBean) null, (LtiContentBean) null, false);
 		assertFalse("Default should be used when both parameters are null", result);
 	}
 
 	@Test
 	public void testGetFrameHeightOverload() {
 		// Test the Bean overload of getFrameHeight method
-		org.sakaiproject.lti.beans.LtiToolBean tool = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean tool = new LtiToolBean();
 		tool.frameheight = 800;
 
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.frameheight = 600;
 
 		// Test with both tool and content (content should override tool)
@@ -1238,14 +1346,14 @@ public class SakaiLTIUtilTest {
 		assertEquals("Default should be used when both are null", "400px", result);
 
 		// Test with null parameters
-		result = SakaiLTIUtil.getFrameHeight((org.sakaiproject.lti.beans.LtiToolBean) null, (org.sakaiproject.lti.beans.LtiContentBean) null, "300px");
+		result = SakaiLTIUtil.getFrameHeight((LtiToolBean) null, (LtiContentBean) null, "300px");
 		assertEquals("Default should be used when both parameters are null", "300px", result);
 	}
 
 	@Test
 	public void testGetLaunchCodeKeyOverload() {
 		// Test the Bean overload of getLaunchCodeKey method
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.id = 123L;
 
 		String result = SakaiLTIUtil.getLaunchCodeKey(content);
@@ -1253,14 +1361,14 @@ public class SakaiLTIUtilTest {
 		assertTrue("Launch code key should contain session prefix and ID", result.contains("123"));
 
 		// Test with null content
-		result = SakaiLTIUtil.getLaunchCodeKey((org.sakaiproject.lti.beans.LtiContentBean) null);
+		result = SakaiLTIUtil.getLaunchCodeKey((LtiContentBean) null);
 		assertNotNull("Launch code key should not be null even with null content", result);
 	}
 
 	@Test
 	public void testGetLaunchCodeOverload() {
 		// Test the Bean overload of getLaunchCode method
-		org.sakaiproject.lti.beans.LtiContentBean content = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean content = new LtiContentBean();
 		content.id = 456L;
 		content.placementsecret = "test-secret";
 
@@ -1269,7 +1377,7 @@ public class SakaiLTIUtilTest {
 		assertTrue("Launch code should contain content ID", result.contains("456"));
 
 		// Test with null content
-		result = SakaiLTIUtil.getLaunchCode((org.sakaiproject.lti.beans.LtiContentBean) null);
+		result = SakaiLTIUtil.getLaunchCode((LtiContentBean) null);
 		assertNotNull("Launch code should not be null even with null content", result);
 	}
 
@@ -1279,7 +1387,7 @@ public class SakaiLTIUtilTest {
 		// by ensuring they produce the same results
 
 		// Create equivalent Bean and Map objects
-		org.sakaiproject.lti.beans.LtiToolBean toolBean = new org.sakaiproject.lti.beans.LtiToolBean();
+		LtiToolBean toolBean = new LtiToolBean();
 		toolBean.newpage = 1; // LTI_TOOL_NEWPAGE_ON
 		toolBean.frameheight = 800;
 
@@ -1287,7 +1395,7 @@ public class SakaiLTIUtilTest {
 		toolMap.put("newpage", 1);
 		toolMap.put("frameheight", 800);
 
-		org.sakaiproject.lti.beans.LtiContentBean contentBean = new org.sakaiproject.lti.beans.LtiContentBean();
+		LtiContentBean contentBean = new LtiContentBean();
 		contentBean.newpage = false; // Boolean for content
 		contentBean.frameheight = 600;
 		contentBean.id = 123L;
@@ -1299,51 +1407,44 @@ public class SakaiLTIUtilTest {
 		contentMap.put("id", 123L);
 		contentMap.put("placementsecret", "test-secret");
 
-		// Test getNewpage delegation
+		// Test getNewpage delegation: Bean overload vs direct Map-based method
 		boolean pojoResult = SakaiLTIUtil.getNewpage(toolBean, contentBean, false);
 		boolean mapResult = SakaiLTIUtil.getNewpage(toolMap, contentMap, false);
 		assertEquals("Bean and Map getNewpage should produce same result", pojoResult, mapResult);
 
-		// Test getFrameHeight delegation
+		// Test getFrameHeight delegation: Bean overload vs direct Map-based method
 		String pojoHeight = SakaiLTIUtil.getFrameHeight(toolBean, contentBean, "400px");
 		String mapHeight = SakaiLTIUtil.getFrameHeight(toolMap, contentMap, "400px");
 		assertEquals("Bean and Map getFrameHeight should produce same result", pojoHeight, mapHeight);
 
-		// Test getLaunchCodeKey delegation
+		// Test getLaunchCodeKey delegation: Bean overload vs direct Map-based method
 		String pojoKey = SakaiLTIUtil.getLaunchCodeKey(contentBean);
 		String mapKey = SakaiLTIUtil.getLaunchCodeKey(contentMap);
 		assertEquals("Bean and Map getLaunchCodeKey should produce same result", pojoKey, mapKey);
 
-		// Test getLaunchCode delegation - both should produce valid codes
+		// Test getLaunchCode delegation: Bean overload vs direct Map-based method
 		String pojoCode = SakaiLTIUtil.getLaunchCode(contentBean);
 		String mapCode = SakaiLTIUtil.getLaunchCode(contentMap);
-		
+
 		// Both codes should be valid (time-dependent, so they won't be identical)
-		assertTrue("Bean getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentBean.asMap(), pojoCode));
+		assertTrue("Bean getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentBean, pojoCode));
 		assertTrue("Map getLaunchCode should produce valid code", SakaiLTIUtil.checkLaunchCode(contentMap, mapCode));
-		
+
 		// Both codes should contain the content ID
 		assertTrue("Bean code should contain content ID", pojoCode.contains(":123:"));
 		assertTrue("Map code should contain content ID", mapCode.contains(":123:"));
 	}
 
 	@Test
-	public void testFindBestToolMatchBeanNullHandling() {
+	public void testFindBestToolMatchNullHandling() {
 		// Test null tools parameter
-		org.sakaiproject.lti.beans.LtiToolBean result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", null);
-		assertNull("findBestToolMatchBean should return null when tools is null", result);
-		
+		Map<String, Object> result = SakaiLTIUtil.findBestToolMatch("http://example.com/launch", "checksum", null);
+		assertNull("findBestToolMatch should return null when tools is null", result);
+
 		// Test empty tools list
-		List<org.sakaiproject.lti.beans.LtiToolBean> emptyTools = new ArrayList<>();
-		result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", emptyTools);
-		assertNull("findBestToolMatchBean should return null when tools list is empty", result);
-		
-		// Test tools list with null entries
-		List<org.sakaiproject.lti.beans.LtiToolBean> toolsWithNulls = new ArrayList<>();
-		toolsWithNulls.add(null);
-		toolsWithNulls.add(null);
-		result = SakaiLTIUtil.findBestToolMatchBean("http://example.com/launch", "checksum", toolsWithNulls);
-		assertNull("findBestToolMatchBean should return null when all tools are null", result);
+		List<Map<String, Object>> emptyTools = new ArrayList<>();
+		result = SakaiLTIUtil.findBestToolMatch("http://example.com/launch", "checksum", emptyTools);
+		assertNull("findBestToolMatch should return null when tools list is empty", result);
 	}
 }
 

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Set;
+import java.util.Stack;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -948,19 +949,29 @@ public class SakaiLTIUtilTest {
 		Element root = doc.createElement("root");
 		doc.appendChild(root);
 
-		Map<String, Object> tool = new HashMap();
-		tool.put(LTIService.LTI_FRAMEHEIGHT, 42);
-		tool.put(LTIService.LTI13, LTIService.LTI13_LTI13);
-		tool.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
-		tool.put(LTIService.LTI_TITLE, "An LTI title");
-		tool.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
-		tool.put(LTIService.LTI_NEWPAGE, 1);
-		tool.put(LTIService.LTI_SENDNAME, 0);
-		tool.put(LTIService.LTI_SECRET, "verysecure");
-		tool.put(LTIService.LTI_CONSUMERKEY, "key12345");
+		LtiToolBean tool = new LtiToolBean();
+		tool.setFrameheight(42);
+		tool.setLti13(LTIService.LTI13_LTI13.intValue());
+		tool.setLaunch("http://localhost:a-launch?x=42");
+		tool.setTitle("An LTI title");
+		tool.setDescription("An LTI DESCRIPTION");
+		tool.setNewpage(1);
+		tool.setSendname(Boolean.FALSE);
+		tool.setSecret("verysecure");
+		tool.setConsumerkey("key12345");
 
-		Element element = SakaiLTIUtil.archiveTool(doc, tool);
-		root.appendChild(element);
+		Stack<Element> stack = new Stack<>();
+		stack.push(root);
+		Element element = tool.toXml(doc, stack);
+		assertNotNull(element);
+
+		// Checksum is appended separately (same as SakaiLTIUtil.archiveTool for maps).
+		String checksum = SakaiLTIUtil.computeToolCheckSum(tool);
+		assertNotNull(checksum);
+		Element checksumEl = doc.createElement(LTIService.SAKAI_TOOL_CHECKSUM);
+		checksumEl.setTextContent(checksum);
+		element.appendChild(checksumEl);
+
 		Map<String, String> expectedToolElements = new HashMap<>();
 		expectedToolElements.put("title", "An LTI title");
 		expectedToolElements.put("description", "An LTI DESCRIPTION");
@@ -972,22 +983,22 @@ public class SakaiLTIUtilTest {
 		expectedToolElements.put("sakai_tool_checksum", "Jon1MG0AtWlH0fcbHrOJ9L/PNb+mti8syZ2b6OGf0Rw=");
 		assertElementXmlEquivalent(doc, LTIService.ARCHIVE_LTI_TOOL_TAG, expectedToolElements, null);
 
-		// Round-trip: merge XML back into a map and verify we get the same tool data.
-		// mergeTool parses the sakai-lti-tool element and populates tool2 with element values.
-		// Checksum is excluded from rehydration (getExcludedArchiveFieldNames), so we assert it is null.
-		Map<String, Object> tool2 = new HashMap();
-		SakaiLTIUtil.mergeTool(element, tool2);
-		assertNull("Checksum is excluded from rehydration", tool2.get(LTIService.SAKAI_TOOL_CHECKSUM));
-		tool2.remove(LTIService.SAKAI_TOOL_CHECKSUM);
-		Map<String, Object> expected = new HashMap();
-		expected.put(LTIService.LTI_TITLE, "An LTI title");
-		expected.put(LTIService.LTI_DESCRIPTION, "An LTI DESCRIPTION");
-		expected.put(LTIService.LTI_LAUNCH, "http://localhost:a-launch?x=42");
-		expected.put(LTIService.LTI_NEWPAGE, 1L);
-		expected.put(LTIService.LTI_FRAMEHEIGHT, 42L);
-		expected.put(LTIService.LTI_SENDNAME, 0L);
-		expected.put(LTIService.LTI13, 1L);
-		assertEquals(expected, tool2);
+		LtiToolBean restored = LtiToolBean.fromXml(element);
+		assertNotNull(restored);
+		assertNull("Checksum is excluded from rehydration (getExcludedArchiveFieldNames)", restored.getSakaiToolChecksum());
+		assertNull("Secret is not archived", restored.getSecret());
+		assertNull("Consumer key is not archived", restored.getConsumerkey());
+
+		assertEquals("An LTI title", restored.getTitle());
+		assertEquals("An LTI DESCRIPTION", restored.getDescription());
+		assertEquals("http://localhost:a-launch?x=42", restored.getLaunch());
+		assertEquals(Integer.valueOf(1), restored.getNewpage());
+		assertEquals(Integer.valueOf(42), restored.getFrameheight());
+		assertEquals(Boolean.FALSE, restored.getSendname());
+		assertEquals(Integer.valueOf(LTIService.LTI13_LTI13.intValue()), restored.getLti13());
+
+		assertEquals("verysecure", tool.getSecret());
+		assertEquals("key12345", tool.getConsumerkey());
 	}
 
 	/**

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTIReportingJob.java
@@ -20,7 +20,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +30,8 @@ import org.quartz.JobExecutionException;
 import org.sakaiproject.email.api.EmailService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;
@@ -62,27 +63,29 @@ public class LTIReportingJob implements Job {
         String from = context.getMergedJobDataMap().getString("from");
 
 
-        Map<String, Object> tool = ltiService.getToolDao(toolId, null);
+        LtiToolBean tool = ltiService.getToolDaoAsBean(Long.valueOf(toolId), null, true);
         if (tool == null) {
             log.warn("Failed to find LTI tool for {}", toolId);
             return;
         }
 
-        String toolTitle = (String) tool.get("title");
+        String toolTitle = tool.getTitle();
 
         DateFormat sqlDf = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, rb.getLocale());
         Instant instant = Instant.now().minus(period, ChronoUnit.MILLIS);
         String fromDate = sqlDf.format(Date.from(instant));
 
         String search = "tool_id:"+ "#exact#"+ toolId+ "#&#"+ "created_at:"+ "#date#>"+ fromDate ;
-        List<Map<String, Object>> contents = ltiService.getContentsDao(search, null, 0, 0, null);
+        List<LtiContentBean> contents = ltiService.getContentsDaoAsBeans(search, null, 0, 0, null);
         DateFormat df = DateFormat.getDateTimeInstance( DateFormat.SHORT, DateFormat.SHORT, rb.getLocale());
 
         boolean sendEmail = false;
         StringBuilder email = new StringBuilder();
         email.append(rb.getFormattedMessage("new.tools.body.header", toolTitle, formatDuration(period)));
-        for(Map<String, Object> content : contents) {
-            String siteId = (String)content.get("SITE_ID");
+        for (LtiContentBean content : contents) {
+            if (content == null) continue;
+            String siteId = content.getSiteId();
+            if (siteId == null) continue;
             try {
                 Site site = siteService.getSite(siteId);
                 // TODO Check the LTI tool is still in the site.

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
@@ -74,6 +74,8 @@ import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.lti.api.LTIExportService;
 import org.sakaiproject.lti.api.LTIExportService.ExportType;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 
@@ -304,10 +306,8 @@ public class LTISecurityServiceImpl implements EntityProducer {
 					identifier the End-User might use to log in (if necessary).
 	*/
 	private void redirectOIDC(HttpServletRequest req, HttpServletResponse res,
-		Site site, Map<String, Object> content, Map<String, Object> tool, String oidc_endpoint, String launchSiteId, ResourceLoader rb)
+		Site site, LtiContentBean content, LtiToolBean tool, String oidc_endpoint, String launchSiteId, ResourceLoader rb)
 	{
-		// req.getRequestURL()=http://localhost:8080/access/lti/site/85fd092b-1755-4aa9-8abc-e6549527dce0/content:0
-		// req.getRequestURI()=/access/lti/site/85fd092b-1755-4aa9-8abc-e6549527dce0/content:0
 		String login_hint = req.getRequestURI();
 		String query_string = req.getQueryString();
 		String messageTypeParm = req.getParameter(SakaiLTIUtil.MESSAGE_TYPE_PARAMETER);
@@ -316,14 +316,12 @@ public class LTISecurityServiceImpl implements EntityProducer {
 			login_hint = login_hint + "?" + query_string;
 		}
 
-
-		String launch_url = StringUtils.trimToNull((String) tool.get(LTIService.LTI_LAUNCH));
+		String launch_url = StringUtils.trimToNull(tool.launch);
 		if ( content != null ) {
-			String content_launch_url = StringUtils.trimToNull((String) content.get(LTIService.LTI_LAUNCH));
+			String content_launch_url = StringUtils.trimToNull(content.launch);
 			if ( content_launch_url != null ) launch_url = content_launch_url;
 
-			// See if we have a lineItem associated with this launch in case we need it later
-			String lineItemStr = (String) content.get(LTIService.LTI_LINEITEM);
+			String lineItemStr = content.contentitem;
 			SakaiLineItem sakaiLineItem = LineItemUtil.parseLineItem(lineItemStr);
 
 			if ( SakaiLTIUtil.MESSAGE_TYPE_PARAMETER_CONTENT_REVIEW.equals(messageTypeParm)) {
@@ -331,9 +329,9 @@ public class LTISecurityServiceImpl implements EntityProducer {
 			}
 		}
 
-		String client_id = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_CLIENT_ID));
+		String client_id = StringUtils.trimToNull(tool.lti13ClientId);
 		String deployment_id = SakaiLTIUtil.resolveLaunchDeploymentId(site, launchSiteId,
-				LTIUtil.toLongNull(tool.get(LTIService.LTI_ID)), tool, ltiService);
+				tool.id, tool.asMap(), ltiService);
 
 		// Use Base64DoubleUrlEncodeSafe to ensure proper URL-safe encoding
 		String encoded_login_hint = Base64DoubleUrlEncodeSafe.encode(login_hint);
@@ -357,13 +355,12 @@ public class LTISecurityServiceImpl implements EntityProducer {
 	}
 
 	/**
-	 * Do some sanity checking on the aunch data to make sure we have enough to accomplish the launch
+	 * Do some sanity checking on the launch data to make sure we have enough to accomplish the launch
 	 */
 	private boolean sanityCheck(HttpServletRequest req, HttpServletResponse res,
-		Map<String, Object> content, Map<String, Object> tool, ResourceLoader rb)
+		LtiContentBean content, LtiToolBean tool, ResourceLoader rb)
 	{
-
-		String oidc_endpoint = (String) tool.get(LTIService.LTI13_TOOL_ENDPOINT);
+		String oidc_endpoint = tool.lti13OidcEndpoint;
 		if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isBlank(oidc_endpoint) ) {
 			String errorMessage = "<p>" + SakaiLTIUtil.getRB(rb, "error.no.oidc_endpoint", "Missing oidc_endpoint value for LTI 1.3 launch") + "</p>";
 			org.tsugi.lti.LTIUtil.sendHTMLPage(res, errorMessage);
@@ -399,8 +396,6 @@ public class LTISecurityServiceImpl implements EntityProducer {
 				String [] retval = null;
 				if ( refId.startsWith("tool:") && refId.length() > 5 )
 				{
-					Map<String,Object> tool;
-
 					String toolStr = refId.substring(5);
 					String contentReturn = req.getParameter("contentReturn");
 					Enumeration attrs =  req.getParameterNames();
@@ -418,93 +413,92 @@ public class LTISecurityServiceImpl implements EntityProducer {
 						throw new EntityNotDefinedException("Could not load tool");
 					}
 
-					tool = ltiService.getToolDao(toolKey, ref.getContext());
-					if (tool == null ) {
+					LtiToolBean toolBean = ltiService.getToolDaoAsBean(toolKey, ref.getContext(), true);
+					if (toolBean == null ) {
 						throw new EntityNotDefinedException("Could not load tool");
 					}
 
 					// Save for LTI 13 Issuer
-					String orig_site_id = StringUtils.trimToNull((String) tool.get(LTIService.LTI_SITE_ID));
-					if ( orig_site_id == null ) {
-						tool.put("orig_site_id_null", "true");
+					if ( StringUtils.isBlank(toolBean.siteId) ) {
+						toolBean.origSiteIdNull = "true";
 					}
-					tool.put(LTIService.LTI_SITE_ID, ref.getContext());
+					toolBean.siteId = ref.getContext();
+
+					// Launch-flow only: pass through from request so they are sent back in the launch
+					String toolStateParam = req.getParameter("tool_state");
+					if (toolStateParam != null) toolBean.toolState = toolStateParam;
+					String platformStateParam = req.getParameter("platform_state");
+					if (platformStateParam != null) toolBean.platformState = platformStateParam;
+					String relaunchUrlParam = req.getParameter("relaunch_url");
+					if (relaunchUrlParam != null) toolBean.relaunchUrl = relaunchUrlParam;
 
 					String state = req.getParameter("state");
 					String nonce = req.getParameter("nonce");
 
-					String oidc_endpoint = (String) tool.get(LTIService.LTI13_TOOL_ENDPOINT);
+					String oidc_endpoint = toolBean.lti13OidcEndpoint;
 					log.debug("State={} nonce={} oidc_endpoint={}",state, nonce, oidc_endpoint);
 
-					// Sanity check for missing config data
-					if ( ! sanityCheck(req, res, null, tool, rb) ) return;
+					if ( ! sanityCheck(req, res, null, toolBean, rb) ) return;
 
-					if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isNotBlank(oidc_endpoint) &&
+					if (SakaiLTIUtil.isLTI13(toolBean) && StringUtils.isNotBlank(oidc_endpoint) &&
 							( StringUtils.isEmpty(state) || StringUtils.isEmpty(nonce) ) ) {
-						redirectOIDC(req, res, site, null, tool, oidc_endpoint, ref.getContext(), rb);
+						redirectOIDC(req, res, site, null, toolBean, oidc_endpoint, ref.getContext(), rb);
 						return;
 					}
 
-					retval = SakaiLTIUtil.postContentItemSelectionRequest(toolKey, tool, state, nonce, rb, contentReturn, propData);
+					retval = SakaiLTIUtil.postContentItemSelectionRequest(toolKey, toolBean, state, nonce, rb, contentReturn, propData);
 
 				}
 				else if ( refId.startsWith("content:") && refId.length() > 8 )
 				{
-					Map<String,Object> content;
-					Map<String,Object> tool = null;
-
 					String contentStr = refId.substring(8);
 					Long contentKey = LTIUtil.toLongKey(contentStr);
 					if (contentKey < 1 ) {
 						throw new EntityNotDefinedException("Could not load content item");
 					}
 
-					content = ltiService.getContentDao(contentKey,ref.getContext());
-					if (content == null ) {
+					LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, ref.getContext());
+					if (contentBean == null ) {
 						throw new EntityNotDefinedException("Could not load content item");
 					}
 
 					// Check to see if we need launch protection
-					int protect = LTIUtil.toInt(content.get(LTIService.LTI_PROTECT));
-					String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(content);
+					int protect = contentBean.protect != null ? (contentBean.protect ? 1 : 0) : -1;
+					String launch_code_key = SakaiLTIUtil.getLaunchCodeKey(contentBean);
 					Session session = sessionManager.getCurrentSession();
 
 					// SAK-43709 - Prior to Sakai-21 there is no protect field in Content
-					// If there is no protect value, we fall back to the pre-21 description in JSON
 					if ( protect < 0 ) {
-						String content_settings = (String) content.get(LTIService.LTI_SETTINGS);
+						String content_settings = contentBean.settings;
 						JSONObject content_json = org.tsugi.lti.LTIUtil.parseJSONObject(content_settings);
 						protect = LTIUtil.toInt(content_json.get(LTIService.LTI_PROTECT));
 					}
 
 					if ( protect > 0 && ! checkSiteUpdate(ref) ) {
 						String launch_code = (String) session.getAttribute(launch_code_key);
-
-						// We don't remove the token until later because LTI 1.3 pass through this twice
-						if ( launch_code == null || ! SakaiLTIUtil.checkLaunchCode(content, launch_code) ) {
+						if ( launch_code == null || ! SakaiLTIUtil.checkLaunchCode(contentBean, launch_code) ) {
 							throw new EntityPermissionException(sessionManager.getCurrentSessionUserId(), "basiclti", ref.getReference());
 						}
 					}
 
-					String siteId = (String) content.get(LTIService.LTI_SITE_ID);
+					String siteId = contentBean.siteId;
 					if ( siteId == null || ! siteId.equals(ref.getContext()) )
 					{
 						throw new EntityNotDefinedException("Incorrect site");
 					}
 
-					Long toolKey = LTIUtil.toLongKey(content.get(LTIService.LTI_TOOL_ID));
-					if ( toolKey >= 0 ) tool = ltiService.getTool(toolKey, ref.getContext());
+					LtiToolBean toolBean = null;
+					Long toolKey = contentBean.toolId != null ? contentBean.toolId : -1L;
+					if ( toolKey >= 0 ) toolBean = ltiService.getToolAsBean(toolKey, ref.getContext());
 
-					ltiService.filterContent(content, tool);
+					ltiService.filterContent(contentBean, toolBean);
 
 					String splash = null;
-					if ( tool != null ) splash = (String) tool.get("splash");
+					if ( toolBean != null ) splash = toolBean.splash;
 					String splashParm = req.getParameter("splash");
-					siteId = null;
-					if ( tool != null ) siteId = (String) tool.get(LTIService.LTI_SITE_ID);
+					siteId = toolBean != null ? toolBean.siteId : null;
 					if ( splashParm == null && splash != null && splash.trim().length() > 1 )
 					{
-							// XSS Note: Administrator-created tools can put HTML in the splash.
 							if ( siteId != null ) splash = formattedText.escapeHtml(splash,false);
 							doSplash(req, res, splash, rb);
 							return;
@@ -512,24 +506,22 @@ public class LTISecurityServiceImpl implements EntityProducer {
 					String state = req.getParameter("state");
 					String nonce = req.getParameter("nonce");
 
-					if ( tool != null ) {
-						String oidc_endpoint = (String) tool.get(LTIService.LTI13_TOOL_ENDPOINT);
+					if ( toolBean != null ) {
+						String oidc_endpoint = toolBean.lti13OidcEndpoint;
 						log.debug("State={} nonce={} oidc_endpoint={}",state, nonce, oidc_endpoint);
 
-						// Sanity check for missing config data
-						if ( ! sanityCheck(req, res, content, tool, rb) ) return;
+						if ( ! sanityCheck(req, res, contentBean, toolBean, rb) ) return;
 
-						if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isNotBlank(oidc_endpoint) &&
+						if (SakaiLTIUtil.isLTI13(toolBean) && StringUtils.isNotBlank(oidc_endpoint) &&
 								(StringUtils.isEmpty(state) || StringUtils.isEmpty(nonce) ) ) {
-							redirectOIDC(req, res, site, content, tool, oidc_endpoint, ref.getContext(), rb);
+							redirectOIDC(req, res, site, contentBean, toolBean, oidc_endpoint, ref.getContext(), rb);
 							return;
 						}
 					}
 
-					retval = SakaiLTIUtil.postLaunchHTML(content, tool, state, nonce, ltiService, rb);
+					retval = SakaiLTIUtil.postLaunchHTML(contentBean, toolBean, state, nonce, ltiService, rb);
 
-					// Once we are ready to do the actual launch, remove the assignments protection key
-					session.removeAttribute(launch_code_key);  // You get one try
+					session.removeAttribute(launch_code_key);
 				}
 				else if (refId.startsWith("export:") && refId.length() > 7)
 				{

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
@@ -330,8 +330,7 @@ public class LTISecurityServiceImpl implements EntityProducer {
 		}
 
 		String client_id = StringUtils.trimToNull(tool.lti13ClientId);
-		String deployment_id = SakaiLTIUtil.resolveLaunchDeploymentId(site, launchSiteId,
-				tool.id, tool.asMap(), ltiService);
+		String deployment_id = SakaiLTIUtil.resolveLaunchDeploymentId(site, launchSiteId, tool.id, tool, ltiService);
 
 		// Use Base64DoubleUrlEncodeSafe to ensure proper URL-safe encoding
 		String encoded_login_hint = Base64DoubleUrlEncodeSafe.encode(login_hint);

--- a/lti/lti-oidc/src/java/org/sakaiproject/lti13/OIDCServlet.java
+++ b/lti/lti-oidc/src/java/org/sakaiproject/lti13/OIDCServlet.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiToolBean;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.tsugi.lti.LTIUtil;
@@ -274,7 +275,7 @@ public class OIDCServlet extends HttpServlet {
 		// For an LTI 1.1 response, check the signature and if it passes, re-sign and forward
 		// to the new URL
 		ltiService = (LTIService) ComponentManager.get("org.sakaiproject.lti.api.LTIService");
-		Map<String, Object> tool = ltiService.getToolDao(toolKey, null, true);
+		LtiToolBean tool = ltiService.getToolDaoAsBean(toolKey, null, true);
 
 		if ( tool == null ) {
 			LTI13Util.return400(response, "Invalid tool_id");
@@ -291,7 +292,7 @@ public class OIDCServlet extends HttpServlet {
 			return;
 		}
 
-		String oauth_secret = (String) tool.get(LTIService.LTI_SECRET);
+		String oauth_secret = SakaiLTIUtil.getSecret(tool);
 		oauth_secret = SakaiLTIUtil.decryptSecret(oauth_secret);
 
 		String URL = SakaiLTIUtil.getOurServletPath(request);

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -709,7 +709,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		String issuerURL = SakaiLTIUtil.getIssuer();
 		context.put("issuerURL", issuerURL);
 
-		String deploymentId = SakaiLTIUtil.getToolDeploymentId(null, toolBean.asMap());
+		String deploymentId = SakaiLTIUtil.getToolDeploymentId(null, toolBean);
 		context.put("deploymentId", deploymentId);
 
 		String configUrl = SakaiLTIUtil.getOurServerUrl() + "/imsblis/lti13/sakai_config";
@@ -785,49 +785,22 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 
 	// Make sure this is ready to handle LTI 1.3 launches
 	private boolean minimalLTI13(Map<String, Object> tool) {
-		boolean retval = false;
-
-		Long tool_id = LTIUtil.toLongNull(tool.get(LTIService.LTI_ID));
-
-		String clientId = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_CLIENT_ID));
-		if (clientId == null ) {
-			clientId = UUID.randomUUID().toString();
-			tool.put(LTIService.LTI13_CLIENT_ID, clientId);
-			retval = true;
+		if (tool == null) {
+			return false;
 		}
-
-		String keyset = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_LMS_KEYSET));
-		if (keyset == null ) {
-			keyset = SakaiLTIUtil.getOurServerUrl() + "/imsblis/lti13/keyset";
-			tool.put(LTIService.LTI13_LMS_KEYSET, keyset);
-			retval = true;
+		LtiToolBean toolBean = LtiToolBean.of(tool);
+		boolean retval = minimalLTI13(toolBean);
+		if (retval) {
+			tool.put(LTIService.LTI13_CLIENT_ID, toolBean.lti13ClientId);
+			tool.put(LTIService.LTI13_LMS_KEYSET, toolBean.lti13LmsKeyset);
+			tool.put(LTIService.LTI13_LMS_ENDPOINT, toolBean.lti13LmsEndpoint);
+			tool.put(LTIService.LTI13_LMS_TOKEN, toolBean.lti13LmsToken);
+			tool.put(LTIService.LTI13_LMS_ISSUER, toolBean.lti13LmsIssuer);
 		}
-
-		String endpoint = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_LMS_ENDPOINT));
-		if (endpoint == null ) {
-			endpoint = SakaiLTIUtil.getOurServerUrl() + "/imsoidc/lti13/oidc_auth";
-			tool.put(LTIService.LTI13_LMS_ENDPOINT, endpoint);
-			retval = true;
-		}
-
-		String tokenurl = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_LMS_TOKEN));
-		if (tokenurl == null && tool_id != null ) {
-			tokenurl = SakaiLTIUtil.getOurServerUrl() + "/imsblis/lti13/token/" + tool_id;
-			tool.put(LTIService.LTI13_LMS_TOKEN, tokenurl);
-		}
-
-		String issuer = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_LMS_ISSUER));
-		if ( issuer == null ) {
-			issuer = SakaiLTIUtil.getIssuer();
-			tool.put(LTIService.LTI13_LMS_ISSUER, issuer);
-			retval = true;
-		}
-
 		return retval;
 	}
 
-	// Bean version of minimalLTI13 - Make sure this is ready to handle LTI 1.3 launches
-	private boolean minimalLTI13(org.sakaiproject.lti.beans.LtiToolBean toolBean) {
+	private boolean minimalLTI13(LtiToolBean toolBean) {
 		boolean retval = false;
 
 		Long tool_id = toolBean.id;
@@ -889,11 +862,10 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		}
 
 		// Build a minimal tool
-		String clientId = UUID.randomUUID().toString();
-		Map<String, Object> tool = new HashMap<String, Object>();
-		tool.put(LTIService.LTI_TITLE, title);
-		tool.put(LTIService.LTI_LAUNCH, "https://example.com/draft-tool-in-progress");
-		tool.put(LTIService.LTI13_CLIENT_ID, clientId);
+		LtiToolBean tool = new LtiToolBean();
+		tool.title = title;
+		tool.launch = "https://example.com/draft-tool-in-progress";
+		tool.lti13ClientId = UUID.randomUUID().toString();
 
 		minimalLTI13(tool);
 
@@ -980,7 +952,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 
 		String clientId = toolBean.lti13ClientId;
 		String issuerURL = SakaiLTIUtil.getIssuer();
-		String deploymentId = SakaiLTIUtil.getToolDeploymentId(null, toolBean.asMap());
+		String deploymentId = SakaiLTIUtil.getToolDeploymentId(null, toolBean);
 
 		String sakaiConfigUrl = SakaiLTIUtil.getOurServerUrl() + "/imsblis/lti13/well_known";
 		sakaiConfigUrl += "?key=" + URLEncoder.encode(toolKey.toString());
@@ -1332,9 +1304,13 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		// Retrieve primary key
 		String id = reqProps.getProperty(LTIService.LTI_ID);
 
-		// find the tool id
-		Map<String, Object> toolSite = ltiService.getToolSiteById(Long.valueOf(id), getSiteId(state));
-		String toolId = String.valueOf(toolSite.get(LTIService.LTI_TOOL_ID));
+		LtiToolSiteBean toolSiteBean = ltiService.getToolSiteAsBean(Long.valueOf(id), getSiteId(state));
+		if (toolSiteBean == null) {
+			addAlert(state, rb.getString("error.id.not.found"));
+			switchPanel(state, "Error");
+			return;
+		}
+		String toolId = String.valueOf(toolSiteBean.getToolId());
 
 		if (!isLti13Tool(toolId, getSiteId(state))) {
 			reqProps.remove(LTIService.LTI_DEPLOYMENT_GROUP);
@@ -1347,7 +1323,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			addAlert(state, rb.getString("error.tool.site.edit") + " retval=" + retval);
 
 		} else if ( retval instanceof Boolean ) { // Success
-			state.setAttribute(STATE_SUCCESS, rb.getString("tool.site.edit.success") + " SiteId=" + toolSite.get(LTIService.LTI_SITE_ID));
+			state.setAttribute(STATE_SUCCESS, rb.getString("tool.site.edit.success") + " SiteId=" + toolSiteBean.getSiteId());
 
 		} else { // Unexpected Error
 			log.error("Unexpected return type from updateToolSite={}, id={}, current siteId={}", retval, id, getSiteId(state));
@@ -1424,15 +1400,19 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		// Retrieve primary key
 		String id = reqProps.getProperty(LTIService.LTI_ID);
 
-		// find the tool id
-		Map<String, Object> toolSite = ltiService.getToolSiteById(Long.valueOf(id), getSiteId(state));
-		String toolId = String.valueOf(toolSite.get(LTIService.LTI_TOOL_ID));
+		LtiToolSiteBean toolSiteBean = ltiService.getToolSiteAsBean(Long.valueOf(id), getSiteId(state));
+		if (toolSiteBean == null) {
+			addAlert(state, rb.getString("error.id.not.found"));
+			switchPanel(state, "Error");
+			return;
+		}
+		String toolId = String.valueOf(toolSiteBean.getToolId());
 
 		// Save to DB
 		boolean retval = ltiService.deleteToolSite(Long.valueOf(id), getSiteId(state));
 
 		if (retval) {	// Success
-			state.setAttribute(STATE_SUCCESS, rb.getString("tool.site.delete.success") + " SiteId=" + toolSite.get(LTIService.LTI_SITE_ID));
+			state.setAttribute(STATE_SUCCESS, rb.getString("tool.site.delete.success") + " SiteId=" + toolSiteBean.getSiteId());
 		} else { // Fail
 			addAlert(state, rb.getString("error.tool.site.delete") + " retval=" + retval);
 		}

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -2182,8 +2182,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return;
 		}
 
-		Map<String, Object> tool = ltiService.getTool(toolKey, getSiteId(state));
-		if (tool == null) {
+		LtiToolBean toolBean = ltiService.getToolAsBean(toolKey, getSiteId(state));
+		if (toolBean == null) {
 			addAlert(state, rb.getString("error.contentitem.missing"));
 			switchPanel(state, errorPanel);
 			return;
@@ -2215,7 +2215,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		if ( isDeepLink ) {
 
 			// Parse and validate the incoming DeepLink
-			String keyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+			String keyset = toolBean.getLti13ToolKeyset();
 			if (keyset == null) {
 				addAlert(state, rb.getString("error.tool.missing.keyset"));
 				switchPanel(state, errorPanel);
@@ -2224,7 +2224,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 
 			DeepLinkResponse dlr;
 			try {
-				dlr = SakaiLTIUtil.getDeepLinkFromToken(tool, id_token);  // Also checks security
+				dlr = SakaiLTIUtil.getDeepLinkFromToken(toolBean, id_token);  // Also checks security
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.deeplink.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2249,7 +2249,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 					return;
 				}
 
-				reqProps = extractLTIDeepLink(item, tool, toolKey);
+				reqProps = extractLTIDeepLink(item, toolBean.asMap(), toolKey);
 				reqProps.setProperty("returnUrl", returnUrl);
 
 				// Create the gradebook column if we need to do so
@@ -2272,7 +2272,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			// Parse and validate the incoming ContentItem
 			ContentItem contentItem;
 			try {
-				contentItem = SakaiLTIUtil.getContentItemFromRequest(tool);
+				contentItem = SakaiLTIUtil.getContentItemFromRequest(toolBean);
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.contentitem.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2304,7 +2304,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 
 				// Prepare data for the next phase
-				reqProps = extractLTIContentItem(item, tool, toolKey);
+				reqProps = extractLTIContentItem(item, toolBean.asMap(), toolKey);
 				reqProps.setProperty("returnUrl", returnUrl);
 
 				// Extract the lineItem material
@@ -2444,8 +2444,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			switchPanel(state, errorPanel);
 			return;
 		}
-		Map<String, Object> tool = ltiService.getTool(toolKey, getSiteId(state));
-		if (tool == null) {
+		LtiToolBean toolBean = ltiService.getToolAsBean(toolKey, getSiteId(state));
+		if (toolBean == null) {
 			addAlert(state, rb.getString("error.contentitem.missing"));
 			switchPanel(state, errorPanel);
 			return;
@@ -2472,7 +2472,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		Long contentKey = null;  // Save for later
 		if ( isDeepLink ) {
 			// Parse and validate the incoming DeepLink
-			String keyset = (String) tool.get(LTIService.LTI13_TOOL_KEYSET);
+			String keyset = toolBean.getLti13ToolKeyset();
 			if (keyset == null) {
 				addAlert(state, rb.getString("error.tool.missing.keyset"));
 				switchPanel(state, errorPanel);
@@ -2481,7 +2481,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 
 			DeepLinkResponse dlr;
 			try {
-				dlr = SakaiLTIUtil.getDeepLinkFromToken(tool, id_token);  // Also checks security
+				dlr = SakaiLTIUtil.getDeepLinkFromToken(toolBean, id_token);  // Also checks security
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.deeplink.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2498,7 +2498,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			for (Object obj : links) {
 				if ( ! (obj instanceof JSONObject) ) continue;
 				JSONObject item = (JSONObject) obj;
-				reqProps = extractLTIDeepLink(item, tool, toolKey);
+				reqProps = extractLTIDeepLink(item, toolBean.asMap(), toolKey);
 
 				String type = getString(item, DeepLinkResponse.TYPE);
 				if (!DeepLinkResponse.TYPE_LTILINKITEM.equals(type)) {
@@ -2508,7 +2508,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 
 				// We need to establish resource link ids for the LTILinkItems
-				reqProps = extractLTIContentItem(item, tool, toolKey);
+				reqProps = extractLTIContentItem(item, toolBean.asMap(), toolKey);
 
 				String title = reqProps.getProperty(LTIService.LTI_TITLE);
 				if (title == null) {
@@ -2536,9 +2536,9 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 				contentKey = (Long) retval;
 				String contentUrl = null;
-				Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
-				if (content != null) {
-					contentUrl = ltiService.getContentLaunch(content);
+				LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, getSiteId(state));
+				if (contentBean != null) {
+					contentUrl = ltiService.getContentLaunch(contentBean);
 					if (contentUrl != null && contentUrl.startsWith("/")) {
 						contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
 					}
@@ -2562,7 +2562,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 						if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 							state.setAttribute(STATE_LINE_ITEM, sakaiLineItem);
 						} else {
-							handleLineItem(state, sakaiLineItem, toolKey, content);
+							handleLineItem(state, sakaiLineItem, toolKey, contentBean != null ? contentBean.asMap() : null);
 						}
 					} catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
 						log.warn("Could not parse input as SakaiLineItem {}",lineItemStr);
@@ -2572,8 +2572,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				item.put("content_key", contentKey);
 				item.put("content_newpage", reqProps.getProperty(LTIService.LTI_NEWPAGE));
 				item.put("tool_key", toolKey);
-				item.put("tool_title", (String) tool.get(LTIService.LTI_TITLE));
-				item.put("tool_newpage", LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE)));
+				item.put("tool_title", toolBean.getTitle());
+				item.put("tool_newpage", (toolBean.getNewpage() != null) ? Long.valueOf(toolBean.getNewpage()) : Long.valueOf(0));
 				new_content.add(item);
 				goodcount++;
 			}
@@ -2583,7 +2583,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			// Parse and validate the incoming ContentItem
 			ContentItem contentItem = null;
 			try {
-				contentItem = SakaiLTIUtil.getContentItemFromRequest(tool);
+				contentItem = SakaiLTIUtil.getContentItemFromRequest(toolBean);
 			} catch (Exception e) {
 				addAlert(state, rb.getString("error.contentitem.bad") + " (" + e.getMessage() + ")");
 				switchPanel(state, errorPanel);
@@ -2606,7 +2606,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 
 				// We need to establish resource link ids for the LTILinkItems
-				reqProps = extractLTIContentItem(item, tool, toolKey);
+				reqProps = extractLTIContentItem(item, toolBean.asMap(), toolKey);
 
 				String title = reqProps.getProperty(LTIService.LTI_TITLE);
 				if (title == null) {
@@ -2634,9 +2634,9 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				}
 				contentKey = (Long) retval;
 				String contentUrl = null;
-				Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
-				if (content != null) {
-					contentUrl = ltiService.getContentLaunch(content);
+				LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, getSiteId(state));
+				if (contentBean != null) {
+					contentUrl = ltiService.getContentLaunch(contentBean);
 					if (contentUrl != null && contentUrl.startsWith("/")) {
 						contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
 					}
@@ -2662,7 +2662,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 						if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 							state.setAttribute(STATE_LINE_ITEM, sakaiLineItem);
 						} else {
-							handleLineItem(state, sakaiLineItem, toolKey, content);
+							handleLineItem(state, sakaiLineItem, toolKey, contentBean != null ? contentBean.asMap() : null);
 						}
 					} catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
 						log.warn("Could not parse input as SakaiLineItem {}",lineItemStr);
@@ -2672,8 +2672,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				item.put("content_key", contentKey);
 				item.put("content_newpage", reqProps.getProperty(LTIService.LTI_NEWPAGE));
 				item.put("tool_key", toolKey);
-				item.put("tool_title", (String) tool.get(LTIService.LTI_TITLE));
-				item.put("tool_newpage", LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE)));
+				item.put("tool_title", toolBean.getTitle());
+				item.put("tool_newpage", (toolBean.getNewpage() != null) ? Long.valueOf(toolBean.getNewpage()) : Long.valueOf(0));
 				new_content.add(item);
 				goodcount++;
 			}
@@ -3454,20 +3454,18 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		}
 
 		String contentUrl = null;
-		Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
+		LtiContentBean contentBean = ltiService.getContentAsBean(contentKey, getSiteId(state));
 
 		// Rare: We just made this a few clicks ago...
-		if (content == null) {
+		if (contentBean == null) {
 			log.error("Unable to load content={}", contentKey);
 			addAlert(state, rb.getString("error.contentitem.content.launch"));
 			return "lti_error";
 		}
 
-		if (content != null) {
-			contentUrl = ltiService.getContentLaunch(content);
-			if (contentUrl != null && contentUrl.startsWith("/")) {
-				contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
-			}
+		contentUrl = ltiService.getContentLaunch(contentBean);
+		if (contentUrl != null && contentUrl.startsWith("/")) {
+			contentUrl = SakaiLTIUtil.getOurServerUrl() + contentUrl;
 		}
 
 		if (contentUrl == null) {
@@ -3476,28 +3474,26 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_error";
 		}
 
-		Long key = LTIUtil.toLongNull(content.get(LTIService.LTI_TOOL_ID));
-		Map<String, Object> tool = ltiService.getTool(key, getSiteId(state));
+		Long key = contentBean.getToolId();
+		LtiToolBean toolBean = ltiService.getToolAsBean(key, getSiteId(state));
 
 		JSONArray new_content = new JSONArray();
 
 		JSONObject item = (JSONObject) new JSONObject();
 		item.put(LTIConstants.TYPE, ContentItem.TYPE_LTILINKITEM);
 		item.put("launch", contentUrl);
-		String title = (String) content.get(LTIService.LTI_TITLE);
+		String title = contentBean.getTitle();
 		if (title == null) {
 			title = rb.getString("contentitem.generic.title");
 		}
 		item.put(ContentItem.TITLE, title);
 
-		Long contentNewPage = LTIUtil.toLongNull(content.get(LTIService.LTI_NEWPAGE));
-		if ( contentNewPage == null ) contentNewPage = Long.valueOf(0);
+		Long contentNewPage = (contentBean.getNewpage() != null && contentBean.getNewpage()) ? Long.valueOf(1) : Long.valueOf(0);
 		item.put("content_newpage", contentNewPage);
 
 		Long toolNewPage = Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT);
-		if ( tool != null ) {
-			toolNewPage = LTIUtil.toLongNull(tool.get(LTIService.LTI_NEWPAGE));
-			if ( toolNewPage == null ) toolNewPage = Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT);
+		if ( toolBean != null ) {
+			toolNewPage = (toolBean.getNewpage() != null) ? Long.valueOf(toolBean.getNewpage()) : Long.valueOf(LTIService.LTI_TOOL_NEWPAGE_CONTENT);
 			item.put("tool_newpage", toolNewPage);
 		}
 
@@ -3509,7 +3505,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 
 		if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 			context.put("contentId",  contentKey);
-			context.put("contentTitle", (String) content.get(LTIService.LTI_TITLE));
+			context.put("contentTitle", contentBean.getTitle());
 			context.put("contentLaunchNewWindow", contentNewPage);
 			context.put("contentToolNewpage", toolNewPage);
 
@@ -3517,10 +3513,10 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			state.removeAttribute(STATE_LINE_ITEM);
 			context.put("lineItem", sakaiLineItem);
 
-			if ( tool != null ) {
-				context.put("toolTitle", (String) tool.get(LTIService.LTI_TITLE));
+			if ( toolBean != null ) {
+				context.put("toolTitle", toolBean.getTitle());
 			} else {
-				context.put("toolTitle", (String) content.get(LTIService.LTI_TITLE));
+				context.put("toolTitle", contentBean.getTitle());
 			}
 			return "lti_assignment_return";
 		} else if ( flow.equals(FLOW_PARAMETER_LESSONS) ) {
@@ -3599,7 +3595,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_tool_system";
 		}
 		Long key = Long.valueOf(id);
-		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentBean(key, getSiteId(state));
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsBean(key, getSiteId(state));
 		if (content == null) {
 			addAlert(state, rb.getString("error.content.not.found"));
 			return "lti_tool_system";
@@ -3661,7 +3657,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_tool_system";
 		}
 		Long key = Long.valueOf(id);
-		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentBean(key, getSiteId(state));
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsBean(key, getSiteId(state));
 		if (content == null) {
 			addAlert(state, rb.getString("error.content.not.found"));
 			return "lti_tool_system";
@@ -3714,7 +3710,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			return "lti_error";
 		}
 		Long key = Long.valueOf(id);
-		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentBean(key, getSiteId(state));
+		org.sakaiproject.lti.beans.LtiContentBean content = ltiService.getContentAsBean(key, getSiteId(state));
 		if (content == null) {
 			addAlert(state, rb.getString("error.content.not.found"));
 			return "lti_error";

--- a/lti/lti-tool/src/webapp/vm/lti_content_delete.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_content_delete.vm
@@ -15,7 +15,7 @@
         <p class="shorttext">
         	$tlang.getString("bl_launch"):
         	#set($tool=false)
-			#set($tool=$ltiService.getToolBean($tool_id_long, $content.siteId))
+			#set($tool=$ltiService.getToolAsBean($tool_id_long, $content.siteId))
 			#if ($!tool)
 				$formattedText.escapeHtml($tool.launch)
 			#end

--- a/lti/lti-tool/src/webapp/vm/lti_tool_site.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_tool_site.vm
@@ -177,10 +177,9 @@ ${includeLatestJQuery}
 				#if ($contentBean.launch)
 					 #set($launch = $formattedText.escapeHtml($contentBean.launch))
 				#else
-					#set($tool=false)
-					#set($tool=$ltiService.getTool($contentBean.toolId, $contentBean.siteId))
-					#if ($!tool)
-						#set($launch = $formattedText.escapeHtml($tool.get("launch")))
+					#set($toolBean = $ltiService.getToolAsBean($contentBean.toolId, $contentBean.siteId))
+					#if ($!toolBean && $!toolBean.launch)
+						#set($launch = $formattedText.escapeHtml($toolBean.launch))
 					#end
 				#end
 				#set($toolUrl = $toolUrlMap.get($contentBean.id))

--- a/lti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/lti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -51,6 +51,7 @@ import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 // lti service
 import org.sakaiproject.lti.api.LTIService;
+import org.sakaiproject.lti.beans.LtiContentBean;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
 import org.sakaiproject.portlet.util.JSPHelper;
 import org.sakaiproject.portlet.util.VelocityHelper;
@@ -314,9 +315,9 @@ public class SakaiIFrame extends GenericPortlet {
 		}
 
 		Long contentKey = (Long) retval;
-		Map<String,Object> newContent = m_ltiService.getContent(contentKey, siteId);
-		String contentUrl = m_ltiService.getContentLaunch(newContent);
-		if ( newContent == null || contentUrl == null ) {
+		LtiContentBean newContentBean = m_ltiService.getContentAsBean(contentKey, siteId);
+		String contentUrl = m_ltiService.getContentLaunch(newContentBean);
+		if ( newContentBean == null || contentUrl == null ) {
 			log.error("Unable to set contentUrl tool={} placement={}",tool_id,placement.getId());
 			placement.getPlacementConfig().setProperty(SOURCE,"");
 			placement.save();
@@ -327,7 +328,7 @@ public class SakaiIFrame extends GenericPortlet {
 
 		log.debug("Patched contentUrl tool={} placement={} url={}",tool_id,placement.getId(),contentUrl);
 
-		return newContent;
+		return newContentBean.asMap();
 	}
 
 	public void doEdit(RenderRequest request, RenderResponse response)
@@ -472,9 +473,9 @@ public class SakaiIFrame extends GenericPortlet {
 					return;
 				} else if ( retval instanceof Long ) {
 					Long contentKey = (Long) retval;
-					Map<String,Object> newContent = m_ltiService.getContent(contentKey, siteId);
-					String contentUrl = m_ltiService.getContentLaunch(newContent);
-					if ( newContent == null || contentUrl == null ) {
+					LtiContentBean newContentBean = m_ltiService.getContentAsBean(contentKey, siteId);
+					String contentUrl = m_ltiService.getContentLaunch(newContentBean);
+					if ( newContentBean == null || contentUrl == null ) {
 						log.error("Unable to set contentUrl tool={} placement={}",toolIdStr,placement.getId());
 						addAlert(request, rb.getString("edit.save.url.fail"));
 						return;

--- a/lti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
+++ b/lti/web-ifp/src/java/org/sakaiproject/portlets/SakaiIFrame.java
@@ -315,7 +315,7 @@ public class SakaiIFrame extends GenericPortlet {
 		}
 
 		Long contentKey = (Long) retval;
-		LtiContentBean newContentBean = m_ltiService.getContentAsBean(contentKey, siteId);
+		LtiContentBean newContentBean = m_ltiService.getContentDaoAsBean(contentKey, siteId);
 		String contentUrl = m_ltiService.getContentLaunch(newContentBean);
 		if ( newContentBean == null || contentUrl == null ) {
 			log.error("Unable to set contentUrl tool={} placement={}",tool_id,placement.getId());
@@ -473,7 +473,7 @@ public class SakaiIFrame extends GenericPortlet {
 					return;
 				} else if ( retval instanceof Long ) {
 					Long contentKey = (Long) retval;
-					LtiContentBean newContentBean = m_ltiService.getContentAsBean(contentKey, siteId);
+					LtiContentBean newContentBean = m_ltiService.getContentDaoAsBean(contentKey, siteId);
 					String contentUrl = m_ltiService.getContentLaunch(newContentBean);
 					if ( newContentBean == null || contentUrl == null ) {
 						log.error("Unable to set contentUrl tool={} placement={}",toolIdStr,placement.getId());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an archive XML import/export layer for LTI beans using a declarative `@FoormField`/`FoormType` system, plus new bean-driven launch/deep-link/selection/gradebook helpers.
* **Bug Fixes**
  * Collection getters now return empty lists instead of null; tool/content insert APIs reject null beans; deployment-group selection now trims IDs and selects the newest updated entry.
* **Refactor**
  * Broad migration from map-based payloads to typed LTI beans and bean-aware filtering; legacy bean alias getters removed in favor of `get*AsBean(s)` naming.
* **Tests**
  * Added XML/archive and Foorm reflection/round-trip unit tests for key beans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->