### PR TITLE
SAK-52575 Global Thymeleaf update deprecated fragments

### DIFF
--- a/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_1.html
+++ b/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_1.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
   <div class="portletBody">
     <div class="page-header">
       <h1 th:text="#{common_title}">Bulk User Membership</h1>
     </div>
-    <div th:replace="fragments/wizard :: step (step1)"></div>
+    <div th:replace="~{fragments/wizard :: step (step1)}"></div>
     <div class="row">
       <div class="title sak-banner-info col-sm-12" th:text="#{automembership.title.step1}"></div>
       <div class="sak-banner-error m-0 mb-2" th:each="failedUser : ${failedUsers}" th:text="#{fail_user(${failedUser})}"></div>
@@ -19,8 +19,8 @@
     </div>
     <form method="post" th:action="@{/step/1}" class="automembership-wizard-form">
       <div class="row">
-        <div th:replace="fragments/box_list :: box (title = #{box.users.list.title}, subtitle = #{box.users.list.subtitle}, name = 'users', disabled = false, value = ${users})" />
-        <div th:replace="fragments/box_list :: box (title = #{box.sites.list.title}, subtitle = #{box.sites.list.subtitle}, name = 'sites', disabled = false, value = ${sitesIds})" />
+        <div th:replace="~{fragments/box_list :: box (title = #{box.users.list.title}, subtitle = #{box.users.list.subtitle}, name = 'users', disabled = false, value = ${users})}" />
+        <div th:replace="~{fragments/box_list :: box (title = #{box.sites.list.title}, subtitle = #{box.sites.list.subtitle}, name = 'sites', disabled = false, value = ${sitesIds})}" />
         <div class="col-sm-12">
           <fieldset style="margin: 15px;">
             <legend class="nopad" th:text="#{action.selection.title}">Action to perform</legend> 
@@ -51,6 +51,6 @@
       </div>
     </form>
   </div>
-  <script th:replace="fragments/javascript :: autoMembershipStep1Js"></script>
+  <script th:replace="~{fragments/javascript :: autoMembershipStep1Js}"></script>
 </body>
 </html>

--- a/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_1_5.html
+++ b/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_1_5.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
   <div class="portletBody">
     <div class="page-header">
       <h1 th:text="#{common_title}">Bulk User Membership</h1>
     </div>
-    <div th:replace="fragments/wizard :: step (step1)"></div>
+    <div th:replace="~{fragments/wizard :: step (step1)}"></div>
     <div class="row">
       <div class="title sak-banner-warn col-sm-12" th:text="#{select.role.title(${siteId})}"></div>
     </div>
@@ -47,6 +47,6 @@
         </div>
     </form>
   </div>
-  <script th:replace="fragments/javascript :: autoMembershipStep1_5Js"></script>
+  <script th:replace="~{fragments/javascript :: autoMembershipStep1_5Js}"></script>
 </body>
 </html>

--- a/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_2.html
+++ b/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_2.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
   <div class="portletBody">
     <div class="page-header">
       <h1 th:text="#{common_title}">Bulk User Membership</h1>
     </div>
-    <div th:replace="fragments/wizard :: step (step2)"></div>
+    <div th:replace="~{fragments/wizard :: step (step2)}"></div>
     <div class="row">
       <div class="title sak-banner-warn" th:text="#{automembership.title.step2(#{${action}})}"></div>
     </div>
     <form method="post" th:action="@{/step/2}" class="automembership-wizard-form" >
       <input type="hidden" name="wizardAction" id="wizardAction" value=""/>
       <div class="row">
-        <div th:replace="fragments/box_list :: box (title = #{box.users.list.title}, subtitle='', name = 'users', disabled = true, value = ${users})" />
-        <div th:replace="fragments/box_list :: box (title = #{box.sites.list.title}, subtitle='', name = 'sites', disabled = true, value = ${sitesIds})" />
+        <div th:replace="~{fragments/box_list :: box (title = #{box.users.list.title}, subtitle='', name = 'users', disabled = true, value = ${users})}" />
+        <div th:replace="~{fragments/box_list :: box (title = #{box.sites.list.title}, subtitle='', name = 'sites', disabled = true, value = ${sitesIds})}" />
       </div>
 
       <div class="row">
@@ -29,6 +29,6 @@
       </div>
     </form>
   </div>
-  <script th:replace="fragments/javascript :: autoMembershipStep2Js"></script>
+  <script th:replace="~{fragments/javascript :: autoMembershipStep2Js}"></script>
 </body>
 </html>

--- a/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_3.html
+++ b/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/auto_membership_step_3.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
   <div class="portletBody">
     <div class="page-header">
       <h1 th:text="#{common_title}">Bulk User Membership</h1>
     </div>
-    <div th:replace="fragments/wizard :: step (step3)"></div>
+    <div th:replace="~{fragments/wizard :: step (step3)}"></div>
     <form method="post" th:action="@{/step/3}" class="automembership-wizard-form">
         <div class="row">
           <div class="col-sm-6" th:each="summary : ${summaries}" th:id="${'summary-' + summary.getCleanedUserName()}" >

--- a/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -9,11 +9,11 @@
 </head>
 <div th:fragment="bootstrap">
   <script>includeLatestJQuery('bulk-user-membership');</script>
