### PR TITLE
SAK-52582 Gradebook reject an invalid number instead of parsing it

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/actions/GradeUpdateAction.java
@@ -133,8 +133,9 @@ public class GradeUpdateAction extends InjectableAction implements Serializable 
 		final String rawNewGrade = StringUtils.trimToEmpty(params.get("newScore").textValue());
 
 		if (StringUtils.isNotBlank(rawNewGrade)) {
-			final Double parsed = localeService.parseDouble(rawNewGrade);
-			if (parsed == null || parsed < 0) {
+			final boolean validNumber = localeService.isValidDouble(rawNewGrade);
+			final Double parsed = validNumber ? localeService.parseDouble(rawNewGrade) : null;
+			if (!validNumber || parsed == null || parsed < 0) {
 				target.add(page.updateLiveGradingMessage(page.getString("feedback.error")));
 				return new ArgumentErrorResponse("Grade not valid");
 			}

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/LocaleServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/util/impl/LocaleServiceTest.java
@@ -220,6 +220,16 @@ public class LocaleServiceTest extends SakaiKernelTestBase {
         Assert.assertTrue(localeService.isValidDouble("1,234", Locale.US));
     }
 
+    @Test
+    public void isValidDoubleMalformedGroupingUsIsInvalid() {
+        Assert.assertFalse(localeService.isValidDouble("3,3", Locale.US));
+    }
+
+    @Test
+    public void isValidDoubleMalformedGroupingGermanyIsInvalid() {
+        Assert.assertFalse(localeService.isValidDouble("3.3", Locale.GERMANY));
+    }
+
     // Regression: the original regex concatenated the decimal separator char directly into the
     // pattern without a preceding \, so for en_US the first grouped-decimal alternative was
     // \d{1,3}(\,\d{3})+.\d+ where '.' matched any character. "1,234x56" would incorrectly


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of grade score input to detect and reject malformed number formats before processing, preventing errors and providing appropriate feedback when invalid entries are submitted.

* **Tests**
  * Extended test coverage with validation checks for malformed decimal number inputs across different locale-specific formatting standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->