### PR TITLE
SAK-52585 Gradebook table Change edit trigger event to single click

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -937,13 +937,18 @@ GbGradeTable.renderTable = function (elementId, tableData) {
       const studentId = student.userId;
       const assignmentId = column.assignmentId;
 
+      const row = cell.getRow();
       GbGradeTable.setScore(studentId, assignmentId, oldScore, newScore)
         .then(() => {
-          GbGradeTable.reformatPreservingEditor(cell.getRow());
+          if (!row.getElement().querySelector(".tabulator-cell.tabulator-editing")) {
+            row.reformat();
+          }
         })
         .catch(error => {
           console.error("Error updating score:", error);
-          GbGradeTable.reformatPreservingEditor(cell.getRow());
+          if (!row.getElement().querySelector(".tabulator-cell.tabulator-editing")) {
+            row.reformat();
+          }
         });
     }
   });
@@ -1812,15 +1817,6 @@ GbGradeTable.redrawCells = function(cells) {
 
     rowComponent && rowComponent.reformat();
   });
-};
-
-GbGradeTable.reformatPreservingEditor = function(row) {
-  const editingEl = document.querySelector(".tabulator-cell.tabulator-editing");
-  row.reformat();
-  if (editingEl && !editingEl.querySelector("input")) {
-    const editRow = GbGradeTable.instance.getRows()[+editingEl.dataset.rowIndex];
-    editRow?.getCells()?.[+editingEl.dataset.colIndex]?.edit(true);
-  }
 };
 
 GbGradeTable.formatCategoryAverage = function(value) {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -895,14 +895,6 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     }
   });
 
-  // Prevent clicks on interactive cell elements from triggering the cell editor
-  const editBlockSelectors = [".dropdown-toggle", ".gb-comment-notification", ".gb-notification", ".gb-view-grade-summary"];
-  GbGradeTable.domElement[0].addEventListener("click", e => {
-    if (e.target.closest(editBlockSelectors.map(s => `.tabulator-cell ${s}`).join(", "))) {
-      e.stopPropagation();
-    }
-  }, true);
-
   GbGradeTable.instance.on("headerClick", (e, column) => {
     if (e.target.classList.contains('gb-title')) {
       const table = column.getTable();
@@ -947,11 +939,11 @@ GbGradeTable.renderTable = function (elementId, tableData) {
 
       GbGradeTable.setScore(studentId, assignmentId, oldScore, newScore)
         .then(() => {
-          cell.getRow().reformat();
+          GbGradeTable.reformatPreservingEditor(cell.getRow());
         })
         .catch(error => {
           console.error("Error updating score:", error);
-          cell.getRow().reformat();
+          GbGradeTable.reformatPreservingEditor(cell.getRow());
         });
     }
   });
@@ -1820,6 +1812,15 @@ GbGradeTable.redrawCells = function(cells) {
 
     rowComponent && rowComponent.reformat();
   });
+};
+
+GbGradeTable.reformatPreservingEditor = function(row) {
+  const editingEl = document.querySelector(".tabulator-cell.tabulator-editing");
+  row.reformat();
+  if (editingEl && !editingEl.querySelector("input")) {
+    const editRow = GbGradeTable.instance.getRows()[+editingEl.dataset.rowIndex];
+    editRow?.getCells()?.[+editingEl.dataset.colIndex]?.edit(true);
+  }
 };
 
 GbGradeTable.formatCategoryAverage = function(value) {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -882,7 +882,7 @@ GbGradeTable.renderTable = function (elementId, tableData) {
     movableColumns: true,
     height: GbGradeTable.calculateIdealHeight(),
     resizable: allowColumnResizing,
-    editTriggerEvent:"dblclick",
+    editTriggerEvent:"click",
     selectableRange:1,
     selectableRangeColumns:true,
     selectableRangeClearCells:true,
@@ -893,6 +893,11 @@ GbGradeTable.renderTable = function (elementId, tableData) {
       rowElement.setAttribute("scope", "row");
       rowElement.classList.add("border-bottom");
     }
+  });
+
+  // Prevent clicks on interactive cell elements from triggering the cell editor
+  $(GbGradeTable.domElement).on("click", ".tabulator-cell .dropdown-toggle, .tabulator-cell .gb-comment-notification, .tabulator-cell .gb-notification, .tabulator-cell .gb-view-grade-summary", function(event) {
+    event.stopPropagation();
   });
 
   GbGradeTable.instance.on("headerClick", (e, column) => {

--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -896,9 +896,12 @@ GbGradeTable.renderTable = function (elementId, tableData) {
   });
 
   // Prevent clicks on interactive cell elements from triggering the cell editor
-  $(GbGradeTable.domElement).on("click", ".tabulator-cell .dropdown-toggle, .tabulator-cell .gb-comment-notification, .tabulator-cell .gb-notification, .tabulator-cell .gb-view-grade-summary", function(event) {
-    event.stopPropagation();
-  });
+  const editBlockSelectors = [".dropdown-toggle", ".gb-comment-notification", ".gb-notification", ".gb-view-grade-summary"];
+  GbGradeTable.domElement[0].addEventListener("click", e => {
+    if (e.target.closest(editBlockSelectors.map(s => `.tabulator-cell ${s}`).join(", "))) {
+      e.stopPropagation();
+    }
+  }, true);
 
   GbGradeTable.instance.on("headerClick", (e, column) => {
     if (e.target.classList.contains('gb-title')) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grade cells now open the in-cell editor with a single click instead of a double-click, streamlining edits.

* **Bug Fixes**
  * Row reformatting after a score save now avoids forcing a reformat when an in-cell editor is active, preserving the editor state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->