### PR TITLE
SAK-52166 Samigo improve importing embedded images with spaces in filenames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - `npm run analyze` - Run lit-analyzer for static type checking
 
 ## Architecture
+- **Request-Scoped State**: Do not use `ThreadLocal`, static fields, or singleton bean fields to pass request/import/user/site-specific state through service calls. Sakai runs on pooled application-server threads, so thread-bound state can leak across requests if cleanup is missed. Prefer explicit return values, operation-scoped helper instances, DTO/result objects, or method parameters.
 
 ### Kernel
 - **Core Services**: The Kernel provides core services that should be used by all tools

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorImportExport.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorImportExport.properties
@@ -46,8 +46,8 @@ import_err_pool = There was an error importing this pool. Ensure that the file i
 import_qti_not_found = There was an error importing this assessment. Ensure that the QTI file name is correct.
 respondus_matching_err_1 = has imported, but there is a problem with the following questions:
 respondus_matching_err_2 = To display in this system, items and choices in matching questions must be paired one to one. Please edit this assessment to add pairs to each question, or delete the question altogether.
-import_attachment_warning = "{0}" was imported, but some attachments could not be migrated and were skipped: {1}. Please review the imported assessment.
-import_attachment_warning_more = , ... ({0} more)
+import_attachment_warning = "{0}" was imported, but some attachments could not be migrated and were skipped: {1}. Please review this import.
+import_attachment_warning_more = ... ({0} more)
 
 import_size_too_big={0} could not be imported because there is a file size limit of {1}MB per import.
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorImportExport.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AuthorImportExport.properties
@@ -46,6 +46,8 @@ import_err_pool = There was an error importing this pool. Ensure that the file i
 import_qti_not_found = There was an error importing this assessment. Ensure that the QTI file name is correct.
 respondus_matching_err_1 = has imported, but there is a problem with the following questions:
 respondus_matching_err_2 = To display in this system, items and choices in matching questions must be paired one to one. Please edit this assessment to add pairs to each question, or delete the question altogether.
+import_attachment_warning = "{0}" was imported, but some attachments could not be migrated and were skipped: {1}. Please review the imported assessment.
+import_attachment_warning_more = , ... ({0} more)
 
 import_size_too_big={0} could not be imported because there is a file size limit of {1}MB per import.
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/qti/XMLImportBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/qti/XMLImportBean.java
@@ -447,7 +447,7 @@ public class XMLImportBean implements Serializable {
 	}
     AuthoringHelper authoringHelper = new AuthoringHelper(qti);
     AssessmentFacade assessment = isCP
-        ? authoringHelper.createImportedAssessment(document, fullFileName.substring(0, fullFileName.lastIndexOf("/")), isRespondus, failedMatchingQuestions)
+        ? authoringHelper.createImportedAssessment(document, new File(fullFileName).getParent(), isRespondus, failedMatchingQuestions)
         : authoringHelper.createImportedAssessment(document, null, isRespondus, failedMatchingQuestions);
     skippedAttachments.addAll(authoringHelper.getSkippedAttachments());
     return assessment;
@@ -602,7 +602,7 @@ public class XMLImportBean implements Serializable {
 	}
     AuthoringHelper authoringHelper = new AuthoringHelper(qti);
     QuestionPoolFacade questionPool = isCP
-        ? authoringHelper.createImportedQuestionPool(document, fullFileName.substring(0, fullFileName.lastIndexOf("/")), isRespondus, failedMatchingQuestions)
+        ? authoringHelper.createImportedQuestionPool(document, new File(fullFileName).getParent(), isRespondus, failedMatchingQuestions)
         : authoringHelper.createImportedQuestionPool(document, null, isRespondus, failedMatchingQuestions);
     skippedAttachments.addAll(authoringHelper.getSkippedAttachments());
     return questionPool;

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/qti/XMLImportBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/qti/XMLImportBean.java
@@ -54,10 +54,10 @@ import org.sakaiproject.tool.assessment.facade.QuestionPoolFacade;
 import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceHelper;
 import org.sakaiproject.tool.assessment.qti.constants.QTIVersion;
+import org.sakaiproject.tool.assessment.qti.helper.AuthoringHelper;
 import org.sakaiproject.tool.assessment.qti.util.XmlUtil;
 import org.sakaiproject.tool.assessment.services.QuestionPoolService;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
-import org.sakaiproject.tool.assessment.services.qti.QTIService;
 import org.sakaiproject.tool.assessment.ui.bean.author.AssessmentBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.ItemAuthorBean;
