### PR TITLE
SAK-52596 Microsoft - Checking decryptedSecret on getGraphClient() method

### DIFF
--- a/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
+++ b/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
@@ -149,6 +149,8 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 
+import static org.sakaiproject.microsoft.impl.MicrosoftConfigurationServiceImpl.decrypt;
+
 @Slf4j
 @Transactional
 public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
@@ -215,11 +217,17 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 					log.debug(MicrosoftCredentials.KEY_SCOPE+"="+microsoftCredentials.getScope());
 					log.debug(MicrosoftCredentials.KEY_AUTHORITY+"="+microsoftCredentials.getAuthority());
 
+					String decryptedSecret = decrypt(microsoftCredentials.getSecret());
+					if (decryptedSecret == null) {
+						log.error("Failed to decrypt Microsoft secret. Check your microsoft.encryption.key.");
+						throw new MicrosoftInvalidCredentialsException();
+					}
+
 					TokenCredential credential = new ClientSecretCredentialBuilder()
 							.authorityHost(microsoftCredentials.getAuthority())
 							.tenantId(microsoftCredentials.getTenantId())
 							.clientId(microsoftCredentials.getClientId())
-							.clientSecret(microsoftCredentials.getSecret())
+							.clientSecret(decryptedSecret)
 							.build();
 					this.graphClient = new GraphServiceClient(credential, microsoftCredentials.getScope());
 


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft integration: client secrets are now processed securely before use, improving authentication reliability and providing clearer error feedback when credentials are invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->