### PR TITLE
SAK-52562 Setting portal.notifications.push.enabled=false should not show 'Push is not enabled - <Enable>' in UI

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-notifications/src/SakaiNotifications.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-notifications/src/SakaiNotifications.js
@@ -522,7 +522,7 @@ export class SakaiNotifications extends SakaiElement {
       ` : nothing}
 
       ${this._state === NOTIFICATIONS || this._state === PWA_INSTALL_INFO ? html`
-        ${Notification.permission !== "granted" && this._online && this._pushEnabled ? html`
+        ${Notification.permission !== "granted" && this._online && this.pushEnabled ? html`
           <div class="alert alert-warning">
             <span class="me-1">${this._i18n.push_not_enabled}</span>
             <button type="button"


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52562

I don't have time to rename all the variables, as mentioned in the ticket, but this should fix the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the push notifications enabled alert to display correctly when push notifications are not permitted by the browser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14595)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->