### PR TITLE
SAK-52572 Missing </td> on <td headers='action-clone'>

### DIFF
--- a/content/content-tool/tool/src/webapp/vm/content/cloudstorage_onedrive_picker.vm
+++ b/content/content-tool/tool/src/webapp/vm/content/cloudstorage_onedrive_picker.vm
@@ -121,6 +121,7 @@
 					#if (!$onedriveItem.isFolder())
 						<a href="#" onclick="return doAttachSubmitOneDrive('$formattedText.escapeUrl(${onedriveItem.id})',true)" title ="$tlang.getString('att.copy')">$tlang.getString("att.copy") <span class="skip">$formattedText.escapeHtml($onedriveItem.name)</span></a>
 					#end
+				</td>
 				<td headers="action-link">
 					#if (!$onedriveItem.isFolder())
 						<a href="#" onclick="return doAttachSubmitOneDrive('$formattedText.escapeUrl(${onedriveItem.id})',false)" title ="$tlang.getString('cloudstorage.attach_link')">$tlang.getString('cloudstorage.attach_link') <span class="skip">$formattedText.escapeHtml($onedriveItem.name)</span></a>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table alignment in OneDrive picker where action cells were misaligned, ensuring the clone/copy and link options now display in their correct columns for improved usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->