### PR TITLE
SAK-52568 webapi Added tests and asciidoc for NotificationsController

### DIFF
--- a/webapi/src/docs/asciidoc/controllers/notifications/notifications-api.adoc
+++ b/webapi/src/docs/asciidoc/controllers/notifications/notifications-api.adoc
@@ -25,8 +25,8 @@ include::{snippets}/get-user-notifications/curl-request.adoc[]
 ==== Example Success Response
 include::{snippets}/get-user-notifications/response-body.adoc[]
 
-=== POST /api/users/me/notifications/:ID:/clear
-Clears the notification with id :ID:, for the currently authenticated user
+=== POST /api/users/me/notifications/{id}/clear
+Clears the notification with id {id}, for the currently authenticated user
 
 [cols="1h,3", grid=rows, frame=topbot]
 |===
@@ -35,6 +35,15 @@ Clears the notification with id :ID:, for the currently authenticated user
 
 ==== Example Request
 include::{snippets}/clear-user-notification/curl-request.adoc[]
+
+==== Responses
+[cols="1,2,2", options="header"]
+|===
+| Status Code | Status | Details
+| 200 OK | Success | Notification was cleared.
+| 401 Unauthorized | Error | User is not authenticated.
+| 500 Internal Server Error | Error | Notification could not be cleared.
+|===
 
 === POST /api/users/me/notifications/clear
 Clears all the notifications for the currently authenticated user
@@ -46,6 +55,15 @@ Clears all the notifications for the currently authenticated user
 
 ==== Example Request
 include::{snippets}/clear-user-notifications/curl-request.adoc[]
+
+==== Responses
+[cols="1,2,2", options="header"]
+|===
+| Status Code | Status | Details
+| 200 OK | Success | Notifications were cleared.
+| 401 Unauthorized | Error | User is not authenticated.
+| 500 Internal Server Error | Error | Notifications could not be cleared.
+|===
 
 === POST /api/users/me/notifications/markViewed
 Marks notifications as viewed. You can supply a siteId and toolId to just mark those notifications
@@ -60,6 +78,15 @@ as viewed
 ==== Example Request
 include::{snippets}/mark-user-notifications-viewed/curl-request.adoc[]
 
+==== Responses
+[cols="1,2,2", options="header"]
+|===
+| Status Code | Status | Details
+| 200 OK | Success | Notifications were marked as viewed.
+| 401 Unauthorized | Error | User is not authenticated.
+| 500 Internal Server Error | Error | Notifications could not be marked as viewed.
+|===
+
 === POST /api/users/me/notifications/test
 Requests a test notification. This will use Sakai's push service to push a notification to your
 browser. Not really much use via Curl but is just here for completeness.
@@ -71,3 +98,11 @@ browser. Not really much use via Curl but is just here for completeness.
 
 ==== Example Request
 include::{snippets}/send-test-notification/curl-request.adoc[]
+
+==== Responses
+[cols="1,2,2", options="header"]
+|===
+| Status Code | Status | Details
+| 200 OK | Success | Test notification was requested.
+| 401 Unauthorized | Error | User is not authenticated.
+|===

