### PR TITLE
SAK-52524 SCORM Add late submission indicator to Results List Page

### DIFF
--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
@@ -36,6 +36,7 @@ public class LearnerExperience implements Serializable
 	@Setter @Getter private long contentPackageId;
 	@Setter @Getter private Date lastAttemptDate;
 	@Setter @Getter private int status;
+	@Setter @Getter private boolean late;
 	@Setter @Getter private int numberOfAttempts;
 
 	public LearnerExperience(Learner learner, long contentPackageId)

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -30,10 +31,12 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.html.link.DownloadLink;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -101,7 +104,7 @@ public class ResultsListPage extends ConsoleBasePage
 		Label heading = new Label( "heading", new ResourceModel( "page.heading.notAllowed" ) );
 		add( heading );
 
-		final AttemptDataProvider dataProvider = new AttemptDataProvider(contentPackageId);
+		final AttemptDataProvider dataProvider = new AttemptDataProvider(contentPackageId, contentPackage.getDueOn());
 		dataProvider.setFilterConfigurerVisible(true);
 		dataProvider.setTableTitle(getLocalizer().getString("table.title", this));
 
@@ -352,6 +355,14 @@ public class ResultsListPage extends ConsoleBasePage
 		columns.add(actionColumn);
 
 		columns.add(new DecoratedDatePropertyColumn(attemptedHeader, "lastAttemptDate", "lastAttemptDate"));
+		columns.add(new AbstractColumn(new ResourceModel("late.indicator")) {
+			@Override
+			public void populateItem(Item item, String componentId, IModel rowModel) {
+				LearnerExperience exp = (LearnerExperience) rowModel.getObject();
+				IModel labelModel = exp.isLate() ? new ResourceModel("late.indicator") : Model.of("");
+				item.add(new Label(componentId, labelModel));
+			}
+		});
 		columns.add(new AccessStatusColumn(statusHeader, "status"));
 
 		ActionColumn attemptNumberActionColumn = new ActionColumn(numberOfAttemptsHeader, "numberOfAttempts", "numberOfAttempts");
@@ -367,9 +378,20 @@ public class ResultsListPage extends ConsoleBasePage
 		private final List<LearnerExperience> learnerExperiences;
 		private final LearnerExperienceComparator comp = new LearnerExperienceComparator();
 
-		public AttemptDataProvider(long contentPackageId)
+		public AttemptDataProvider(long contentPackageId, Date dueOn)
 		{
 			this.learnerExperiences = resultService.getLearnerExperiences(contentPackageId);
+			if (dueOn != null)
+			{
+				for (LearnerExperience exp : learnerExperiences)
+				{
+					Date attemptDate = exp.getLastAttemptDate();
+					if (attemptDate != null && attemptDate.after(dueOn))
+					{
+						exp.setLate(true);
+					}
+				}
+			}
 			setSort( "learnerName", SortOrder.ASCENDING );
 		}
 

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.properties
@@ -16,6 +16,8 @@ column.header.attempted = Attempted
 column.header.status = Status
 column.header.attempt.number = Attempts
 
+late.indicator = Late
+
 column.header.detail.action = Detail
 column.header.summary.action = Summary
 column.header.begin.date = Started


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Results list now displays a "late" indicator for submissions completed after the due date, making it easy to identify which learners submitted their work late.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->