### PR TITLE
SAK-52559 LTI Change Location of deployment_id in UI

### DIFF
--- a/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/lti/lti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -105,7 +105,6 @@ public interface LTIService extends LTISubstitutionsFilter {
             "description:textarea:label=bl_description:maxlength=4096:archive=true",
             "status:radio:label=bl_status:choices=enable,disable",
             "visible:radio:label=bl_visible:choices=visible,stealth:role=admin",
-            "deployment_id:text:label=bl_deployment_id:maxlength=255:role=admin:archive=true",
             "launch:url:label=bl_launch:maxlength=1024:required=true:archive=true",
             "newpage:radio:label=bl_newpage:choices=off,on,content:archive=true",
             "frameheight:integer:label=bl_frameheight:archive=true",
@@ -142,8 +141,9 @@ public interface LTIService extends LTISubstitutionsFilter {
             "lti13:radio:label=bl_lti13:choices=off,on,both:role=admin:archive=true",
 
             // LTI 1.3 security values from the tool
-            "lti13_tool_security:header:fields=lti13_tool_keyset,lti13_oidc_endpoint,lti13_oidc_redirect",
+            "lti13_tool_security:header:fields=lti13_tool_keyset,deployment_id,lti13_oidc_endpoint,lti13_oidc_redirect",
             "lti13_tool_keyset:text:label=bl_lti13_tool_keyset:maxlength=1024:role=admin",  // From the tool - keep legacy field name
+            "deployment_id:text:label=bl_deployment_id:maxlength=255:role=admin:archive=true",
             "lti13_oidc_endpoint:text:label=bl_lti13_oidc_endpoint:maxlength=1024:role=admin",  // From the tool - keep legacy field name
             "lti13_oidc_redirect:text:label=bl_lti13_oidc_redirect:maxlength=1024:role=admin",  // From the tool - keep legacy field name
 

--- a/lti/lti-impl/src/bundle/ltiservice.properties
+++ b/lti/lti-impl/src/bundle/ltiservice.properties
@@ -32,7 +32,6 @@ bl_status_disable=Disabled
 bl_visible=Tool Visibility
 bl_visible_visible=Visible
 bl_visible_stealth=Stealthed (Manual Deployment)
-bl_deployment_id=Deployment ID (optional; max 255 characters)
 bl_launch=Launch URL (1.1) / Target Link URI (1.3)
 bl_allowlaunch=Allow launch URL to be changed
 bl_allowlaunch_allow=Allow
@@ -118,6 +117,7 @@ bl_lti13_lms_endpoint=LTI 1.3 LMS OIDC Endpoint URL (provide to the tool)
 bl_lti13_lms_token=LTI 1.3 LMS OAuth Token URL (provide to the tool)
 
 lti13_tool_security=All of these values are required for LTI 1.3 to function.  These values can be retrieved from an LTI 1.3 tool using dynamic registration or by entering the values from the tool here.
+bl_deployment_id=LTI 1.3 Deployment ID (optional; max 255 characters)
 bl_lti13_oidc_endpoint=LTI 1.3 Tool OpenID Connect/Initialization Endpoint (provided by the tool)
 bl_lti13_oidc_redirect=LTI 1.3 Tool Redirect Endpoint(s) (comma separated and provided by the tool)
 bl_lti13_tool_keyset=LTI 1.3 Tool Keyset / JWK URL (provided by the tool)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized the Deployment ID field into the LTI 1.3 tool-security section and updated its label to specify LTI 1.3.
  * Updated the tool-security header to include Deployment ID among displayed security-related fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->