--- a/webapi/src/docs/asciidoc/controllers/notifications/notifications-api.adoc
+++ b/webapi/src/docs/asciidoc/controllers/notifications/notifications-api.adoc
@@ -1,0 +1,73 @@
+== Notifications
+
+__See the login api about session cookies__
+
+=== GET /api/users/me/notifications
+Returns notifications for the currently authenticated user
+
+[cols="1h,3", grid=rows, frame=topbot]
+|===
+| Authentication | User must be authenticated
+| Produces       | application/json
+|===
+
+==== Example Request
+include::{snippets}/get-user-notifications/curl-request.adoc[]
+
+==== Responses
+[cols="1,2,2", options="header"]
+|===
+| Status Code | Status | Details
+| 200 OK | Success | Returns an array of notifications.
+| 401 Unauthorized | Error | User is not authenticated.
+|===
+
+==== Example Success Response
+include::{snippets}/get-user-notifications/response-body.adoc[]
+
+=== POST /api/users/me/notifications/:ID:/clear
+Clears the notification with id :ID:, for the currently authenticated user
+
+[cols="1h,3", grid=rows, frame=topbot]
+|===
+| Authentication | User must be authenticated
+|===
+
+==== Example Request
+include::{snippets}/clear-user-notification/curl-request.adoc[]
+
+=== POST /api/users/me/notifications/clear
+Clears all the notifications for the currently authenticated user
+
+[cols="1h,3", grid=rows, frame=topbot]
+|===
+| Authentication | User must be authenticated
+|===
+
+==== Example Request
+include::{snippets}/clear-user-notifications/curl-request.adoc[]
+
+=== POST /api/users/me/notifications/markViewed
+Marks notifications as viewed. You can supply a siteId and toolId to just mark those notifications
+as viewed
+
+[cols="1h,3", grid=rows, frame=topbot]
+|===
+| Authentication | User must be authenticated
+| Consumes | application/x-www-form-urlencoded
+|===
+
+==== Example Request
+include::{snippets}/mark-user-notifications-viewed/curl-request.adoc[]
+
+=== POST /api/users/me/notifications/test
+Requests a test notification. This will use Sakai's push service to push a notification to your
+browser. Not really much use via Curl but is just here for completeness.
+
+[cols="1h,3", grid=rows, frame=topbot]
+|===
+| Authentication | User must be authenticated
+|===
+
+==== Example Request
+include::{snippets}/send-test-notification/curl-request.adoc[]

--- a/webapi/src/docs/asciidoc/webapi.adoc
+++ b/webapi/src/docs/asciidoc/webapi.adoc
@@ -12,4 +12,6 @@ include::controllers/calendar/calendar-api.adoc[]
 
 include::controllers/grades/grades-api.adoc[]
 
