### PR TITLE
SAK-52547 Assignments preserve the category for GB linkage

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -263,6 +263,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     private static final String ANNOUNCEMENT_NOTIFICATION_INVOKEE = "org.sakaiproject.announcement.impl.SiteEmailNotificationAnnc";
 
     private static ResourceLoader rb = new ResourceLoader("assignment");
+    private static final String NEW_ASSIGNMENT_CATEGORY = "new_assignment_category";
 
     public void init() {
         allowSubmitByInstructor = serverConfigurationService.getBoolean("assignments.instructor.submit.for.student", true);
@@ -4739,12 +4740,22 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 originalGBAssignment = gradingService.getExternalAssignment(oAssignment.getContext(), associatedGradebookAssignment);
                             }
 
+                            Optional<Long> importedCategoryId = Optional.empty();
+                            if (isOriginalAssignmentExternal && originalGBAssignment != null) {
+                                importedCategoryId = createCategoryForGbAssignmentIfNecessary(originalGBAssignment, oAssignment.getContext(), nAssignment.getContext());
+                            }
+
                             if (nAssignment.getDraft()) {
                                 // assignment is in the draft state
                                 if (isOriginalAssignmentExternal) {
                                     // if this is an external defined assignments will create when publishing
                                     nProperties.remove(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
                                     nProperties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ADD);
+                                    if (importedCategoryId.isPresent()) {
+                                        nProperties.put(NEW_ASSIGNMENT_CATEGORY, importedCategoryId.get().toString());
+                                    } else {
+                                        nProperties.remove(NEW_ASSIGNMENT_CATEGORY);
+                                    }
                                 } else {
                                     if (newGbAssignment != null) {
                                         if (StringUtils.isNotBlank(newGbAssignment.getId().toString())) {
@@ -4760,11 +4771,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 // not in draft state
                                 if (isOriginalAssignmentExternal) {
                                     // external gradebook items are created by assignments and linked using the assignments reference
-                                    Long categoryId = null;
-                                    if (originalGBAssignment != null) {
-                                        categoryId = createCategoryForGbAssignmentIfNecessary(originalGBAssignment, oAssignment.getContext(), nAssignment.getContext())
-                                                .orElse(null);
-                                    }
+                                    Long categoryId = importedCategoryId.orElse(null);
 
                                     try {
                                         gradingService.addExternalAssessment(

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -4802,6 +4802,11 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
                                         nProperties.remove(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
                                         nProperties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ADD);
+                                        if (importedCategoryId.isPresent()) {
+                                            nProperties.put(NEW_ASSIGNMENT_CATEGORY, importedCategoryId.get().toString());
+                                        } else {
+                                            nProperties.remove(NEW_ASSIGNMENT_CATEGORY);
+                                        }
                                         nAssignment.setModifier(sessionManager.getCurrentSessionUserId());
                                         assignmentRepository.merge(nAssignment);
                                         log.info("Renamed duplicate assignment to '{}' and set to draft in site {}. Will be added to GB on publish.", uniqueTitle, nAssignment.getContext());

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -2127,6 +2127,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         when(securityService.unlock(AssignmentServiceConstants.SECURE_ACCESS_ASSIGNMENT, toContextReference)).thenReturn(true);
         when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, toContextReference)).thenReturn(true);
         when(serverConfigurationService.getBoolean("import.importAsDraft", true)).thenReturn(true);
+        when(serverConfigurationService.getBoolean("assignment.import.importAsDraft", true)).thenReturn(true);
         when(sessionManager.getCurrentSessionUserId()).thenReturn(userId);
 
         User currentUser = mock(User.class);

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -22,12 +22,14 @@
 package org.sakaiproject.assignment.impl;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -87,6 +89,9 @@ import org.sakaiproject.exception.IdInvalidException;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.IdUsedException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.grading.api.CategoryDefinition;
+import org.sakaiproject.grading.api.GradebookInformation;
+import org.sakaiproject.grading.api.GradingConstants;
 import org.sakaiproject.grading.api.GradingService;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
@@ -125,6 +130,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringContextTests {
 
     private static final Faker faker = new Faker();
+    private static final String NEW_ASSIGNMENT_CATEGORY = "new_assignment_category";
 
     @Autowired private AssignmentEventObserver assignmentEventObserver;
     @Autowired private AssignmentService assignmentService;
@@ -2099,6 +2105,61 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
                 }
             }
         }
+    }
+
+    @Test
+    public void transferCopyEntitiesPreservesExternalGradebookCategoryForDraftImport() throws Exception {
+        String fromContext = UUID.randomUUID().toString();
+        String toContext = UUID.randomUUID().toString();
+        String userId = UUID.randomUUID().toString();
+        String externalId = "/assignment/a/" + fromContext + "/" + UUID.randomUUID();
+        String categoryName = "Homework";
+        Long destinationCategoryId = 42L;
+
+        Assignment sourceAssignment = createNewAssignment(fromContext);
+        sourceAssignment.setTitle("Categorized assignment");
+        sourceAssignment.setTypeOfGrade(Assignment.GradeType.SCORE_GRADE_TYPE);
+        sourceAssignment.getProperties().put(AssignmentConstants.NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, AssignmentConstants.GRADEBOOK_INTEGRATION_ADD);
+        sourceAssignment.getProperties().put(AssignmentConstants.PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT, externalId);
+
+        String toContextReference = AssignmentReferenceReckoner.reckoner().context(toContext).reckon().getReference();
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_ADD_ASSIGNMENT, toContextReference)).thenReturn(true);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_ACCESS_ASSIGNMENT, toContextReference)).thenReturn(true);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, toContextReference)).thenReturn(true);
+        when(serverConfigurationService.getBoolean("import.importAsDraft", true)).thenReturn(true);
+        when(sessionManager.getCurrentSessionUserId()).thenReturn(userId);
+
+        User currentUser = mock(User.class);
+        when(currentUser.getId()).thenReturn(userId);
+        when(userDirectoryService.getCurrentUser()).thenReturn(currentUser);
+
+        org.sakaiproject.grading.api.Assignment sourceGradebookItem = new org.sakaiproject.grading.api.Assignment();
+        sourceGradebookItem.setName(sourceAssignment.getTitle());
+        sourceGradebookItem.setExternalId(externalId);
+        sourceGradebookItem.setCategoryName(categoryName);
+        when(gradingService.isExternalAssignmentDefined(fromContext, externalId)).thenReturn(true);
+        when(gradingService.getExternalAssignment(fromContext, externalId)).thenReturn(sourceGradebookItem);
+
+        GradebookInformation destinationGradebookInformation = new GradebookInformation();
+        destinationGradebookInformation.setCategoryType(GradingConstants.CATEGORY_TYPE_ONLY_CATEGORY);
+        destinationGradebookInformation.setCategories(new ArrayList<>());
+        when(gradingService.getGradebookInformation(toContext, toContext)).thenReturn(destinationGradebookInformation);
+        when(gradingService.getCategoryDefinitions(toContext, toContext))
+                .thenReturn(Collections.singletonList(new CategoryDefinition(destinationCategoryId, categoryName)));
+
+        AssignmentServiceImpl assignmentServiceImpl = (AssignmentServiceImpl) AopTestUtils.getTargetObject(assignmentService);
+        assignmentServiceImpl.transferCopyEntities(fromContext, toContext, Collections.singletonList(sourceAssignment.getId()), Collections.<String>emptyList());
+
+        Assignment importedAssignment = assignmentService.getAssignmentsForContext(toContext).stream().findFirst().orElse(null);
+        Assert.assertNotNull(importedAssignment);
+        Assert.assertTrue(importedAssignment.getDraft());
+        Assert.assertEquals(AssignmentConstants.GRADEBOOK_INTEGRATION_ADD,
+                importedAssignment.getProperties().get(AssignmentConstants.NEW_ASSIGNMENT_ADD_TO_GRADEBOOK));
+        Assert.assertNull(importedAssignment.getProperties().get(AssignmentConstants.PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT));
+        Assert.assertEquals(destinationCategoryId.toString(),
+                importedAssignment.getProperties().get(NEW_ASSIGNMENT_CATEGORY));
+        verify(gradingService, never()).addExternalAssessment(
+                anyString(), anyString(), anyString(), anyString(), anyString(), any(), any(), anyString(), anyString(), any(), any(), anyString());
     }
 
     @Test

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -23,6 +23,7 @@ package org.sakaiproject.assignment.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -84,6 +85,7 @@ import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.EntityTransferrer;
 import org.sakaiproject.event.api.Event;
 import org.sakaiproject.exception.IdInvalidException;
 import org.sakaiproject.exception.IdUnusedException;
