### PR TITLE
SAK-52576 LTI fix stealthed tool link launches

### DIFF
--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -794,7 +794,7 @@ public abstract class BaseLTIService implements LTIService {
 		Long visible = LTIUtil.toLong(tool.get(LTIService.LTI_VISIBLE));
 		String contentSite = (String) reqProps.get(LTIService.LTI_SITE_ID);
 		log.debug("checking if tool {} is stealth and about to deploy to site {}, visible={}", toolKey, contentSite, visible);
-		if ( contentSite != null && visible != null && visible.equals(LTIService.LTI_VISIBLE_STEALTH) ) {
+		if ( contentSite != null && visible != null && visible == LTIService.LTI_VISIBLE_STEALTH ) {
 			boolean isDeployed = toolDeployed(toolKey, contentSite);
 			if ( isDeployed ) {
 				// The tool is already deployed to the site, our work is done

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
@@ -180,10 +180,13 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		List<Map<String, Object>> sites = jdbcTemplate.queryForList(
 				"SELECT DISTINCT lti_content.SITE_ID FROM lti_content"
 				+ " INNER JOIN SAKAI_SITE ON lti_content.SITE_ID = SAKAI_SITE.SITE_ID"
-				+ " WHERE lti_content.tool_id = ?", toolKey);
+				+ " WHERE lti_content.tool_id = ?"
+				+ " AND NOT EXISTS (SELECT 1 FROM lti_tool_site"
+				+ " WHERE lti_tool_site.tool_id = lti_content.tool_id"
+				+ " AND lti_tool_site.SITE_ID = lti_content.SITE_ID)", toolKey);
 		for (Map<String, Object> site : sites) {
 			String contentSite = StringUtils.trimToNull((String) site.get(LTI_SITE_ID));
-			if (contentSite == null || toolDeployed(toolKey, contentSite)) {
+			if (contentSite == null) {
 				continue;
 			}
 

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
@@ -172,6 +172,32 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return insertThingDao("lti_tools", LTIService.TOOL_MODEL, null, newProps, siteId, isAdminRole, isMaintainRole);
 	}
 
+	private void deployToolToContentSites(Long toolKey, boolean isAdminRole, boolean isMaintainRole) {
+		if (toolKey == null || !isAdminRole || !isMaintainRole) {
+			return;
+		}
+
+		List<Map<String, Object>> sites = jdbcTemplate.queryForList(
+				"SELECT DISTINCT lti_content.SITE_ID FROM lti_content"
+				+ " INNER JOIN SAKAI_SITE ON lti_content.SITE_ID = SAKAI_SITE.SITE_ID"
+				+ " WHERE lti_content.tool_id = ?", toolKey);
+		for (Map<String, Object> site : sites) {
+			String contentSite = StringUtils.trimToNull((String) site.get(LTI_SITE_ID));
+			if (contentSite == null || toolDeployed(toolKey, contentSite)) {
+				continue;
+			}
+
+			Properties props = new Properties();
+			props.setProperty(LTIService.LTI_TOOL_ID, toolKey.toString());
+			props.setProperty(LTIService.LTI_SITE_ID, contentSite);
+			props.setProperty("notes", rb.getString("tool.added.by.insert.content"));
+			Object insertResult = insertToolSiteDao(props, contentSite, isAdminRole, isMaintainRole);
+			if (insertResult instanceof String) {
+				log.warn("Unable to deploy stealthed tool {} to site {}: {}", toolKey, contentSite, insertResult);
+			}
+		}
+	}
+
 	public Map<String, Object> getToolDao(Long key, String siteId, boolean isAdminRole)
 	{
 		return getThingDao("lti_tools", LTIService.TOOL_MODEL, key, siteId, isAdminRole);
@@ -182,7 +208,18 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 	}
 
 	public Object updateToolDao(Long key, Object newProps, String siteId, boolean isAdminRole, boolean isMaintainRole) {
-		return updateThingDao("lti_tools", LTIService.TOOL_MODEL, null, key, (Object) newProps, siteId, isAdminRole, isMaintainRole);
+		Long stealth = Long.valueOf(LTIService.LTI_VISIBLE_STEALTH);
+		Map<String, Object> oldTool = getToolDao(key, siteId, true);
+		Long oldVisible = oldTool == null ? null : LTIUtil.toLongNull(oldTool.get(LTI_VISIBLE));
+		Object result = updateThingDao("lti_tools", LTIService.TOOL_MODEL, null, key, (Object) newProps, siteId, isAdminRole, isMaintainRole);
+		if (Boolean.TRUE.equals(result)) {
+			Map<String, Object> updatedTool = getToolDao(key, siteId, true);
+			Long updatedVisible = updatedTool == null ? null : LTIUtil.toLongNull(updatedTool.get(LTI_VISIBLE));
+			if (!stealth.equals(oldVisible) && stealth.equals(updatedVisible)) {
+				deployToolToContentSites(key, isAdminRole, isMaintainRole);
+			}
+		}
+		return result;
 	}
 
 	public List<Map<String, Object>> getToolsDao(String search, String order, int first, int last, String siteId, boolean isAdminRole) {


### PR DESCRIPTION
SAK-50758 tightened non-admin LTI tool lookup so global stealthed tools are only visible to a site when an explicit lti_tool_site deployment row exists. That is correct after a stealthed deployment is removed, but existing LTI content links created while the tool was visible may only have lti_content.tool_id and no matching deployment row.

When an admin later changes that tool to stealth, existing Assignments, Lessons, and site navigation links still point at the content row, but callers resolve the associated tool through getTool(toolKey, siteId). Without a deployment row, that lookup returns null, so consumers treat the item as deleted or misconfigured. The visible symptom is the launch error 'External tool item is missing or improperly configured' and a '-' launch URL in the Tool Links list when the URL should be inherited from the tool.

There was a second issue in the new-link path. insertToolContentDao already had logic to auto-deploy a stealthed tool to the target site for admins, but it compared a Long visible value with the int LTI_VISIBLE_STEALTH using Long.equals(Integer). That comparison is always false, so the deployment row was never inserted for newly created stealthed links either.

Fix this by adding deployment rows for every existing site that already has lti_content rows for a tool when that tool transitions into stealth, joining SAKAI_SITE so stale or orphaned content site ids are not revived. This preserves existing links at the moment the visibility changes while preserving the SAK-50758 removal behavior: if an admin later removes a deployment row, getTool will again hide that stealthed tool from the site. Also use numeric comparison for the Long visible value so new admin-created stealthed links are deployed correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected visibility comparison to ensure tools are evaluated properly for deployment.

* **New Features**
  * Tools now automatically deploy to associated content sites when their visibility is changed to stealth mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->