### PR TITLE
SAK-52489 LTI: Installed tool information missing some fields

### DIFF
--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -720,6 +720,9 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		tool.put(LTIService.LTI_SECRET, LTIService.SECRET_HIDDEN);
 		tool.put(LTIService.LTI_CONSUMERKEY, LTIService.SECRET_HIDDEN);
 
+		// Make sure this is ready to handle LTI 1.3 launches
+		minimalLTI13(tool);
+
 		String formOutput = ltiService.formOutput(tool, mappingForm);
 		context.put("formOutput", formOutput);
 


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52489

This fix only applies to 25.x. It is not a bug in either 26.x (where a different data model/bean is now used) or 23.x.