### PR TITLE
SAK-49891 Samigo allow questions to be copied into the current question pool (duplicate question)

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -236,6 +236,8 @@ public class QuestionPoolBean implements Serializable {
   @Autowired
   private SecurityService securityService;
 
+  @Getter private String infoDuplicatedQuestion = StringUtils.EMPTY;
+
   /**
    * Creates a new QuestionPoolBean object.
    */
@@ -1400,9 +1402,8 @@ public String getAddOrEdit()
 					// return to an irrelevant screen. I think it's better
 					// just to skip that item. One could argue for a warning
 					// message.
-					if (!hasItemInDestPool(sourceItemId, destId)) {
-						delegate.moveItemToPool(sourceItemId, sourceId, destId);
-					}
+					infoDuplicatedQuestion = addMessageIfDuplicatedInDestPool(sourceItemId, destId);
+					delegate.moveItemToPool(sourceItemId, sourceId, destId);
 					EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SAVEITEM, "/sam/" + AgentFacade.getCurrentSiteId() + "/moved, itemId=" + sourceItemId, true));
 				}
 			} catch (Exception e) {
@@ -1478,25 +1479,15 @@ public String getAddOrEdit()
 
 		return EDIT_ASSESSMENT;
 	}
-     
-  public boolean hasItemInDestPool(Long sourceItemId, Long destId){
-  
-              QuestionPoolService delegate = new QuestionPoolService();
-              // check if the item already exists in the destPool
-              if (delegate.hasItem(sourceItemId, destId)){
-                // we do not want to add duplicated items, show message
 
-                FacesContext context=FacesContext.getCurrentInstance();
-                String err;
-                err=rb.getString("copy_duplicate_error");
-                context.addMessage(null,new FacesMessage(err));
-                return true;
-              }
-  	      else {	
-                return false;
- 	      } 
+  public String addMessageIfDuplicatedInDestPool(Long sourceItemId, Long destId){
+      QuestionPoolService delegate = new QuestionPoolService();
+      // check if the item already exists in the destPool
+      if (delegate.hasItem(sourceItemId, destId)){
+          // if has duplicated items, show message
+          return rb.getString("copy_duplicate_error");
+      } else return StringUtils.EMPTY;
   }
-
 
   public String copyQuestion() {
 		if (getSourcePart() != null)
@@ -1526,12 +1517,11 @@ public String getAddOrEdit()
 						// return to an irrelevant screen. I think it's better
 						// just to skip that item. One could argue for a warning
 						// message.
-						if (!hasItemInDestPool(sourceItemId, destId)) {
-							Long copyItemFacadeId = questionPoolService
-									.copyItemFacade(sourceItem.getData());
-							delegate.addItemToPool(copyItemFacadeId, new Long(
-									destId));
-						}
+						infoDuplicatedQuestion = addMessageIfDuplicatedInDestPool(sourceItemId, destId);
+						Long copyItemFacadeId = questionPoolService
+								.copyItemFacade(sourceItem.getData());
+						delegate.addItemToPool(copyItemFacadeId, new Long(
+								destId));
 						EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SAVEITEM, "/sam/" + AgentFacade.getCurrentSiteId() + "/copied, itemId=" + sourceItemId, true));
 					}
 				} catch (Exception e) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -1484,10 +1484,8 @@ public String getAddOrEdit()
   public String addMessageIfDuplicatedInDestPool(Long sourceItemId, Long destId){
       QuestionPoolService delegate = new QuestionPoolService();
       // check if the item already exists in the destPool
-      if (delegate.hasItem(sourceItemId, destId)){
-          // if has duplicated items, show message
-          return rb.getString("copy_duplicate_error");
-      } else return StringUtils.EMPTY;
+      // if has duplicated items, show message
+      return delegate.hasItem(sourceItemId, destId) ? rb.getString("copy_duplicate_error") : StringUtils.EMPTY;
   }
 
   public String copyQuestion() {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -1384,6 +1384,7 @@ public String getAddOrEdit()
 	}
   
      public String moveQuestion() {
+		infoDuplicatedQuestion = StringUtils.EMPTY;
 		Long sourceId = getCurrentPool().getId();
 		List<Long> sourceItemIds = getCurrentItemIds();
 		String originId = Long.toString(ORIGIN_TOP.equals(getOutcome())?0:getOutcomePool());
@@ -1402,7 +1403,7 @@ public String getAddOrEdit()
 					// return to an irrelevant screen. I think it's better
 					// just to skip that item. One could argue for a warning
 					// message.
-					infoDuplicatedQuestion = addMessageIfDuplicatedInDestPool(sourceItemId, destId);
+					if (StringUtils.isEmpty(infoDuplicatedQuestion)) infoDuplicatedQuestion = addMessageIfDuplicatedInDestPool(sourceItemId, destId);
 					delegate.moveItemToPool(sourceItemId, sourceId, destId);
 					EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SAVEITEM, "/sam/" + AgentFacade.getCurrentSiteId() + "/moved, itemId=" + sourceItemId, true));
 				}
@@ -1490,6 +1491,7 @@ public String getAddOrEdit()
   }
 
   public String copyQuestion() {
+		infoDuplicatedQuestion = StringUtils.EMPTY;
 		if (getSourcePart() != null)
 			return copyQuestionsFromPart();
 
@@ -1517,7 +1519,7 @@ public String getAddOrEdit()
 						// return to an irrelevant screen. I think it's better
 						// just to skip that item. One could argue for a warning
 						// message.
-						infoDuplicatedQuestion = addMessageIfDuplicatedInDestPool(sourceItemId, destId);
+						if (StringUtils.isEmpty(infoDuplicatedQuestion)) infoDuplicatedQuestion = addMessageIfDuplicatedInDestPool(sourceItemId, destId);
 						Long copyItemFacadeId = questionPoolService
 								.copyItemFacade(sourceItem.getData());
 						delegate.addItemToPool(copyItemFacadeId, new Long(

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/editPool.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/editPool.jsp
@@ -110,6 +110,7 @@ function textCounter(field, maxlimit) {
   </h1>
 </div>
 
+<h:outputText value="#{questionpool.infoDuplicatedQuestion}" rendered ="#{!questionpool.infoDuplicatedQuestion.isEmpty()}" escape="false" styleClass="sak-banner-info"/>
 <h:messages styleClass="sak-banner-error" rendered="#{facesContext.maximumSeverity ne null}" layout="table"/>
 
 <h:outputText rendered="#{questionpool.importToAuthoring eq true}" value="#{questionPoolMessages.msg_imp_editpool}"/>


### PR DESCRIPTION
SAK-49891 Tests & Quizzes: Allow question to be copied into the current question pool (duplicate question)

https://sakaiproject.atlassian.net/browse/SAK-49891


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moving and copying questions now always proceeds even if the destination already contains the question; operations complete for all selected items and destinations.
  * When a duplicate would result, an informational banner appears on the pool edit page to notify users of the duplicated question (displayed once per operation).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->