@@ -285,12 +285,12 @@ public class XMLImportBean implements Serializable {
   private void processFile(String fileName, String uploadFile, boolean isRespondus) throws Exception
   {
     itemAuthorBean.setTarget(ItemAuthorBean.FROM_ASSESSMENT); // save to assessment
-    QTIService.clearLastSkippedAttachments();
 
     AssessmentService assessmentService = new AssessmentService();
     // Create an assessment based on the uploaded file
     List failedMatchingQuestions = new ArrayList();
-    AssessmentFacade assessment = createImportedAssessment(fileName, qtiVersion, isRespondus, failedMatchingQuestions);
+    List<String> skippedAttachments = new ArrayList<>();
+    AssessmentFacade assessment = createImportedAssessment(fileName, qtiVersion, isRespondus, failedMatchingQuestions, skippedAttachments);
     if (failedMatchingQuestions.size() > 0)
     {
       String importedFilename = getImportedFilename(uploadFile);	
@@ -311,7 +311,6 @@ public class XMLImportBean implements Serializable {
       FacesContext.getCurrentInstance().addMessage(null, message);
     }
 
-    List<String> skippedAttachments = QTIService.getLastSkippedAttachments();
     if (!skippedAttachments.isEmpty()) {
       String importedFilename = getImportedFilename(uploadFile);
       String warningText = MessageFormat.format(
@@ -437,7 +436,7 @@ public class XMLImportBean implements Serializable {
    * @return
    */
   
-  private AssessmentFacade createImportedAssessment(String fullFileName, int qti, boolean isRespondus, List failedMatchingQuestions) throws Exception
+  private AssessmentFacade createImportedAssessment(String fullFileName, int qti, boolean isRespondus, List failedMatchingQuestions, List<String> skippedAttachments) throws Exception
   {
     //trim = true so that xml processing instruction at top line, even if not.
     Document document = null;
@@ -446,13 +445,12 @@ public class XMLImportBean implements Serializable {
 	} catch (Exception e) {
 		throw(e);
 	}
-    QTIService qtiService = new QTIService();
-    if (isCP) {
-    	return qtiService.createImportedAssessment(document, qti, fullFileName.substring(0, fullFileName.lastIndexOf("/")), isRespondus, failedMatchingQuestions, null);
-    }
-    else {
-    	return qtiService.createImportedAssessment(document, qti, null, isRespondus, failedMatchingQuestions, null);
-    }
+    AuthoringHelper authoringHelper = new AuthoringHelper(qti);
+    AssessmentFacade assessment = isCP
+        ? authoringHelper.createImportedAssessment(document, fullFileName.substring(0, fullFileName.lastIndexOf("/")), isRespondus, failedMatchingQuestions)
+        : authoringHelper.createImportedAssessment(document, null, isRespondus, failedMatchingQuestions);
+    skippedAttachments.addAll(authoringHelper.getSkippedAttachments());
+    return assessment;
   }
 
   public AuthorBean getAuthorBean()
@@ -546,7 +544,6 @@ public class XMLImportBean implements Serializable {
     String fileName = uploadFile;
     String unzipLocation = null;
     boolean fileNotFound = false;
-    QTIService.clearLastSkippedAttachments();
     if (isCP) {
         ImportService importService = new ImportService();
         unzipLocation = importService.unzipImportFile(uploadFile);
@@ -595,7 +592,7 @@ public class XMLImportBean implements Serializable {
    * @return
  * @throws Exception 
    */
-  private QuestionPoolFacade createImportedQuestionPool(String fullFileName, int qti, boolean isRespondus, List failedMatchingQuestions) throws Exception {
+  private QuestionPoolFacade createImportedQuestionPool(String fullFileName, int qti, boolean isRespondus, List failedMatchingQuestions, List<String> skippedAttachments) throws Exception {
     //trim = true so that xml processing instruction at top line, even if not.
     Document document;
 	try {
@@ -603,12 +600,12 @@ public class XMLImportBean implements Serializable {
 	} catch (Exception e) {
 		throw(e);
 	}
-    QTIService qtiService = new QTIService();
-    if (isCP) {
-        return qtiService.createImportedQuestionPool(document, qti, fullFileName.substring(0, fullFileName.lastIndexOf("/")), isRespondus, failedMatchingQuestions);
-    } else {
-        return qtiService.createImportedQuestionPool(document, qti, null, isRespondus, failedMatchingQuestions);
-    }
+    AuthoringHelper authoringHelper = new AuthoringHelper(qti);
+    QuestionPoolFacade questionPool = isCP
+        ? authoringHelper.createImportedQuestionPool(document, fullFileName.substring(0, fullFileName.lastIndexOf("/")), isRespondus, failedMatchingQuestions)
+        : authoringHelper.createImportedQuestionPool(document, null, isRespondus, failedMatchingQuestions);
+    skippedAttachments.addAll(authoringHelper.getSkippedAttachments());
+    return questionPool;
   }
   
   public QuestionPoolBean getQuestionPoolBean()
@@ -637,7 +634,8 @@ public class XMLImportBean implements Serializable {
     QuestionPoolService questionPoolService = new QuestionPoolService();
     // Create a pool based on the uploaded file
     List failedMatchingQuestions = new ArrayList();
-    QuestionPoolFacade questionPool = createImportedQuestionPool(fileName, qtiVersion, isRespondus, failedMatchingQuestions);
+    List<String> skippedAttachments = new ArrayList<>();
+    QuestionPoolFacade questionPool = createImportedQuestionPool(fileName, qtiVersion, isRespondus, failedMatchingQuestions, skippedAttachments);
     if (failedMatchingQuestions.size() > 0) {
       String importedFilename = getImportedFilename(uploadFile);
       StringBuffer sb = new StringBuffer("\"");
@@ -657,7 +655,6 @@ public class XMLImportBean implements Serializable {
       FacesContext.getCurrentInstance().addMessage(null, message);
     }
 
-    List<String> skippedAttachments = QTIService.getLastSkippedAttachments();
     if (!skippedAttachments.isEmpty()) {
       String importedFilename = getImportedFilename(uploadFile);
       String warningText = MessageFormat.format(

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/qti/XMLImportBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/qti/XMLImportBean.java
@@ -28,7 +28,6 @@ import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -48,7 +47,6 @@ import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.spring.SpringBeanLocator;
 import org.sakaiproject.tool.assessment.contentpackaging.ImportService;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
-import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacadeQueries;
 import org.sakaiproject.tool.assessment.facade.AssessmentTemplateFacade;
@@ -287,6 +285,7 @@ public class XMLImportBean implements Serializable {
   private void processFile(String fileName, String uploadFile, boolean isRespondus) throws Exception
   {
     itemAuthorBean.setTarget(ItemAuthorBean.FROM_ASSESSMENT); // save to assessment
+    QTIService.clearLastSkippedAttachments();
 
     AssessmentService assessmentService = new AssessmentService();
     // Create an assessment based on the uploaded file
@@ -309,6 +308,22 @@ public class XMLImportBean implements Serializable {
       sb.append(". ");
       sb.append(rb.getString("respondus_matching_err_2"));
       FacesMessage message = new FacesMessage(sb.toString());
+      FacesContext.getCurrentInstance().addMessage(null, message);
+    }
+
+    List<String> skippedAttachments = QTIService.getLastSkippedAttachments();
+    if (!skippedAttachments.isEmpty()) {
+      String importedFilename = getImportedFilename(uploadFile);
+      String warningText = MessageFormat.format(
+          rb.getString("import_attachment_warning"),
+          importedFilename,
+          buildSkippedAttachmentList(skippedAttachments));
+      if (skippedAttachments.size() > 5) {
+        warningText = warningText + MessageFormat.format(
+            rb.getString("import_attachment_warning_more"),
+            skippedAttachments.size() - 5);
+      }
+      FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_WARN, warningText, null);
       FacesContext.getCurrentInstance().addMessage(null, message);
     }
     
@@ -377,6 +392,26 @@ public class XMLImportBean implements Serializable {
 	  String temp_filename_3 = temp_filename_1.substring(0, temp_filename_1.substring(0, temp_filename_1.indexOf(".")).lastIndexOf("_"));
 	  String final_filename = temp_filename_3 + temp_filename_2;
 	  return final_filename;
+  }
+
+  private String extractAttachmentName(String attachmentReference) {
+    if (attachmentReference == null) {
+      return "";
+    }
+    int lastSlash = attachmentReference.lastIndexOf('/');
+    return lastSlash > -1 ? attachmentReference.substring(lastSlash + 1) : attachmentReference;
+  }
+
+  private String buildSkippedAttachmentList(List<String> skippedAttachments) {
+    StringBuilder skippedList = new StringBuilder();
+    int displayed = Math.min(skippedAttachments.size(), 5);
+    for (int i = 0; i < displayed; i++) {
+      if (i > 0) {
+        skippedList.append(", ");
+      }
+      skippedList.append(extractAttachmentName(skippedAttachments.get(i)));
+    }
+    return skippedList.toString();
   }
   
   private void deleteDirectory(File directory) {
@@ -511,6 +546,7 @@ public class XMLImportBean implements Serializable {
     String fileName = uploadFile;
     String unzipLocation = null;
     boolean fileNotFound = false;
+    QTIService.clearLastSkippedAttachments();
     if (isCP) {
         ImportService importService = new ImportService();
         unzipLocation = importService.unzipImportFile(uploadFile);
@@ -618,6 +654,22 @@ public class XMLImportBean implements Serializable {
       sb.append(". ");
       sb.append(rb.getString("respondus_matching_err_2"));
       FacesMessage message = new FacesMessage(sb.toString());
+      FacesContext.getCurrentInstance().addMessage(null, message);
+    }
+
+    List<String> skippedAttachments = QTIService.getLastSkippedAttachments();
+    if (!skippedAttachments.isEmpty()) {
+      String importedFilename = getImportedFilename(uploadFile);
+      String warningText = MessageFormat.format(
+          rb.getString("import_attachment_warning"),
+          importedFilename,
+          buildSkippedAttachmentList(skippedAttachments));
+      if (skippedAttachments.size() > 5) {
+        warningText = warningText + MessageFormat.format(
+            rb.getString("import_attachment_warning_more"),
+            skippedAttachments.size() - 5);
+      }
+      FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_WARN, warningText, null);
       FacesContext.getCurrentInstance().addMessage(null, message);
     }
 

--- a/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/questionpool/poolList.jsp
@@ -167,7 +167,7 @@
  
 <h:outputText rendered="#{questionpool.importToAuthoring eq false and authorization.createQuestionPool eq true}" escape="false" value="</p>"/>
 
-<h:messages styleClass="sak-banner-error" rendered="#{facesContext.maximumSeverity ne null}" layout="table"/>
+<h:messages styleClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
  
 <%@ include file="/jsf/questionpool/poolTreeTable.jsp" %>
 

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.tool.assessment.data.dao.assessment.*;
 import org.sakaiproject.tool.assessment.facade.*;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
+import org.sakaiproject.tool.assessment.services.qti.QTIService;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.cover.SecurityService;
 import org.w3c.dom.Document;
@@ -72,14 +73,6 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.questionpool.QuestionPoolItemIfc;
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
-import org.sakaiproject.tool.assessment.facade.AgentFacade;
-import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
-import org.sakaiproject.tool.assessment.facade.ItemFacade;
-import org.sakaiproject.tool.assessment.facade.QuestionPoolAccessFacade;
-import org.sakaiproject.tool.assessment.facade.QuestionPoolFacade;
-import org.sakaiproject.tool.assessment.facade.QuestionPoolIteratorFacade;
-import org.sakaiproject.tool.assessment.facade.SectionFacade;
-import org.sakaiproject.tool.assessment.facade.TypeFacade;
 import org.sakaiproject.tool.assessment.integration.helper.integrated.AgentHelperImpl;
 import org.sakaiproject.tool.assessment.qti.asi.Assessment;
 import org.sakaiproject.tool.assessment.qti.asi.Item;
@@ -1077,6 +1070,7 @@ public class AuthoringHelper
       
       // Assessment Attachment
       exHelper.makeAssessmentAttachmentSet(assessment);
+      QTIService.setLastSkippedAttachments(exHelper.getSkippedAttachments());
 
       assessmentService.saveAssessment(assessment);
       return assessment;
@@ -1231,12 +1225,13 @@ public class AuthoringHelper
 
                item = itemService.saveItem(item);
                EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SAVEITEM, "/sam/" + AgentFacade.getCurrentSiteId() + "/saved itemId=" + item.getItemId().toString(), true));
-               
+
                QuestionPoolItemData questionPoolItem = new QuestionPoolItemData();
+               QTIService.setLastSkippedAttachments(exHelper.getSkippedAttachments());
                questionPoolItem.setQuestionPoolId(questionpool.getQuestionPoolId());
-               questionPoolItem.setItemId(item.getItemId());         
+               questionPoolItem.setItemId(item.getItemId());
                questionpool.addQuestionPoolItem((QuestionPoolItemIfc) questionPoolItem);
-               
+
              } // ... end for each item
       }
       // need error message if more than one section, for now

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/AuthoringHelper.java
@@ -45,7 +45,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.tool.assessment.data.dao.assessment.*;
 import org.sakaiproject.tool.assessment.facade.*;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
-import org.sakaiproject.tool.assessment.services.qti.QTIService;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.cover.SecurityService;
 import org.w3c.dom.Document;
@@ -110,6 +109,7 @@ public class AuthoringHelper
   private AuthoringXml ax;
 
   private int qtiVersion;
+  private List<String> skippedAttachments = new ArrayList<>();
   private static final String VALIDATE_XSD_PATH ="xml/xsd/";
 
 
@@ -131,6 +131,16 @@ public class AuthoringHelper
         "Version Codes supported: QTIVersion.VERSION_1_2, QTIVersion.VERSION_2_0");
     }
     ax = new AuthoringXml(qtiVersion);
+  }
+
+  public List<String> getSkippedAttachments()
+  {
+    return new ArrayList<>(skippedAttachments);
+  }
+
+  private void setSkippedAttachments(ExtractionHelper exHelper)
+  {
+    skippedAttachments = exHelper.getSkippedAttachments();
   }
 
   /**
@@ -1070,7 +1080,7 @@ public class AuthoringHelper
       
       // Assessment Attachment
       exHelper.makeAssessmentAttachmentSet(assessment);
-      QTIService.setLastSkippedAttachments(exHelper.getSkippedAttachments());
+      setSkippedAttachments(exHelper);
 
       assessmentService.saveAssessment(assessment);
       return assessment;
@@ -1227,7 +1237,6 @@ public class AuthoringHelper
                EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_ASSESSMENT_SAVEITEM, "/sam/" + AgentFacade.getCurrentSiteId() + "/saved itemId=" + item.getItemId().toString(), true));
 
                QuestionPoolItemData questionPoolItem = new QuestionPoolItemData();
-               QTIService.setLastSkippedAttachments(exHelper.getSkippedAttachments());
                questionPoolItem.setQuestionPoolId(questionpool.getQuestionPoolId());
                questionPoolItem.setItemId(item.getItemId());
                questionpool.addQuestionPoolItem((QuestionPoolItemIfc) questionPoolItem);
@@ -1238,6 +1247,7 @@ public class AuthoringHelper
        
       // update the questionpoool with all sections and items
       questionpool = questionPoolService.savePool(questionpool);
+      setSkippedAttachments(exHelper);
        
  	  return questionpool;		
  	}

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/ExtractionHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/ExtractionHelper.java
@@ -23,7 +23,10 @@
 
 package org.sakaiproject.tool.assessment.qti.helper;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -137,6 +140,8 @@ public class ExtractionHelper
   private MergeConfig mcx;
   private String unzipLocation;
   private String siteId;
+  private final List<String> skippedAttachments = new ArrayList<>();
+  private Map<String, File> importedAttachmentIndex;
 
 
   /**
@@ -1124,6 +1129,11 @@ public class ExtractionHelper
     	String fullFilePath = unzipLocation + "/" + attachmentInfo[0];
     	String filename = attachmentInfo[1];
     	ContentResource contentResource = attachmentHelper.createContentResource(fullFilePath, filename, attachmentInfo[2]);
+    	if (contentResource == null) {
+    	  log.warn("QTI Import - Physical file not found in ZIP package for assessment attachment {}. Migration of this resource will be skipped.", attachmentInfo[0]);
+    	  recordSkippedAttachment(attachmentInfo[0]);
+    	  continue;
+    	}
     	assessmentAttachment = assessmentService.createAssessmentAttachment(assessment, contentResource.getId(), filename, ServerConfigurationService.getServerUrl());
     	assessmentAttachment.setAssessment((AssessmentIfc)assessment.getData());
     	set.add(assessmentAttachment);
@@ -1159,6 +1169,11 @@ public class ExtractionHelper
     	String fullFilePath = unzipLocation + "/" + attachmentInfo[0];
     	String filename = attachmentInfo[1];
     	ContentResource contentResource = attachmentHelper.createContentResource(fullFilePath, filename, attachmentInfo[2]);
+    	if (contentResource == null) {
+    	  log.warn("QTI Import - Physical file not found in ZIP package for section attachment {}. Migration of this resource will be skipped.", attachmentInfo[0]);
+    	  recordSkippedAttachment(attachmentInfo[0]);
+    	  continue;
+    	}
     	sectionAttachment = assessmentService.createSectionAttachment(section, contentResource.getId(), filename, ServerConfigurationService.getServerUrl());
     	sectionAttachment.setSection(section.getData());
     	set.add(sectionAttachment);
@@ -1204,7 +1219,11 @@ public class ExtractionHelper
 		  } else {
 			  String fullFilePath = unzipLocation + "/" + attachmentInfo[0];
 			  ContentResource contentResource = attachmentHelper.createContentResource(fullFilePath, filename, attachmentInfo[2]);
-			  // contentResource could be null but is OK (exception catched)
+			  if (contentResource == null) {
+			    log.warn("QTI Import - Physical file not found in ZIP package for item attachment {}. Migration of this resource will be skipped.", attachmentInfo[0]);
+			    recordSkippedAttachment(attachmentInfo[0]);
+			    continue;
+			  }
 			  itemAttachment = assessmentService.createItemAttachment(item, contentResource.getId(), filename, ServerConfigurationService.getServerUrl());
 		  }
 		  itemAttachment.setItem(item.getData());
@@ -1231,7 +1250,6 @@ public class ExtractionHelper
 	  String referenceRoot = AssessmentService.getContentHostingService().REFERENCE_ROOT;
 	  String prependString = accessURL + referenceRoot;
 	  StringBuffer updatedText = null;
-	  ContentResource contentResource = null;
 	  AttachmentHelper attachmentHelper = new AttachmentHelper();
 	  String resourceId = null;
 		  String importedPrependString = getImportedPrependString(processedText);
@@ -1270,15 +1288,21 @@ public class ExtractionHelper
 			  // oldSplittedResourceId[1] = group or user
 			  // oldSplittedResourceId[2] = b917f0b9-e21d-4819-80ee-35feac91c9eb or ktsao
 			  // oldSplittedResourceId[3] = Blue Hill.jpg
+			  ContentResource contentResource = null;
 			  endIndex = splittedString[i].indexOf("\"",splittedString[i].indexOf("\"")+1);
 			  oldResourceId = splittedString[i].substring(splittedString[i].indexOf("\"")+1, endIndex);
-			  String[] oldSplittedResourceId = oldResourceId.split("/");
-			  fullFilePath = unzipLocation + "/" + oldResourceId.replace(" ", "");
+			  String decodedResourceId = decodeImportedAttachmentPath(oldResourceId);
+			  String[] oldSplittedResourceId = decodedResourceId.split("/");
 			  filename = oldSplittedResourceId[oldSplittedResourceId.length - 1];
-			  MimetypesFileTypeMap mimetypesFileTypeMap = new MimetypesFileTypeMap();
-			  contentType = mimetypesFileTypeMap.getContentType(filename);
-			  contentResource = attachmentHelper.createContentResource(fullFilePath, filename, contentType);
-
+			  fullFilePath = resolveImportedAttachmentPath(oldResourceId);
+			  if (fullFilePath != null) {
+			    MimetypesFileTypeMap mimetypesFileTypeMap = new MimetypesFileTypeMap();
+			    contentType = mimetypesFileTypeMap.getContentType(filename);
+			    contentResource = attachmentHelper.createContentResource(fullFilePath, filename, contentType);
+			  } else {
+			    log.warn("QTI Import - Physical file not found in ZIP package for resource " + oldResourceId + ". Migration of this resource will be skipped.");
+			    recordSkippedAttachment(oldResourceId);
+			  }
 			  if (contentResource != null) {
 				  resourceId = contentResource.getId();
 				  updatedText.append(splittedString[i].substring(0,splittedString[i].indexOf("\"")+1));
@@ -1287,11 +1311,167 @@ public class ExtractionHelper
 				  updatedText.append(splittedString[i].substring(endIndex));
 			  }
 			  else {
-				  throw new RuntimeException("resourceId is null");
+				  updatedText.append(splittedString[i].substring(0, endIndex));
+				  updatedText.append(splittedString[i].substring(endIndex));
 			  }
 
 		  }
 		  return updatedText.toString();	  
+  }
+
+  private String resolveImportedAttachmentPath(String resourceId)
+  {
+    if (unzipLocation == null || resourceId == null) {
+      return null;
+    }
+
+    File unzipRoot = new File(unzipLocation);
+    if (!unzipRoot.isDirectory()) {
+      return null;
+    }
+
+    String[] candidatePaths = new String[] {
+      stripLeadingSlash(resourceId),
+      stripLeadingSlash(decodeImportedAttachmentPath(resourceId)),
+      normalizeImportedAttachmentPath(resourceId),
+      normalizeImportedAttachmentPathWithoutSpaces(resourceId)
+    };
+
+    for (String candidatePath : candidatePaths) {
+      if (StringUtils.isBlank(candidatePath)) {
+        continue;
+      }
+      File candidateFile = new File(unzipRoot, candidatePath);
+      if (candidateFile.isFile()) {
+        return candidateFile.getPath();
+      }
+
+      File indexedMatch = getImportedAttachmentIndex().get(candidatePath);
+      if (indexedMatch != null) {
+        return indexedMatch.getPath();
+      }
+    }
+
+    return null;
+  }
+
+  private Map<String, File> getImportedAttachmentIndex()
+  {
+    if (importedAttachmentIndex != null) {
+      return importedAttachmentIndex;
+    }
+
+    Map<String, File> attachmentIndex = new HashMap<>();
+    buildImportedAttachmentIndex(new File(unzipLocation), "", attachmentIndex);
+    importedAttachmentIndex = attachmentIndex;
+    return importedAttachmentIndex;
+  }
+
+  private void buildImportedAttachmentIndex(File directory, String relativePath, Map<String, File> attachmentIndex)
+  {
+    if (directory == null || !directory.isDirectory()) {
+      return;
+    }
+
+    File[] children = directory.listFiles();
+    if (children == null) {
+      return;
+    }
+
+    for (File child : children) {
+      String childRelativePath = StringUtils.isBlank(relativePath) ? child.getName() : relativePath + "/" + child.getName();
+      if (child.isDirectory()) {
+        buildImportedAttachmentIndex(child, childRelativePath, attachmentIndex);
+      } else {
+        indexImportedAttachmentPath(attachmentIndex, normalizeImportedAttachmentPath(childRelativePath), child);
+        indexImportedAttachmentPath(attachmentIndex, normalizeImportedAttachmentPathWithoutSpaces(childRelativePath), child);
+      }
+    }
+  }
+
+  private void indexImportedAttachmentPath(Map<String, File> attachmentIndex, String key, File child)
+  {
+    if (StringUtils.isBlank(key) || child == null) {
+      return;
+    }
+
+    File existing = attachmentIndex.get(key);
+    if (existing == null) {
+      attachmentIndex.put(key, child);
+      return;
+    }
+
+    if (!existing.equals(child)) {
+      log.warn("QTI Import - Ambiguous attachment path after normalization: {} matches {} and {}", key, existing.getPath(), child.getPath());
+      attachmentIndex.put(key, null);
+    }
+  }
+
+  private String decodeImportedAttachmentPath(String resourceId)
+  {
+    if (resourceId == null) {
+      return null;
+    }
+
+    try {
+      return URLDecoder.decode(resourceId, StandardCharsets.UTF_8.name());
+    } catch (java.io.UnsupportedEncodingException e) {
+      log.warn("QTI Import - Could not decode resource URL: {}", resourceId);
+      return resourceId;
+    }
+  }
+
+  private String stripLeadingSlash(String path)
+  {
+    if (path == null) {
+      return null;
+    }
+    return path.startsWith("/") ? path.substring(1) : path;
+  }
+
+  private String normalizeImportedAttachmentPath(String resourceId)
+  {
+    String decodedPath = stripLeadingSlash(decodeImportedAttachmentPath(resourceId));
+    if (decodedPath == null) {
+      return null;
+    }
+    return normalizePathSeparators(decodedPath);
+  }
+
+  private String normalizeImportedAttachmentPathWithoutSpaces(String resourceId)
+  {
+    String normalizedPath = normalizeImportedAttachmentPath(resourceId);
+    if (normalizedPath == null) {
+      return null;
+    }
+
+    StringBuilder stripped = new StringBuilder(normalizedPath.length());
+    for (int i = 0; i < normalizedPath.length(); i++) {
+      char character = normalizedPath.charAt(i);
+      int characterType = Character.getType(character);
+      if (Character.isWhitespace(character) || characterType == Character.FORMAT || characterType == Character.CONTROL) {
+        continue;
+      }
+      stripped.append(character);
+    }
+    return stripped.toString();
+  }
+
+  private String normalizePathSeparators(String path)
+  {
+    if (path == null) {
+      return null;
+    }
+
+    StringBuilder normalized = new StringBuilder(path.length());
+    for (int i = 0; i < path.length(); i++) {
+      char character = path.charAt(i);
+      if (character == '\\') {
+        character = '/';
+      }
+      normalized.append(Character.toLowerCase(character));
+    }
+    return normalized.toString();
   }
   
   public String makeFCKAttachmentFromRespondus(String text) {  
@@ -1338,6 +1518,7 @@ public class ExtractionHelper
 			  updatedText.append(makeAudioAttachment(splittedString[i].substring(endIndex), url));
 		  }
 		  else {
+			  recordSkippedAttachment(filename);
 			  throw new RuntimeException("resourceId is null");
 		  }
 	  }
@@ -1372,6 +1553,7 @@ public class ExtractionHelper
 			  updatedText.append(makeOtherAttachment(splittedString[i].substring(endIndex), url));
 		  }
 		  else {
+			  recordSkippedAttachment(filename);
 			  throw new RuntimeException("resourceId is null");
 		  }
 	  }
@@ -1405,6 +1587,7 @@ public class ExtractionHelper
 			  updatedText.append(splittedString[i].substring(endIndex));
 		  }
 		  else {
+			  recordSkippedAttachment(filename);
 			  throw new RuntimeException("resourceId is null");
 		  }
 	  }
@@ -1475,7 +1658,22 @@ public class ExtractionHelper
 
 	  return updatedText.toString();
   }
-  
+
+  public List<String> getSkippedAttachments()
+  {
+    return new ArrayList<>(skippedAttachments);
+  }
+
+  private void recordSkippedAttachment(String attachmentReference)
+  {
+    if (StringUtils.isBlank(attachmentReference)) {
+      return;
+    }
+    if (!skippedAttachments.contains(attachmentReference)) {
+      skippedAttachments.add(attachmentReference);
+    }
+  }
+
   private String getImportedPrependString(String text) {
 		String accessPath = ServerConfigurationService.getAccessPath();
 		String referenceRoot = AssessmentService.getContentHostingService().REFERENCE_ROOT;
@@ -3092,6 +3290,7 @@ public class ExtractionHelper
   public void setUnzipLocation(String unzipLocation)
   {
     this.unzipLocation = unzipLocation;
+    this.importedAttachmentIndex = null;
   }
 
   public void setMcx(MergeConfig mcx)

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/ExtractionHelper.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/ExtractionHelper.java
@@ -1300,7 +1300,7 @@ public class ExtractionHelper
 			    contentType = mimetypesFileTypeMap.getContentType(filename);
 			    contentResource = attachmentHelper.createContentResource(fullFilePath, filename, contentType);
 			  } else {
-			    log.warn("QTI Import - Physical file not found in ZIP package for resource " + oldResourceId + ". Migration of this resource will be skipped.");
+			    log.warn("QTI Import - Physical file not found in ZIP package for resource {}. Migration of this resource will be skipped.", oldResourceId);
 			    recordSkippedAttachment(oldResourceId);
 			  }
 			  if (contentResource != null) {
@@ -1330,6 +1330,15 @@ public class ExtractionHelper
       return null;
     }
 
+    String unzipRootCanonicalPath;
+    try {
+      unzipRootCanonicalPath = unzipRoot.getCanonicalPath();
+    } catch (IOException e) {
+      log.warn("QTI Import - Could not resolve ZIP root path {}", unzipRoot.getPath(), e);
+      return null;
+    }
+    String unzipRootCanonicalPrefix = unzipRootCanonicalPath + File.separator;
+
     String[] candidatePaths = new String[] {
       stripLeadingSlash(resourceId),
       stripLeadingSlash(decodeImportedAttachmentPath(resourceId)),
@@ -1343,16 +1352,35 @@ public class ExtractionHelper
       }
       File candidateFile = new File(unzipRoot, candidatePath);
       if (candidateFile.isFile()) {
-        return candidateFile.getPath();
+        try {
+          String candidateCanonicalPath = candidateFile.getCanonicalPath();
+          if (isWithinUnzipRoot(unzipRootCanonicalPath, unzipRootCanonicalPrefix, candidateCanonicalPath)) {
+            return candidateCanonicalPath;
+          }
+        } catch (IOException e) {
+          log.warn("QTI Import - Could not resolve candidate attachment path {}", candidateFile.getPath(), e);
+        }
       }
 
       File indexedMatch = getImportedAttachmentIndex().get(candidatePath);
       if (indexedMatch != null) {
-        return indexedMatch.getPath();
+        try {
+          String indexedCanonicalPath = indexedMatch.getCanonicalPath();
+          if (isWithinUnzipRoot(unzipRootCanonicalPath, unzipRootCanonicalPrefix, indexedCanonicalPath)) {
+            return indexedCanonicalPath;
+          }
+        } catch (IOException e) {
+          log.warn("QTI Import - Could not resolve indexed attachment path {}", indexedMatch.getPath(), e);
+        }
       }
     }
 
     return null;
+  }
+
+  private boolean isWithinUnzipRoot(String unzipRootCanonicalPath, String unzipRootCanonicalPrefix, String candidateCanonicalPath)
+  {
+    return candidateCanonicalPath != null && (candidateCanonicalPath.equals(unzipRootCanonicalPath) || candidateCanonicalPath.startsWith(unzipRootCanonicalPrefix));
   }
 
   private Map<String, File> getImportedAttachmentIndex()

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/services/qti/QTIService.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/services/qti/QTIService.java
@@ -21,7 +21,6 @@
 
 package org.sakaiproject.tool.assessment.services.qti;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
@@ -44,33 +43,8 @@ import org.w3c.dom.Document;
  */
 public class QTIService implements QTIServiceAPI
 {
-  private static final ThreadLocal<List<String>> lastSkippedAttachments = new ThreadLocal<>();
-
   public QTIService()
   {
-  }
-
-  public static void setLastSkippedAttachments(List<String> skippedAttachments)
-  {
-    if (skippedAttachments == null || skippedAttachments.isEmpty()) {
-      lastSkippedAttachments.remove();
-      return;
-    }
-    lastSkippedAttachments.set(new ArrayList<>(skippedAttachments));
-  }
-
-  public static List<String> getLastSkippedAttachments()
-  {
-    List<String> skippedAttachments = lastSkippedAttachments.get();
-    if (skippedAttachments == null) {
-      return new ArrayList<>();
-    }
-    return new ArrayList<>(skippedAttachments);
-  }
-
-  public static void clearLastSkippedAttachments()
-  {
-    lastSkippedAttachments.remove();
   }
 
     //IMPORTING ASSESSMENT

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/services/qti/QTIService.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/services/qti/QTIService.java
@@ -24,17 +24,15 @@ package org.sakaiproject.tool.assessment.services.qti;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.w3c.dom.Document;
-
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
 import org.sakaiproject.tool.assessment.facade.ItemFacade;
 import org.sakaiproject.tool.assessment.facade.QuestionPoolFacade;
 import org.sakaiproject.tool.assessment.qti.constants.QTIVersion;
-import org.sakaiproject.tool.assessment.qti.exception.RespondusMatchingException;
 import org.sakaiproject.tool.assessment.qti.helper.AuthoringHelper;
 import org.sakaiproject.tool.assessment.qti.util.XmlUtil;
 import org.sakaiproject.tool.assessment.shared.api.qti.QTIServiceAPI;
 import org.sakaiproject.util.MergeConfig;
+import org.w3c.dom.Document;
 /**
  * <p>This service provides translation between database and QTI representations.
  * This is used to import/export IMS QTI format XML, and for web services.
@@ -46,8 +44,33 @@ import org.sakaiproject.util.MergeConfig;
  */
 public class QTIService implements QTIServiceAPI
 {
+  private static final ThreadLocal<List<String>> lastSkippedAttachments = new ThreadLocal<>();
+
   public QTIService()
   {
+  }
+
+  public static void setLastSkippedAttachments(List<String> skippedAttachments)
+  {
+    if (skippedAttachments == null || skippedAttachments.isEmpty()) {
+      lastSkippedAttachments.remove();
+      return;
+    }
+    lastSkippedAttachments.set(new ArrayList<>(skippedAttachments));
+  }
+
+  public static List<String> getLastSkippedAttachments()
+  {
+    List<String> skippedAttachments = lastSkippedAttachments.get();
+    if (skippedAttachments == null) {
+      return new ArrayList<>();
+    }
+    return new ArrayList<>(skippedAttachments);
+  }
+
+  public static void clearLastSkippedAttachments()
+  {
+    lastSkippedAttachments.remove();
   }
 
     //IMPORTING ASSESSMENT


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imports now track attachments that can’t be migrated and display a warning after import, including the imported filename and a truncated list of skipped items (with an additional count when applicable).
  * Added localized text for these attachment-migration warnings.

* **Bug Fixes**
  * Improved reliability of the question pool list banner so warnings/errors render correctly.

* **Improvements**
  * Enhanced attachment/resource resolution during imports so missing items are identified more accurately and reflected in the post-import warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->