### PR TITLE
SAK-52545 Update Apache Wicket 9.22.0

### DIFF
--- a/delegatedaccess/pom.xml
+++ b/delegatedaccess/pom.xml
@@ -18,7 +18,7 @@
 	
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wicket.version>9.21.0</wicket.version>
+		<wicket.version>9.22.0</wicket.version>
 	</properties>
 
     <modules>

--- a/gradebookng/pom.xml
+++ b/gradebookng/pom.xml
@@ -14,7 +14,7 @@
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wicket.version>9.21.0</wicket.version>
+		<wicket.version>9.22.0</wicket.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -50,7 +50,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- dependencies versions -->
         <oauth.version>20100527</oauth.version>
-        <wicket.version>9.21.0</wicket.version>
+        <wicket.version>9.22.0</wicket.version>
     </properties>
 
     <dependencyManagement>

--- a/scormplayer/pom.xml
+++ b/scormplayer/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scorm.wicket.version>9.21.0</scorm.wicket.version>
+        <scorm.wicket.version>9.22.0</scorm.wicket.version>
     </properties>
 
     <modules>

--- a/site/term-manager/pom.xml
+++ b/site/term-manager/pom.xml
@@ -18,7 +18,7 @@
 
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <my.wicket.version>9.21.0</my.wicket.version>
+      <my.wicket.version>9.22.0</my.wicket.version>
    </properties>
 
    <dependencyManagement>

--- a/sitestats/pom.xml
+++ b/sitestats/pom.xml
@@ -20,7 +20,7 @@
     <commons-betwixt.version>0.8</commons-betwixt.version>
     <fop.version>2.11</fop.version>
     <jfreechart.version>1.5.3</jfreechart.version>
-    <sst.wicket.version>9.21.0</sst.wicket.version>
+    <sst.wicket.version>9.22.0</sst.wicket.version>
   </properties>
 
   <!-- Project modules -->

--- a/wicket/wicket9/pom.xml
+++ b/wicket/wicket9/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wicket9.version>9.21.0</wicket9.version>
+		<wicket9.version>9.22.0</wicket9.version>
 	</properties>
 
 	<name>Sakai Wicket 9 Tool</name>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache Wicket framework dependency from version 9.21.0 to 9.22.0 across all modules, including delegatedaccess, gradebookng, oauth, scormplayer, site/term-manager, sitestats, and wicket/wicket9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->