### PR TITLE
SAK-52559 LTI Add support for deployment_group to ToolSite

### DIFF
--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -175,6 +175,7 @@ public interface LTIService extends LTISubstitutionsFilter {
             "tool_id:integer:hidden=true",
             "SITE_ID:text:label=bl_tool_site_SITE_ID:required=true:maxlength=99:role=admin",
             "notes:text:label=bl_tool_site_notes:maxlength=1024",
+            "deployment_group:text:label=bl_deployment_group:maxlength=128:alphanumeric=true:truncate=false",
             "created_at:autodate",
             "updated_at:autodate",
     };
@@ -287,6 +288,19 @@ public interface LTIService extends LTISubstitutionsFilter {
     String LTI13_LMS_KEYSET = "lti13_lms_keyset";
     String LTI13_LMS_TOKEN = "lti13_lms_token";
     String LTI13_LMS_ENDPOINT = "lti13_lms_endpoint";
+
+    /**
+     * Optional per-site deployment identifier for LTI 1.3 (lti_tool_site.deployment_group).
+     * When set for a tool deployed to the launch site, it overrides the platform-wide
+     * {@code lti.deployment_id} for OIDC and JWT {@code deployment_id}.
+     */
+    String LTI_DEPLOYMENT_GROUP = "deployment_group";
+
+    /**
+     * Internal {@link java.util.Properties} key passed into {@code postLaunchJWT} to override
+     * the JWT {@code deployment_id} claim (not an LTI database column).
+     */
+    String LTI_JWT_DEPLOYMENT_ID_OVERRIDE_PROP = "lti_jwt_deployment_id_override";
 
     // Checksum for import and export
     String SAKAI_TOOL_CHECKSUM = "sakai_tool_checksum";
@@ -941,6 +955,43 @@ public interface LTIService extends LTISubstitutionsFilter {
         return toolSiteMaps.stream()
                 .map(org.sakaiproject.lti.beans.LtiToolSiteBean::of)
                 .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns the optional {@link #LTI_DEPLOYMENT_GROUP} for a tool deployed to the given site,
+     * or null when unset or when there is no matching tool-site row.
+     *
+     * @param toolKey primary key of the LTI tool
+     * @param launchSiteId site id where the launch occurs (must match the tool-site row {@link #LTI_SITE_ID})
+     */
+    default String getDeploymentGroupForLaunch(Long toolKey, String launchSiteId) {
+        if (toolKey == null || launchSiteId == null) {
+            return null;
+        }
+        String trimmedSite = launchSiteId.trim();
+        if (trimmedSite.isEmpty()) {
+            return null;
+        }
+        List<Map<String, Object>> rows = getToolSitesByToolId(String.valueOf(toolKey), trimmedSite);
+        if (rows == null) {
+            return null;
+        }
+        for (Map<String, Object> row : rows) {
+            Object siteObj = row.get(LTI_SITE_ID);
+            if (siteObj == null) {
+                continue;
+            }
+            if (!trimmedSite.equals(siteObj.toString().trim())) {
+                continue;
+            }
+            Object dg = row.get(LTI_DEPLOYMENT_GROUP);
+            if (dg == null) {
+                return null;
+            }
+            String s = dg.toString().trim();
+            return s.isEmpty() ? null : s;
+        }
+        return null;
     }
 
     // ------------------------------------------------------------------------------------

--- a/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/beans/LtiToolSiteBean.java
@@ -46,6 +46,7 @@ public class LtiToolSiteBean extends LTIBaseBean {
     public Long toolId;                // TOOL_SITE_MODEL: "tool_id:integer:hidden=true"
     public String siteId;              // TOOL_SITE_MODEL: "SITE_ID:text:label=bl_tool_site_SITE_ID:required=true:maxlength=99:role=admin"
     public String notes;               // TOOL_SITE_MODEL: "notes:text:label=bl_tool_site_notes:maxlength=1024"
+    public String deploymentGroup;     // TOOL_SITE_MODEL: "deployment_group:text:label=bl_deployment_group:maxlength=128:alphanumeric=true"
     public Date createdAt;             // TOOL_SITE_MODEL: "created_at:autodate"
     public Date updatedAt;             // TOOL_SITE_MODEL: "updated_at:autodate"
 
@@ -66,6 +67,7 @@ public class LtiToolSiteBean extends LTIBaseBean {
         toolSite.setToolId(getLongValue(map, LTIService.LTI_TOOL_ID));
         toolSite.setSiteId(getStringValue(map, LTIService.LTI_SITE_ID));
         toolSite.setNotes(getStringValue(map, "notes"));
+        toolSite.setDeploymentGroup(getStringValue(map, LTIService.LTI_DEPLOYMENT_GROUP));
         toolSite.setCreatedAt(getDateValue(map, LTIService.LTI_CREATED_AT));
         toolSite.setUpdatedAt(getDateValue(map, LTIService.LTI_UPDATED_AT));
         
@@ -84,6 +86,7 @@ public class LtiToolSiteBean extends LTIBaseBean {
         putIfNotNull(map, LTIService.LTI_TOOL_ID, toolId);
         putIfNotNull(map, LTIService.LTI_SITE_ID, siteId);
         putIfNotNull(map, "notes", notes);
+        putIfNotNull(map, LTIService.LTI_DEPLOYMENT_GROUP, deploymentGroup);
         putIfNotNull(map, LTIService.LTI_CREATED_AT, createdAt);
         putIfNotNull(map, LTIService.LTI_UPDATED_AT, updatedAt);
         

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -1271,6 +1271,11 @@ public class SakaiLTIUtil {
 			LTI13Util.addCustomToLaunch(ltiProps, custom);
 
 			if (isLTI13) {
+				Long toolKey = LTIUtil.toLongNull(tool.get(LTIService.LTI_ID));
+				String deploymentGroup = ltiService.getDeploymentGroupForLaunch(toolKey, context);
+				if (StringUtils.isNotBlank(deploymentGroup)) {
+					toolProps.setProperty(LTIService.LTI_JWT_DEPLOYMENT_ID_OVERRIDE_PROP, deploymentGroup);
+				}
 				return postLaunchJWT(toolProps, ltiProps, site, tool, content, rb);
 			}
 			return postLaunchHTML(toolProps, ltiProps, rb);
@@ -1568,6 +1573,11 @@ public class SakaiLTIUtil {
 				setProperty(toolProps, "state", state);  // So far LTI 1.3 only
 				setProperty(toolProps, "nonce", nonce);  // So far LTI 1.3 only
 				toolProps.put(LTIService.LTI_DEBUG, dodebug ? "1" : "0");
+
+				String deploymentGroup = ltiService.getDeploymentGroupForLaunch(toolKey, context);
+				if (StringUtils.isNotBlank(deploymentGroup)) {
+					toolProps.setProperty(LTIService.LTI_JWT_DEPLOYMENT_ID_OVERRIDE_PROP, deploymentGroup);
+				}
 
 				Map<String, Object> content = null;
 				return postLaunchJWT(toolProps, ltiProps, site, tool, content, rb);
@@ -1868,7 +1878,11 @@ public class SakaiLTIUtil {
 			lj.nonce = toolProps.getProperty("nonce");
 			lj.issued = Long.valueOf(System.currentTimeMillis() / 1000L);
 			lj.expires = lj.issued + 3600L;
-			lj.deployment_id = getDeploymentId(context_id);
+			String deploymentId = StringUtils.trimToNull(toolProps.getProperty(LTIService.LTI_JWT_DEPLOYMENT_ID_OVERRIDE_PROP));
+			if (deploymentId == null) {
+				deploymentId = getDeploymentId(context_id);
+			}
+			lj.deployment_id = deploymentId;
 
 			String lti1_roles = fixLegacyRoles(ltiProps.getProperty("roles"));
 			if (lti1_roles != null ) {

--- a/lti/lti-common/src/java/org/sakaiproject/util/foorm/Foorm.java
+++ b/lti/lti-common/src/java/org/sakaiproject/util/foorm/Foorm.java
@@ -1151,6 +1151,14 @@ public class Foorm {
 				if (sdf == null) {
 					if (dataMap != null)
 						dataMap.put(field, null);
+				} else if ("true".equals(info.getProperty("alphanumeric")) && !sdf.matches("^[a-zA-Z0-9]+$")) {
+					if (sb.length() > 0)
+						sb.append(", ");
+					error = getI18N("foorm.alphanumeric.field", "Field must contain only letters and numbers:", loader) + " "
+							+ getI18N(label, loader);
+					sb.append(error);
+					if (errors != null)
+						errors.put(label, error);
 				} else {
 					if (dataMap != null)
 						dataMap.put(field, sdf);

--- a/lti/lti-impl/src/bundle/ltiservice.properties
+++ b/lti/lti-impl/src/bundle/ltiservice.properties
@@ -5,6 +5,7 @@ foorm.missing.field=Required Field:
 foorm.maxlength.field=Field >
 foorm.integer.field=Field should be an integer:
 foorm.id.field=Field has invalid characters:
+foorm.alphanumeric.field=Field must contain only letters and numbers:
 foorm.url.field=Field is not a url:
 
 error.missing.toolid=Missing Tool ID
@@ -46,6 +47,7 @@ bl_allowsecret_disallow=Do not allow
 SITE_ID=Site Id (Leave blank to make tool available in all sites)
 bl_tool_site_SITE_ID=Site Id
 bl_tool_site_notes=Notes
+bl_deployment_group=Deployment group (LTI 1.3 deployment id for this site; optional, letters and numbers only)
 bl_content_site_id=Site ID
 bl_frameheight=Frame Height
 bl_allowframeheight=Allow frame height to be changed

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/LTISecurityServiceImpl.java
@@ -304,7 +304,7 @@ public class LTISecurityServiceImpl implements EntityProducer {
 					identifier the End-User might use to log in (if necessary).
 	*/
 	private void redirectOIDC(HttpServletRequest req, HttpServletResponse res,
-		Map<String, Object> content, Map<String, Object> tool, String oidc_endpoint, ResourceLoader rb)
+		Map<String, Object> content, Map<String, Object> tool, String oidc_endpoint, String launchSiteId, ResourceLoader rb)
 	{
 		// req.getRequestURL()=http://localhost:8080/access/lti/site/85fd092b-1755-4aa9-8abc-e6549527dce0/content:0
 		// req.getRequestURI()=/access/lti/site/85fd092b-1755-4aa9-8abc-e6549527dce0/content:0
@@ -332,7 +332,14 @@ public class LTISecurityServiceImpl implements EntityProducer {
 		}
 
 		String client_id = StringUtils.trimToNull((String) tool.get(LTIService.LTI13_CLIENT_ID));
-		String deployment_id = ServerConfigurationService.getString(SakaiLTIUtil.LTI13_DEPLOYMENT_ID, SakaiLTIUtil.LTI13_DEPLOYMENT_ID_DEFAULT);
+		String deployment_id = null;
+		Long toolKey = LTIUtil.toLongNull(tool.get(LTIService.LTI_ID));
+		if (toolKey != null && StringUtils.isNotBlank(launchSiteId)) {
+			deployment_id = StringUtils.trimToNull(ltiService.getDeploymentGroupForLaunch(toolKey, launchSiteId));
+		}
+		if (deployment_id == null) {
+			deployment_id = ServerConfigurationService.getString(SakaiLTIUtil.LTI13_DEPLOYMENT_ID, SakaiLTIUtil.LTI13_DEPLOYMENT_ID_DEFAULT);
+		}
 
 		// Use Base64DoubleUrlEncodeSafe to ensure proper URL-safe encoding
 		String encoded_login_hint = Base64DoubleUrlEncodeSafe.encode(login_hint);
@@ -433,8 +440,8 @@ public class LTISecurityServiceImpl implements EntityProducer {
 					if ( ! sanityCheck(req, res, null, tool, rb) ) return;
 
 					if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isNotBlank(oidc_endpoint) &&
-							( StringUtils.isEmpty(state) || StringUtils.isEmpty(state) ) ) {
-						redirectOIDC(req, res, null, tool, oidc_endpoint, rb);
+							( StringUtils.isEmpty(state) || StringUtils.isEmpty(nonce) ) ) {
+						redirectOIDC(req, res, null, tool, oidc_endpoint, ref.getContext(), rb);
 						return;
 					}
 
@@ -514,7 +521,7 @@ public class LTISecurityServiceImpl implements EntityProducer {
 
 						if (SakaiLTIUtil.isLTI13(tool) && StringUtils.isNotBlank(oidc_endpoint) &&
 								(StringUtils.isEmpty(state) || StringUtils.isEmpty(nonce) ) ) {
-							redirectOIDC(req, res, content, tool, oidc_endpoint, rb);
+							redirectOIDC(req, res, content, tool, oidc_endpoint, ref.getContext(), rb);
 							return;
 						}
 					}

--- a/lti/lti-tool/src/bundle/ltitool.properties
+++ b/lti/lti-tool/src/bundle/ltitool.properties
@@ -268,6 +268,11 @@ search.uses=Search by Usage
 searchby=Search by {0}
 search.notes=Search by Notes
 search.deployment=Search by Deployment
+tool.site.deployment_group=Deployment group (optional)
+tool.site.deployment_group.hint=If set, the same value is stored for every site in the list below. Letters and numbers only; used as the LTI 1.3 deployment id for launches from that site when configured.
+tool.site.deployment_group.pattern=Letters and numbers only
+tool.site.table.deployment_group=Deployment group
+tool.site.search.deployment_group=Search by deployment group
 
 register.may.popup=The registration process may open a popup window.  If it opens a popup window, when registration is complete, come back to this page and manually activate the deployment.
 register.external.pre.launch=We will now launch an external web site in a new window to do the actual installation.  When that process completes, come back to this window and either continue to the Activation process or go back to the deployment list.

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -224,6 +224,21 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 	}
 
 	/**
+	 * @return true when the tool is configured for LTI 1.3 or both (not LTI 1.1 only).
+	 */
+	private boolean isLti13Tool(String toolId, String siteId) {
+		if (StringUtils.isBlank(toolId)) {
+			return false;
+		}
+		try {
+			Map<String, Object> toolMap = ltiService.getTool(Long.valueOf(toolId), siteId);
+			return toolMap != null && SakaiLTIUtil.isLTI13(toolMap);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
+	/**
 	 * Setup the velocity context and choose the template for the response.
 	 */
 	public String buildErrorPanelContext(VelocityPortlet portlet, Context context,
@@ -1113,6 +1128,14 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		List<LtiToolSiteBean> ltiToolSiteBeans = ltiService.getToolSitesByToolIdAsBeans(tool_id, getSiteId(state));
 		context.put("ltiToolSites", ltiToolSiteBeans);
 
+		boolean showDeploymentGroup = isLti13Tool(tool_id, getSiteId(state));
+		context.put("showDeploymentGroup", showDeploymentGroup);
+		int toolSiteActionSorterColumn = -1;
+		if (ltiService.isAdmin(getSiteId(state))) {
+			toolSiteActionSorterColumn = showDeploymentGroup ? 3 : 2;
+		}
+		context.put("toolSiteActionSorterColumn", toolSiteActionSorterColumn);
+
 		context.put("messageSuccess", state.getAttribute(STATE_SUCCESS));
 		state.removeAttribute(STATE_SUCCESS);
 		return "lti_tool_site_deploy";
@@ -1148,6 +1171,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		context.put("previousPost", previousPost);
 
 		context.put("isAdmin", ltiService.isAdmin(getSiteId(state)));
+		context.put("showDeploymentGroup", isLti13Tool(toolId, getSiteId(state)));
 
 		// Remove previous form inputs
 		state.removeAttribute(STATE_POST);
@@ -1227,6 +1251,12 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			props.setProperty("tool_id", toolId);
 			props.setProperty("SITE_ID", inputSiteId);
 			props.setProperty("notes", reqProps.getProperty("notes"));
+			if (isLti13Tool(toolId, getSiteId(state))) {
+				String deploymentGroup = StringUtils.trimToNull(reqProps.getProperty(LTIService.LTI_DEPLOYMENT_GROUP));
+				if (deploymentGroup != null) {
+					props.setProperty(LTIService.LTI_DEPLOYMENT_GROUP, deploymentGroup);
+				}
+			}
 
 			Object retval = ltiService.insertToolSite(props, getSiteId(state));
 
@@ -1289,7 +1319,10 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		formOutput += formOutput2;
 		context.put("formOutput", formOutput);
 
-		String[] mappingFormInput = foorm.filterForm(ltiService.getToolSiteModel(getSiteId(state)), null, "^SITE_ID:.*");
+		boolean showDeploymentGroup = isLti13Tool(toolId, getSiteId(state));
+		context.put("showDeploymentGroup", showDeploymentGroup);
+		String excludeToolSiteInput = showDeploymentGroup ? "^SITE_ID:.*" : "^SITE_ID:.*|^deployment_group:.*";
+		String[] mappingFormInput = foorm.filterForm(ltiService.getToolSiteModel(getSiteId(state)), null, excludeToolSiteInput);
 		String formInput = ltiService.formInput(toolSiteBean, mappingFormInput);
 		context.put("formInput", formInput);
 
@@ -1319,6 +1352,10 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		// find the tool id
 		Map<String, Object> toolSite = ltiService.getToolSiteById(Long.valueOf(id), getSiteId(state));
 		String toolId = String.valueOf(toolSite.get(LTIService.LTI_TOOL_ID));
+
+		if (!isLti13Tool(toolId, getSiteId(state))) {
+			reqProps.remove(LTIService.LTI_DEPLOYMENT_GROUP);
+		}
 
 		// Save to DB
 		Object retval = ltiService.updateToolSite(Long.valueOf(id), reqProps, getSiteId(state));
@@ -1371,7 +1408,12 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		String formOutput = ltiService.formOutput(toolBean, mappingFormOutput);
 
 		// Display toolSite attributes (Read-only)
-		String[] mappingFormOutput2 = foorm.filterForm(ltiService.getToolSiteModel(getSiteId(state)), "^SITE_ID:.*|^notes:.*", null);
+		boolean showDeploymentGroup = isLti13Tool(toolId, getSiteId(state));
+		context.put("showDeploymentGroup", showDeploymentGroup);
+		String includeToolSiteDeleteFields = showDeploymentGroup
+				? "^SITE_ID:.*|^notes:.*|^deployment_group:.*"
+				: "^SITE_ID:.*|^notes:.*";
+		String[] mappingFormOutput2 = foorm.filterForm(ltiService.getToolSiteModel(getSiteId(state)), includeToolSiteDeleteFields, null);
 		String formOutput2 = ltiService.formOutput(toolSiteBean, mappingFormOutput2);
 		formOutput += formOutput2;
 		context.put("formOutput", formOutput);

--- a/lti/lti-tool/src/webapp/vm/lti_tool_site_deploy.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_tool_site_deploy.vm
@@ -58,13 +58,14 @@ ${includeLatestJQuery}
 
                 },
                 // Default sort
-                sortList : [ [ 4,0] ],
+                sortList : [ [ 0,0] ],
                 headers: {
-                    // special configuration for this column (we start counting zero)
-                    2: {
+#if ($toolSiteActionSorterColumn >= 0)
+                    $toolSiteActionSorterColumn: {
                         // disable it by setting the property sorter to false
                         sorter: false
                     }
+#end
                 }
             })
 
@@ -133,6 +134,9 @@ ${includeLatestJQuery}
                     <thead>
                         <tr>
                             <th id="site_id" data-placeholder="$tlang.getString('search.siteid')">$tlang.getString("bl_site")</th>
+#if ($showDeploymentGroup)
+                            <th id="deployment_group" data-placeholder="$tlang.getString('tool.site.search.deployment_group')">$tlang.getString("tool.site.table.deployment_group")</th>
+#end
                             <th id="site_notes" data-placeholder="$tlang.getString('search.notes')">$tlang.getString("bl_notes")</th>
                             #if ($isAdmin) <th id="action" class="filter-false">$tlang.getString("bl_action")</th>#end
                         </tr>
@@ -146,6 +150,9 @@ ${includeLatestJQuery}
                                     #set($siteId=$toolSite.siteId)
                                     $!siteId
                                 </td>
+#if ($showDeploymentGroup)
+                                <td headers="deployment_group">$formattedText.escapeHtml($!toolSite.deploymentGroup)</td>
+#end
                                 <td headers="site_notes">$formattedText.escapeHtml($toolSite.notes)</td>
 
                                 #if ($isAdmin)

--- a/lti/lti-tool/src/webapp/vm/lti_tool_site_insert.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_tool_site_insert.vm
@@ -16,6 +16,16 @@
             </div>
         </div>
 
+        #if ($showDeploymentGroup)
+        <div id="deployment-group-input-container">
+            <label for="deployment-group-input">$tlang.getString("tool.site.deployment_group")</label>
+            <div id="deployment-group-input-info" class="text-muted">$tlang.getString("tool.site.deployment_group.hint")</div>
+            <div id="div-deployment-group-input">
+                <input type="text" id="deployment-group-input" class="form-control" name="deployment_group" size="40" maxlength="128" pattern="[A-Za-z0-9]*" title="$tlang.getString('tool.site.deployment_group.pattern')" value="$!previousPost.get("deployment_group")">
+            </div>
+        </div>
+        #end
+
         <div id="tool-site-ids-input-container">
             <label for="tool-site-ids-input">
                 <span style="color: red;">*</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional deployment group configuration for LTI 1.3 tool sites
  * Deployment group field displays only for LTI 1.3 tools in the administration interface
  * Deployment groups support searching and appear in tool site tables

* **Enhancements**
  * Deployment group values are validated to contain only letters and numbers
  * Enhanced LTI 1.3 JWT generation to support deployment group overrides during launch

* **Bug Fixes**
  * Fixed nonce validation check in LTI 1.3 OIDC redirect flow

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14586)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->