### PR TITLE
SAK-31603 OAuth should be disabled by default

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4875,8 +4875,8 @@
 # OAuth
 # #####
 # Disable OAuth support
-# DEFAULT: true
-# oauth.enabled=false
+# DEFAULT: false
+oauth.enabled=false
 
 # ######################################
 # SIGNUP TOOL added in Sakai 10

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -4876,7 +4876,7 @@
 # #####
 # Disable OAuth support
 # DEFAULT: false
-oauth.enabled=false
+#oauth.enabled=true
 
 # ######################################
 # SIGNUP TOOL added in Sakai 10

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
@@ -142,7 +142,7 @@ preference.pages=prefs_noti_title, prefs_timezone_title, prefs_lang_title, prefs
 portal.chat.video = true
 
 # Enable OAuth
-oauth.enabled=true
+oauth.enabled=false
 
 # enable final grade mode
 gradebook.enable.finalgrade=true

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/experimental.sakai.properties
@@ -141,7 +141,7 @@ preference.pages=prefs_noti_title, prefs_timezone_title, prefs_lang_title, prefs
 # SAK-26063
 portal.chat.video = true
 
-# Enable OAuth
+# OAuth disabled - Deprecated
 oauth.enabled=false
 
 # enable final grade mode

--- a/oauth/README.md
+++ b/oauth/README.md
@@ -126,8 +126,10 @@ current userId.
 
 The OAuth service can be configured through sakai.properties.
 
-The OAuth service is enabled by default. To disable OAuth on all requests this in the sakai.properties:
-`oauth.enabled=false`
+The OAuth service is disabled by default. To enable OAuth on all requests set this in sakai.properties:
+`oauth.enabled=true`
+
+OAuth in Sakai is deprecated (SAK-52541) and will be removed in a future release.
 
 ### Testing
 

--- a/oauth/impl/src/webapp/WEB-INF/components.xml
+++ b/oauth/impl/src/webapp/WEB-INF/components.xml
@@ -47,7 +47,7 @@
             <bean factory-bean="org.sakaiproject.component.api.ServerConfigurationService"
                     factory-method="getBoolean">
                 <constructor-arg value="oauth.enabled"/>
-                <constructor-arg value="true"/>
+                <constructor-arg value="false"/>
             </bean>
         </property>
     </bean>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * OAuth is now disabled by default; enable explicitly via configuration if needed.
  * Experimental/legacy OAuth toggles marked as deprecated.

* **Documentation**
  * Updated OAuth docs to reflect disabled-by-default and include a deprecation notice indicating OAuth will be removed in a future release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->