@@ -2127,7 +2129,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         when(securityService.unlock(AssignmentServiceConstants.SECURE_ACCESS_ASSIGNMENT, toContextReference)).thenReturn(true);
         when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT, toContextReference)).thenReturn(true);
         when(serverConfigurationService.getBoolean("import.importAsDraft", true)).thenReturn(true);
-        when(serverConfigurationService.getBoolean("assignment.import.importAsDraft", true)).thenReturn(true);
+        when(serverConfigurationService.getBoolean(eq("assignment.import.importAsDraft"), anyBoolean())).thenReturn(true);
         when(sessionManager.getCurrentSessionUserId()).thenReturn(userId);
 
         User currentUser = mock(User.class);
@@ -2148,8 +2150,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         when(gradingService.getCategoryDefinitions(toContext, toContext))
                 .thenReturn(Collections.singletonList(new CategoryDefinition(destinationCategoryId, categoryName)));
 
-        AssignmentServiceImpl assignmentServiceImpl = (AssignmentServiceImpl) AopTestUtils.getTargetObject(assignmentService);
-        assignmentServiceImpl.transferCopyEntities(fromContext, toContext, Collections.singletonList(sourceAssignment.getId()), Collections.<String>emptyList());
+        ((EntityTransferrer) assignmentService).transferCopyEntities(fromContext, toContext, Collections.singletonList(sourceAssignment.getId()), Collections.<String>emptyList());
 
         Assignment importedAssignment = assignmentService.getAssignmentsForContext(toContext).stream().findFirst().orElse(null);
         Assert.assertNotNull(importedAssignment);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11518,18 +11518,21 @@ public class AssignmentAction extends PagedResourceActionII {
         Map<String, Long> gradebookCategoriesMap = addToGradebookOnPublish
                 ? getBulkPublishGradebookCategories(state, siteId, assignment)
                 : Collections.emptyMap();
+        boolean publishAssignment = !addToGradebookOnPublish || !gradebookCategoriesMap.isEmpty();
 
-        if (addToGradebookOnPublish) {
+        if (addToGradebookOnPublish && publishAssignment) {
             String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
             properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ASSOCIATE);
             properties.put(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT, assignmentReference);
             properties.remove(NEW_ASSIGNMENT_CATEGORY);
         }
 
-        assignment.setDraft(Boolean.FALSE);
-        assignmentService.updateAssignment(assignment);
+        if (publishAssignment) {
+            assignment.setDraft(Boolean.FALSE);
+            assignmentService.updateAssignment(assignment);
+        }
 
-        if (addToGradebookOnPublish) {
+        if (addToGradebookOnPublish && publishAssignment) {
             for (Map.Entry<String, Long> entry : gradebookCategoriesMap.entrySet()) {
                 initIntegrateWithGradebook(state, entry.getKey(), assignment.getTitle(), oAssociateGradebookAssignment,
                         assignment, assignment.getTitle(), assignment.getDueDate(), assignment.getTypeOfGrade(),

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11487,8 +11487,7 @@ public class AssignmentAction extends PagedResourceActionII {
             try {
                 String id = AssignmentReferenceReckoner.reckoner().reference(ref).reckon().getId();
                 Assignment assignment = assignmentService.getAssignment(id);
-                assignment.setDraft(Boolean.FALSE);
-                assignmentService.updateAssignment(assignment);
+                publishAssignment(state, siteId, assignment);
             } catch (IdUnusedException e) {
                 log.warn("Cannot find assignment with ref: {}", ref);
                 addAlert(state, rb.getFormattedMessage("options_cannotFindAssignment", ref));
@@ -11506,6 +11505,83 @@ public class AssignmentAction extends PagedResourceActionII {
             // reset paging information after the assignment been deleted
             resetPaging(state);
         }
+    }
+
+    private void publishAssignment(SessionState state, String siteId, Assignment assignment) throws PermissionException {
+        Map<String, String> properties = assignment.getProperties();
+        String addtoGradebook = properties.get(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK);
+        String oAssociateGradebookAssignment = properties.get(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT);
+        boolean addToGradebookOnPublish = BooleanUtils.toBoolean(assignment.getDraft())
+                && GRADEBOOK_INTEGRATION_ADD.equals(addtoGradebook)
+                && assignment.getTypeOfGrade() == Assignment.GradeType.SCORE_GRADE_TYPE;
+
+        Map<String, Long> gradebookCategoriesMap = addToGradebookOnPublish
+                ? getBulkPublishGradebookCategories(state, siteId, assignment)
+                : Collections.emptyMap();
+
+        if (addToGradebookOnPublish) {
+            String assignmentReference = AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference();
+            properties.put(NEW_ASSIGNMENT_ADD_TO_GRADEBOOK, GRADEBOOK_INTEGRATION_ASSOCIATE);
+            properties.put(PROP_ASSIGNMENT_ASSOCIATE_GRADEBOOK_ASSIGNMENT, assignmentReference);
+            properties.remove(NEW_ASSIGNMENT_CATEGORY);
+        }
+
+        assignment.setDraft(Boolean.FALSE);
+        assignmentService.updateAssignment(assignment);
+
+        if (addToGradebookOnPublish) {
+            for (Map.Entry<String, Long> entry : gradebookCategoriesMap.entrySet()) {
+                initIntegrateWithGradebook(state, entry.getKey(), assignment.getTitle(), oAssociateGradebookAssignment,
+                        assignment, assignment.getTitle(), assignment.getDueDate(), assignment.getTypeOfGrade(),
+                        assignment.getMaxGradePoint().toString(), addtoGradebook, null, entry.getValue());
+            }
+        }
+    }
+
+    private Map<String, Long> getBulkPublishGradebookCategories(SessionState state, String siteId, Assignment assignment) {
+        Map<String, Long> gradebookCategoriesMap = new LinkedHashMap<>();
+        if (!gradingService.isGradebookGroupEnabled(siteId)) {
+            gradebookCategoriesMap.put(siteId, NumberUtils.toLong(assignment.getProperties().get(NEW_ASSIGNMENT_CATEGORY), -1L));
+            return gradebookCategoriesMap;
+        }
+
+        List<String> groupIdList = new ArrayList<>();
+        try {
+            Site site = siteService.getSite(siteId);
+            groupIdList = assignment.getGroups().stream()
+                    .map(site::getGroup)
+                    .filter(Objects::nonNull)
+                    .map(Group::getId)
+                    .collect(Collectors.toList());
+        } catch (IdUnusedException e) {
+            log.warn("Cannot find site {} while publishing assignment {}", siteId, assignment.getId());
+            addAlert(state, rb.getFormattedMessage("options_cannotFindAssignment", assignment.getId()));
+            return gradebookCategoriesMap;
+        }
+
+        List<String> selectedGradebookUids = new ArrayList<>();
+        buildGradebookUidList(state, siteId, selectedGradebookUids, GRADEBOOK_INTEGRATION_ADD, groupIdList, true);
+
+        String categoriesString = StringUtils.trimToNull(assignment.getProperties().get(NEW_ASSIGNMENT_CATEGORY));
+        if (categoriesString == null) {
+            selectedGradebookUids.forEach(gbUid -> gradebookCategoriesMap.put(gbUid, -1L));
+            return gradebookCategoriesMap;
+        }
+
+        List<String> selectedCategories = Arrays.stream(categoriesString.split(","))
+                .map(StringUtils::trimToNull)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        for (String gbUid : selectedGradebookUids) {
+            Long categoryId = gradingService.getCategoryDefinitions(gbUid, siteId).stream()
+                    .filter(category -> selectedCategories.contains(category.getId().toString()))
+                    .map(CategoryDefinition::getId)
+                    .findFirst()
+                    .orElse(-1L);
+            gradebookCategoriesMap.put(gbUid, categoryId);
+        }
+        return gradebookCategoriesMap;
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve destination gradebook category when assignments are imported as drafts; reuse the stored category for subsequent imports and handle renamed/conflicted imports consistently.

* **New Features**
  * Centralized publish flow that computes and applies bulk gradebook category mappings, including group-aware mapping, sensible fallbacks, and user alerts when site resolution fails.

* **Tests**
  * Added test coverage verifying draft import preserves category and avoids creating external gradebook assessments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14588)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->