-  <script th:inline="javascript">
+  <script>
       (function() {
-        const toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-        if (toolId) {
-          setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+        const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+        if (toolFrameId) {
+          setMainFrameHeight(toolFrameId);
         }
     })();
   </script>

--- a/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/fragments/wizard.html
+++ b/admin-bulk-user-membership/tool/src/main/webapp/WEB-INF/templates/fragments/wizard.html
@@ -12,7 +12,7 @@
     <div th:class="${current} == 'step3' ? 'col-sm-4 bordered wizard-step-active' : 'col-sm-4 bordered'">
       <span th:text="#{automembership.wizard.step3}">Step 3: Results Screen</span>
     </div>
-    <script th:replace="fragments/javascript :: wizardJs" />
+    <script th:replace="~{fragments/javascript :: wizardJs}" />
   </div>
 </body>
 </html>

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/PostemTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/PostemTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.microsoft.playwright.Locator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+class PostemTest extends SakaiUiTestBase {
+
+    private static String sakaiUrl;
+
+    @Test
+    void instructorCanOpenPostemListAndAddFeedbackPages() {
+        sakai.login("instructor1");
+        page.navigate(ensureCourseUrl());
+        sakai.toolClick("Post");
+
+        assertNoTemplateRenderingError();
+        assertThat(page.locator("body")).containsText(Pattern.compile("Postem|There are currently no items", Pattern.CASE_INSENSITIVE));
+
+        Locator addFeedback = page.locator(".navIntraTool a")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Add$", Pattern.CASE_INSENSITIVE)))
+            .first();
+        assertThat(addFeedback).isVisible();
+        addFeedback.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+
+        assertNoTemplateRenderingError();
+        assertThat(page.locator("body")).containsText(Pattern.compile("Add/Update Feedback File", Pattern.CASE_INSENSITIVE));
+        assertThat(page.locator("#addContentForm")).isVisible();
+        assertThat(page.locator("#title")).isVisible();
+        assertThat(page.locator("#released")).isVisible();
+    }
+
+    private String ensureCourseUrl() {
+        if (sakaiUrl == null || sakaiUrl.isBlank()) {
+            sakaiUrl = sakai.createCourse("instructor1", List.of("sakai\\.postem"));
+        }
+        return sakaiUrl;
+    }
+
+    private void assertNoTemplateRenderingError() {
+        String bodyText = page.locator("body").textContent();
+        Pattern templateError = Pattern.compile(
+            "TemplateProcessingException|TemplateOutputException|An error happened during template rendering",
+            Pattern.CASE_INSENSITIVE
+        );
+        assertFalse(templateError.matcher(bodyText == null ? "" : bodyText).find(), "Postem rendered a Thymeleaf error");
+    }
+}

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteInfoTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteInfoTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.microsoft.playwright.Locator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+class SiteInfoTest extends SakaiUiTestBase {
+
+    private static String sakaiUrl;
+
+    @Test
+    void canOpenManageGroupsHelper() {
+        sakai.login("instructor1");
+        page.navigate(ensureCourseUrl());
+        sakai.toolClick("Site Info");
+
+        assertNoTemplateRenderingError();
+        assertThat(page.locator("body")).containsText(Pattern.compile("Site Information|Site Info", Pattern.CASE_INSENSITIVE));
+
+        Locator manageGroups = page.locator(".navIntraTool a")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Manage Groups$", Pattern.CASE_INSENSITIVE)))
+            .first();
+        assertThat(manageGroups).isVisible();
+        manageGroups.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+
+        assertNoTemplateRenderingError();
+        assertThat(page.locator("body")).containsText(Pattern.compile("Group List|No groups", Pattern.CASE_INSENSITIVE));
+
+        Locator createGroup = page.locator(".navIntraTool a")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Create New Group$", Pattern.CASE_INSENSITIVE)))
+            .first();
+        assertThat(createGroup).isVisible();
+        createGroup.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+
+        assertNoTemplateRenderingError();
+        assertThat(page.locator("#creategroup-form")).isVisible();
+        assertThat(page.locator("#groupTitle")).isVisible();
+        assertThat(page.locator("#groupMembers")).isVisible();
+    }
+
+    private String ensureCourseUrl() {
+        if (sakaiUrl == null || sakaiUrl.isBlank()) {
+            sakaiUrl = sakai.createCourse("instructor1", List.of("sakai\\.announcements"));
+        }
+        return sakaiUrl;
+    }
+
+    private void assertNoTemplateRenderingError() {
+        String bodyText = page.locator("body").textContent();
+        Pattern templateError = Pattern.compile(
+            "TemplateProcessingException|TemplateOutputException|An error happened during template rendering",
+            Pattern.CASE_INSENSITIVE
+        );
+        assertFalse(templateError.matcher(bodyText == null ? "" : bodyText).find(), "Manage Groups rendered a Thymeleaf error");
+    }
+}

--- a/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -8,15 +8,14 @@
             <script src="/library/js/spinner.js"></script>
             <title>Email Template Service</title>
         </head>
-        <div th:fragment="jQuery">
-            <script>includeLatestJQuery('sakai.emailtemplateservice');</script>
-            <script th:inline="javascript">
-                $(document).ready(function () {
-                    var toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-                    if (toolId) {
-                        setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+        <div th:fragment="scripts">
+            <script>
+                (() => {
+                    const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+                    if (toolFrameId) {
+                        setMainFrameHeight(toolFrameId);
                     }
-                });
+                })();
             </script>
         </div>
     </body>

--- a/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/fragments/menus.html
+++ b/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/fragments/menus.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
     <body>
-        <div th:fragment="main (current)">
+        <th:block th:fragment="main (current)">
             <ul class="navIntraTool">
                 <li role="presentation">
                     <span th:if="${current}=='list'" th:text="#{mainview.list}" class="current">Template List</span>
@@ -13,6 +13,6 @@
                     <span th:case="*"><a href="#" th:href="@{/new}" th:text="#{mainview.new}"></a></span>
                 </li>
             </ul>
-        </div>
+        </th:block>
     </body>
 </html>

--- a/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"	xmlns:th="http://www.thymeleaf.org">
-    <head th:replace="fragments/common :: head"/>
+    <head th:replace="~{fragments/common :: head}"/>
     <body>
-        <div th:replace="fragments/common :: jQuery" />
+        <div th:replace="~{fragments/common :: scripts}" />
         <div class="portletBody">
-            <div id="menu" th:include="fragments/menus :: main (list)" />
+            <div id="menu" th:insert="~{fragments/menus :: main (list)}" />
 
             <div id="banner" class="sak-banner-success" th:if="${success}" th:text="#{template.saved.message(${templateKey}, ${templateLocale})}">
                 Success message

--- a/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/modify_email.html
+++ b/emailtemplateservice/tool/src/main/webapp/WEB-INF/templates/modify_email.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-    <head th:replace="fragments/common :: head"/>
+    <head th:replace="~{fragments/common :: head}"/>
     <head>
         <title th:text="#{modifyemail.page.title}">Modify Email Template</title>
     </head>
 
     <body>
         <div class="portletBody container-fluid">
-            <div th:if="${emailTemplate.id == null}" id="menu" th:include="fragments/menus :: main (new)" />
-            <div th:unless="${emailTemplate.id == null}"id="menu" th:include="fragments/menus :: main (edit)" />
+            <div th:if="${emailTemplate.id == null}" id="menu" th:insert="~{fragments/menus :: main (new)}" />
+            <div th:unless="${emailTemplate.id == null}" id="menu" th:insert="~{fragments/menus :: main (edit)}" />
             <div class="page-header">
                 <h1 th:if="${emailTemplate.id == null}" th:text="#{modifyemail.new.template.header}"/>
                 <h1 th:unless="${emailTemplate.id == null}" th:text="#{modifyemail.modify.template.header(${emailTemplate.key},${emailTemplate.locale})}"/>

--- a/mailsender/tool/src/webapp/content/templates/compose.html
+++ b/mailsender/tool/src/webapp/content/templates/compose.html
@@ -18,7 +18,7 @@
                 <span id="mailsender.unit_sizes" th:text="#{mailsender.unit_sizes}"/>
                 <span id="max-attachment-size" th:text="${comp.maxUploadFileSize}"/>
             </div>
-            <div id="menu" th:include="fragments/menus :: main (compose)" />
+            <div id="menu" th:insert="~{fragments/menus :: main (compose)}" />
             <div th:if="${noemail}" th:utext="#{no.from.address}" class="sak-banner-error"/>
             <div th:if="${error != null}" th:text="${error}" class="sak-banner-error"/>
             <form id="mainForm" method="post" th:action="@{/compose}" enctype="multipart/form-data" data-dirty="false" th:object="${emailEntry}" class="d-grid">

--- a/mailsender/tool/src/webapp/content/templates/fragments/menus.html
+++ b/mailsender/tool/src/webapp/content/templates/fragments/menus.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
     <body>
-        <div th:fragment="main (current)">
+        <th:block th:fragment="main (current)">
             <ul class="navIntraTool">
                 <li role="presentation">
                     <span th:class="${current} == 'compose' ? 'current'">
@@ -22,6 +22,6 @@
                     </span>
                 </li>
             </ul>
-        </div>
+        </th:block>
     </body>
 </html>

--- a/mailsender/tool/src/webapp/content/templates/options.html
+++ b/mailsender/tool/src/webapp/content/templates/options.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <div class="portletBody">
-            <div id="menu" th:include="fragments/menus :: main (options)" />
+            <div id="menu" th:insert="~{fragments/menus :: main (options)}" />
                 <div th:if="${error != null}" th:text="${error}" class="sak-banner-error"/>
                 <form id="optionsForm" method="post" class="form-horizontal" >
                     <div class="page-header">

--- a/mailsender/tool/src/webapp/content/templates/permissions.html
+++ b/mailsender/tool/src/webapp/content/templates/permissions.html
@@ -9,7 +9,7 @@
     </head>
     <body>
         <div class="portletBody">
-            <div id="menu" th:include="fragments/menus :: main (permissions)" />
+            <div id="menu" th:insert="~{fragments/menus :: main (permissions)}" />
                 <h3 th:text="#{mailsender.navbar.permissions}">Permissions</h3>
                 <sakai-permissions id="permissions-wc" tool="mailtool" bundle-key="mailsender" />
         </div>

--- a/mailsender/tool/src/webapp/content/templates/results.html
+++ b/mailsender/tool/src/webapp/content/templates/results.html
@@ -7,7 +7,7 @@
     </head> 
     <body>
         <div class="portletBody">
-            <div id="menu" th:include="fragments/menus :: main (compose)" />
+            <div id="menu" th:insert="~{fragments/menus :: main (compose)}" />
             <br/>
             <span th:text="#{message.sent.to}" style="margin-bottom: 5px ">Message sent to:</span>
             <ul th:each="user:${listaus}">

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/body.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/body.html
@@ -104,7 +104,7 @@
 						class="row table-space table-row"
 						th:id="|row_${row.id}|"
 						th:classappend="${index.even} ? 'index-background' : ''"
-						th:insert="fragments/synchronizationRow :: siteRow(${row})"
+						th:insert="~{fragments/synchronizationRow :: siteRow(${row})}"
 					></div>
 					<div th:id="|rowContainer_${row.id}|" class="row text-center hidden"></div>
 				</th:block>

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/config.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/config.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-	<div th:replace="fragments/common :: bootstrap" />
-	<div th:include="fragments/common :: admin (${isAdmin})" />
+	<div th:replace="~{fragments/common :: bootstrap}" />
+	<div th:insert="~{fragments/common :: admin (${isAdmin})}" />
 
 	<div th:if="${isAdmin}">
 		<div class="portletBody">
-			<div id="menu" th:include="fragments/menus :: main (config)" />
+			<div id="menu" th:insert="~{fragments/menus :: main (config)}" />
 			<div class="page-header">
 			  <h1 th:text="#{config_title}"></h1>
 			</div>
 
-			<div th:include="fragments/common :: error" />
+			<div th:insert="~{fragments/common :: error}" />
 
 			<form id="userform" th:action="@{/save-config}" method="post">
 				<fieldset class="config-fieldset">
@@ -22,7 +22,7 @@
 						<label th:for="|cb_${item.key}|" th:text="#{|config.${item.key}|}"></label>
 						
 						<div id="newsite-container" th:if="${item.key} == 'SYNCH:CREATE_TEAM'" th:classappend="${item.value} ? '' : 'hidden'">
-							<th:block th:replace="fragments/siteFilter :: siteFilter (prefix='siteFilter',columnClassName='col-sm-2')">
+							<th:block th:replace="~{fragments/siteFilter :: siteFilter (prefix='siteFilter',columnClassName='col-sm-2')}">
 							</th:block>
 							<div class="row form-group">
 								<div class="col-sm-2 text-end text-bold property-filter">
@@ -39,7 +39,7 @@
 				<fieldset class="config-fieldset">
 					<legend th:text="#{config.job_config}"></legend>
 					<div class="form-group">
-						<div th:insert="fragments/siteFilter :: siteFilter (prefix='jobSiteFilter',columnClassName='col-lg-2')">
+						<div th:insert="~{fragments/siteFilter :: siteFilter (prefix='jobSiteFilter',columnClassName='col-lg-2')}">
 						</div>
 					</div>
 				</fieldset>

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/credentials.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/credentials.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-	<div th:replace="fragments/common :: bootstrap" />
-	<div th:include="fragments/common :: admin (${isAdmin})" />
+	<div th:replace="~{fragments/common :: bootstrap}" />
+	<div th:insert="~{fragments/common :: admin (${isAdmin})}" />
 	
 	<div th:if="${isAdmin}">
 		<div class="portletBody">
-			<div id="menu" th:include="fragments/menus :: main (credentials)" />
+			<div id="menu" th:insert="~{fragments/menus :: main (credentials)}" />
 			<div class="page-header">
 				<h1 th:text="#{credentials_title}"></h1>
 			</div>
 			
-			<div th:include="fragments/common :: error" />
+			<div th:insert="~{fragments/common :: error}" />
 			<div class="sak-banner-success" th:if="${test_message != null}" th:text="${test_message}"></div>
 			
 			<form class="form-horizontal" th:action="@{/save-credentials}" method="post">

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/editGroupSynchronization.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/editGroupSynchronization.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-	<div th:replace="fragments/common :: bootstrap" />
-	<div th:include="fragments/common :: admin (${isAdmin})" />
+	<div th:replace="~{fragments/common :: bootstrap}" />
+	<div th:insert="~{fragments/common :: admin (${isAdmin})}" />
 
 	<div th:if="${isAdmin}">
 		<div class="portletBody">
-			<div id="menu" th:include="fragments/menus :: main (editGroup)" />
+			<div id="menu" th:insert="~{fragments/menus :: main (editGroup)}" />
 			<div class="page-header" style="display: flex;gap: 77px;align-content: center;align-items: center;">
 				<div>
 				<h1 class="header-title" th:text="#{group_synch.new_title}"></h1>
@@ -26,7 +26,7 @@
 				</div>
 			</div>
 
-			<div th:include="fragments/common :: error" />
+			<div th:insert="~{fragments/common :: error}" />
 			<div class="sak-banner-error hidden" id="delete_error" th:text="#{error.delete_group_synchronization}"></div>
 			<div id="error-banner"></div>
 

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/errorNoAdmin.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/errorNoAdmin.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-	<div th:replace="fragments/common :: bootstrap" />
+	<div th:replace="~{fragments/common :: bootstrap}" />
 
 	<div class="sak-banner-error" role="alert" th:text="#{common_danger}">
 		You must be an admin to use this tool, please contact your Administrator.

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/fragments/autoConfig.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/fragments/autoConfig.html
@@ -13,7 +13,7 @@
 
 					<div id="autoconfig-body-container" class="modal-body">
 						<div id="autoconfig-container">
-							<div th:replace="fragments/siteFilter :: siteFilter"></div>
+							<div th:replace="~{fragments/siteFilter :: siteFilter}"></div>
 
 							<div class="row form-group">
 								<div class="col-sm-4 text-end text-bold" th:text="#{filter.team_pattern}"></div>

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -12,23 +12,23 @@
 <div th:fragment="bootstrap">
 	<script>includeLatestJQuery('microsoft-admin');</script>
 	<script>includeWebjarLibrary('bootstrap');</script>
-	<script th:inline="javascript">
+	<script>
 		(function() {
-			const toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-			if (toolId) {
-			  setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+			const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+			if (toolFrameId) {
+			  setMainFrameHeight(toolFrameId);
 			}
 		})();
 	</script>
 </div>
 
-<div th:fragment="admin (admin)">
+<th:block th:fragment="admin (admin)">
 	<div th:unless="${admin}" class="sak-banner-error" role="alert" th:text="#{common_danger}">
 		You must be an admin to use this tool, please contact your Administrator.
 	</div>
-</div>
+</th:block>
 
-<div th:fragment="error">
+<th:block th:fragment="error">
 	<div th:if="${exception_error != null}">
 		<div class="sak-banner-error" id="exception_error"  th:text="${exception_error}"></div>
 
@@ -38,6 +38,6 @@
 			})();
 		</script>
 	</div>
-</div>
+</th:block>
 </body>
 </html>

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/fragments/menus.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/fragments/menus.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
-	<div th:fragment="main (active)">
+	<th:block th:fragment="main (active)">
 	<ul class="navIntraTool">
 		<li class="firstToolBarItem">
 		<span th:class="${active == 'index' ? 'current' : ''}">
@@ -34,6 +34,6 @@
 		</span>
 		</li>
 	</ul>
-	</div>
+	</th:block>
 </body>
 </html>

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/index.html
@@ -1,27 +1,27 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-	<div th:replace="fragments/common :: bootstrap" />
-	<div th:replace="fragments/common :: admin (${isAdmin})" />
+	<div th:replace="~{fragments/common :: bootstrap}" />
+	<div th:replace="~{fragments/common :: admin (${isAdmin})}" />
 
 	<div th:if="${isAdmin}">
 		<div class="portletBody">
-			<div id="menu" th:replace="fragments/menus :: main (index)" />
+			<div id="menu" th:insert="~{fragments/menus :: main (index)}" />
 			<div class="page-header">
 				<h1 th:text="#{index_title}"></h1>
 			</div>
 
-			<div th:replace="fragments/common :: error" />
+			<div th:replace="~{fragments/common :: error}" />
 			<div class="sak-banner-error hidden" id="ajax_error"></div>
 
-			<div th:replace="fragments/autoConfig :: progressbar"></div>
+			<div th:replace="~{fragments/autoConfig :: progressbar}"></div>
 
 			<div id="body-container"></div>
 		</div>
 
-		<div th:replace="fragments/autoConfig :: modal"></div>
-		<div th:replace="fragments/autoConfig :: script"></div>
+		<div th:replace="~{fragments/autoConfig :: modal}"></div>
+		<div th:replace="~{fragments/autoConfig :: script}"></div>
 		
 		<script th:inline="javascript">
 			(function () {

--- a/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/newSiteSynchronization.html
+++ b/microsoft-integration/admin-tool/src/main/webapp/WEB-INF/templates/newSiteSynchronization.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 
 <body>
-	<div th:replace="fragments/common :: bootstrap" />
-	<div th:include="fragments/common :: admin (${isAdmin})" />
+	<div th:replace="~{fragments/common :: bootstrap}" />
+	<div th:insert="~{fragments/common :: admin (${isAdmin})}" />
 
 	<div th:if="${isAdmin}">
 		<div class="portletBody">
-			<div id="menu" th:include="fragments/menus :: main (new)" />
+			<div id="menu" th:insert="~{fragments/menus :: main (new)}" />
 			<div class="page-header">
 				<h1 th:text="#{site_synch.new_title}"></h1>
 			</div>
 
-			<div th:include="fragments/common :: error" />
+			<div th:insert="~{fragments/common :: error}" />
 
 			<form id="siteSynchForm" th:action="@{/save-siteSynchronization}" method="post">
 				<div class="col-md-12 synchContainer">
@@ -25,7 +25,7 @@
 								<legend class="collapse-button" role="button" data-bs-toggle="collapse" data-bs-target=".fieldset-content"
 									th:text="#{site_synch.filters}" tabindex="0"></legend>
 								<div class="fieldset-content collapse show">
-									<div th:replace="fragments/siteFilter :: siteFilter">
+									<div th:replace="~{fragments/siteFilter :: siteFilter}">
 									</div>
 
 									<div class="act">

--- a/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/body.html
+++ b/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/body.html
@@ -26,7 +26,7 @@
 		<div class="accordion-collapse collapse team-container" th:classappend="${expanded}? 'show'" th:id="${teamKey}" data-bs-parent="#accordion_all">
 			<div class="accordion-body panel-body">
 				<th:block th:if="${expanded and currentItem != null}">
-					<div th:replace="fragments/driveItems :: printObject(${currentItem})"></div>
+					<div th:replace="~{fragments/driveItems :: printObject(${currentItem})}"></div>
 				</th:block>
 				<div th:if="${itemsList == null}" th:text="#{container_empty}" class="sak-banner-info"></div>
 			</div>

--- a/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/error.html
+++ b/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/error.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
 		<th:block th:fragment="error">
 			<div th:if="${exception_error != null}" class="sak-banner-error" id="exception_error"  th:text="${exception_error}"></div>

--- a/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -5,18 +5,18 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
 	<script src="/library/js/headscripts.js" type="text/javascript"></script>
-	<script th:inline="javascript" th:insert="js/common.js"></script>
+	<script th:inline="javascript" th:insert="~{js/common.js}"></script>
 	<title th:text="#{index_title}">Microsoft Collaborative Documents</title>
 </head>
 
 <div th:fragment="bootstrap">
 	<script>includeLatestJQuery('microsoft-collaborative-documents');</script>
 	<script>includeWebjarLibrary('dropzone');</script>
-	<script th:inline="javascript">
+	<script>
 		(function() {
-			const toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-			if (toolId) {
-			  setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+			const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+			if (toolFrameId) {
+			  setMainFrameHeight(toolFrameId);
 			}
 		})();
 	</script>

--- a/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/fragments/driveItems.html
+++ b/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/fragments/driveItems.html
@@ -1,24 +1,24 @@
 <th:block th:fragment="printObject(item)" th:with="df=#{date.format}">
 	<th:block th:if="${item}">
 		<th:block th:if="${item instanceof T(org.sakaiproject.microsoft.api.data.MicrosoftTeamWrapper)}">
-			<th:block th:replace="fragments/driveItems :: printTeam(${item})"></th:block>
+			<th:block th:replace="~{fragments/driveItems :: printTeam(${item})}"></th:block>
 		</th:block>
 
 		<th:block th:if="${item instanceof T(org.sakaiproject.microsoft.api.data.MicrosoftDriveItem)}">
-			<th:block th:replace="fragments/driveItems :: printFolder(${item})"></th:block>
+			<th:block th:replace="~{fragments/driveItems :: printFolder(${item})}"></th:block>
 		</th:block>
 	</th:block>
 </th:block>
 
 <th:block th:fragment="printTeam(item)">
 	<div th:class="${allowCreateFolders or allowCreateFiles}? 'breadcrumb-header'">
-		<th:block th:replace="fragments/driveItems :: menuNew(${item})" />
+		<th:block th:replace="~{fragments/driveItems :: menuNew(${item})}" />
 	</div>
 	
 	<th:block th:if="${item.hasItems()}">
-		<div th:replace="fragments/driveItems :: printItemsHeader()"></div>
+		<div th:replace="~{fragments/driveItems :: printItemsHeader()}"></div>
 		<th:block th:each="elem: ${item.items}">
-			<div th:replace="fragments/driveItems :: printItem(${elem})"></div>
+			<div th:replace="~{fragments/driveItems :: printItem(${elem})}"></div>
 		</th:block>
 	</th:block>
 	<div th:if="${!item.hasItems()}" th:text="#{container_empty}" class="sak-banner-info"></div>
@@ -31,14 +31,14 @@
 <th:block th:fragment="printFolder(item)">
 	<div class="folder-container" th:id="${item.id}">
 		<div th:class="${allowCreateFolders or allowCreateFiles}? 'breadcrumb-header'">
-			<th:block th:replace="fragments/driveItems :: menuNew(${item})" />
-			<th:block th:replace="fragments/driveItems :: printBreadcrumbs(${item})" />
+			<th:block th:replace="~{fragments/driveItems :: menuNew(${item})}" />
+			<th:block th:replace="~{fragments/driveItems :: printBreadcrumbs(${item})}" />
 		</div>
 		
 		<th:block th:if="${item.hasChildren()}">
-			<div th:replace="fragments/driveItems :: printItemsHeader()"></div>
+			<div th:replace="~{fragments/driveItems :: printItemsHeader()}"></div>
 			<th:block th:each="elem: ${item.children}">
-				<div th:replace="fragments/driveItems :: printItem(${elem})"></div>
+				<div th:replace="~{fragments/driveItems :: printItem(${elem})}"></div>
 			</th:block>
 		</th:block>
 		<div th:if="${!item.hasChildren()}" th:text="#{container_empty}" class="sak-banner-info"></div>
@@ -71,13 +71,13 @@
 		<li class="breadcrumb-item">
 			<a href="#" th:attr="onclick=|loadTeam('${currentTeam?.id}')|" th:text="${currentTeam?.name}" role="button" tabindex="0"></a>
 		</li>
-		<li th:replace="fragments/driveItems :: printHierarchyLink(${item}, true)" />
+		<li th:replace="~{fragments/driveItems :: printHierarchyLink(${item}, true)}" />
 	</ol>
 </th:block>
 
 <th:block th:fragment="printHierarchyLink(item, first)">
 	<th:block th:if="${item.parent}">
-		<li th:replace="fragments/driveItems :: printHierarchyLink(${item.parent}, false)" />
+		<li th:replace="~{fragments/driveItems :: printHierarchyLink(${item.parent}, false)}" />
 	</th:block>
 	<li class="breadcrumb-item">
 		<a th:if="${!first}" href="#" th:data-itemid="${item.id}" onclick="loadFolder(this)" th:text="${item.name}" role="button" tabindex="-1" />

--- a/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/index.html
+++ b/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
 		<div class="portletBody">
 			<div class="menu-container">
@@ -16,7 +16,7 @@
 					</a>
 				</div>
 			
-				<div class="menu" th:insert="fragments/menus :: main (index)" />
+				<div class="menu" th:insert="~{fragments/menus :: main (index)}" />
 			</div>
 
 			<div class="sak-banner-error hidden" id="exception_error"></div>

--- a/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/permissions.html
+++ b/microsoft-integration/collaborative-documents/src/main/webapp/WEB-INF/templates/permissions.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
-		<div class="menu" th:insert="fragments/menus :: main (permissions)" />
+		<div class="menu" th:insert="~{fragments/menus :: main (permissions)}" />
 
 		<sakai-permissions tool="microsoft" bundle-key="microsoft" th:attr="on-refresh=@{/index}" />
 	</body>

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/body.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/body.html
@@ -65,7 +65,7 @@
 						<div class="accordion-body">
 							<div th:if="${itemsList}" class="row display-flex">
 								<th:block th:each="item, stat: ${itemsList}">
-									<div th:insert="fragments/driveItems :: printItem(${item})" class="video-item col-lg-3 col-md-4 col-sm-12" th:tabindex="${stat.first} ? 0 : -1"></div>
+									<div th:insert="~{fragments/driveItems :: printItem(${item})}" class="video-item col-lg-3 col-md-4 col-sm-12" th:tabindex="${stat.first} ? 0 : -1"></div>
 								</th:block>
 							</div>
 							<div th:if="${itemsList == null}" th:text="#{container_empty}" class="sak-banner-info"></div>
@@ -129,7 +129,7 @@
 				<div class="accordion-collapse collapse" th:classappend="${expanded} ? 'show'" th:id="|section_tree_${typeKey}|">
 					<div class="accordion-body">
 						<th:block th:if="${itemsList}">
-							<div th:replace="fragments/driveItems :: exploreAndPrintItems(rowId=|t_${typeKey}|, itemsList=${itemsList}, level=0)"></div>
+							<div th:replace="~{fragments/driveItems :: exploreAndPrintItems(rowId=|t_${typeKey}|, itemsList=${itemsList}, level=0)}"></div>
 						</th:block>
 						<div th:if="${itemsList == null}" th:text="#{container_empty}" class="sak-banner-info"></div>
 					</div>

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/error.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/error.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
 		<div th:if="${exception_error != null}" class="sak-banner-error" id="exception_error"  th:text="${exception_error}"></div>
 	</body>

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -5,17 +5,17 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
 	<script src="/library/js/headscripts.js" type="text/javascript"></script>
-	<script th:inline="javascript" th:insert="js/common.js"></script>
+	<script th:inline="javascript" th:insert="~{js/common.js}"></script>
 	<title th:text="#{index_title}">Microsoft Video Gallery</title>
 </head>
 
 <div th:fragment="bootstrap">
 	<script>includeLatestJQuery('microsoft-video-gallery');</script>
-	<script th:inline="javascript">
+	<script>
 		(function() {
-			const toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-			if (toolId) {
-			  setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+			const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+			if (toolFrameId) {
+			  setMainFrameHeight(toolFrameId);
 			}
 		})();
 	</script>

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/fragments/driveItems.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/fragments/driveItems.html
@@ -6,29 +6,29 @@
 				<li class="breadcrumb-item">
 					<a href="#" aria-expanded="true" th:attr="onclick=|toggleFolder('${typeKey}','${rowId}')|" th:text="${typesMap.get(typeKey)}" role="button" tabindex="0"></a>
 				</li>
-				<li th:replace="fragments/driveItems :: printHierarchyLink(${currentItem}, true)" />
+				<li th:replace="~{fragments/driveItems :: printHierarchyLink(${currentItem}, true)}" />
 				</ol>
 			</th:block>
 		</div>
 
 		<div th:if="${itemsList.empty}" th:text="#{container_empty}" class="row sak-banner-info"></div>
 		<div th:if="${!itemsList.empty}" class="row display-flex">
-			<th:block th:each="item: ${itemsList}">
-				<div th:insert="fragments/driveItems :: printItem(${item})" class="video-item col-lg-3 col-md-4 col-sm-12" th:tabindex="${stat.first} ? 0 : -1"></div>
+			<th:block th:each="item, stat: ${itemsList}">
+				<div th:insert="~{fragments/driveItems :: printItem(${item})}" class="video-item col-lg-3 col-md-4 col-sm-12" th:tabindex="${stat.first} ? 0 : -1"></div>
 			</th:block>
 		</div>
 	</div>
 	
 	<th:block th:each="item: ${itemsList}">
 		<th:block th:if="${ item.isFolder() and item.hasChildren() }">
-			<div th:replace="fragments/driveItems :: exploreAndPrintItems(currentItem=${item}, itemsList=${item.getChildren()}, level=${level + 1})"></div>
+			<div th:replace="~{fragments/driveItems :: exploreAndPrintItems(currentItem=${item}, itemsList=${item.getChildren()}, level=${level + 1})}"></div>
 		</th:block>
 	</th:block>
 </th:block>
 
 <th:block th:fragment="printHierarchyLink(item, first)">
 	<th:block th:if="${item.parent}">
-		<li th:replace="fragments/driveItems :: printHierarchyLink(${item.parent}, false)" />
+		<li th:replace="~{fragments/driveItems :: printHierarchyLink(${item.parent}, false)}" />
 	</th:block>
 	<li class="breadcrumb-item">
 		<a th:if="${!first}" href="#" aria-expanded="true" th:attr="onclick=|toggleFolder('${typeKey}', 'f_${item.id}')|" th:text="${item.name}" role="button" tabindex="-1"></a>

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
-		<div class="menu" th:insert="fragments/menus :: main (index)" />
+		<div class="menu" th:insert="~{fragments/menus :: main (index)}" />
 
 		<div class="sak-banner-error hidden" id="exception_error"></div>
 

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/index_ws.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/index_ws.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
 		<div class="sak-banner-error hidden" id="exception_error"></div>
 
@@ -23,7 +23,7 @@
 				</a>
 			</div>
 			
-			<th:block th:replace="index :: common-body" />
+			<th:block th:replace="~{index :: common-body}" />
 		</th:block>
 	</body>
 </html>

--- a/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/permissions.html
+++ b/microsoft-integration/media-gallery-tool/src/main/webapp/WEB-INF/templates/permissions.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
 	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head th:replace="fragments/common :: head" />
+	<head th:replace="~{fragments/common :: head}" />
 
 	<body>
-		<div th:replace="fragments/common :: bootstrap" />
+		<div th:replace="~{fragments/common :: bootstrap}" />
 
-		<div class="menu" th:insert="fragments/menus :: main (permissions)" />
+		<div class="menu" th:insert="~{fragments/menus :: main (permissions)}" />
 
 		<sakai-permissions tool="microsoft.channels" bundle-key="microsoft" th:attr="on-refresh=@{/index}" />
 	</body>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/create_gradebook.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/create_gradebook.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head">
+<head th:replace="~{fragments/common :: head}">
 </head>
 
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-        <div id="menu" th:include="fragments/menus :: main (add)" />
+        <div id="menu" th:insert="~{fragments/menus :: main (add)}" />
         <div class="page-header">
             <h1 th:text="#{create_update}" /></h1>
         </div>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/delete_confirm.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/delete_confirm.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (index)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
         <div class="sak-banner-warn" th:text="#{delete_confirm}"></div>
         <table>
             <tr>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/fragments/menus.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/fragments/menus.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
-    <div th:fragment="main (current)">
+    <th:block th:fragment="main (current)">
         <ul class="navIntraTool" role="menu">
             <li role="menuitem">
                 <span th:class="${current}=='index' ? 'current'">
@@ -16,6 +16,6 @@
                 </span>
             </li>
         </ul>
-    </div>
+    </th:block>
 </body>
 </html>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/gradebook_view.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/gradebook_view.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-        <div id="menu" th:include="fragments/menus :: main (index)" />
+        <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
         <div class="page-header"><h1 th:text="#{gradebook_view}">View</h1></div>
         <div class="sak-banner-info" th:if="${studentsList == null or studentsList.isEmpty()}" th:text="#{no_gradebooks}">There are currently no items at this location.</div>
         <div class="sak-banner-info" th:text="#{gradebook_lastmodified} + ' ' + ${currentGradebook.updatedDateTime}"></div>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/index.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head"/>
+<head th:replace="~{fragments/common :: head}"/>
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-        <div id="menu" th:include="fragments/menus :: main (index)" />
+        <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
         <div class="page-header"><h1 th:text="#{bar_main}">Postem</h1></div>
         <div class="sak-banner-info" th:if="${gradebooksList== null or gradebooksList.isEmpty()}" >There are currently no items at this location.</div>
 	<div class="table-responsive">

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/permission_error.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/permission_error.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
         <div class="sak-banner-error">
             <span th:text="#{perm_error}" />

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/student_grade_view.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/student_grade_view.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-        <div id="menu" th:include="fragments/menus :: main (index)" />
+        <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
         <div class="sak-banner-info" th:if="${student == null}" th:text="${literalErrorMessage}"></div>
         <br/>
         <p th:if="${student != null}" th:text="#{grade_view}"></p>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/student_view.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/student_view.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-        <div id="menu" th:include="fragments/menus :: main (index)" />
+        <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
         <div class="page-header">
             <h1 th:text="#{view_student}"></h1>
         </div>

--- a/postem/postem-app/src/main/webapp/WEB-INF/templates/verify.html
+++ b/postem/postem-app/src/main/webapp/WEB-INF/templates/verify.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
    xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-    <div th:replace="fragments/common :: jQuery" />
+    <div th:replace="~{fragments/common :: jQuery}" />
     <div class="portletBody">
-        <div id="menu" th:include="fragments/menus :: main (index)" />
+        <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
         <div class="page-header">
             <h1 th:text="#{title_verify}"></h1>
         </div>

--- a/reset-pass/reset-pass/src/main/webapp/WEB-INF/templates/form.html
+++ b/reset-pass/reset-pass/src/main/webapp/WEB-INF/templates/form.html
@@ -1,5 +1,5 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
     <div class="portletBody">
 

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -69,7 +69,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-assignments" class="collapsed" aria-expanded="false"><span th:text="${assignmentsToolTitle}">Assignments</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${assignments}, toolId='assignments', collapseId='collapse-assignments')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${assignments}, toolId='assignments', collapseId='collapse-assignments')}"></div>
       </div>
       <div th:if="${assessments != null}" class="card">
         <div class="card-header">
@@ -77,7 +77,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-assessments" class="collapsed" aria-expanded="false"><span th:text="${assessmentsToolTitle}">Tests & Quizzes</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${assessments}, toolId='assessments', collapseId='collapse-assessments')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${assessments}, toolId='assessments', collapseId='collapse-assessments')}"></div>
       </div>
       <div th:if="${signupMeetings != null}" class="card">
         <div class="card-header">
@@ -85,7 +85,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-signup" class="collapsed" aria-expanded="false"><span th:text="${signupMeetingsToolTitle}">Sign up</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${signupMeetings}, toolId='signupMeetings', collapseId='collapse-signup')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${signupMeetings}, toolId='signupMeetings', collapseId='collapse-signup')}"></div>
       </div>
       <div th:if="${gradebookItems != null}" class="card">
         <div class="card-header">
@@ -93,7 +93,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-gradebook" class="collapsed" aria-expanded="false"><span th:text="${gradebookItemsToolTitle}">Gradebook</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${gradebookItems}, toolId='gradebookItems', collapseId='collapse-gradebook')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${gradebookItems}, toolId='gradebookItems', collapseId='collapse-gradebook')}"></div>
       </div>
       <div th:if="${resources != null}" class="card">
         <div class="card-header">
@@ -101,7 +101,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-resources" class="collapsed" aria-expanded="false"><span th:text="${resourcesToolTitle}">Resources</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${resources}, toolId='resources', collapseId='collapse-resources')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${resources}, toolId='resources', collapseId='collapse-resources')}"></div>
       </div>
       <div th:if="${calendarEvents != null}" class="card">
         <div class="card-header">
@@ -109,7 +109,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-calendar" class="collapsed" aria-expanded="false"><span th:text="${calendarEventsToolTitle}">Calendar</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${calendarEvents}, toolId='calendarEvents', collapseId='collapse-calendar')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${calendarEvents}, toolId='calendarEvents', collapseId='collapse-calendar')}"></div>
       </div>
       <div th:if="${forums != null}" class="card">
         <div class="card-header">
@@ -117,7 +117,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-forums" class="collapsed" aria-expanded="false"><span th:text="${forumsToolTitle}">Forums</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${forums}, toolId='forums', collapseId='collapse-forums')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${forums}, toolId='forums', collapseId='collapse-forums')}"></div>
       </div>
       <div th:if="${announcements != null}" class="card">
         <div class="card-header">
@@ -125,7 +125,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-announcements" class="collapsed" aria-expanded="false"><span th:text="${announcementsToolTitle}">Announcements</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${announcements}, toolId='announcements', collapseId='collapse-announcements')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${announcements}, toolId='announcements', collapseId='collapse-announcements')}"></div>
       </div>
       <div th:if="${lessons != null}" class="card">
         <div class="card-header">
@@ -133,7 +133,7 @@
             <a data-bs-toggle="collapse" data-parent="#accordion" href="#collapse-lessons" class="collapsed" aria-expanded="false"><span th:text="${lessonsToolTitle}">Lessons</span><span class="allocatedSpinPlaceholder"></span></a>
           </h4>
         </div>
-        <div th:replace="tool_fragment :: tool_fragment(items=${lessons}, toolId='lessons', collapseId='collapse-lessons')"></div>
+        <div th:replace="~{tool_fragment :: tool_fragment(items=${lessons}, toolId='lessons', collapseId='collapse-lessons')}"></div>
       </div>
 
       <div class="act">

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step1.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step1.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (autogroups)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (autogroups)}" />
     <div><h1 th:text="#{autogroups.header.wizard}"></h1></div>
-    <div th:replace="fragments/wizard :: step (step1)"></div>
+    <div th:replace="~{fragments/wizard :: step (step1)}"></div>
     <br/>
     <div class="row" th:if="${step1ErrorMessage != null}">
       <div class="col-sm-8">
@@ -43,6 +43,6 @@
       </div>
     </div>
   </div>
-  <script th:replace="fragments/javascript :: autoGroupsStep1Js" />
+  <script th:replace="~{fragments/javascript :: autoGroupsStep1Js}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step2.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step2.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (autogroups)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (autogroups)}" />
     <div><h1 th:text="#{autogroups.header.wizard}"></h1></div>
-    <div th:replace="fragments/wizard :: step (step2)"></div><br/>
+    <div th:replace="~{fragments/wizard :: step (step2)}"></div><br/>
     <div class="row" th:if="${step2ErrorMessage != null}">
       <div class="col-sm-8">
         <div class="sak-banner-error" th:text="${step2ErrorMessage}">You must at least select a role or a section.</div>
@@ -68,6 +68,6 @@
       </div>
     </div>
   </div>
-  <script th:replace="fragments/javascript :: autoGroupsStep2Js" />
+  <script th:replace="~{fragments/javascript :: autoGroupsStep2Js}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step3.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step3.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (autogroups)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (autogroups)}" />
     <div><h1 th:text="#{autogroups.header.wizard}"></h1></div>
-    <div th:replace="fragments/wizard :: step (step3)"></div><br/>
+    <div th:replace="~{fragments/wizard :: step (step3)}"></div><br/>
     <div class="row">
       <div class="col-sm-8">
         <div class="card mb-3 p-3">
@@ -92,6 +92,6 @@
       </div>
     </div>
   </div>
-  <script th:replace="fragments/javascript :: autoGroupsStep3Js" />
+  <script th:replace="~{fragments/javascript :: autoGroupsStep3Js}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step4.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/auto_groups_step4.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (autogroups)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (autogroups)}" />
     <div><h1 th:text="#{autogroups.header.wizard}"></h1></div>
-    <div th:replace="fragments/wizard :: step (step4)"></div>
+    <div th:replace="~{fragments/wizard :: step (step4)}"></div>
     <br/>
     <div class="row">
       <div class="col-sm-8">
@@ -67,6 +67,6 @@
       </div>
     </div>
   </div>
-  <script th:replace="fragments/javascript :: autoGroupsStep4Js" />
+  <script th:replace="~{fragments/javascript :: autoGroupsStep4Js}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -8,15 +8,14 @@
 <script src="/library/js/spinner.js"></script>
 <title th:text="#{grouphelper.tool.title}">Group Manager</title>
 </head>
-<div th:fragment="jQuery">
-  <script>includeLatestJQuery('sakai-site-group-manager');</script>
-  <script th:inline="javascript">
-    $(document).ready(function () {
-      var toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-      if (toolId) {
-        setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+<div th:fragment="scripts">
+  <script>
+    (() => {
+      const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+      if (toolFrameId) {
+        setMainFrameHeight(toolFrameId);
       }
-    });
+    })();
   </script>
 </div>
 </body>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/menus.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/menus.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
-  <div th:fragment="main (current)">
+  <th:block th:fragment="main (current)">
     <ul class="navIntraTool">
       <li role="presentation"><span th:class="${current}=='index' ? 'current'">
         <span th:if="${current}=='index'" th:text="#{menu.group.list}">Group List</span>
@@ -24,6 +24,6 @@
         <a th:unless="${current}=='import'" href="#" th:href="@{/import}" th:text="#{menu.bulk.creation}">Bulk creation</a>
       </span></li>
     </ul>
-  </div>
+  </th:block>
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/wizard.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/fragments/wizard.html
@@ -18,6 +18,6 @@
         <div th:class="${current} == 'step4' ? 'col bordered wizard-step-active' : 'col bordered'" th:text="#{autogroups.wizard.step4}">Step 4: Preview</div>
       </div>
     </div>
-    <script th:replace="fragments/javascript :: wizardJs" />
+    <script th:replace="~{fragments/javascript :: wizardJs}" />
   </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/group.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (group)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (group)}" />
     <div>
       <h1 th:if="${groupForm.groupId == null}" th:text="#{groups.header.new}"></h1>
       <h1 th:if="${groupForm.groupId != null}" th:text="#{groups.header.edit}"></h1>
@@ -104,6 +104,6 @@
       </div>
     </form>
   </div>
-  <script th:replace="fragments/javascript :: groupJs" />
+  <script th:replace="~{fragments/javascript :: groupJs}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (import)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (import)}" />
     <div><h1 th:text="#{import.header}"></h1></div>
     <div class="row">
       <div class="col-sm-6">
@@ -43,6 +43,6 @@
       </div>
     </form>
   </div>
-  <script th:replace="fragments/javascript :: importJs" />
+  <script th:replace="~{fragments/javascript :: importJs}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import_confirmation.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/import_confirmation.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (import)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (import)}" />
     <div><h1 th:text="#{import.confirmation.header}"></h1></div>
     <p th:text="#{import.confirmation.instructions}"></p>
     <div class="sak-banner-error" th:text="#{import.confirmation.error}" th:if="${membershipErrors}"></div>
@@ -35,6 +35,6 @@
         </div>
       </form>
   </div>
-  <script th:replace="fragments/javascript :: importConfirmJs" />
+  <script th:replace="~{fragments/javascript :: importConfirmJs}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (index)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
     <div class="page-header"><h1 th:text="#{index.header.grouplist}"></h1></div>
     <div class="sak-banner-info" th:if="${groupList.isEmpty()}" th:text="#{index.warning.groupempty}">No groups in this site.</div>
     <div class="sak-banner-error" th:if="${errorMessage != null}" th:text="${errorMessage}"></div>
@@ -104,6 +104,6 @@
       </div>
     </form>
   </div>
-  <script th:replace="fragments/javascript :: indexJs" />
+  <script th:replace="~{fragments/javascript :: indexJs}" />
 </body>
 </html>

--- a/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/joinable_set.html
+++ b/site-manage/site-group-manager/src/main/webapp/WEB-INF/templates/joinable_set.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: jQuery" />
+  <div th:replace="~{fragments/common :: scripts}" />
   <div class="portletBody">
-    <div id="menu" th:include="fragments/menus :: main (joinableset)" />
+    <div id="menu" th:insert="~{fragments/menus :: main (joinableset)}" />
     <div>
       <h1 th:if="${joinableSetForm.joinableSetId == null}" th:text="#{joinableset.header.new}"></h1>
       <h1 th:if="${joinableSetForm.joinableSetId != null}" th:text="#{joinableset.header.edit}"></h1>
@@ -182,6 +182,6 @@
       </div>
     </div>
   </div>
-  <script th:replace="fragments/javascript :: joinableSetJs" />
+  <script th:replace="~{fragments/javascript :: joinableSetJs}" />
 </body>
 </html>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/edit.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/edit.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
-  <div th:include="fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})" />
-  <div th:include="fragments/common :: admin (${isAdmin})" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
+  <div th:insert="~{fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})}" />
+  <div th:insert="~{fragments/common :: admin (${isAdmin})}" />
   <div th:if="${isLoadBundlesFromDb} and ${isAdmin}">
     <div class="portletBody">
-      <div id="menu" th:include="fragments/menus :: main (edit)" />
+      <div id="menu" th:insert="~{fragments/menus :: main (edit)}" />
       <h3 th:text="#{edit.edit}">Edit Message</h3>
       <form class="form-horizontal" action="#" th:action="@{/edit}" th:object="${messageEntity}" method="post">
         <input type="hidden" th:field="*{id}" />

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/fragments/common.html
@@ -8,31 +8,30 @@
 <title th:text="#{common.title}">Message Bundle Manager</title>
 </head>
 <div th:fragment="bootstrap">
-  <script>includeLatestJQuery('common.html');</script>
-  <script th:inline="javascript">
-    $(document).ready(function () {
-      var toolId = /*[[${#httpServletRequest.getAttribute('sakai.tool.placement.id')}]]*/'toolId';
-      if (toolId) {
-        setMainFrameHeight('Main' + toolId.replace(/-/g, 'x'));
+  <script>
+    (() => {
+      const toolFrameId = window.name || (window.frameElement && window.frameElement.id);
+      if (toolFrameId) {
+        setMainFrameHeight(toolFrameId);
       }
-    });
+    })();
   </script>
 </div>
-<div th:fragment="loadBundlesFromDb (enabled)">
+<th:block th:fragment="loadBundlesFromDb (enabled)">
   <div th:unless="${enabled}">
     <div class="sak-banner-warn" role="alert" th:text="#{common.warning}">
       Message bundle editing is not activated, please see your Administrator.
     </div>
     <p></p>
   </div>
-</div>
-<div th:fragment="admin (admin)">
+</th:block>
+<th:block th:fragment="admin (admin)">
   <div th:unless="${admin}">
     <div class="sak-banner-error" role="alert" th:text="#{common.danger}">
       You must be an admin to use this tool, please see your Administrator.
     </div>
     <p></p>
   </div>
-</div>
+</th:block>
 </body>
 </html>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/fragments/menus.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/fragments/menus.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <body>
-  <div th:fragment="main (active)">
+  <th:block th:fragment="main (active)">
     <ul class="navIntraTool">
       <li role="presentation" th:class="${active}=='index'? 'active'"><span><a href="#" th:href="@{/index}" th:text="#{index.status}">Status</a></span></li>
       <li role="presentation" th:class="${active}=='modified'? 'active'"><span><a href="#" th:href="@{/modified}" th:text="#{modified.modified}">Modified Messages</a></span></li>
       <li role="presentation" th:class="${active}=='modules'? 'active'"><span><a href="#" th:href="@{/modules}" th:text="#{modules.modules}">Messages by Module</a></span></li>
       <li role="presentation" th:class="${active}=='search'? 'active'"><span><a href="#" th:href="@{/search}" th:text="#{search.searchMessages}">Search Messages</a></span></li>
     </ul>
-  </div>
+  </th:block>
 </body>
 </html>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
-  <div th:include="fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})" />
-  <div th:include="fragments/common :: admin (${isAdmin})" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
+  <div th:insert="~{fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})}" />
+  <div th:insert="~{fragments/common :: admin (${isAdmin})}" />
   <div th:if="${isLoadBundlesFromDb} and ${isAdmin}">
     <div class="portletBody">
-      <div id="menu" th:include="fragments/menus :: main (index)" />
+      <div id="menu" th:insert="~{fragments/menus :: main (index)}" />
       <h3 th:text="#{index.status}">Status</h3>
       <!-- TODO more to come on this page in the future -->
       <p th:text="#{index.found(${countModifiedMessageProperties}, ${countMessageProperties})}">Found 1 modified of 100 message properties.</p>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/modified.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/modified.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
-  <div th:include="fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})" />
-  <div th:include="fragments/common :: admin (${isAdmin})" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
+  <div th:insert="~{fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})}" />
+  <div th:insert="~{fragments/common :: admin (${isAdmin})}" />
   <div th:if="${isLoadBundlesFromDb} and ${isAdmin}">
     <div class="portletBody">
-      <div id="menu" th:include="fragments/menus :: main (modified)" />
+      <div id="menu" th:insert="~{fragments/menus :: main (modified)}" />
       <h3 th:text="#{modified.modified}">Modified Messages</h3>
       <table id="modifiedTable" class="table table-striped table-bordered dataTable">
         <thead>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/modules.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/modules.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
-  <div th:include="fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
+  <div th:insert="~{fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})}" />
   <div th:if="${isLoadBundlesFromDb} and ${isAdmin}">
     <div class="portletBody">
-      <div id="menu" th:include="fragments/menus :: main (modules)" />
+      <div id="menu" th:insert="~{fragments/menus :: main (modules)}" />
       <h3 th:text="#{modules.modules}">Messages by Module</h3>
       <form id="filterForm" action="#" th:action="@{/modules}" th:object="${modulesFilterEntity}" method="post">
         <label for="moduleSelect" th:text="#{modules.module.select}">Select a Module</label>

--- a/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/search.html
+++ b/site/sakai-message-bundle-manager-tool/src/main/webapp/WEB-INF/templates/search.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/common :: head" />
+<head th:replace="~{fragments/common :: head}" />
 <body>
-  <div th:replace="fragments/common :: bootstrap" />
-  <div th:include="fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})" />
+  <div th:replace="~{fragments/common :: bootstrap}" />
+  <div th:insert="~{fragments/common :: loadBundlesFromDb (${isLoadBundlesFromDb})}" />
   <div th:if="${isLoadBundlesFromDb} and ${isAdmin}">
     <div class="portletBody">
-      <div id="menu" th:include="fragments/menus :: main (search)" />
+      <div id="menu" th:insert="~{fragments/menus :: main (search)}" />
       <h3 th:text="#{search.searchMessages}">Search Messages</h3>
       <form id="searchForm" action="#" th:action="@{/search}" th:object="${searchEntity}" method="post">
         <label for="searchValue" th:text="#{search.text}">Enter text</label>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for Postem and Site Info to verify navigation, page rendering, and forms.

* **Refactor**
  * Updated Thymeleaf fragment usage across many templates to the modern context-relative syntax.
  * Switched fragment insertion semantics (include → insert/replace) for more consistent composition.
  * Frame-height logic now derives target frame ID client-side.
  * Replaced rendered div wrappers with non-rendering block wrappers to streamline markup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->