+include::controllers/notifications/notifications-api.adoc[]
+
 include::controllers/scorm/scorm-api.adoc[]

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/NotificationsController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/NotificationsController.java
@@ -28,6 +28,7 @@ import org.sakaiproject.messaging.api.UserNotificationTransferBean;
 
 import java.util.List;
 
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
@@ -35,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NotificationsController extends AbstractSakaiApiController {
 
     @Autowired
+    @Setter
     private UserMessagingService userMessagingService;
 
     @GetMapping(value = "/users/me/notifications", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -97,5 +99,4 @@ public class NotificationsController extends AbstractSakaiApiController {
 
         userMessagingService.sendTestNotification();
     }
-
 }

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/CalendarControllerTests.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/CalendarControllerTests.java
@@ -26,11 +26,9 @@ import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/GradesControllerTests.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/GradesControllerTests.java
@@ -34,7 +34,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import org.sakaiproject.authz.api.AuthzGroupService;

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
@@ -15,9 +15,7 @@
  */
 package org.sakaiproject.webapi.controllers.test;
 
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -126,8 +124,8 @@ public class NotificationsControllerTests extends BaseControllerTests {
 
         mockMvc.perform(get("/users/me/notifications"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", hasSize(2)))
-            .andExpect(jsonPath("$.[*].id", hasItems(noti1.id.intValue(), noti2.id.intValue())))
+            .andExpect(jsonPath("$.length()", is(2)))
+            .andExpect(jsonPath("$.[0].id", is(noti1.id.intValue())))
             .andExpect(jsonPath("$.[0].from", is(noti1.from)))
             .andExpect(jsonPath("$.[0].to", is(noti1.to)))
             .andExpect(jsonPath("$.[0].event", is(noti1.event)))
@@ -138,6 +136,7 @@ public class NotificationsControllerTests extends BaseControllerTests {
             .andExpect(jsonPath("$.[0].fromDisplayName", is(noti1.fromDisplayName)))
             .andExpect(jsonPath("$.[0].siteTitle", is(noti1.siteTitle)))
             .andExpect(jsonPath("$.[0].formattedEventDate", is(noti1.formattedEventDate)))
+            .andExpect(jsonPath("$.[1].id", is(noti2.id.intValue())))
             .andExpect(jsonPath("$.[1].from", is(noti2.from)))
             .andExpect(jsonPath("$.[1].to", is(noti2.to)))
             .andExpect(jsonPath("$.[1].event", is(noti2.event)))

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2003-2025 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.webapi.controllers.test;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import org.sakaiproject.messaging.api.UserMessagingService;
+import org.sakaiproject.messaging.api.UserNotificationTransferBean;
+import org.sakaiproject.portal.api.PortalService;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.webapi.controllers.NotificationsController;
+
+import static org.mockito.Mockito.*;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { WebApiTestConfiguration.class })
+public class NotificationsControllerTests extends BaseControllerTests {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private UserMessagingService userMessagingService;
+
+    @Mock
+    private PortalService portalService;
+
+    @Mock
+    private SessionManager sessionManager;
+
+    @Mock
+    private SiteService siteService;
+
+    private AutoCloseable mocks;
+
+    private String user1Id = "user1";
+
+    @Before
+    public void setup() {
+
+        mocks = MockitoAnnotations.openMocks(this);
+
+        reset(userMessagingService);
+
+        var controller = new NotificationsController();
+
+        controller.setUserMessagingService(userMessagingService);
+        controller.setSiteService(siteService);
+        controller.setPortalService(portalService);
+
+        var session = mock(Session.class);
+        when(session.getUserId()).thenReturn(user1Id);
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        controller.setSessionManager(sessionManager);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).apply(configurer).build();
+	}
+
+    @After
+    public void tearDown() throws Exception {
+
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    public void testGetUsersNotifications() throws Exception {
+
+        // Mock up some notifications
+
+        String event1 = "annc.new";
+        String ref1 = "/announcement/1";
+        UserNotificationTransferBean noti1 = new UserNotificationTransferBean();
+        noti1.id = 1L;
+        noti1.from = "sender-id";
+        noti1.to = user1Id;
+        noti1.event = event1;
+        noti1.ref = ref1;
+        noti1.siteId = "site1";
+        noti1.title = "Title 1";
+        noti1.tool = "sakai.announcements";
+        noti1.fromDisplayName = "Sender Uno";
+        noti1.siteTitle = "Math 101";
+        noti1.eventDate = Instant.now();
+        noti1.formattedEventDate = "12 Dec 2024";
+
+        String event2 = "assn.new";
+        String ref2 = "/assignment/1";
+        UserNotificationTransferBean noti2 = new UserNotificationTransferBean();
+        noti2.id = 2L;
+        noti2.from = "sender-id";
+        noti2.to = user1Id;
+        noti2.event = event2;
+        noti2.ref = ref2;
+        noti2.siteId = "site1";
+        noti2.title = "Title 2";
+        noti2.tool = "sakai.assignments";
+        noti2.fromDisplayName = "Sender Uno";
+        noti2.siteTitle = "Math 101";
+        noti2.eventDate = Instant.now();
+        noti2.formattedEventDate = "18 Jan 2026";
+
+        when(userMessagingService.getNotifications()).thenReturn(List.of(noti1, noti2));
+
+        mockMvc.perform(get("/users/me/notifications"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.[0].from", is(noti1.from)))
+            .andExpect(jsonPath("$.[0].to", is(noti1.to)))
+            .andExpect(jsonPath("$.[0].event", is(noti1.event)))
+            .andExpect(jsonPath("$.[0].ref", is(noti1.ref)))
+            .andExpect(jsonPath("$.[0].siteId", is(noti1.siteId)))
+            .andExpect(jsonPath("$.[0].title", is(noti1.title)))
+            .andExpect(jsonPath("$.[1].from", is(noti2.from)))
+            .andExpect(jsonPath("$.[1].to", is(noti2.to)))
+            .andExpect(jsonPath("$.[1].event", is(noti2.event)))
+            .andExpect(jsonPath("$.[1].ref", is(noti2.ref)))
+            .andExpect(jsonPath("$.[1].siteId", is(noti2.siteId)))
+            .andExpect(jsonPath("$.[1].title", is(noti2.title)))
+            .andDo(document("get-user-notifications"));
+    }
+
+    @Test
+    public void testClearNotification() throws Exception {
+
+        long id = 1L;
+        mockMvc.perform(post("/users/me/notifications/" + id + "/clear"))
+            .andExpect(status().isOk())
+            .andDo(document("clear-user-notification"));
+
+        verify(userMessagingService).clearNotification(id);
+    }
+
+    @Test
+    public void testClearAllNotifications() throws Exception {
+
+        mockMvc.perform(post("/users/me/notifications/clear"))
+            .andExpect(status().isOk())
+            .andDo(document("clear-user-notifications"));
+
+        verify(userMessagingService).clearAllNotifications();
+    }
+
+    @Test
+    public void testMarkAllNotificationsViewed() throws Exception {
+
+        String siteId = "site1";
+        String toolId = "tool1";
+        mockMvc.perform(post("/users/me/notifications/markViewed").param("siteId", siteId).param("toolId", toolId))
+            .andExpect(status().isOk())
+            .andDo(document("mark-user-notifications-viewed"));
+
+        verify(userMessagingService).markAllNotificationsViewed(siteId, toolId);
+    }
+
+    @Test
+    public void testSendTestNotification() throws Exception {
+
+        mockMvc.perform(post("/users/me/notifications/test"))
+            .andExpect(status().isOk())
+            .andDo(document("send-test-notification"));
+
+        verify(userMessagingService).sendTestNotification();
+    }
+}

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
@@ -15,11 +15,13 @@
  */
 package org.sakaiproject.webapi.controllers.test;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.hamcrest.CoreMatchers.is;
 
 import java.time.Instant;
 import java.util.List;
@@ -124,18 +126,28 @@ public class NotificationsControllerTests extends BaseControllerTests {
 
         mockMvc.perform(get("/users/me/notifications"))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$.[*].id", hasItems(noti1.id.intValue(), noti2.id.intValue())))
             .andExpect(jsonPath("$.[0].from", is(noti1.from)))
             .andExpect(jsonPath("$.[0].to", is(noti1.to)))
             .andExpect(jsonPath("$.[0].event", is(noti1.event)))
             .andExpect(jsonPath("$.[0].ref", is(noti1.ref)))
             .andExpect(jsonPath("$.[0].siteId", is(noti1.siteId)))
             .andExpect(jsonPath("$.[0].title", is(noti1.title)))
+            .andExpect(jsonPath("$.[0].tool", is(noti1.tool)))
+            .andExpect(jsonPath("$.[0].fromDisplayName", is(noti1.fromDisplayName)))
+            .andExpect(jsonPath("$.[0].siteTitle", is(noti1.siteTitle)))
+            .andExpect(jsonPath("$.[0].formattedEventDate", is(noti1.formattedEventDate)))
             .andExpect(jsonPath("$.[1].from", is(noti2.from)))
             .andExpect(jsonPath("$.[1].to", is(noti2.to)))
             .andExpect(jsonPath("$.[1].event", is(noti2.event)))
             .andExpect(jsonPath("$.[1].ref", is(noti2.ref)))
             .andExpect(jsonPath("$.[1].siteId", is(noti2.siteId)))
             .andExpect(jsonPath("$.[1].title", is(noti2.title)))
+            .andExpect(jsonPath("$.[1].tool", is(noti2.tool)))
+            .andExpect(jsonPath("$.[1].fromDisplayName", is(noti2.fromDisplayName)))
+            .andExpect(jsonPath("$.[1].siteTitle", is(noti2.siteTitle)))
+            .andExpect(jsonPath("$.[1].formattedEventDate", is(noti2.formattedEventDate)))
             .andDo(document("get-user-notifications"));
     }
 

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/NotificationsControllerTests.java
@@ -24,11 +24,11 @@ import static org.hamcrest.CoreMatchers.is;
 import java.time.Instant;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -44,58 +44,43 @@ import org.sakaiproject.webapi.controllers.NotificationsController;
 
 import static org.mockito.Mockito.*;
 
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { WebApiTestConfiguration.class })
 public class NotificationsControllerTests extends BaseControllerTests {
 
     private MockMvc mockMvc;
 
-    @Mock
+    @Autowired
     private UserMessagingService userMessagingService;
 
-    @Mock
+    @Autowired
     private PortalService portalService;
 
-    @Mock
+    @Autowired
     private SessionManager sessionManager;
 
-    @Mock
+    @Autowired
     private SiteService siteService;
-
-    private AutoCloseable mocks;
 
     private String user1Id = "user1";
 
     @Before
     public void setup() {
 
-        mocks = MockitoAnnotations.openMocks(this);
+        reset(userMessagingService, portalService, sessionManager, siteService);
 
-        reset(userMessagingService);
-
-        var controller = new NotificationsController();
+        NotificationsController controller = new NotificationsController();
 
         controller.setUserMessagingService(userMessagingService);
         controller.setSiteService(siteService);
         controller.setPortalService(portalService);
 
-        var session = mock(Session.class);
+        Session session = mock(Session.class);
         when(session.getUserId()).thenReturn(user1Id);
         when(sessionManager.getCurrentSession()).thenReturn(session);
         controller.setSessionManager(sessionManager);
 
         mockMvc = MockMvcBuilders.standaloneSetup(controller).apply(configurer).build();
-	}
-
-    @After
-    public void tearDown() throws Exception {
-
-        if (mocks != null) {
-            mocks.close();
-        }
     }
 
     @Test

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/WebApiTestConfiguration.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/WebApiTestConfiguration.java
@@ -22,6 +22,7 @@ import org.sakaiproject.portal.api.PortalService;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.SessionManager;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -34,6 +35,7 @@ public class WebApiTestConfiguration {
     }
 
     @Bean
+    @Qualifier("org.sakaiproject.tool.api.SessionManager")
     public SessionManager sessionManager() {
         return mock(SessionManager.class);
     }

--- a/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/WebApiTestConfiguration.java
+++ b/webapi/src/test/java/org/sakaiproject/webapi/controllers/test/WebApiTestConfiguration.java
@@ -15,7 +15,36 @@
  */
 package org.sakaiproject.webapi.controllers.test;
 
+import static org.mockito.Mockito.mock;
+
+import org.sakaiproject.messaging.api.UserMessagingService;
+import org.sakaiproject.portal.api.PortalService;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.SessionManager;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class WebApiTestConfiguration { }
+public class WebApiTestConfiguration {
+
+    @Bean
+    public PortalService portalService() {
+        return mock(PortalService.class);
+    }
+
+    @Bean
+    public SessionManager sessionManager() {
+        return mock(SessionManager.class);
+    }
+
+    @Bean
+    public SiteService siteService() {
+        return mock(SiteService.class);
+    }
+
+    @Bean
+    public UserMessagingService userMessagingService() {
+        return mock(UserMessagingService.class);
+    }
+}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Notifications API reference page for authenticated endpoints under `/api/users/me/notifications`, including example requests/responses and supported actions (list, clear single/all, mark viewed, send test).
* **Tests / New Features**
  * Added REST controller test coverage for all Notifications endpoints with JSON validation and behavior verification.
* **Chores**
  * Updated test Spring configuration to provide required mock service beans.
  * Minor controller wiring adjustment and cleaned up unused test imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->