### PR TITLE
SAK-52561 Polls add bar and pie chart type selector to results view

### DIFF
--- a/polls/api/src/main/resources/bundle/polls.properties
+++ b/polls/api/src/main/resources/bundle/polls.properties
@@ -104,8 +104,10 @@ results_poll_size=Number of people who have voted: {0}
 results_cancel=Back
 results_cancel_tooltip=Back
 results_chart_type=Chart Type:
+results_chart_bar=Bar
+results_chart_pie=Pie
 results_chart_title=Chart
-results_chart_summary=Bar chart of poll results by option.
+results_chart_summary=Chart of poll results by option.
 
 permissions_title=Permissions
 permissions_instruction=Set permissions for Poll in worksite

--- a/polls/tool/src/main/webapp/WEB-INF/templates/polls/results.html
+++ b/polls/tool/src/main/webapp/WEB-INF/templates/polls/results.html
@@ -12,8 +12,17 @@
 
     <section class="card mb-4" aria-labelledby="poll-results-chart-heading">
       <div class="card-body">
-        <h2 id="poll-results-chart-heading" class="h5 mb-3" th:text="#{results_chart_title}">Chart</h2>
-        <p id="poll-results-chart-summary" class="visually-hidden" th:text="#{results_chart_summary}">Bar chart of poll results by option.</p>
+        <div class="d-flex align-items-center justify-content-between mb-3">
+          <h2 id="poll-results-chart-heading" class="h5 mb-0" th:text="#{results_chart_title}">Chart</h2>
+          <div class="d-flex align-items-center gap-2">
+            <label for="chart-type-selection" class="mb-0" th:text="#{results_chart_type}">Chart Type:</label>
+            <select id="chart-type-selection" class="form-select form-select-sm" style="width: auto;">
+              <option value="bar" th:text="#{results_chart_bar}">Bar</option>
+              <option value="pie" th:text="#{results_chart_pie}">Pie</option>
+            </select>
+          </div>
+        </div>
+        <p id="poll-results-chart-summary" class="visually-hidden" th:text="#{results_chart_summary}">Chart of poll results by option.</p>
         <div class="position-relative" style="min-height: 20rem;">
           <canvas id="poll-results-chart" aria-describedby="poll-results-chart-summary" height="320"></canvas>
         </div>

--- a/polls/tool/src/main/webapp/js/polls-results-chart.js
+++ b/polls/tool/src/main/webapp/js/polls-results-chart.js
@@ -7,19 +7,20 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  const COOKIE_NAME = "polls-chart-type";
+  const ALLOWED_TYPES = new Set(["bar", "pie"]);
+  const DEFAULT_TYPE = "bar";
   const PIE_COLORS = [
     "#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f",
     "#edc948", "#b07aa1", "#ff9da7", "#9c755f", "#bab0ac"
   ];
 
