### PR TITLE
SAK-52567 LTI handle assignments with line items created from Gradebook

### DIFF
--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -2039,6 +2039,7 @@ public class LTI13Servlet extends HttpServlet {
 		if ( item == null )  {
 			return; // Error already handled
 		}
+		log.debug("item={}; resourceLinkId={}", item, item.resourceLinkId);
 
 		Site site = null;
 		org.sakaiproject.lti.beans.LtiToolBean tool = null;
@@ -2086,7 +2087,12 @@ public class LTI13Servlet extends HttpServlet {
 
 		Assignment retval;
 		try {
-			retval = LineItemUtil.createLineItem(site, sat.tool_id, null /*content*/, item);
+			Map<String, Object> content = null;
+			Long contentKey = LineItemUtil.getContentIdFromResourceLinkId(item.resourceLinkId);
+			if (contentKey != null) {
+			    content = ltiService.getContent(contentKey, site.getId());
+			}
+			retval = LineItemUtil.createLineItem(site, sat.tool_id, content, item);
 		} catch (Exception e) {
 			log.error("Could not create lineitem: "+e.getMessage());
 			LTI13Util.return400(response, "Could not create lineitem: "+e.getMessage());

--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -2757,21 +2757,29 @@ public class SakaiLTIUtil {
 
 			// Check if this is a gradebook column that is owned by assignments
 			String external_id = gradebookColumn.getExternalId();
-			log.debug("external_id: {} {}", external_id);
-			if ( external_id != null && LineItemUtil.isAssignmentColumn(external_id) ) {
+			// Check if the column was created in Gradebook and is associated with an assignment (assumes only one; cannot handle multiple yet)
+			org.sakaiproject.assignment.api.model.Assignment assignment = LineItemUtil.getAssignmentForGradebookLink(siteId, gradebookColumn.getId());
+			log.debug("external_id: {} assignment with GB item from GB={}", external_id, assignment);
+			if ( external_id != null && (LineItemUtil.isAssignmentColumn(external_id) || (assignment != null)) ) {
 				pushAdvisor(); // Add security advisor to allow access to assignments
 				try {
 					org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
-					org.sakaiproject.assignment.api.model.Assignment assignment;
-					try {
+					if (assignmentService == null) {
+					    String warning = "AssignmentService not available";
+					    log.warn(warning);
+					    return warning;
+					}
+					if (assignment == null) {
+					    // Try fetching an assignment where the gb column originates from the Assignments tool
+					    try {
 						org.sakaiproject.assignment.api.AssignmentReferenceReckoner.AssignmentReference assignmentReference = org.sakaiproject.assignment.api.AssignmentReferenceReckoner.reckoner().reference(external_id).reckon();
 						log.debug("assignmentReference.id {}", assignmentReference.getId());
 						assignment = assignmentService.getAssignment(assignmentReference.getId());
-					} catch (Exception e) {
+					    } catch (Exception e) {
 						log.error("Error getting assignment", e);
 						return "Error retrieving assignment: " + e.getMessage();
+					    }
 					}
-
 					if ( assignment != null ) {
 						log.debug("Gradebook column is owned by assignment: {}", assignment.getId());
 						try {

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.time.Instant;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.json.simple.JSONObject;
@@ -777,7 +778,9 @@ public class LineItemUtil {
 				key = refMap != null ? refMap.get(assignmentExternalId) : null;
 			}
 			boolean owned = toolId == null || toolIdMatchesKey(toolId, key);
-			return new LtiLineItemRowResolution(true, false, owned, key, null);
+			// Pass to the constructor an assignment object if it is associated with this gradebook item; otherwise, the value is null.
+			org.sakaiproject.assignment.api.model.Assignment asn = getAssignmentForGradebookLink(contextId, gbColumn.getId());
+			return new LtiLineItemRowResolution(true, false, owned, key, asn);
 		}
 
 		boolean assignmentApp = ASSIGNMENTS_EXTERNAL_APP_NAME.equals(appName)
@@ -833,7 +836,51 @@ public class LineItemUtil {
 			return new LtiLineItemRowResolution(false, true, owned, key, null);
 		}
 
+		org.sakaiproject.assignment.api.model.Assignment asn = getAssignmentForGradebookLink(contextId, gbColumn.getId());
+		if (asn != null) {
+			if (refMap == null) {
+			    refMap = getExternalIdsForToolAssignments(contextId);
+			}
+			org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
+			if (assignmentService == null) {
+			    log.warn("AssignmentService not available");
+			    return LtiLineItemRowResolution.none();
+			}
+			String key = refMap != null ? refMap.get(assignmentService.assignmentReference(contextId, asn.getId())) : null;
+			if (StringUtils.isBlank(key)) {
+			    return LtiLineItemRowResolution.none();
+			}
+			boolean owned = toolId == null || toolIdMatchesKey(toolId, key);
+			return new LtiLineItemRowResolution(false, true, owned, key, asn);
+		}
+
 		return LtiLineItemRowResolution.none();
+	}
+
+	/**
+	 * Return an assignment object from the Assignments tool if it's associated with a gradebook item which was created in Gradebook, instead of
+	 * externally managed by the Assignments tool.
+	 * @param contextId - The site id
+	 * @param gbColumnId - The gradebook item id
+	 * @return Return an assignment object from the Assignments tool if it's associated with the gbColumnId and that GB item originates from Gradebook.
+	 */
+	public static org.sakaiproject.assignment.api.model.Assignment getAssignmentForGradebookLink(String contextId, Long gbColumnId) {
+		org.sakaiproject.assignment.api.model.Assignment asn = null;
+		// More than one assignment could be associated with a gradebook assignment. Return only the first, and log a warning if there are more.
+		org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);
+		List<org.sakaiproject.assignment.api.model.Assignment> assignmentsLinkedToGbColumn = null;
+		try {
+			assignmentsLinkedToGbColumn = assignmentService.getAssignmentsForGradebookLink(contextId, String.valueOf(gbColumnId));
+		} catch (Exception e) {
+			log.debug("Could not find an assignment assoicated with gradebook item {} in site {}", gbColumnId, contextId);
+		}
+		if (assignmentsLinkedToGbColumn != null && assignmentsLinkedToGbColumn.size() > 0) {
+			asn = assignmentsLinkedToGbColumn.get(0);
+			if (assignmentsLinkedToGbColumn.size() > 1) {
+				log.warn("More than one assignment is associated with gradebook item {} in site {}", gbColumnId, contextId);
+			}
+		}
+		return asn;
 	}
 
 	/**
@@ -1043,6 +1090,8 @@ public class LineItemUtil {
 				SakaiLineItem item = getLineItem(signed_placement, gbColumn, sakaiAsn);
 				if ( parts.length > 1 && ! StringUtils.equals("0", parts[1]) ) {
 					item.resourceLinkId = "content:" + parts[1];
+				} else if (sakaiAsn != null && sakaiAsn.getContentId() != null && Integer.compare(sakaiAsn.getContentId(), 0) > 0) {
+					item.resourceLinkId = "content:" + String.valueOf(sakaiAsn.getContentId());
 				}
 
 				if ( filter != null ) {
@@ -1060,6 +1109,15 @@ public class LineItemUtil {
 		}
 
 		return retval;
+	}
+
+	public static Long getContentIdFromResourceLinkId(String resourceLinkId) {
+		if (!StringUtils.startsWith(resourceLinkId, "content:")) {
+		    return null;
+		}
+		String key = StringUtils.substringAfter(resourceLinkId, "content:");
+		long contentId = NumberUtils.toLong(key, -1L);
+		return (contentId > 0) ? Long.valueOf(contentId) : null;
 	}
 
 	public static SakaiLineItem getLineItem(String signed_placement, Assignment gbColumn) {


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52567

Design considerations forthcoming after the wave of bot feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line item creation now attempts to resolve and attach linked content when a resourceLinkId is present.
  * Added helpers to extract content IDs and locate assignments linked to gradebook columns.

* **Bug Fixes**
  * Improved detection of gradebook columns tied to assignments so scores and comments route correctly.
  * Better fallback handling for older assignment-reference columns.
  * Logs and graceful fallback when assignment lookup cannot complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->