### PR TITLE
SAK-52454 Samigo lock Search Questions to bottom of list

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
@@ -450,16 +450,16 @@ class SamigoTest extends SakaiUiTestBase {
             .setHasText(Pattern.compile("^\\s*Search questions\\s*$", Pattern.CASE_INSENSITIVE)))).hasCount(1);
 
         Object result = select.evaluate("select => {"
-             "const options = Array.from(select.options);"
-             "const normalized = t => (t || '').trim().toLowerCase();"
-             "const isExisting = option => option.parentElement"
-             "  && option.parentElement.tagName === 'OPTGROUP'"
-             "  && option.parentElement.label === 'Existing';"
-             "const searchIndex = options.findIndex(option => normalized(option.textContent) === 'search questions');"
-             "const firstExistingIndex = options.findIndex(option => isExisting(option));"
-             "const lastIndex = options.length - 1;"
-             "return searchIndex === lastIndex && firstExistingIndex > 0 && isExisting(options[searchIndex]);"
-             "}");
+             + "const options = Array.from(select.options);"
+             + "const normalized = t => (t || '').trim().toLowerCase();"
+             + "const isExisting = option => option.parentElement"
+             + "  && option.parentElement.tagName === 'OPTGROUP'"
+             + "  && option.parentElement.label === 'Existing';"
+             + "const searchIndex = options.findIndex(option => normalized(option.textContent) === 'search questions');"
+             + "const firstExistingIndex = options.findIndex(option => isExisting(option));"
+             + "const lastIndex = options.length - 1;"
+             + "return searchIndex === lastIndex && firstExistingIndex > 0 && isExisting(options[searchIndex]);"
+             + "}");
         assertEquals(Boolean.TRUE, result);
     }
 

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
@@ -450,11 +450,16 @@ class SamigoTest extends SakaiUiTestBase {
             .setHasText(Pattern.compile("^\\s*Search questions\\s*$", Pattern.CASE_INSENSITIVE)))).hasCount(1);
 
         Object result = select.evaluate("select => {"
-            + "const options = Array.from(select.options);"
-            + "const searchIndex = options.findIndex(option => option.textContent.trim().toLowerCase() === 'search questions');"
-            + "const firstExistingIndex = options.findIndex(option => option.parentElement.tagName === 'OPTGROUP' && option.parentElement.label === 'Existing');"
-            + "return searchIndex >= firstExistingIndex && firstExistingIndex > 0;"
-            + "}");
+             "const options = Array.from(select.options);"
+             "const normalized = t => (t || '').trim().toLowerCase();"
+             "const isExisting = option => option.parentElement"
+             "  && option.parentElement.tagName === 'OPTGROUP'"
+             "  && option.parentElement.label === 'Existing';"
+             "const searchIndex = options.findIndex(option => normalized(option.textContent) === 'search questions');"
+             "const firstExistingIndex = options.findIndex(option => isExisting(option));"
+             "const lastIndex = options.length - 1;"
+             "return searchIndex === lastIndex && firstExistingIndex > 0 && isExisting(options[searchIndex]);"
+             "}");
         assertEquals(Boolean.TRUE, result);
     }
 

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
@@ -73,6 +73,8 @@ class SamigoTest extends SakaiUiTestBase {
         page.locator("#authorIndexForm\\:title").fill(SAMIGO_TITLE);
         page.locator("#authorIndexForm\\:createnew").click(new Locator.ClickOptions().setForce(true));
 
+        assertExistingQuestionActionsAreSeparatedAtBottom();
+
         addMultipleChoiceQuestion(
             "99.99",
             "What is chiefly responsible for the increase in the average length of life in the USA during the last fifty years?",
@@ -432,6 +434,28 @@ class SamigoTest extends SakaiUiTestBase {
         }
 
         return false;
+    }
+
+    private void assertExistingQuestionActionsAreSeparatedAtBottom() {
+        Locator select = page.locator("#assessmentForm\\:parts\\:0\\:changeQType").first();
+        assertThat(select).isVisible();
+
+        Locator searchQuestions = select.locator("option").filter(new Locator.FilterOptions()
+            .setHasText(Pattern.compile("^\\s*Search questions\\s*$", Pattern.CASE_INSENSITIVE)));
+        if (searchQuestions.count() == 0) {
+            return;
+        }
+
+        assertThat(select.locator("optgroup[label='Existing'] option").filter(new Locator.FilterOptions()
+            .setHasText(Pattern.compile("^\\s*Search questions\\s*$", Pattern.CASE_INSENSITIVE)))).hasCount(1);
+
+        Object result = select.evaluate("select => {"
+            + "const options = Array.from(select.options);"
+            + "const searchIndex = options.findIndex(option => option.textContent.trim().toLowerCase() === 'search questions');"
+            + "const firstExistingIndex = options.findIndex(option => option.parentElement.tagName === 'OPTGROUP' && option.parentElement.label === 'Existing');"
+            + "return searchIndex >= firstExistingIndex && firstExistingIndex > 0;"
+            + "}");
+        assertEquals(Boolean.TRUE, result);
     }
 
     private void selectQuestionType(Pattern labelPattern) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemConfigBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemConfigBean.java
@@ -30,6 +30,7 @@ import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.SessionScoped;
 import javax.faces.model.SelectItem;
+import javax.faces.model.SelectItemGroup;
 
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
@@ -405,9 +406,22 @@ public class ItemConfigBean implements Serializable {
     if (isShowImageMapQuestion())
     	list.add(new SelectItem(String.valueOf(TypeIfc.IMAGEMAP_QUESTION), getResourceDisplayName("image_map_question"))); // IMAGEMAP_QUESTION
 
-    if (isShowSearchQuestion())
-      list.add(new SelectItem("17", getResourceDisplayName("search_question"))); // SEARCH IN THE LIST OF QUESTIONS
-    
+    Comparator<SelectItem> comparator = new Comparator<SelectItem>() {
+        @Override
+        public int compare(SelectItem s1, SelectItem s2) {
+            // the items must be compared based on their label
+            return s1.getLabel().compareTo(s2.getLabel());
+        }
+    };
+
+    Collections.sort(list, comparator);
+
+    List<SelectItem> existingQuestionActions = new ArrayList<SelectItem>();
+
+    if (isSelectFromQuestionPool()) {
+      existingQuestionActions.add(new SelectItem("10", getResourceDisplayName("import_from_q")));
+    }
+
     if (isSelectFromQuestionBank()) {
     	// Check if the question bank tool is installed and not stealthed or hidden
     	// and only show the option if it's reasonable, such as when questionpools are
@@ -421,22 +435,19 @@ public class ItemConfigBean implements Serializable {
 							"hiddenTools@org.sakaiproject.tool.api.ActiveToolManager", "")
 					.contains("sakai.questionbank.client")) {
 
-			list.add(new SelectItem("100",
+			existingQuestionActions.add(new SelectItem("100",
 					getResourceDisplayName("import_from_question_bank")));
     	}
     }
-    
-    Comparator<SelectItem> comparator = new Comparator<SelectItem>() {
-        @Override
-        public int compare(SelectItem s1, SelectItem s2) {
-            // the items must be compared based on their value (assuming String or Integer value here)
-            return s1.getLabel().compareTo(s2.getLabel());
-        }
-    };
-    
-    Collections.sort(list, comparator);
-    if (isSelectFromQuestionPool()) {
-      list.add(new SelectItem("10", getResourceDisplayName("import_from_q")));
+
+    if (isShowSearchQuestion()) {
+      existingQuestionActions.add(new SelectItem("17", getResourceDisplayName("search_question"))); // SEARCH IN THE LIST OF QUESTIONS
+    }
+
+    if (!existingQuestionActions.isEmpty()) {
+      Collections.sort(existingQuestionActions, comparator);
+      list.add(new SelectItemGroup(getResourceDisplayName("existing"), getResourceDisplayName("existing_desc"), false,
+          existingQuestionActions.toArray(new SelectItem[existingQuestionActions.size()])));
     }
     
     return list;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Question-type selector now groups existing question actions (import from pool, import from bank when available, and search) into a single, sorted group for clearer organization.
  * The "Search questions" entry is positioned consistently within the selector for more predictable navigation.

* **Tests**
  * End-to-end tests now verify the selector grouping and the consistent placement of the "Search questions" option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->