### PR TITLE
SAK-52551 Signup calendar files should have content disposition attachment instead of inline

### DIFF
--- a/signup/impl/src/main/java/org/sakaiproject/signup/impl/SignupEmailFacadeImpl.java
+++ b/signup/impl/src/main/java/org/sakaiproject/signup/impl/SignupEmailFacadeImpl.java
@@ -730,12 +730,12 @@ public class SignupEmailFacadeImpl implements SignupEmailFacade {
 			return null;
 		}
 
-		// Explicitly define the Content-Type and Content-Diposition headers so the invitation appears inline
+		// Explicitly define the Content-Type and Content-Diposition headers so the invitation appears attached
 		String filename = StringUtils.substringAfterLast(path, File.separator);
 		String type = String.format("text/calendar; charset=\"utf-8\"; method=%s; name=signup-invite.ics", method);
 		File file = new File(path);
 		DataSource dataSource = new Attachment.RenamedDataSource(new FileDataSource(file), filename);
-		return new Attachment(dataSource, type, Attachment.ContentDisposition.INLINE);
+		return new Attachment(dataSource, type, Attachment.ContentDisposition.ATTACHMENT);
 	}
 	
 	


### PR DESCRIPTION
SAK-52551 Outlook does not allow the viewing of embedded ICS files

https://sakaiproject.atlassian.net/browse/SAK-52551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email calendar formatting by delivering calendar invitations as attachments instead of inline content, enhancing compatibility with email clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->