-  function getCookie(name) {
-    const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
-    return match ? decodeURIComponent(match[1]) : null;
+  function getChartType() {
+    const stored = localStorage.getItem("polls-chart-type");
+    return ALLOWED_TYPES.has(stored) ? stored : DEFAULT_TYPE;
   }
 
-  function setCookie(name, value) {
-    document.cookie = name + "=" + encodeURIComponent(value) + "; path=/; max-age=" + (365 * 24 * 3600);
+  function saveChartType(type) {
+    localStorage.setItem("polls-chart-type", type);
   }
 
   const rootStyles = getComputedStyle(document.documentElement);
@@ -112,14 +113,12 @@ document.addEventListener("DOMContentLoaded", () => {
     chart = new Chart(canvas, buildConfig(type));
   }
 
-  const ALLOWED_TYPES = new Set(["bar", "pie"]);
-  const savedTypeRaw = getCookie(COOKIE_NAME);
-  const savedType = ALLOWED_TYPES.has(savedTypeRaw) ? savedTypeRaw : "bar";
+  const savedType = getChartType();
   if (select) {
     select.value = savedType;
     select.addEventListener("change", () => {
-      const type = ALLOWED_TYPES.has(select.value) ? select.value : "bar";
-      setCookie(COOKIE_NAME, type);
+      const type = ALLOWED_TYPES.has(select.value) ? select.value : DEFAULT_TYPE;
+      saveChartType(type);
       renderChart(type);
     });
   }

--- a/polls/tool/src/main/webapp/js/polls-results-chart.js
+++ b/polls/tool/src/main/webapp/js/polls-results-chart.js
@@ -112,11 +112,13 @@ document.addEventListener("DOMContentLoaded", () => {
     chart = new Chart(canvas, buildConfig(type));
   }
 
-  const savedType = getCookie(COOKIE_NAME) || "bar";
+  const ALLOWED_TYPES = new Set(["bar", "pie"]);
+  const savedTypeRaw = getCookie(COOKIE_NAME);
+  const savedType = ALLOWED_TYPES.has(savedTypeRaw) ? savedTypeRaw : "bar";
   if (select) {
     select.value = savedType;
     select.addEventListener("change", () => {
-      const type = select.value;
+      const type = ALLOWED_TYPES.has(select.value) ? select.value : "bar";
       setCookie(COOKIE_NAME, type);
       renderChart(type);
     });

--- a/polls/tool/src/main/webapp/js/polls-results-chart.js
+++ b/polls/tool/src/main/webapp/js/polls-results-chart.js
@@ -1,9 +1,25 @@
 document.addEventListener("DOMContentLoaded", () => {
   const canvas = document.getElementById("poll-results-chart");
+  const select = document.getElementById("chart-type-selection");
   const chartData = window.pollResultsChartData;
 
   if (!canvas || typeof Chart === "undefined" || !chartData) {
     return;
+  }
+
+  const COOKIE_NAME = "polls-chart-type";
+  const PIE_COLORS = [
+    "#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f",
+    "#edc948", "#b07aa1", "#ff9da7", "#9c755f", "#bab0ac"
+  ];
+
+  function getCookie(name) {
+    const match = document.cookie.match(new RegExp("(?:^|; )" + name + "=([^;]*)"));
+    return match ? decodeURIComponent(match[1]) : null;
+  }
+
+  function setCookie(name, value) {
+    document.cookie = name + "=" + encodeURIComponent(value) + "; path=/; max-age=" + (365 * 24 * 3600);
   }
 
   const rootStyles = getComputedStyle(document.documentElement);
@@ -11,64 +27,100 @@ document.addEventListener("DOMContentLoaded", () => {
   const borderColor = rootStyles.getPropertyValue("--sakai-border-color").trim() || "#d6dde6";
   const barColor = rootStyles.getPropertyValue("--sakai-primary-color-1").trim() || "#0d6efd";
 
-  new Chart(canvas, {
-    type: "bar",
-    data: {
-      labels: chartData.labels,
-      datasets: [{
-        data: chartData.votes,
-        backgroundColor: barColor,
-        borderRadius: 6,
-        maxBarThickness: 36
-      }]
-    },
-    options: {
-      animation: false,
-      maintainAspectRatio: false,
-      indexAxis: "y",
-      plugins: {
-        legend: {
-          display: false
+  let chart = null;
+
+  function buildConfig(type) {
+    if (type === "pie") {
+      return {
+        type: "pie",
+        data: {
+          labels: chartData.labels,
+          datasets: [{
+            data: chartData.votes,
+            backgroundColor: PIE_COLORS.slice(0, chartData.labels.length)
+          }]
         },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              const percentage = chartData.percentages[context.dataIndex] || "0%";
-              return `${chartData.votesLabel}: ${context.raw} (${percentage})`;
+        options: {
+          animation: false,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              display: true,
+              position: "right",
+              labels: { color: textColor }
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const percentage = chartData.percentages[context.dataIndex] || "0%";
+                  return `${context.label}: ${context.raw} ${chartData.votesLabel} (${percentage})`;
+                }
+              }
             }
           }
         }
+      };
+    }
+
+    return {
+      type: "bar",
+      data: {
+        labels: chartData.labels,
+        datasets: [{
+          data: chartData.votes,
+          backgroundColor: barColor,
+          borderRadius: 6,
+          maxBarThickness: 36
+        }]
       },
-      scales: {
-        x: {
-          beginAtZero: true,
-          ticks: {
-            precision: 0,
-            color: textColor
-          },
-          title: {
-            display: true,
-            text: chartData.votesLabel,
-            color: textColor
-          },
-          grid: {
-            color: borderColor
+      options: {
+        animation: false,
+        maintainAspectRatio: false,
+        indexAxis: "y",
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                const percentage = chartData.percentages[context.dataIndex] || "0%";
+                return `${chartData.votesLabel}: ${context.raw} (${percentage})`;
+              }
+            }
           }
         },
-        y: {
-          ticks: {
-            color: textColor
+        scales: {
+          x: {
+            beginAtZero: true,
+            ticks: { precision: 0, color: textColor },
+            title: { display: true, text: chartData.votesLabel, color: textColor },
+            grid: { color: borderColor }
           },
-          title: {
-            display: true,
-            text: chartData.optionLabel,
-            color: textColor
-          },
-          grid: {
-            display: false
+          y: {
+            ticks: { color: textColor },
+            title: { display: true, text: chartData.optionLabel, color: textColor },
+            grid: { display: false }
           }
         }
       }
+    };
+  }
+
+  function renderChart(type) {
+    if (chart) {
+      chart.destroy();
     }
-  });
+    chart = new Chart(canvas, buildConfig(type));
+  }
+
+  const savedType = getCookie(COOKIE_NAME) || "bar";
+  if (select) {
+    select.value = savedType;
+    select.addEventListener("change", () => {
+      const type = select.value;
+      setCookie(COOKIE_NAME, type);
+      renderChart(type);
+    });
+  }
+
+  renderChart(savedType);
 });


### PR DESCRIPTION
## Summary
  - Add bar/pie chart type selector to the poll results page (SAK-52561)
  - User preference is persisted via cookie (`polls-chart-type`)
  - Added i18n keys `results_chart_bar` and `results_chart_pie` to polls.properties
  - Updated `results_chart_summary` to be chart-type agnostic

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chart type selector on poll results so users can view results as bar or pie charts.
  * The chosen chart type is persisted and restored on future visits.

* **Bug Fixes**
  * Updated results summary text to be generic and reflect the selected chart type instead of referencing only bar charts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14590)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->