### PR TITLE
SAK-52589 Global use UserSortNameComparator with preferred locale

### DIFF
--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -83,6 +84,7 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.MergedList;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 
 /**
  * Allows some basic functions on announcements.
@@ -267,7 +269,7 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 				for (Message msg : announcements) {
 					messageList.add(new AnnouncementWrapper((AnnouncementMessage) msg, defaultChannel, null, null));
 				}
-				Comparator<AnnouncementWrapper> sortedAnnouncements = new AnnouncementWrapperComparator(sortCurrentOrder, announcementSortAsc);
+				Comparator<AnnouncementWrapper> sortedAnnouncements = new AnnouncementWrapperComparator(sortCurrentOrder, announcementSortAsc, getLocale());
 				messageList.sort(sortedAnnouncements);
 				announcements.clear();
 				announcements.addAll(messageList);
@@ -864,5 +866,12 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 	
 	@Setter
 	private ToolManager toolManager;
+
+	@Setter
+	private LocaleService localeService;
+
+	private Locale getLocale() {
+		return localeService.getLocaleForCurrentSiteAndUser();
+	}
 	
 }

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Properties;
@@ -106,6 +107,7 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.SortedIterator;
 import org.sakaiproject.util.StringUtil;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.event.api.Event;
 
 /**
@@ -256,6 +258,8 @@ public class AnnouncementAction extends PagedResourceActionII
 
     private FormattedText formattedText;
 
+    private LocaleService localeService;
+
     private enum BulkOperation {
 
         DELETE("delete"),
@@ -281,6 +285,11 @@ public class AnnouncementAction extends PagedResourceActionII
         userDirectoryService = ComponentManager.get(UserDirectoryService.class);
         serverConfigurationService = ComponentManager.get(ServerConfigurationService.class);
         formattedText = ComponentManager.get(FormattedText.class);
+        localeService = ComponentManager.get(LocaleService.class);
+    }
+
+    private Locale getLocale() {
+        return localeService.getLocaleForCurrentSiteAndUser();
     }
 
 	public String getCurrentOrder() {
@@ -954,7 +963,7 @@ public class AnnouncementAction extends PagedResourceActionII
 				//context.put("groups", groups);
 				Collection<Group> sortedGroups = new ArrayList<>();
 
-				for (Iterator<Group> i = new SortedIterator(groups.iterator(), new AnnouncementGroupComparator(AnnouncementGroupComparator.Criteria.TITLE, true)); i.hasNext();)
+				for (Iterator<Group> i = new SortedIterator(groups.iterator(), new AnnouncementGroupComparator(AnnouncementGroupComparator.Criteria.TITLE, true, getLocale())); i.hasNext();)
 					{
 						sortedGroups.add(i.next());
 					}
@@ -992,10 +1001,10 @@ public class AnnouncementAction extends PagedResourceActionII
 		SortedIterator<AnnouncementWrapper> sortedMessageIterator;
 		//For Announcement in User's MyWorkspace, the sort order for announcement is by date SAK-22667
 		if (isOnWorkspaceTab()){
-			sortedMessageIterator = new SortedIterator<>(messageList.iterator(), new AnnouncementWrapperComparator(SORT_DATE, state.getCurrentSortAsc()));
+			sortedMessageIterator = new SortedIterator<>(messageList.iterator(), new AnnouncementWrapperComparator(SORT_DATE, state.getCurrentSortAsc(), getLocale()));
 		} else {
 			sortedMessageIterator = new SortedIterator<>(messageList.iterator(), new AnnouncementWrapperComparator(state
-					.getCurrentSortedBy(), state.getCurrentSortAsc()));
+					.getCurrentSortedBy(), state.getCurrentSortAsc(), getLocale()));
 		}
 		
 		while (sortedMessageIterator.hasNext())
@@ -1720,7 +1729,7 @@ public class AnnouncementAction extends PagedResourceActionII
 				if (groups.size() > 0)
 				{
 					Collection sortedGroups = new Vector();
-					for (Iterator i = new SortedIterator(groups.iterator(), new AnnouncementGroupComparator(AnnouncementGroupComparator.Criteria.TITLE, true)); i.hasNext();)
+					for (Iterator i = new SortedIterator(groups.iterator(), new AnnouncementGroupComparator(AnnouncementGroupComparator.Criteria.TITLE, true, getLocale())); i.hasNext();)
 					{
 						sortedGroups.add(i.next());
 					}
@@ -4286,7 +4295,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			sortedBy = isOnWorkspaceTab() ? SORT_DATE : getCurrentOrder();
 			asc = false;
 		}
-		SortedIterator<AnnouncementWrapper> rvSorted = new SortedIterator<>(rv.iterator(), new AnnouncementWrapperComparator(sortedBy, asc));
+		SortedIterator<AnnouncementWrapper> rvSorted = new SortedIterator<>(rv.iterator(), new AnnouncementWrapperComparator(sortedBy, asc, getLocale()));
 
 		PagingPosition page = new PagingPosition(first, last);
 		page.validate(rv.size());

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1705,7 +1705,7 @@ public class AnnouncementAction extends PagedResourceActionII
 				// TODO: this is almost right (see chef_announcements-revise.vm)... ideally, we would let the check groups that they can add to,
 				// and uncheck groups they can remove from... only matters if the user does not have both add and remove -ggolden
 				final boolean own = edit == null ? true : edit.getHeader().getFrom().getId().equals(SessionManager.getCurrentSessionUserId());
-				Collection groups = channel.getGroupsAllowRemoveMessage(own);
+				Collection<Group> groups = channel.getGroupsAllowRemoveMessage(own);
 				context.put("allowedRemoveGroups", groups);
 				
 				// group list which user can add message to
@@ -1714,11 +1714,9 @@ public class AnnouncementAction extends PagedResourceActionII
 				// add to these any groups that the message already has
 				if (edit != null)
 				{
-					final Collection otherGroups = edit.getHeader().getGroupObjects();
-					for (Iterator i = otherGroups.iterator(); i.hasNext();)
+					final Collection<Group> otherGroups = edit.getHeader().getGroupObjects();
+					for (Group g : otherGroups)
 					{
-						Group g = (Group) i.next();
-						
 						if (!groups.contains(g))
 						{
 							groups.add(g);
@@ -1728,11 +1726,9 @@ public class AnnouncementAction extends PagedResourceActionII
 
 				if (groups.size() > 0)
 				{
-					Collection sortedGroups = new Vector();
-					for (Iterator i = new SortedIterator(groups.iterator(), new AnnouncementGroupComparator(AnnouncementGroupComparator.Criteria.TITLE, true, getLocale())); i.hasNext();)
-					{
-						sortedGroups.add(i.next());
-					}
+					Locale locale = getLocale();
+					List<Group> sortedGroups = new ArrayList<>(groups);
+					sortedGroups.sort(new AnnouncementGroupComparator(AnnouncementGroupComparator.Criteria.TITLE, true, locale));
 					context.put("groups", sortedGroups);
 				}
 			}

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementGroupComparator.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementGroupComparator.java
@@ -15,35 +15,24 @@
  */
 package org.sakaiproject.announcement.tool;
 
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.sakaiproject.site.api.Group;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
 
 /**
  * Comparator for announcements.
  */
-@Slf4j
 class AnnouncementGroupComparator implements Comparator<Group> {
 
     public enum Criteria {TITLE, DESCRIPTION};
 
-    private static RuleBasedCollator collator_ini = (RuleBasedCollator)Collator.getInstance();
-    private Collator collator = Collator.getInstance();
+    private final Comparator<String> stringComparator;
 
     // the criteria
     Criteria m_criteria = null;
-
-    {
-        try {
-            collator = new RuleBasedCollator(collator_ini.getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-        } catch (ParseException e) {
-            log.error("{} Cannot init RuleBasedCollator. Will use the default Collator instead.", this, e);
-        }
-    }
 
     // the criteria - asc
     boolean m_asc = true;
@@ -53,9 +42,10 @@ class AnnouncementGroupComparator implements Comparator<Group> {
      *  @param criteria The sort criteria string
      * @param asc      The sort order string. "true" if ascending; "false" otherwise.
      */
-    public AnnouncementGroupComparator(Criteria criteria, boolean asc) {
+    public AnnouncementGroupComparator(Criteria criteria, boolean asc, Locale locale) {
         m_criteria = criteria;
         m_asc = asc;
+        stringComparator = new AlphaNumericComparator(Objects.requireNonNull(locale));
 
     } // constructor
 
@@ -72,7 +62,7 @@ class AnnouncementGroupComparator implements Comparator<Group> {
             // sorted by the group title
             String factor1 = (o1).getTitle();
             String factor2 = (o2).getTitle();
-            result = collator.compare(factor1, factor2);
+            result = stringComparator.compare(factor1, factor2);
         } else if (m_criteria.equals(Criteria.DESCRIPTION)) {
             // sorted by the group title
             String factor1 = (o1).getDescription();
@@ -83,7 +73,7 @@ class AnnouncementGroupComparator implements Comparator<Group> {
             if (factor2 == null) {
                 factor2 = "";
             }
-            result = collator.compare(factor1, factor2);
+            result = stringComparator.compare(factor1, factor2);
         }
 
         // sort ascending or descending

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementGroupComparator.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementGroupComparator.java
@@ -43,7 +43,7 @@ class AnnouncementGroupComparator implements Comparator<Group> {
      * @param asc      The sort order string. "true" if ascending; "false" otherwise.
      */
     public AnnouncementGroupComparator(Criteria criteria, boolean asc, Locale locale) {
-        m_criteria = criteria;
+        m_criteria = Objects.requireNonNull(criteria, "criteria must not be null");
         m_asc = asc;
         stringComparator = new AlphaNumericComparator(Objects.requireNonNull(locale));
 

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementWrapperComparator.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementWrapperComparator.java
@@ -15,36 +15,27 @@
  */
 package org.sakaiproject.announcement.tool;
 
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.time.Instant;
 import java.util.Comparator;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.sakaiproject.announcement.cover.AnnouncementService;
 import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
  * Comparator for announcements.
  */
-@Slf4j
 public class AnnouncementWrapperComparator implements Comparator<AnnouncementWrapper> {
 
-    private static RuleBasedCollator collator_ini = (RuleBasedCollator)Collator.getInstance();
-    private Collator collator = Collator.getInstance();
+    private final Comparator<String> stringComparator;
+    private final UserSortNameComparator userSortNameComparator;
     
     // the criteria
     String m_criteria = null;
-
-    {
-        try {
-            collator = new RuleBasedCollator(collator_ini.getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-        } catch (ParseException e) {
-            log.error("{} Cannot init RuleBasedCollator. Will use the default Collator instead.", this, e);
-        }
-    }
 
     // the criteria - asc
     boolean m_asc = true;
@@ -54,9 +45,11 @@ public class AnnouncementWrapperComparator implements Comparator<AnnouncementWra
      *  @param criteria The sort criteria string
      * @param asc      The sort order string. "true" if ascending; "false" otherwise.
      */
-    public AnnouncementWrapperComparator(String criteria, boolean asc) {
+    public AnnouncementWrapperComparator(String criteria, boolean asc, Locale locale) {
         m_criteria = criteria;
         m_asc = asc;
+        stringComparator = new AlphaNumericComparator(Objects.requireNonNull(locale));
+        userSortNameComparator = new UserSortNameComparator(locale);
 
     } // constructor
 
@@ -124,16 +117,13 @@ public class AnnouncementWrapperComparator implements Comparator<AnnouncementWra
             result = compareInstantsNullSafe(o1retractDate, o2retractDate);
             break;
         case AnnouncementAction.SORT_SUBJECT:
-            result = collator.compare(o1.getAnnouncementHeader().getSubject(), o2.getAnnouncementHeader().getSubject());
+            result = stringComparator.compare(o1.getAnnouncementHeader().getSubject(), o2.getAnnouncementHeader().getSubject());
             break;
         case AnnouncementAction.SORT_CHANNEL:
-            result = collator.compare(o1.getChannelDisplayName(), o2.getChannelDisplayName());
+            result = stringComparator.compare(o1.getChannelDisplayName(), o2.getChannelDisplayName());
             break;
         case AnnouncementAction.SORT_FROM:
-            // The anonymous user doesn't have a sort name (it's null).
-            String sortName1 = o1.getAnnouncementHeader().getFrom().getSortName();
-            String sortName2 = o2.getAnnouncementHeader().getFrom().getSortName();
-            result = compareStringNullSafe(sortName1, sortName2);
+            result = compareFromNullSafe(o1.getAnnouncementHeader().getFrom(), o2.getAnnouncementHeader().getFrom());
             break;
         case AnnouncementAction.SORT_PUBLIC:
         	String factor1 = o1.getProperties().getProperty(ResourceProperties.PROP_PUBVIEW);
@@ -165,9 +155,20 @@ public class AnnouncementWrapperComparator implements Comparator<AnnouncementWra
             return 1;
         }
         else {
-            result = collator.compare(sortName1, sortName2);
+            result = stringComparator.compare(sortName1, sortName2);
         }
         return result;
+    }
+
+    private int compareFromNullSafe(User user1, User user2) {
+        if (user1 == null && user2 == null) {
+            return 0;
+        } else if (user1 == null) {
+            return -1;
+        } else if (user2 == null) {
+            return 1;
+        }
+        return userSortNameComparator.compareSortNames(user1.getSortName(), user1.getDisplayId(), user2.getSortName(), user2.getDisplayId());
     }
 
     private int compareInstantsNullSafe(Instant date1, Instant o2ModDate) {

--- a/announcement/announcement-tool/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/announcement/announcement-tool/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -15,7 +15,7 @@
 		<property name="toolManager"><ref bean="org.sakaiproject.tool.api.ToolManager"/></property>
 		<property name="entityManager"><ref bean="org.sakaiproject.entity.api.EntityManager"/></property>
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
 	</bean>
 	
 </beans>
-

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AnonymousSubmissionComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AnonymousSubmissionComparator.java
@@ -16,30 +16,25 @@
 package org.sakaiproject.assignment.api.sort;
 
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Locale;
 
 import org.sakaiproject.assignment.api.model.AssignmentSubmission;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
  * Sorts assignment submissions by the submission's anonymous ID.
  */
-@Slf4j
 public class AnonymousSubmissionComparator implements Comparator<AssignmentSubmission> {
 
     private Collator collator;
 
     public AnonymousSubmissionComparator() {
-        try {
-            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-        } catch (ParseException e) {
-            // error with init RuleBasedCollator with rules
-            // use the default Collator
-            collator = Collator.getInstance();
-            log.warn("{} AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead. {}", this, e);
-        }
+        this(Locale.getDefault());
+    }
+
+    public AnonymousSubmissionComparator(Locale locale) {
+        collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
     }
 
     @Override

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AnonymousSubmissionComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AnonymousSubmissionComparator.java
@@ -29,10 +29,6 @@ public class AnonymousSubmissionComparator implements Comparator<AssignmentSubmi
 
     private Collator collator;
 
-    public AnonymousSubmissionComparator() {
-        this(Locale.getDefault());
-    }
-
     public AnonymousSubmissionComparator(Locale locale) {
         collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
     }

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AssignmentSubmissionComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AssignmentSubmissionComparator.java
@@ -19,6 +19,7 @@ import java.text.Collator;
 import java.text.ParseException;
 import java.text.RuleBasedCollator;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -41,25 +42,32 @@ import org.sakaiproject.util.comparator.UserSortNameComparator;
 public class AssignmentSubmissionComparator implements Comparator<AssignmentSubmission> {
 
     private Collator collator;
+    private Locale locale;
     private SiteService siteService;
     private AssignmentService assignmentService;
     private UserDirectoryService userDirectoryService;
-    private static final UserSortNameComparator userSortNameComparator = new UserSortNameComparator();
+    private UserSortNameComparator userSortNameComparator;
 
     // private to prevent no arg instantiation
     private AssignmentSubmissionComparator() {
     }
 
     public AssignmentSubmissionComparator(AssignmentService assignmentService, SiteService siteService, UserDirectoryService userDirectoryService) {
+        this(assignmentService, siteService, userDirectoryService, Locale.getDefault());
+    }
+
+    public AssignmentSubmissionComparator(AssignmentService assignmentService, SiteService siteService, UserDirectoryService userDirectoryService, Locale locale) {
         this.assignmentService = assignmentService;
         this.siteService = siteService;
         this.userDirectoryService = userDirectoryService;
+        this.locale = locale;
+        this.userSortNameComparator = new UserSortNameComparator(locale);
         try {
-            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
+            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance(locale)).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
         } catch (ParseException e) {
             // error with init RuleBasedCollator with rules
             // use the default Collator
-            collator = Collator.getInstance();
+            collator = Collator.getInstance(locale);
             log.warn("AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead.", e);
         }
     }
@@ -119,7 +127,7 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
         } else if (s1 == null) {
             result = -1;
         } else {
-            result = collator.compare(s1.toLowerCase(), s2.toLowerCase());
+            result = collator.compare(s1.toLowerCase(locale), s2.toLowerCase(locale));
         }
         return result;
     }

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AssignmentSubmissionComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AssignmentSubmissionComparator.java
@@ -52,10 +52,6 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
     private AssignmentSubmissionComparator() {
     }
 
-    public AssignmentSubmissionComparator(AssignmentService assignmentService, SiteService siteService, UserDirectoryService userDirectoryService) {
-        this(assignmentService, siteService, userDirectoryService, Locale.getDefault());
-    }
-
     public AssignmentSubmissionComparator(AssignmentService assignmentService, SiteService siteService, UserDirectoryService userDirectoryService, Locale locale) {
         this.assignmentService = assignmentService;
         this.siteService = siteService;

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AssignmentSubmissionComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/AssignmentSubmissionComparator.java
@@ -16,8 +16,6 @@
 package org.sakaiproject.assignment.api.sort;
 
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.Optional;
@@ -33,6 +31,7 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
+import org.sakaiproject.util.comparator.SakaiCollators;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
@@ -58,14 +57,7 @@ public class AssignmentSubmissionComparator implements Comparator<AssignmentSubm
         this.userDirectoryService = userDirectoryService;
         this.locale = locale;
         this.userSortNameComparator = new UserSortNameComparator(locale);
-        try {
-            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance(locale)).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-        } catch (ParseException e) {
-            // error with init RuleBasedCollator with rules
-            // use the default Collator
-            collator = Collator.getInstance(locale);
-            log.warn("AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead.", e);
-        }
+        collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
     }
 
     @Override

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/UserIdComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/UserIdComparator.java
@@ -34,10 +34,9 @@ public class UserIdComparator implements Comparator<String> {
     private Collator collator;
     private UserDirectoryService userDirectoryService;
 
-    public UserIdComparator(UserDirectoryService userDirectoryService) {
+    public UserIdComparator(UserDirectoryService userDirectoryService, Locale locale) {
         this.userDirectoryService = userDirectoryService;
-        // TODO this should be in a service and should repect the current user's locale
-        collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(Locale.getDefault(), Collator.SECONDARY);
+        collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.SECONDARY);
     }
 
     @Override

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/sort/UserIdComparator.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/sort/UserIdComparator.java
@@ -16,14 +16,14 @@
 package org.sakaiproject.assignment.api.sort;
 
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
+import java.util.Locale;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
  * Sorts a collection of User IDs by their sortnames.
@@ -37,16 +37,7 @@ public class UserIdComparator implements Comparator<String> {
     public UserIdComparator(UserDirectoryService userDirectoryService) {
         this.userDirectoryService = userDirectoryService;
         // TODO this should be in a service and should repect the current user's locale
-        try {
-            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-        } catch (ParseException e) {
-            // error with init RuleBasedCollator with rules
-            // use the default Collator
-            collator = Collator.getInstance();
-            log.warn("{} UserIdComparator cannot init RuleBasedCollator. Will use the default Collator instead. {}", this, e);
-        }
-        // This is to ignore case of the values
-        collator.setStrength(Collator.SECONDARY);
+        collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(Locale.getDefault(), Collator.SECONDARY);
     }
 
     @Override

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -2610,7 +2610,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     StringBuilder exceptionMessage = new StringBuilder();
                     SortedIterator sortedIterator;
                     if (assignmentUsesAnonymousGrading(assignment)){
-                        sortedIterator = new SortedIterator(submissions.iterator(), new AnonymousSubmissionComparator());
+                        sortedIterator = new SortedIterator(submissions.iterator(), new AnonymousSubmissionComparator(
+                                localeService.getLocaleForSiteAndUser(assignment.getContext(), sessionManager.getCurrentSessionUserId())));
                     } else {
                         sortedIterator = new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator(applicationContext.getBean(AssignmentService.class), siteService, userDirectoryService,
                                 localeService.getLocaleForSiteAndUser(assignment.getContext(), sessionManager.getCurrentSessionUserId())));

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -186,6 +186,7 @@ import org.sakaiproject.util.SortedIterator;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.ObjectFactory;
@@ -236,6 +237,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Setter private GradingService gradingService;
     @Setter private LearningResourceStoreService learningResourceStoreService;
     @Setter private LinkMigrationHelper linkMigrationHelper;
+    @Setter private LocaleService localeService;
     @Setter private TransactionTemplate transactionTemplate;
     @Setter private ResourceLoader resourceLoader;
     @Setter private RubricsService rubricsService;
@@ -2427,7 +2429,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 				log.warn("Creating a list of users, user = {}, {}", member.getUserId(), e.getMessage());
 			}
 		});
-        users.sort(new UserSortNameComparator());
+        users.sort(new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()));
         return users;
     }
 
@@ -2574,7 +2576,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                                 assignment.getTitle(),
                                 assignment.getTypeOfGrade().toString(),
                                 assignment.getTypeOfSubmission(),
-                                new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator(applicationContext.getBean(AssignmentService.class), siteService, userDirectoryService)),
+                                new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator(applicationContext.getBean(AssignmentService.class), siteService, userDirectoryService,
+                                        localeService.getLocaleForSiteAndUser(assignment.getContext(), sessionManager.getCurrentSessionUserId()))),
                                 out,
                                 exceptionMessage,
                                 withStudentSubmissionText,
@@ -2609,7 +2612,8 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     if (assignmentUsesAnonymousGrading(assignment)){
                         sortedIterator = new SortedIterator(submissions.iterator(), new AnonymousSubmissionComparator());
                     } else {
-                        sortedIterator = new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator(applicationContext.getBean(AssignmentService.class), siteService, userDirectoryService));
+                        sortedIterator = new SortedIterator(submissions.iterator(), new AssignmentSubmissionComparator(applicationContext.getBean(AssignmentService.class), siteService, userDirectoryService,
+                                localeService.getLocaleForSiteAndUser(assignment.getContext(), sessionManager.getCurrentSessionUserId())));
                     }
                     if (allowGradeSubmission(reference)) {
                         zipSubmissions(reference,

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
@@ -18,9 +18,6 @@ package org.sakaiproject.assignment.impl;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.text.NumberFormat;
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +26,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -63,7 +61,6 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
-import org.springframework.util.comparator.NullSafeComparator;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -88,23 +85,10 @@ public class GradeSheetExporter {
     /**
     * A comparator that sorts by student sortName
     */
-    private static final Comparator<Submitter> SUBMITTER_NAME_COMPARATOR = new Comparator<Submitter>() {
-        Collator collator;
-        {
-            this.collator = Collator.getInstance();
-            try {
-                this.collator = new RuleBasedCollator(
-                        ((RuleBasedCollator) this.collator).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-            } catch (final ParseException e) {
-                log.warn(this + " Cannot init RuleBasedCollator. Will use the default Collator instead.", e);
-            }
-        }
-
-        @Override
-        public int compare(final Submitter s1, final Submitter s2) {
-            return new NullSafeComparator<>(collator, false).compare(s1.getSortName(), s2.getSortName());
-        }
-    };
+    private Comparator<Submitter> getSubmitterNameComparator(Locale locale) {
+        UserSortNameComparator comparator = new UserSortNameComparator(locale);
+        return (Submitter s1, Submitter s2) -> comparator.compareSortNames(s1.getSortName(), s1.id, s2.getSortName(), s2.id);
+    }
 
     /**
      * @param reference The reference, either to a specific assignment, or just to an assignment context.
@@ -356,7 +340,7 @@ public class GradeSheetExporter {
                 }
 
                 final List<Submitter> submitters = new ArrayList<>(results.keySet());
-                Collections.sort(submitters, SUBMITTER_NAME_COMPARATOR);
+                Collections.sort(submitters, getSubmitterNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
 
                 // Date submitted and Late.
                 CellStyle dateCellStyle = wb.createCellStyle();
@@ -608,7 +592,7 @@ public class GradeSheetExporter {
 
 
                 final List<Submitter> submitters = new ArrayList(results.keySet());
-                Collections.sort(submitters, SUBMITTER_NAME_COMPARATOR);
+                Collections.sort(submitters, getSubmitterNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
 
                 for (final Submitter submitter : submitters) {
                     List<Object> rowValues = results.get(submitter);

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
@@ -144,6 +144,9 @@ public class GradeSheetExporter {
             // site members excluding those who can add assignments
             // hashmap which stores the Excel row number for particular user
 
+            Locale locale = localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId());
+            UserSortNameComparator userSortNameComparator = new UserSortNameComparator(locale);
+            Comparator<Submitter> submitterNameComparator = getSubmitterNameComparator(locale);
             String refToCheck = group == null ? site.getReference() : group.getReference();
             List<String> allowAddAnySubmissionUsers = assignmentService.allowAddAnySubmissionUsers(refToCheck);
             List<User> members = userDirectoryService.getUsers(allowAddAnySubmissionUsers);
@@ -151,7 +154,7 @@ public class GradeSheetExporter {
                     site != null && candidateDetailProvider.isAdditionalNotesEnabled(site);
             // For details of all the users in the site.
             Map<String, Submitter> submitterMap = new HashMap<>();
-            members.sort(new UserSortNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
+            members.sort(userSortNameComparator);
             for (User user : members) {
                 // put user displayid and sortname in the first two cells
                 Submitter submitter = new Submitter(user.getDisplayId(), user.getSortName());
@@ -340,7 +343,7 @@ public class GradeSheetExporter {
                 }
 
                 final List<Submitter> submitters = new ArrayList<>(results.keySet());
-                Collections.sort(submitters, getSubmitterNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
+                Collections.sort(submitters, submitterNameComparator);
 
                 // Date submitted and Late.
                 CellStyle dateCellStyle = wb.createCellStyle();
@@ -448,6 +451,9 @@ public class GradeSheetExporter {
             // site members excluding those who can add assignments
             // hashmap which stores the Excel row number for particular user
 
+            Locale locale = localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId());
+            UserSortNameComparator userSortNameComparator = new UserSortNameComparator(locale);
+            Comparator<Submitter> submitterNameComparator = getSubmitterNameComparator(locale);
             String refToCheck = group == null ? site.getReference() : group.getReference();
             List<String> allowAddAnySubmissionUsers = assignmentService.allowAddAnySubmissionUsers(refToCheck);
             List<User> members = userDirectoryService.getUsers(allowAddAnySubmissionUsers);
@@ -455,7 +461,7 @@ public class GradeSheetExporter {
                     site != null && candidateDetailProvider.isAdditionalNotesEnabled(site);
             // For details of all the users in the site.
             Map<String, Submitter> submitterMap = new HashMap<>();
-            members.sort(new UserSortNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
+            members.sort(userSortNameComparator);
             for (User user : members) {
                 // put user displayid and sortname in the first two cells
                 Submitter submitter = new Submitter(user.getDisplayId(), user.getSortName());
@@ -591,8 +597,8 @@ public class GradeSheetExporter {
                 }
 
 
-                final List<Submitter> submitters = new ArrayList(results.keySet());
-                Collections.sort(submitters, getSubmitterNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
+                final List<Submitter> submitters = new ArrayList<>(results.keySet());
+                Collections.sort(submitters, submitterNameComparator);
 
                 for (final Submitter submitter : submitters) {
                     List<Object> rowValues = results.get(submitter);

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/GradeSheetExporter.java
@@ -55,11 +55,13 @@ import org.sakaiproject.assignment.api.sort.AssignmentComparator;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.CandidateDetailProvider;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.springframework.util.comparator.NullSafeComparator;
 
@@ -78,6 +80,8 @@ public class GradeSheetExporter {
     @Setter private SiteService siteService;
     @Setter private UserDirectoryService userDirectoryService;
     @Setter private FormattedText formattedText;
+    @Setter private LocaleService localeService;
+    @Setter private SessionManager sessionManager;
 
     @Setter private ResourceLoader rb = new ResourceLoader("assignment");
 
@@ -163,7 +167,7 @@ public class GradeSheetExporter {
                     site != null && candidateDetailProvider.isAdditionalNotesEnabled(site);
             // For details of all the users in the site.
             Map<String, Submitter> submitterMap = new HashMap<>();
-            members.sort(new UserSortNameComparator());
+            members.sort(new UserSortNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
             for (User user : members) {
                 // put user displayid and sortname in the first two cells
                 Submitter submitter = new Submitter(user.getDisplayId(), user.getSortName());
@@ -467,7 +471,7 @@ public class GradeSheetExporter {
                     site != null && candidateDetailProvider.isAdditionalNotesEnabled(site);
             // For details of all the users in the site.
             Map<String, Submitter> submitterMap = new HashMap<>();
-            members.sort(new UserSortNameComparator());
+            members.sort(new UserSortNameComparator(localeService.getLocaleForSiteAndUser(context, sessionManager.getCurrentSessionUserId())));
             for (User user : members) {
                 // put user displayid and sortname in the first two cells
                 Submitter submitter = new Submitter(user.getDisplayId(), user.getSortName());

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -113,7 +114,7 @@ public class AssignmentComparatorTest {
 		}
 
 		sortNameComparator = new UserIdComparator(userDirectoryService);
-		submitterNameComparator = new AssignmentSubmissionComparator(assignmentService, siteService, userDirectoryService);
+		submitterNameComparator = new AssignmentSubmissionComparator(assignmentService, siteService, userDirectoryService, Locale.US);
 	}
 
 	/**

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentComparatorTest.java
@@ -113,7 +113,7 @@ public class AssignmentComparatorTest {
 			namesWithSpaceSubmissions[i] = createSubmissionForUserID(USERS_WITH_SPACE_PREFIX + i);
 		}
 
-		sortNameComparator = new UserIdComparator(userDirectoryService);
+		sortNameComparator = new UserIdComparator(userDirectoryService, Locale.US);
 		submitterNameComparator = new AssignmentSubmissionComparator(assignmentService, siteService, userDirectoryService, Locale.US);
 	}
 

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTestConfiguration.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTestConfiguration.java
@@ -18,6 +18,7 @@ package org.sakaiproject.assignment.impl;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Properties;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
@@ -71,6 +72,7 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotificationPreferencesRegistration;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.api.LocaleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -270,6 +272,14 @@ public class AssignmentTestConfiguration {
     @Bean(name = "org.sakaiproject.util.api.LinkMigrationHelper")
     public LinkMigrationHelper linkMigrationHelper() {
         return mock(LinkMigrationHelper.class);
+    }
+
+    @Bean(name = "org.sakaiproject.util.api.LocaleService")
+    public LocaleService localeService() {
+        LocaleService localeService = mock(LocaleService.class);
+        Mockito.when(localeService.getLocaleForCurrentSiteAndUser()).thenReturn(Locale.US);
+        Mockito.when(localeService.getLocaleForSiteAndUser(Mockito.any(), Mockito.any())).thenReturn(Locale.US);
+        return localeService;
     }
 
     @Bean(name = "org.sakaiproject.time.api.UserTimeService")

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/GradeReportTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/GradeReportTest.java
@@ -35,9 +35,11 @@ import org.sakaiproject.assignment.api.model.AssignmentSubmission;
 import org.sakaiproject.assignment.api.model.AssignmentSubmissionSubmitter;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 
 import org.sakaiproject.util.ResourceLoader;
 
@@ -63,6 +65,8 @@ import org.junit.Assert;
 public class GradeReportTest {
 
     @Autowired private FormattedText formattedText;
+    @Autowired private LocaleService localeService;
+    @Autowired private SessionManager sessionManager;
     @Autowired private SiteService siteService;
     @Autowired private UserDirectoryService userDirectoryService;
 
@@ -126,6 +130,8 @@ public class GradeReportTest {
         exporter.setUserDirectoryService(userDirectoryService);
         exporter.setRb(resourceLoader);
         exporter.setFormattedText(formattedText);
+        exporter.setLocaleService(localeService);
+        exporter.setSessionManager(sessionManager);
     }
 
     @Test

--- a/assignment/impl/src/webapp/WEB-INF/components.xml
+++ b/assignment/impl/src/webapp/WEB-INF/components.xml
@@ -37,6 +37,7 @@
         <property name="gradingService" ref="org.sakaiproject.grading.api.GradingService"/>
         <property name="learningResourceStoreService" ref="org.sakaiproject.event.api.LearningResourceStoreService"/>
         <property name="linkMigrationHelper" ref="org.sakaiproject.util.api.LinkMigrationHelper"/>
+        <property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
         <property name="transactionTemplate">
             <bean class="org.springframework.transaction.support.TransactionTemplate">
                 <property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager"/>
@@ -108,6 +109,8 @@
         <property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
         <property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
         <property name="formattedText" ref="org.sakaiproject.util.api.FormattedText"/>
+        <property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
+        <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
     </bean>
 
     <bean id="org.sakaiproject.assignment.taggable.api.AssignmentActivityProducer"

--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -96,6 +96,7 @@ import org.tsugi.lti.LTIUtil;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 
 @Slf4j
 @Setter
@@ -123,6 +124,7 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
     private ServerConfigurationService serverConfigurationService;
     private UserDirectoryService userDirectoryService;
     private UserTimeService userTimeService;
+    private LocaleService localeService;
     private FormattedText formattedText;
     private LTIService ltiService;
 
@@ -1066,7 +1068,8 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                 .filter(submission -> submission.getSubmitters().stream()
                         .map(AssignmentSubmissionSubmitter::getSubmitter)
                         .anyMatch(visibleUserIds::contains))
-                .sorted(new AssignmentSubmissionComparator(assignmentService, siteService, userDirectoryService))
+                .sorted(new AssignmentSubmissionComparator(assignmentService, siteService, userDirectoryService,
+                        localeService.getLocaleForSiteAndUser(site.getId(), sessionManager.getCurrentSessionUserId())))
                 .collect(Collectors.toList());
 
         int submissionIndex = -1;

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -41,8 +41,6 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.Normalizer;
 import java.text.NumberFormat;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -234,6 +232,7 @@ import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.AlphaNumericComparator;
+import org.sakaiproject.util.comparator.SakaiCollators;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.lti.util.SakaiLTIUtil;
@@ -17007,14 +17006,7 @@ public class AssignmentAction extends PagedResourceActionII {
             m_user = user;
             Locale locale = localeService.getLocaleForCurrentSiteAndUser();
             userSortNameComparator = new UserSortNameComparator(locale);
-            try {
-                collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance(locale)).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-            } catch (ParseException e) {
-                // error with init RuleBasedCollator with rules
-                // use the default Collator
-                collator = Collator.getInstance(locale);
-                log.warn(this + " AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead. " + e);
-            }
+            collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
         } // constructor
 
         /**

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -16954,6 +16954,7 @@ public class AssignmentAction extends PagedResourceActionII {
      */
     private class AssignmentComparator implements Comparator {
         Collator collator = null;
+        UserSortNameComparator userSortNameComparator = null;
         Map<String, Integer> crSubmissionScoreMap = new HashMap<>();
 
         /**
@@ -17004,12 +17005,14 @@ public class AssignmentAction extends PagedResourceActionII {
             m_criteria = criteria;
             m_asc = asc;
             m_user = user;
+            Locale locale = localeService.getLocaleForCurrentSiteAndUser();
+            userSortNameComparator = new UserSortNameComparator(locale);
             try {
-                collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
+                collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance(locale)).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
             } catch (ParseException e) {
                 // error with init RuleBasedCollator with rules
                 // use the default Collator
-                collator = Collator.getInstance();
+                collator = Collator.getInstance(locale);
                 log.warn(this + " AssignmentComparator cannot init RuleBasedCollator. Will use the default Collator instead. " + e);
             }
         } // constructor
@@ -17123,7 +17126,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 try {
                     User u1 = userDirectoryService.getUser(((Assignment) o1).getModifier());
                     User u2 = userDirectoryService.getUser(((Assignment) o2).getModifier());
-                    result = new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()).compare(u1, u2);
+                    result = userSortNameComparator.compare(u1, u2);
                 } catch (UserNotDefinedException e) {
                     log.error("Could not get user {} or {}: {}", ((Assignment) o1).getModifier(), ((Assignment) o2).getModifier(), e.getMessage());
                 }
@@ -17288,7 +17291,7 @@ public class AssignmentAction extends PagedResourceActionII {
                     String anon2 = u2.getSubmission().getId();
                     result = compareString(anon1, anon2);
                 } else if (u1.getUser() != null && u2.getUser() != null) {
-                    result = new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()).compare(u1.getUser(), u2.getUser());
+                    result = userSortNameComparator.compare(u1.getUser(), u2.getUser());
                 } else {
                     String lName1 = u1.getUser() == null ? u1.getGroup().getTitle() : u1.getUser().getSortName();
                     String lName2 = u2.getUser() == null ? u2.getGroup().getTitle() : u2.getUser().getSortName();

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -232,6 +232,7 @@ import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.SortedIterator;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.AlphaNumericComparator;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.sakaiproject.lti.api.LTIService;
@@ -1167,6 +1168,7 @@ public class AssignmentAction extends PagedResourceActionII {
     private FormattedText formattedText;
     private GradingService gradingService;
     private LearningResourceStoreService learningResourceStoreService;
+    private LocaleService localeService;
     private NotificationService notificationService;
 	private PreferencesService preferencesService;
 	private RubricsService rubricsService;
@@ -1212,6 +1214,7 @@ public class AssignmentAction extends PagedResourceActionII {
         formattedText = ComponentManager.get(FormattedText.class);
         gradingService = (GradingService) ComponentManager.get("org.sakaiproject.grading.api.GradingService");
         learningResourceStoreService = ComponentManager.get(LearningResourceStoreService.class);
+        localeService = ComponentManager.get(LocaleService.class);
         notificationService = ComponentManager.get(NotificationService.class);
 		preferencesService  = ComponentManager.get(PreferencesService.class);
 		rubricsService  = ComponentManager.get(RubricsService.class);
@@ -3750,7 +3753,7 @@ public class AssignmentAction extends PagedResourceActionII {
                             log.warn(this + ":setAssignmentFormContext cannot get user " + e.getMessage() + " user id=" + userId);
                         }
                     }
-                    Collections.sort(usersList, new UserSortNameComparator());
+                    Collections.sort(usersList, new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()));
                     roleUsers.put(r.getId(), usersList);
                 }
             }
@@ -17120,7 +17123,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 try {
                     User u1 = userDirectoryService.getUser(((Assignment) o1).getModifier());
                     User u2 = userDirectoryService.getUser(((Assignment) o2).getModifier());
-                    result = new UserSortNameComparator().compare(u1, u2);
+                    result = new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()).compare(u1, u2);
                 } catch (UserNotDefinedException e) {
                     log.error("Could not get user {} or {}: {}", ((Assignment) o1).getModifier(), ((Assignment) o2).getModifier(), e.getMessage());
                 }
@@ -17285,7 +17288,7 @@ public class AssignmentAction extends PagedResourceActionII {
                     String anon2 = u2.getSubmission().getId();
                     result = compareString(anon1, anon2);
                 } else if (u1.getUser() != null && u2.getUser() != null) {
-                    result = new UserSortNameComparator().compare(u1.getUser(), u2.getUser());
+                    result = new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()).compare(u1.getUser(), u2.getUser());
                 } else {
                     String lName1 = u1.getUser() == null ? u1.getGroup().getTitle() : u1.getUser().getSortName();
                     String lName2 = u2.getUser() == null ? u2.getGroup().getTitle() : u2.getUser().getSortName();

--- a/assignment/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/assignment/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -35,6 +35,7 @@
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
 		<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService" />
 		<property name="formattedText" ref="org.sakaiproject.util.api.FormattedText"/>
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
 		<property name="ltiService" ref="org.sakaiproject.lti.api.LTIService" />
 	</bean>
 	

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/FirstNameComparator.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/FirstNameComparator.java
@@ -17,6 +17,7 @@ package org.sakaiproject.gradebookng.business;
 
 import java.text.Collator;
 import java.util.Comparator;
+import java.util.Locale;
 
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.sakaiproject.user.api.User;
@@ -24,14 +25,23 @@ import org.sakaiproject.user.api.User;
 /**
  * Comparator class for sorting a list of users by first name. Secondary sort is on last name to maintain consistent order for those with
  * the same first name
+ * TODO: Move this to kernel next to UserSortNameComparator if first-name sorting is needed outside Gradebook.
  */
 public class FirstNameComparator implements Comparator<User> {
 
-	private final Collator collator = Collator.getInstance();
+	private final Collator collator;
+
+	public FirstNameComparator() {
+		this(Locale.getDefault());
+	}
+
+	public FirstNameComparator(Locale locale) {
+		this.collator = Collator.getInstance(locale);
+		this.collator.setStrength(Collator.PRIMARY);
+	}
 
 	@Override
 	public int compare(final User u1, final User u2) {
-		this.collator.setStrength(Collator.PRIMARY);
 		return new CompareToBuilder()
 				.append(u1.getFirstName(), u2.getFirstName(), this.collator)
 				.append(u1.getLastName(), u2.getLastName(), this.collator)

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/FirstNameComparatorGbUser.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/FirstNameComparatorGbUser.java
@@ -17,6 +17,7 @@ package org.sakaiproject.gradebookng.business;
 
 import java.text.Collator;
 import java.util.Comparator;
+import java.util.Locale;
 
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.sakaiproject.gradebookng.business.model.GbUser;
@@ -27,11 +28,19 @@ import org.sakaiproject.gradebookng.business.model.GbUser;
  */
 public class FirstNameComparatorGbUser implements Comparator<GbUser> {
 
-    private final Collator collator = Collator.getInstance();
+    private final Collator collator;
+
+    public FirstNameComparatorGbUser() {
+        this(Locale.getDefault());
+    }
+
+    public FirstNameComparatorGbUser(Locale locale) {
+        this.collator = Collator.getInstance(locale);
+        this.collator.setStrength(Collator.PRIMARY);
+    }
 
     @Override
     public int compare(final GbUser u1, final GbUser u2) {
-        this.collator.setStrength(Collator.PRIMARY);
         return new CompareToBuilder()
                 .append(u1.getFirstName(), u2.getFirstName(), this.collator)
                 .append(u1.getLastName(), u2.getLastName(), this.collator)

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -1065,8 +1065,9 @@ public class GradebookNgBusinessService {
 		List<User> users = getUsers(userUuids);
 		List<GbUser> gbUsers = new ArrayList<>(users.size());
 		if (settings.getStudentSortOrder() != null) {
-			Comparator<User> comp = GbStudentNameSortOrder.FIRST_NAME == settings.getNameSortOrder() ? new FirstNameComparator()
-					: new UserSortNameComparator(localeService.getLocaleForSiteAndUser(site.getId(), userDirectoryService.getCurrentUser().getId()));
+			Locale locale = localeService.getLocaleForSiteAndUser(site.getId(), userDirectoryService.getCurrentUser().getId());
+			Comparator<User> comp = GbStudentNameSortOrder.FIRST_NAME == settings.getNameSortOrder() ? new FirstNameComparator(locale)
+					: new UserSortNameComparator(locale);
 			if (SortDirection.DESCENDING == settings.getStudentSortOrder()) {
 				comp = Collections.reverseOrder(comp);
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/business/GradebookNgBusinessService.java
@@ -115,6 +115,7 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
@@ -172,6 +173,9 @@ public class GradebookNgBusinessService {
 	
 	@Setter
 	private FormattedText formattedText;
+
+	@Setter
+	private LocaleService localeService;
 
 	@Setter
 	private UserTimeService userTimeService;
@@ -289,7 +293,7 @@ public class GradebookNgBusinessService {
 	public List<User> getUsers(final List<String> userUuids) throws GbException {
 		try {
 			final List<User> users = this.userDirectoryService.getUsers(userUuids);
-			users.sort(new UserSortNameComparator()); // TODO: remove this sort, it causes double sorting in various scenarios
+			users.sort(new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser())); // TODO: remove this sort, it causes double sorting in various scenarios
 			return users;
 		} catch (final RuntimeException e) {
 			// an LDAP exception can sometimes be thrown here, catch and rethrow
@@ -1061,7 +1065,8 @@ public class GradebookNgBusinessService {
 		List<User> users = getUsers(userUuids);
 		List<GbUser> gbUsers = new ArrayList<>(users.size());
 		if (settings.getStudentSortOrder() != null) {
-			Comparator<User> comp = GbStudentNameSortOrder.FIRST_NAME == settings.getNameSortOrder() ? new FirstNameComparator() : new UserSortNameComparator();
+			Comparator<User> comp = GbStudentNameSortOrder.FIRST_NAME == settings.getNameSortOrder() ? new FirstNameComparator()
+					: new UserSortNameComparator(localeService.getLocaleForSiteAndUser(site.getId(), userDirectoryService.getCurrentUser().getId()));
 			if (SortDirection.DESCENDING == settings.getStudentSortOrder()) {
 				comp = Collections.reverseOrder(comp);
 			}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/rest/GradebookNgEntityProvider.java
@@ -62,6 +62,7 @@ import org.sakaiproject.tool.api.SessionManager;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
@@ -110,6 +111,9 @@ public class GradebookNgEntityProvider extends AbstractEntityProvider implements
 
 	@Setter
 	private FormattedText formattedText;
+
+	@Setter
+	private LocaleService localeService;
 
 	@Override
 	public String[] getHandledOutputFormats() {
@@ -353,7 +357,9 @@ public class GradebookNgEntityProvider extends AbstractEntityProvider implements
 			} else {
 				// Cache the users in the session. The client needs to show the users to the caller, so they can
 				// confirm, but we don't want to call this logic again for no reason.
-				List<BasicUser> basicUsers = users.stream().sorted(new UserSortNameComparator()).map(BasicUser::new).collect(Collectors.toList());
+				List<BasicUser> basicUsers = users.stream()
+						.sorted(new UserSortNameComparator(localeService.getLocaleForSiteAndUser((String) params.get("siteId"), getCurrentUserId())))
+						.map(BasicUser::new).collect(Collectors.toList());
 				return new ActionReturn(basicUsers);
 			}
 		} else {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradingSchemaPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradingSchemaPanel.java
@@ -415,7 +415,7 @@ public class SettingsGradingSchemaPanel extends BasePanel implements IFormModelU
 				.collect(Collectors.toList());
 
 		final List<GbUser> users = this.businessService.getGbUsers(currentSiteId, userUuids);
-		users.sort(new FirstNameComparatorGbUser());
+		users.sort(new FirstNameComparatorGbUser(localeService.getLocaleForCurrentSiteAndUser()));
 
 		return users;
 	}

--- a/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/gradebookng/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -19,6 +19,7 @@
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 		<property name="rubricsService" ref="org.sakaiproject.rubrics.api.RubricsService" />
 		<property name="formattedText" ref="org.sakaiproject.util.api.FormattedText" />
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService" />
 		<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService" />
 		<property name="taskService" ref="org.sakaiproject.tasks.api.TaskService" />
 	</bean>
@@ -36,6 +37,7 @@
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
 		<property name="formattedText" ref="org.sakaiproject.util.api.FormattedText" />
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService" />
 	</bean>
 	
 	<bean

--- a/kernel/api/src/main/java/org/sakaiproject/util/comparator/AlphaNumericComparator.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/comparator/AlphaNumericComparator.java
@@ -17,20 +17,53 @@ package org.sakaiproject.util.comparator;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.text.Collator;
 import java.util.Comparator;
+import java.util.Locale;
+import java.util.Objects;
 
 public class AlphaNumericComparator implements Comparator<String> {
-	private static Comparator stringComparator = Comparator
-				.comparing(s -> String.valueOf(s).replaceAll("\\d", ""), String.CASE_INSENSITIVE_ORDER)
-				.thenComparingLong(s -> StringUtils.isNumeric(s.toString().replaceAll("\\D", "")) ?
-						Long.parseLong(s.toString().replaceAll("\\D", "")) : 0);
+	private final Comparator<String> stringComparator;
+	private final Comparator<String> fallbackComparator;
+
+	public AlphaNumericComparator() {
+		this(String.CASE_INSENSITIVE_ORDER, Comparator.naturalOrder());
+	}
+
+	public AlphaNumericComparator(Locale locale) {
+		Collator collator = Collator.getInstance(Objects.requireNonNull(locale));
+		collator.setStrength(Collator.SECONDARY);
+		Comparator<String> localeComparator = collator::compare;
+		this.stringComparator = buildComparator(localeComparator);
+		this.fallbackComparator = localeComparator;
+	}
+
+	private AlphaNumericComparator(Comparator<String> textComparator, Comparator<String> fallbackComparator) {
+		this.stringComparator = buildComparator(textComparator);
+		this.fallbackComparator = fallbackComparator;
+	}
 
 	@Override
 	public int compare(String o1, String o2) {
 		try {
 			return stringComparator.compare(o1, o2);
 		} catch (NumberFormatException nfe) {
-			return Comparator.comparing(String::valueOf).compare(o1, o2);
+			return fallbackComparator.compare(String.valueOf(o1), String.valueOf(o2));
 		}
+	}
+
+	private static Comparator<String> buildComparator(Comparator<String> textComparator) {
+		return Comparator
+				.comparing(AlphaNumericComparator::getTextPart, textComparator)
+				.thenComparingLong(AlphaNumericComparator::getNumberPart);
+	}
+
+	private static String getTextPart(String value) {
+		return String.valueOf(value).replaceAll("\\d", "");
+	}
+
+	private static long getNumberPart(String value) {
+		String numberPart = String.valueOf(value).replaceAll("\\D", "");
+		return StringUtils.isNumeric(numberPart) ? Long.parseLong(numberPart) : 0;
 	}
 }

--- a/kernel/api/src/main/java/org/sakaiproject/util/comparator/AlphaNumericComparator.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/comparator/AlphaNumericComparator.java
@@ -15,8 +15,7 @@
  */
 package org.sakaiproject.util.comparator;
 
-import org.apache.commons.lang3.StringUtils;
-
+import java.math.BigInteger;
 import java.text.Collator;
 import java.util.Comparator;
 import java.util.Locale;
@@ -24,46 +23,38 @@ import java.util.Objects;
 
 public class AlphaNumericComparator implements Comparator<String> {
 	private final Comparator<String> stringComparator;
-	private final Comparator<String> fallbackComparator;
 
 	public AlphaNumericComparator() {
-		this(String.CASE_INSENSITIVE_ORDER, Comparator.naturalOrder());
+		this(String.CASE_INSENSITIVE_ORDER);
 	}
 
 	public AlphaNumericComparator(Locale locale) {
-		Collator collator = Collator.getInstance(Objects.requireNonNull(locale));
-		collator.setStrength(Collator.SECONDARY);
+		Collator collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(Objects.requireNonNull(locale), Collator.SECONDARY);
 		Comparator<String> localeComparator = collator::compare;
 		this.stringComparator = buildComparator(localeComparator);
-		this.fallbackComparator = localeComparator;
 	}
 
-	private AlphaNumericComparator(Comparator<String> textComparator, Comparator<String> fallbackComparator) {
+	private AlphaNumericComparator(Comparator<String> textComparator) {
 		this.stringComparator = buildComparator(textComparator);
-		this.fallbackComparator = fallbackComparator;
 	}
 
 	@Override
 	public int compare(String o1, String o2) {
-		try {
-			return stringComparator.compare(o1, o2);
-		} catch (NumberFormatException nfe) {
-			return fallbackComparator.compare(String.valueOf(o1), String.valueOf(o2));
-		}
+		return stringComparator.compare(o1, o2);
 	}
 
 	private static Comparator<String> buildComparator(Comparator<String> textComparator) {
 		return Comparator
 				.comparing(AlphaNumericComparator::getTextPart, textComparator)
-				.thenComparingLong(AlphaNumericComparator::getNumberPart);
+				.thenComparing(AlphaNumericComparator::getNumberPart);
 	}
 
 	private static String getTextPart(String value) {
 		return String.valueOf(value).replaceAll("\\d", "");
 	}
 
-	private static long getNumberPart(String value) {
+	private static BigInteger getNumberPart(String value) {
 		String numberPart = String.valueOf(value).replaceAll("\\D", "");
-		return StringUtils.isNumeric(numberPart) ? Long.parseLong(numberPart) : 0;
+		return numberPart.isEmpty() ? BigInteger.ZERO : new BigInteger(numberPart);
 	}
 }

--- a/kernel/api/src/main/java/org/sakaiproject/util/comparator/GroupTitleComparator.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/comparator/GroupTitleComparator.java
@@ -16,11 +16,20 @@
 package org.sakaiproject.util.comparator;
 
 import java.util.Comparator;
+import java.util.Locale;
 
 import org.sakaiproject.site.api.Group;
 
 public class GroupTitleComparator implements Comparator<Group> {
-    private AlphaNumericComparator alphaNumeric = new AlphaNumericComparator();
+    private final AlphaNumericComparator alphaNumeric;
+
+    public GroupTitleComparator() {
+        this.alphaNumeric = new AlphaNumericComparator();
+    }
+
+    public GroupTitleComparator(Locale locale) {
+        this.alphaNumeric = new AlphaNumericComparator(locale);
+    }
 
     public int compare(Group lhs, Group rhs) {
         return alphaNumeric.compare(lhs.getTitle(), rhs.getTitle());

--- a/kernel/api/src/main/java/org/sakaiproject/util/comparator/SakaiCollators.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/comparator/SakaiCollators.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.util.comparator;
+
+import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class SakaiCollators {
+
+    private SakaiCollators() {
+    }
+
+    public static Collator getCollatorWithUnderscoreAfterSpace(Locale locale, int strength) {
+        Collator collator = Collator.getInstance(Objects.requireNonNull(locale));
+
+        if (collator instanceof RuleBasedCollator) {
+            try {
+                collator = new RuleBasedCollator(((RuleBasedCollator) collator).getRules()
+                        .replaceAll("<'\u005f'", "<' '<'\u005f'"));
+            } catch (ParseException e) {
+                collator = Collator.getInstance(locale);
+            }
+        }
+
+        collator.setStrength(strength);
+        return collator;
+    }
+
+    public static Collator getSortNameCollator(Locale locale) {
+        return getCollatorWithUnderscoreAfterSpace(locale, Collator.SECONDARY);
+    }
+}

--- a/kernel/api/src/main/java/org/sakaiproject/util/comparator/UserSortNameComparator.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/comparator/UserSortNameComparator.java
@@ -16,9 +16,9 @@
 package org.sakaiproject.util.comparator;
 
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
+import java.util.Locale;
+import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,12 +37,20 @@ public class UserSortNameComparator implements Comparator<User> {
     private boolean useDisplayName = false;
 
     public UserSortNameComparator() {
-        collator = Collator.getInstance();
-        collator.setStrength(Collator.SECONDARY); // ignore case but do differentiate on accents
+        this(Locale.getDefault());
+    }
+
+    public UserSortNameComparator(Locale locale) {
+        collator = createCollator(Objects.requireNonNull(locale));
     }
 
     public UserSortNameComparator(boolean nullsLow) {
         this();
+        this.nullsLow = nullsLow;
+    }
+
+    public UserSortNameComparator(boolean nullsLow, Locale locale) {
+        this(locale);
         this.nullsLow = nullsLow;
     }
 
@@ -52,12 +60,16 @@ public class UserSortNameComparator implements Comparator<User> {
         this.useDisplayName = useDisplayName;
     }
 
+    public UserSortNameComparator(boolean nullsLow, boolean useDisplayName, Locale locale) {
+        this(locale);
+        this.nullsLow = nullsLow;
+        this.useDisplayName = useDisplayName;
+    }
+
     public int compare(User u1, User u2) {
         if (u1 == u2) return 0;
         if (u1 == null) return (nullsLow ? -1 : 1);
         if (u2 == null) return (nullsLow ? 1 : -1);
-
-        Comparator c = new NullSafeComparator<>(collator, nullsLow);
 
         String prop1 = u1.getSortName();
         String prop2 = u2.getSortName();
@@ -67,17 +79,45 @@ public class UserSortNameComparator implements Comparator<User> {
             prop2 = u2.getDisplayName();
         }
 
-        // Replace spaces to handle sorting scenarios where surname has space
-        prop1 = StringUtils.replace(prop1, " ", "+");
-        prop2 = StringUtils.replace(prop2, " ", "+");
+        return compareSortNames(prop1, u1.getDisplayId(), prop2, u2.getDisplayId());
+    }
+
+    private static Collator createCollator(Locale locale) {
+        Collator collator = Collator.getInstance(locale);
+        collator.setStrength(Collator.SECONDARY); // ignore case but do differentiate on accents
+        return collator;
+    }
+
+    public int compareSortNames(String sortName1, String displayId1, String sortName2, String displayId2) {
+        return compareSortNames(sortName1, displayId1, sortName2, displayId2, nullsLow, collator);
+    }
+
+    /**
+     * Allows Sakai user-like models, such as Sections' coursemanagement.User, to share the same sort-name behavior
+     * without implementing org.sakaiproject.user.api.User.
+     */
+    public static int compareSortNames(String sortName1, String displayId1, String sortName2, String displayId2,
+            boolean nullsLow, Locale locale) {
+        return compareSortNames(sortName1, displayId1, sortName2, displayId2, nullsLow,
+                createCollator(Objects.requireNonNull(locale)));
+    }
+
+    private static int compareSortNames(String sortName1, String displayId1, String sortName2, String displayId2,
+            boolean nullsLow, Collator collator) {
+        Comparator<String> comparator = new NullSafeComparator<>(
+                (String value1, String value2) -> collator.compare(value1, value2), nullsLow);
+
+        // Replace spaces to handle sorting scenarios where surname has space.
+        String prop1 = StringUtils.replace(sortName1, " ", "+");
+        String prop2 = StringUtils.replace(sortName2, " ", "+");
 
         // Secondary comparison on display name if full name is identical
         // E.g., John Smith (smithj1) and John Smith (smithj2)
-        if (c.compare(prop1, prop2) == 0) {
-            prop1 = u1.getDisplayId();
-            prop2 = u2.getDisplayId();
+        if (comparator.compare(prop1, prop2) == 0) {
+            prop1 = displayId1;
+            prop2 = displayId2;
         }
 
-        return c.compare(prop1, prop2);
+        return comparator.compare(prop1, prop2);
     }
 }

--- a/kernel/api/src/main/java/org/sakaiproject/util/comparator/UserSortNameComparator.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/comparator/UserSortNameComparator.java
@@ -20,8 +20,6 @@ import java.util.Comparator;
 import java.util.Locale;
 import java.util.Objects;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.user.api.User;
 import org.springframework.util.comparator.NullSafeComparator;
@@ -29,7 +27,6 @@ import org.springframework.util.comparator.NullSafeComparator;
 /**
  * This sorts users.
  */
-@Slf4j
 public class UserSortNameComparator implements Comparator<User> {
 
     private Collator collator;
@@ -83,23 +80,11 @@ public class UserSortNameComparator implements Comparator<User> {
     }
 
     private static Collator createCollator(Locale locale) {
-        Collator collator = Collator.getInstance(locale);
-        collator.setStrength(Collator.SECONDARY); // ignore case but do differentiate on accents
-        return collator;
+        return SakaiCollators.getSortNameCollator(locale);
     }
 
     public int compareSortNames(String sortName1, String displayId1, String sortName2, String displayId2) {
         return compareSortNames(sortName1, displayId1, sortName2, displayId2, nullsLow, collator);
-    }
-
-    /**
-     * Allows Sakai user-like models, such as Sections' coursemanagement.User, to share the same sort-name behavior
-     * without implementing org.sakaiproject.user.api.User.
-     */
-    public static int compareSortNames(String sortName1, String displayId1, String sortName2, String displayId2,
-            boolean nullsLow, Locale locale) {
-        return compareSortNames(sortName1, displayId1, sortName2, displayId2, nullsLow,
-                createCollator(Objects.requireNonNull(locale)));
     }
 
     private static int compareSortNames(String sortName1, String displayId1, String sortName2, String displayId2,

--- a/kernel/api/src/test/java/org/sakaiproject/util/comparator/AlphaNumericComparatorTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/comparator/AlphaNumericComparatorTest.java
@@ -17,8 +17,10 @@ package org.sakaiproject.util.comparator;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.Assert.*;
 
@@ -34,5 +36,17 @@ public class AlphaNumericComparatorTest {
         rawData.sort(alphaNumeric);
 
         assertEquals(expectedSort, rawData);
+    }
+
+    @Test
+    public void localeAlphanumericCompare() {
+        for (Locale locale : Arrays.asList(Locale.forLanguageTag("es"), Locale.forLanguageTag("eu"), Locale.forLanguageTag("ca"))) {
+            List<String> rawData = new ArrayList<>(Arrays.asList("Sección 10", "Sección 2", "Sección 1"));
+            List<String> expectedSort = Arrays.asList("Sección 1", "Sección 2", "Sección 10");
+
+            rawData.sort(new AlphaNumericComparator(locale));
+
+            assertEquals(expectedSort, rawData);
+        }
     }
 }

--- a/kernel/api/src/test/java/org/sakaiproject/util/comparator/AlphaNumericComparatorTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/comparator/AlphaNumericComparatorTest.java
@@ -39,6 +39,16 @@ public class AlphaNumericComparatorTest {
     }
 
     @Test
+    public void alphanumericCompareLargeNumberParts() {
+        List<String> rawData = Arrays.asList("X1000000000000000000000000000000000000000", "X999999999999999999999999999999999999999", "X2");
+        List<String> expectedSort = Arrays.asList("X2", "X999999999999999999999999999999999999999", "X1000000000000000000000000000000000000000");
+
+        rawData.sort(alphaNumeric);
+
+        assertEquals(expectedSort, rawData);
+    }
+
+    @Test
     public void localeAlphanumericCompare() {
         for (Locale locale : Arrays.asList(Locale.forLanguageTag("es"), Locale.forLanguageTag("eu"), Locale.forLanguageTag("ca"))) {
             List<String> rawData = new ArrayList<>(Arrays.asList("Sección 10", "Sección 2", "Sección 1"));

--- a/kernel/api/src/test/java/org/sakaiproject/util/comparator/SakaiCollatorsTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/comparator/SakaiCollatorsTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.util.comparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.text.Collator;
+import java.util.Locale;
+
+import org.junit.Test;
+
+public class SakaiCollatorsTest {
+
+    @Test
+    public void underscoreSortsImmediatelyAfterSpace() {
+        Collator collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(Locale.US, Collator.TERTIARY);
+
+        assertTrue(collator.compare(" a", "_a") < 0);
+        assertTrue(collator.compare("_a", "a") < 0);
+    }
+
+    @Test
+    public void sortNameCollatorUsesSecondaryStrength() {
+        Collator collator = SakaiCollators.getSortNameCollator(Locale.US);
+
+        assertEquals(0, collator.compare("Smith, John", "smith, john"));
+    }
+}

--- a/kernel/api/src/test/java/org/sakaiproject/util/comparator/UserSortNameComparatorTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/comparator/UserSortNameComparatorTest.java
@@ -165,6 +165,24 @@ public class UserSortNameComparatorTest {
     }
 
     @Test
+    public void spanishSortNameCompareUsesSuppliedLocale() {
+        UserSortNameComparator usComparator = new UserSortNameComparator(Locale.US);
+        UserSortNameComparator spanishComparator = new UserSortNameComparator(Locale.forLanguageTag("es"));
+
+        assertComparesBefore(usComparator, "Ña, Ana", "Nz, Ana");
+        assertComparesBefore(spanishComparator, "Nz, Ana", "Ña, Ana");
+    }
+
+    @Test
+    public void swedishSortNameCompareUsesSuppliedLocale() {
+        UserSortNameComparator usComparator = new UserSortNameComparator(Locale.US);
+        UserSortNameComparator swedishComparator = new UserSortNameComparator(Locale.forLanguageTag("sv-SE"));
+
+        assertComparesBefore(usComparator, "Åberg, Anna", "Zetterberg, Zoe");
+        assertComparesBefore(swedishComparator, "Zetterberg, Zoe", "Åberg, Anna");
+    }
+
+    @Test
     public void localeAwareSortNameCompareWithBasqueNames() {
         UserSortNameComparator comparator = new UserSortNameComparator(Locale.forLanguageTag("eu"));
 

--- a/kernel/api/src/test/java/org/sakaiproject/util/comparator/UserSortNameComparatorTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/comparator/UserSortNameComparatorTest.java
@@ -156,21 +156,6 @@ public class UserSortNameComparatorTest {
     }
 
     @Test
-    public void staticSortNameCompareMatchesUserComparator() {
-        Locale locale = Locale.forLanguageTag("es");
-        UserSortNameComparator comparator = new UserSortNameComparator(locale);
-        User userA = mockUser("Martinez Torcal, Apple", "student1");
-        User userB = mockUser("Martin Troncoso, X", "student2");
-
-        int comparatorResult = comparator.compare(userA, userB);
-        int staticResult = UserSortNameComparator.compareSortNames(userA.getSortName(), userA.getDisplayId(),
-                userB.getSortName(), userB.getDisplayId(), false, locale);
-
-        assertEquals(Integer.signum(comparatorResult), Integer.signum(staticResult));
-        assertEquals(1, Integer.signum(staticResult));
-    }
-
-    @Test
     public void localeAwareSortNameCompareWithSpanishNames() {
         UserSortNameComparator comparator = new UserSortNameComparator(Locale.forLanguageTag("es"));
 

--- a/kernel/api/src/test/java/org/sakaiproject/util/comparator/UserSortNameComparatorTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/comparator/UserSortNameComparatorTest.java
@@ -16,7 +16,10 @@
 package org.sakaiproject.util.comparator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+
+import java.util.Locale;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -150,5 +153,57 @@ public class UserSortNameComparatorTest {
         assertEquals(1, comparator.compare(userA, userB));
         assertEquals(1, comparator.compare(userA, userC));
         assertEquals(-1, comparator.compare(userB, userC));
+    }
+
+    @Test
+    public void staticSortNameCompareMatchesUserComparator() {
+        Locale locale = Locale.forLanguageTag("es");
+        UserSortNameComparator comparator = new UserSortNameComparator(locale);
+        User userA = mockUser("Martinez Torcal, Apple", "student1");
+        User userB = mockUser("Martin Troncoso, X", "student2");
+
+        int comparatorResult = comparator.compare(userA, userB);
+        int staticResult = UserSortNameComparator.compareSortNames(userA.getSortName(), userA.getDisplayId(),
+                userB.getSortName(), userB.getDisplayId(), false, locale);
+
+        assertEquals(Integer.signum(comparatorResult), Integer.signum(staticResult));
+        assertEquals(1, Integer.signum(staticResult));
+    }
+
+    @Test
+    public void localeAwareSortNameCompareWithSpanishNames() {
+        UserSortNameComparator comparator = new UserSortNameComparator(Locale.forLanguageTag("es"));
+
+        assertComparesBefore(comparator, "Martin Troncoso, X", "Martinez Torcal, Apple");
+        assertComparesBefore(comparator, "Inigo, Ana", "Iñigo, Ana");
+        assertComparesBefore(comparator, "de la Cruz, Ana", "Delgado, Ana");
+    }
+
+    @Test
+    public void localeAwareSortNameCompareWithBasqueNames() {
+        UserSortNameComparator comparator = new UserSortNameComparator(Locale.forLanguageTag("eu"));
+
+        assertComparesBefore(comparator, "Etxe Berria, Aitor", "Etxeberria, Aitor");
+        assertComparesBefore(comparator, "Goikoetxea, Ane", "Goñi, Ane");
+    }
+
+    @Test
+    public void localeAwareSortNameCompareWithCatalanNames() {
+        UserSortNameComparator comparator = new UserSortNameComparator(Locale.forLanguageTag("ca"));
+
+        assertComparesBefore(comparator, "L·lull, Ramon", "Llull, Ramon");
+        assertComparesBefore(comparator, "Marti, Nuria", "Martí, Nuria");
+	}
+
+    private void assertComparesBefore(UserSortNameComparator comparator, String sortName1, String sortName2) {
+        assertEquals(-1, Integer.signum(comparator.compare(
+                mockUser(sortName1, "student1"), mockUser(sortName2, "student2"))));
+    }
+
+    private User mockUser(String sortName, String displayId) {
+        User user = Mockito.mock(User.class);
+        when(user.getSortName()).thenReturn(sortName);
+        when(user.getDisplayId()).thenReturn(displayId);
+        return user;
     }
 }

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/CommentGradingPaneProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/CommentGradingPaneProducer.java
@@ -38,6 +38,7 @@ import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import uk.org.ponder.messageutil.MessageLocator;
@@ -67,6 +68,7 @@ public class CommentGradingPaneProducer implements ViewComponentProducer, ViewPa
 	private MessageLocator messageLocator;
         private SecurityService securityService;
         private SiteService siteService;
+        private LocaleService localeService;
 	public LocaleGetter localeGetter;
          
 	
@@ -92,6 +94,10 @@ public class CommentGradingPaneProducer implements ViewComponentProducer, ViewPa
 
 	public void setMessageLocator(MessageLocator messageLocator) {
 		this.messageLocator = messageLocator;
+	}
+
+	public void setLocaleService(LocaleService localeService) {
+		this.localeService = localeService;
 	}
 	
 	private class SimpleUser implements Comparable<SimpleUser> {
@@ -214,7 +220,7 @@ public class CommentGradingPaneProducer implements ViewComponentProducer, ViewPa
 		    	} catch (Exception e) {
 		        }
 		    }
-		    Collections.sort(missing, new UserSortNameComparator());
+		    Collections.sort(missing, new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()));
 		    UIOutput.make(tofill, "missing-head");
 		    UIOutput.make(tofill, "missing-div");
 		    for (User user : missing) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/QuestionGradingPaneProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/QuestionGradingPaneProducer.java
@@ -38,6 +38,7 @@ import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.user.api.User;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.sakaiproject.time.api.UserTimeService;
 
@@ -69,6 +70,7 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
         private SecurityService securityService;
         private SiteService siteService;
 	@Setter private UserTimeService userTimeService;
+	private LocaleService localeService;
 	private MessageLocator messageLocator;
 	public LocaleGetter localeGetter;                                                                                             
 	
@@ -94,6 +96,10 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 
 	public void setMessageLocator(MessageLocator messageLocator) {
 		this.messageLocator = messageLocator;
+	}
+
+	public void setLocaleService(LocaleService localeService) {
+		this.localeService = localeService;
 	}
 	
 	private class SimpleUser implements Comparable<SimpleUser> {
@@ -237,7 +243,7 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 				} catch (Exception e) {
 				}
 			}
-		    Collections.sort(missing, new UserSortNameComparator());
+		    Collections.sort(missing, new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()));
 		    UIOutput.make(tofill, "missing-head");
 		    UIOutput.make(tofill, "missing-div");
 		    for (User user : missing) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/QuestionGradingPaneProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/QuestionGradingPaneProducer.java
@@ -70,7 +70,7 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
         private SecurityService securityService;
         private SiteService siteService;
 	@Setter private UserTimeService userTimeService;
-	private LocaleService localeService;
+	@Setter private LocaleService localeService;
 	private MessageLocator messageLocator;
 	public LocaleGetter localeGetter;                                                                                             
 	
@@ -98,10 +98,6 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 		this.messageLocator = messageLocator;
 	}
 
-	public void setLocaleService(LocaleService localeService) {
-		this.localeService = localeService;
-	}
-	
 	private class SimpleUser implements Comparable<SimpleUser> {
 		public String displayName;
 		public String userId;

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/QuestionGradingPaneProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/QuestionGradingPaneProducer.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.HashSet;
 
@@ -98,15 +99,12 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 		this.messageLocator = messageLocator;
 	}
 
-	private class SimpleUser implements Comparable<SimpleUser> {
-		public String displayName;
+	private class SimpleUser {
+		public String sortName;
+		public String displayId;
 		public String userId;
 		public Double grade;
 		public SimplePageQuestionResponse response = null;
-		
-		public int compareTo(SimpleUser user) {
-			return displayName.compareTo(user.displayName);
-		}
 	}
 
 	public void fillComponents(UIContainer tofill, ViewParameters viewparams, ComponentChecker checker) {
@@ -171,7 +169,9 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 				notSubmitted.remove(response.getUserId());
 				try {
 					SimpleUser user = new SimpleUser();
-					user.displayName = UserDirectoryService.getUser(response.getUserId()).getSortName();
+					User directoryUser = UserDirectoryService.getUser(response.getUserId());
+					user.sortName = directoryUser.getSortName();
+					user.displayId = directoryUser.getDisplayId();
 					user.userId = response.getUserId();
 					if (manuallyGraded && !response.isOverridden())
 					    user.grade = null;
@@ -184,8 +184,11 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 			}
 		}
 		
+		Locale locale = localeService.getLocaleForCurrentSiteAndUser();
+		UserSortNameComparator userSortNameComparator = new UserSortNameComparator(locale);
 		ArrayList<SimpleUser> simpleUsers = new ArrayList<SimpleUser>(users.values());
-		Collections.sort(simpleUsers);
+		simpleUsers.sort((user1, user2) -> userSortNameComparator.compareSortNames(user1.sortName, user1.displayId,
+				user2.sortName, user2.displayId));
 		
 		if(simpleUsers.size() > 0) {
 			UIOutput.make(tofill, "gradingTable");
@@ -208,7 +211,7 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 			
 			UIOutput.make(branch, "data-row");
 			
-			UIOutput.make(branch, "student-name", user.displayName);
+			UIOutput.make(branch, "student-name", user.sortName);
 			if("multipleChoice".equals(questionItem.getAttribute("questionType"))) {
 				UIOutput.make(branch, "student-response", user.response.getOriginalText());
 			}else {
@@ -225,7 +228,7 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 				UIOutput.make(branch, "responsePoints",
 					(user.grade == null? "" : String.valueOf(user.grade)));
 				UIOutput.make(branch, "pointsBox").
-					decorate(new UIFreeAttributeDecorator("title", messageLocator.getMessage("simplepage.grade-for-student").replace("{}", user.displayName)));
+					decorate(new UIFreeAttributeDecorator("title", messageLocator.getMessage("simplepage.grade-for-student").replace("{}", user.sortName)));
 				UIOutput.make(branch, "maxpoints", " / " + (questionItem.getGradebookPoints()));
 			}
 		}
@@ -239,7 +242,7 @@ public class QuestionGradingPaneProducer implements ViewComponentProducer, ViewP
 				} catch (Exception e) {
 				}
 			}
-		    Collections.sort(missing, new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()));
+		    Collections.sort(missing, userSortNameComparator);
 		    UIOutput.make(tofill, "missing-head");
 		    UIOutput.make(tofill, "missing-div");
 		    for (User user : missing) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -99,6 +99,7 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import uk.org.ponder.localeutil.LocaleGetter;
 import uk.org.ponder.messageutil.MessageLocator;
@@ -155,6 +156,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 	private FormatAwareDateInputEvolver dateevolver;
 	@Setter private UserTimeService userTimeService;
 	@Setter private FormattedText formattedText;
+	@Setter private LocaleService localeService;
 	private HttpServletRequest httpServletRequest;
 	private HttpServletResponse httpServletResponse;
 	// have to do it here because we need it in urlCache. It has to happen before Spring initialization
@@ -5101,9 +5103,9 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 
 				// Sort the site member list before filling the "possOwners" list
 				List<Member> siteMemberList = new ArrayList<Member>(simplePageBean.getCurrentSite().getMembers());
+				UserSortNameComparator userComparator = new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser());
 				Collections.sort(siteMemberList, new Comparator<Member>() {
 					public int compare(Member lhs, Member rhs) {
-						UserSortNameComparator userComparator = new UserSortNameComparator();
 						return userComparator.compare(getUser(lhs.getUserId()), getUser(rhs.getUserId()));
 					}
 				});

--- a/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
@@ -43,6 +43,7 @@
 		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 		<property name="simplePageToolDao" ref="org.sakaiproject.lessonbuildertool.model.SimplePageToolDao" />
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService" />
 		<property name="dateEvolver" ref="fieldDateInputEvolver" />
 		<property name="forumEntity" ref="org.sakaiproject.lessonbuildertool.service.ForumEntity"/>
 		<property name="quizEntity" ref="org.sakaiproject.lessonbuildertool.service.SamigoEntity"/>
@@ -219,6 +220,7 @@
 	<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 	<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
     	<property name="messageLocator" ref="messageLocator"/>
+	<property name="localeService" ref="org.sakaiproject.util.api.LocaleService" />
 	<property name="localeGetter" ref="requestLocaleProxy" />
     </bean>
     
@@ -231,6 +233,7 @@
 	<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 	<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService"/>
     	<property name="messageLocator" ref="messageLocator"/>
+	<property name="localeService" ref="org.sakaiproject.util.api.LocaleService" />
 	<property name="localeGetter" ref="requestLocaleProxy" />
     </bean>
 

--- a/mailsender/impl/src/java/org/sakaiproject/mailsender/logic/impl/ComposeLogicImpl.java
+++ b/mailsender/impl/src/java/org/sakaiproject/mailsender/logic/impl/ComposeLogicImpl.java
@@ -44,6 +44,7 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import lombok.extern.slf4j.Slf4j;
@@ -60,6 +61,7 @@ public class ComposeLogicImpl implements ComposeLogic
 	protected ToolManager toolManager;
 	protected ServerConfigurationService serverConfigurationService;
 	protected ConfigLogic configLogic;
+	protected LocaleService localeService;
 	protected HashSet<String> ignoreRoles = new HashSet<String>();
 
 	/**
@@ -454,6 +456,10 @@ public class ComposeLogicImpl implements ComposeLogic
 		this.configLogic = configLogic;
 	}
 
+	public void setLocaleService(LocaleService localeService) {
+		this.localeService = localeService;
+	}
+
 	/**
 	 * Inject method for setting any roles that should be ignored.
 	 *
@@ -489,7 +495,7 @@ public class ComposeLogicImpl implements ComposeLogic
 	private List<User> getSortedUsers(Set<String> userIds)
 	{
 		List<User> users = this.userDirectoryService.getUsers(userIds);
-		users.sort(new UserSortNameComparator());
+		users.sort(new UserSortNameComparator(localeService.getLocaleForSiteAndUser(externalLogic.getSiteID(), externalLogic.getCurrentUserId())));
 		return users;
 	}
 

--- a/mailsender/impl/src/webapp/WEB-INF/components.xml
+++ b/mailsender/impl/src/webapp/WEB-INF/components.xml
@@ -37,6 +37,7 @@
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService" />
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 		<property name="configLogic" ref="org.sakaiproject.mailsender.logic.ConfigLogic" />
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService" />
 	</bean>
 
 	<!--

--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MembershipItem.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MembershipItem.java
@@ -21,26 +21,23 @@
 package org.sakaiproject.api.app.messageforums;
 
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
 import java.util.UUID;
 
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.user.api.User;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Recipient Item for storing different types of recipients user/group/role
  */
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
-@Slf4j
 public class MembershipItem implements Comparable<MembershipItem> {
 
     public static final int TYPE_NOT_SPECIFIED = 0;
@@ -52,19 +49,7 @@ public class MembershipItem implements Comparable<MembershipItem> {
     public static final int TYPE_MYGROUPROLES = 6;
     public static final int TYPE_MYGROUPMEMBERS = 7;
 
-    private static Collator collator = Collator.getInstance();
-    static
-    {
-        try
-        {
-            // collator to ignore spaces
-            collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-        }
-        catch (ParseException e)
-        {
-            log.error("Unable to create RuleBasedCollator", e);
-        }
-    }
+    private static Collator collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
 
     public static final Comparator<MembershipItem> compareByType = Comparator.comparingInt(MembershipItem::getType);
     public static final Comparator<MembershipItem> compareByName = (o1, o2) -> collator.compare(o1.getName(), o2.getName());

--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MembershipItem.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MembershipItem.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.user.api.User;
-import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.comparator.SakaiCollators;
 
 import lombok.EqualsAndHashCode;
@@ -92,7 +91,7 @@ public class MembershipItem implements Comparable<MembershipItem> {
 
     @Override
     public int compareTo(MembershipItem item) {
-        return compareByType.thenComparing(getNameComparator(new ResourceLoader().getLocale())).compare(this, item);
+        return compareByType.thenComparing(getNameComparator(Locale.getDefault())).compare(this, item);
     }
 }
  

--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MembershipItem.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MembershipItem.java
@@ -22,11 +22,13 @@ package org.sakaiproject.api.app.messageforums;
 
 import java.text.Collator;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.user.api.User;
+import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.comparator.SakaiCollators;
 
 import lombok.EqualsAndHashCode;
@@ -49,10 +51,12 @@ public class MembershipItem implements Comparable<MembershipItem> {
     public static final int TYPE_MYGROUPROLES = 6;
     public static final int TYPE_MYGROUPMEMBERS = 7;
 
-    private static Collator collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
-
     public static final Comparator<MembershipItem> compareByType = Comparator.comparingInt(MembershipItem::getType);
-    public static final Comparator<MembershipItem> compareByName = (o1, o2) -> collator.compare(o1.getName(), o2.getName());
+
+    public static Comparator<MembershipItem> getNameComparator(Locale resolvedLocale) {
+        Collator collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(resolvedLocale, Collator.TERTIARY);
+        return (o1, o2) -> collator.compare(o1.getName(), o2.getName());
+    }
 
     @EqualsAndHashCode.Include
     private String id;
@@ -88,7 +92,7 @@ public class MembershipItem implements Comparable<MembershipItem> {
 
     @Override
     public int compareTo(MembershipItem item) {
-        return compareByType.thenComparing(compareByName).compare(this, item);
+        return compareByType.thenComparing(getNameComparator(new ResourceLoader().getLocale())).compare(this, item);
     }
 }
  

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
@@ -87,6 +87,7 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
@@ -428,6 +429,8 @@ public class MessageForumStatisticsBean {
 	private UIPermissionsManager uiPermissionsManager;
 	@ManagedProperty(value="#{Components[\"org.sakaiproject.util.api.FormattedText\"]}")
 	private FormattedText formattedText;
+	@ManagedProperty(value="#{Components[\"org.sakaiproject.util.api.LocaleService\"]}")
+	private LocaleService localeService;
 
 	public boolean getDiscussionGeneric() {
 		return this.discussionGeneric;
@@ -485,6 +488,10 @@ public class MessageForumStatisticsBean {
 
 	public void setFormattedText(FormattedText formattedText) {
 		this.formattedText = formattedText;
+	}
+
+	public void setLocaleService(LocaleService localeService) {
+		this.localeService = localeService;
 	}
 
 	public void setSecurityService(SecurityService securityService) {
@@ -2616,7 +2623,8 @@ public class MessageForumStatisticsBean {
 			}
 		}
 
-		Collections.sort(list);
+		list.sort(MembershipItem.compareByType.thenComparing(
+				MembershipItem.getNameComparator(localeService.getLocaleForCurrentSiteAndUser())));
 
 		return list;
 	}

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MembershipManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MembershipManagerImpl.java
@@ -54,6 +54,7 @@ import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.api.LocaleService;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -64,6 +65,7 @@ public class MembershipManagerImpl implements MembershipManager {
   @Setter private PrivacyManager privacyManager;
   @Setter private PrivateMessageManager prtMsgManager;
   @Setter private ServerConfigurationService serverConfigurationService;
+  @Setter private LocaleService localeService;
   @Setter private SiteService siteService;
   @Setter private ToolManager toolManager;
   @Setter private UserDirectoryService userDirectoryService;
@@ -447,7 +449,8 @@ public class MembershipManagerImpl implements MembershipManager {
             
     MembershipItem[] membershipArray = new MembershipItem[memberMap.size()];
     membershipArray = (MembershipItem[]) memberMap.values().toArray(membershipArray);
-    Arrays.sort(membershipArray);
+    Arrays.sort(membershipArray, MembershipItem.compareByType.thenComparing(
+        MembershipItem.getNameComparator(localeService.getLocaleForCurrentSiteAndUser())));
     
     return Arrays.asList(membershipArray);     
   }

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/scheduler/PrivateMessageSchedulerServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/scheduler/PrivateMessageSchedulerServiceImpl.java
@@ -53,6 +53,7 @@ import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.api.LocaleService;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -94,6 +95,8 @@ public class PrivateMessageSchedulerServiceImpl implements PrivateMessageSchedul
 	private ServerConfigurationService serverConfigurationService;
 	@Setter
 	private PrivacyManager privacyManager;
+	@Setter
+	private LocaleService localeService;
 
 	private static final String MESSAGECENTER_BUNDLE = "org.sakaiproject.api.app.messagecenter.bundle.Messages";
 	private ResourceLoader rl;
@@ -191,7 +194,7 @@ public class PrivateMessageSchedulerServiceImpl implements PrivateMessageSchedul
 
 		Map<User, Boolean> returnSet = null;
 		/** get List of unfiltered course members */
-		List allCourseUsers = convertMemberMapToList(getAllCourseUsersAsMap(pvtMsg));
+		List allCourseUsers = convertMemberMapToList(getAllCourseUsersAsMap(pvtMsg), pvtMsg);
 
 		Map courseMemberMap = null;
 		try {
@@ -203,7 +206,7 @@ public class PrivateMessageSchedulerServiceImpl implements PrivateMessageSchedul
 			log.warn(e.getMessage(), e);
 			return Collections.EMPTY_MAP;
 		}
-		List<MembershipItem> members = convertMemberMapToList(courseMemberMap);
+		List<MembershipItem> members = convertMemberMapToList(courseMemberMap, pvtMsg);
 		SelectedLists selectedLists = populateDraftRecipients(pvtMsg.getId(), messageManager, members, members);
 
 		Map<User, Boolean> composeToSet = getRecipientsHelper(selectedLists.to, allCourseUsers, Boolean.FALSE, courseMemberMap);
@@ -355,10 +358,17 @@ public class PrivateMessageSchedulerServiceImpl implements PrivateMessageSchedul
 	}
 
 	public List<MembershipItem> convertMemberMapToList(Map<String, MembershipItem> memberMap) {
+		return convertMemberMapToList(memberMap, null);
+	}
+
+	private List<MembershipItem> convertMemberMapToList(Map<String, MembershipItem> memberMap, PrivateMessage pvtMsg) {
 
 		MembershipItem[] membershipArray = new MembershipItem[memberMap.size()];
 		membershipArray = (MembershipItem[]) memberMap.values().toArray(membershipArray);
-		Arrays.sort(membershipArray);
+		String siteId = pvtMsg != null ? pvtMsg.getRecipients().get(0).getContextId() : null;
+		String userId = pvtMsg != null ? pvtMsg.getAuthorId() : null;
+		Arrays.sort(membershipArray, MembershipItem.compareByType.thenComparing(
+				MembershipItem.getNameComparator(localeService.getLocaleForSiteAndUser(siteId, userId))));
 
 		return Arrays.asList(membershipArray);
 	}
@@ -519,7 +529,7 @@ public class PrivateMessageSchedulerServiceImpl implements PrivateMessageSchedul
 		// set FERPA status for all items in map - allCourseUsers
 		// needed by PrivacyManager to determine status
 
-		return setPrivacyStatus(convertMemberMapToList(getAllCourseUsersAsMap(pvtMsg)), returnMap, pvtMsg);
+		return setPrivacyStatus(convertMemberMapToList(getAllCourseUsersAsMap(pvtMsg), pvtMsg), returnMap, pvtMsg);
 	}
 
 	private boolean isGroupAlreadyInMap(Map<String, MembershipItem> returnMap, MembershipItem membershipItem) {

--- a/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MsgcntrTestConfiguration.java
+++ b/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MsgcntrTestConfiguration.java
@@ -59,6 +59,7 @@ import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotificationPreferencesRegistration;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.api.LocaleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -74,6 +75,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
 import java.io.IOException;
+import java.util.Locale;
 
 import static org.mockito.Mockito.mock;
 
@@ -165,6 +167,14 @@ public class MsgcntrTestConfiguration {
     @Bean(name = "org.sakaiproject.util.api.FormattedText")
     public FormattedText formattedText() {
         return mock(FormattedText.class);
+    }
+
+    @Bean(name = "org.sakaiproject.util.api.LocaleService")
+    public LocaleService localeService() {
+        LocaleService localeService = mock(LocaleService.class);
+        Mockito.when(localeService.getLocaleForCurrentSiteAndUser()).thenReturn(Locale.US);
+        Mockito.when(localeService.getLocaleForSiteAndUser(Mockito.any(), Mockito.any())).thenReturn(Locale.US);
+        return localeService;
     }
 
     @Bean(name = "org.sakaiproject.authz.api.FunctionManager")

--- a/msgcntr/messageforums-component-impl/src/webapp/WEB-INF/components.xml
+++ b/msgcntr/messageforums-component-impl/src/webapp/WEB-INF/components.xml
@@ -241,6 +241,7 @@
         <property name="privacyManager" ref="org.sakaiproject.api.privacy.PrivacyManager"/>
         <property name="prtMsgManager" ref="org.sakaiproject.api.app.messageforums.ui.PrivateMessageManager"/>
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
+        <property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
     </bean>
 
     <bean id="org.sakaiproject.api.app.messageforums.ForumTopicEntityProvider" class="org.sakaiproject.component.app.messageforums.entity.ForumTopicEntityProviderImpl">
@@ -401,6 +402,7 @@
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
         <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>
         <property name="privacyManager" ref="org.sakaiproject.api.privacy.PrivacyManager" />
+        <property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
     </bean>
 
     <bean id="org.sakaiproject.component.app.messageforums.elfinder.ForumToolFsVolumeFactory"

--- a/roster2/tool/src/java/org/sakaiproject/roster/api/RosterMemberComparator.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/api/RosterMemberComparator.java
@@ -35,9 +35,10 @@
 package org.sakaiproject.roster.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.sakaiproject.util.comparator.UserNameComparator;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import java.util.Comparator;
+import java.util.Locale;
 
 /**
  * <code>Comparator</code> for <code>RosterMember</code>s.
@@ -48,10 +49,11 @@ import java.util.Comparator;
 public class RosterMemberComparator implements Comparator<RosterMember> {
 
     private final boolean firstNameLastName;
-    private UserNameComparator userNameComparator = new UserNameComparator();
+    private final UserSortNameComparator userSortNameComparator;
 
-    public RosterMemberComparator(boolean firstNameLastName) {
+    public RosterMemberComparator(boolean firstNameLastName, Locale locale) {
         this.firstNameLastName = firstNameLastName;
+        this.userSortNameComparator = new UserSortNameComparator(locale);
     }
 	
     /**
@@ -63,9 +65,11 @@ public class RosterMemberComparator implements Comparator<RosterMember> {
     public int compare(RosterMember member1, RosterMember member2) {
 
         if (firstNameLastName) {
-            return userNameComparator.compare(member1.getDisplayName(), member2.getDisplayName());
+            return userSortNameComparator.compareSortNames(member1.getDisplayName(), member1.getDisplayId(),
+                    member2.getDisplayName(), member2.getDisplayId());
         } else {
-            return userNameComparator.compare(member1.getSortName(), member2.getSortName());
+            return userSortNameComparator.compareSortNames(member1.getSortName(), member1.getDisplayId(),
+                    member2.getSortName(), member2.getDisplayId());
         }
     }
 }

--- a/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
+++ b/roster2/tool/src/java/org/sakaiproject/roster/impl/SakaiProxyImpl.java
@@ -111,6 +111,7 @@ import org.sakaiproject.user.api.CandidateDetailProvider;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
+import org.sakaiproject.util.api.LocaleService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -118,7 +119,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -157,8 +157,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 
     @Resource private ToolManager toolManager;
     @Resource private UserDirectoryService userDirectoryService;
-
-    @Setter private RosterMemberComparator memberComparator;
+    @Resource private LocaleService localeService;
 
     private static final String SAK_PROP_SHOW_PERMS_TO_MAINTAINERS = "roster.showPermsToMaintainers";
     private static final boolean SAK_PROP_SHOW_PERMS_TO_MAINTAINERS_DEFAULT = true;
@@ -190,7 +189,6 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
         }
 
         eventTrackingService.addObserver(this);
-        memberComparator = new RosterMemberComparator(getFirstNameLastName());
         userPropsRegex = Pattern.compile(serverConfigurationService.getString("roster.filter.user.properties.regex", "^udp\\.dn$|additionalInfo|specialNeeds|studentNumber"));
     }
 
@@ -259,6 +257,10 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
 
         return serverConfigurationService.getBoolean(
                 "roster.display.firstNameLastName", DEFAULT_FIRST_NAME_LAST_NAME);
+    }
+
+    private RosterMemberComparator getMemberComparator() {
+        return new RosterMemberComparator(getFirstNameLastName(), localeService.getLocaleForCurrentSiteAndUser());
     }
 
     @Override
@@ -538,7 +540,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
                 filtered.addAll(unfiltered.stream().filter(RosterMember::isInstructor).toList());
 
                 // The group loop is shuffling members, sort the list again
-                filtered.sort(memberComparator);
+                filtered.sort(getMemberComparator());
             } else if (null != site.getGroup(groupId)) {
                 // get all members of requested groupId if current user is
                 // member
@@ -814,6 +816,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
             cacheMembersMap.put(siteId, siteMembers);
             log.debug("Caching on '{}' ...", siteId);
 
+            RosterMemberComparator memberComparator = getMemberComparator();
             cacheMembersMap.values().forEach(a -> a.sort(memberComparator));
             cache.putAll(cacheMembersMap);
             siteMembers = (List<RosterMember>) cache.get(key);
@@ -888,6 +891,7 @@ public class SakaiProxyImpl implements SakaiProxy, Observer {
                 members.add(member);
             }
 
+            RosterMemberComparator memberComparator = getMemberComparator();
             members.sort(memberComparator);
             waiting.sort(memberComparator);
             enrolled.sort(memberComparator);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
@@ -109,9 +109,6 @@ import org.sakaiproject.util.api.FormattedText;
 @ManagedBean(name="itemauthor")
 @SessionScoped
 public class ItemAuthorBean implements Serializable {
-  private static final Collator COLLATOR = SakaiCollators
-      .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
-
 
   /** Use serialVersionUID for interoperability. */
   private final static long serialVersionUID = 8266438770394956874L;
@@ -946,9 +943,13 @@ public class ItemAuthorBean implements Serializable {
 		public int compare(Object o1, Object o2) {
 			SelectItem i1 = (SelectItem) o1;
 			SelectItem i2 = (SelectItem) o2;
-			return COLLATOR.compare(i1.getLabel(), i2.getLabel());
+			return getCollator().compare(i1.getLabel(), i2.getLabel());
 		}
 	}
+
+  private Collator getCollator() {
+    return SakaiCollators.getCollatorWithUnderscoreAfterSpace(rb.getLocale(), Collator.TERTIARY);
+  }
   
   /**
    * Corresponding answer number list ordered for match

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/ItemAuthorBean.java
@@ -29,8 +29,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -93,6 +91,7 @@ import org.sakaiproject.tool.assessment.facade.TypeFacade;
 import org.sakaiproject.tool.assessment.services.ItemService;
 import org.sakaiproject.tool.assessment.services.PublishedItemService;
 import org.sakaiproject.tool.assessment.services.QuestionPoolService;
+import org.sakaiproject.util.comparator.SakaiCollators;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.SectionContentsBean;
@@ -110,6 +109,9 @@ import org.sakaiproject.util.api.FormattedText;
 @ManagedBean(name="itemauthor")
 @SessionScoped
 public class ItemAuthorBean implements Serializable {
+  private static final Collator COLLATOR = SakaiCollators
+      .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
+
 
   /** Use serialVersionUID for interoperability. */
   private final static long serialVersionUID = 8266438770394956874L;
@@ -944,12 +946,7 @@ public class ItemAuthorBean implements Serializable {
 		public int compare(Object o1, Object o2) {
 			SelectItem i1 = (SelectItem) o1;
 			SelectItem i2 = (SelectItem) o2;
-			RuleBasedCollator collator_ini = (RuleBasedCollator)Collator.getInstance();
-			try {
-				RuleBasedCollator collator= new RuleBasedCollator(collator_ini.getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				return collator.compare(i1.getLabel(), i2.getLabel());
-			} catch (ParseException e) {}
-			return Collator.getInstance().compare(i1.getLabel(), i2.getLabel());
+			return COLLATOR.compare(i1.getLabel(), i2.getLabel());
 		}
 	}
   

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/SectionBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/SectionBean.java
@@ -75,9 +75,6 @@ import lombok.extern.slf4j.Slf4j;
 @ManagedBean(name="sectionBean")
 @SessionScoped
 public class SectionBean implements Serializable {
-  private static final Collator COLLATOR = SakaiCollators
-      .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
-
 
 /** Use serialVersionUID for interoperability. */
 private final static long serialVersionUID = 4216587136245498157L;
@@ -496,8 +493,12 @@ private List attachmentList;
 	  public int compare(Object o1, Object o2) {
 		  SelectItem i1 = (SelectItem)o1;
 		  SelectItem i2 = (SelectItem)o2;
-		  return COLLATOR.compare(i1.getLabel(), i2.getLabel());
+		  return getCollator().compare(i1.getLabel(), i2.getLabel());
 	  }
+  }
+
+  private Collator getCollator() {
+    return SakaiCollators.getCollatorWithUnderscoreAfterSpace(rb.getLocale(), Collator.TERTIARY);
   }
 
   /**List of available question pools.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/SectionBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/SectionBean.java
@@ -23,8 +23,6 @@ package org.sakaiproject.tool.assessment.ui.bean.author;
 
 import java.io.Serializable;
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -66,6 +64,7 @@ import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -76,6 +75,9 @@ import lombok.extern.slf4j.Slf4j;
 @ManagedBean(name="sectionBean")
 @SessionScoped
 public class SectionBean implements Serializable {
+  private static final Collator COLLATOR = SakaiCollators
+      .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
+
 
 /** Use serialVersionUID for interoperability. */
 private final static long serialVersionUID = 4216587136245498157L;
@@ -494,12 +496,7 @@ private List attachmentList;
 	  public int compare(Object o1, Object o2) {
 		  SelectItem i1 = (SelectItem)o1;
 		  SelectItem i2 = (SelectItem)o2;
-			try{
-				RuleBasedCollator r_collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				return r_collator.compare(i1.getLabel(), i2.getLabel());
-			}catch(ParseException e){
-				  return Collator.getInstance().compare(i1.getLabel(),i2.getLabel());
-			}
+		  return COLLATOR.compare(i1.getLabel(), i2.getLabel());
 	  }
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -113,6 +113,7 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.SakaiCollators;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
@@ -125,8 +126,6 @@ public class QuestionPoolBean implements Serializable {
 	
 	  /** Use serialVersionUID for interoperability. */
 	  private final static long serialVersionUID = 418920360211039758L;
-	  private static final Collator COLLATOR = SakaiCollators
-			  .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
 	  private static final ResourceLoader rb = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.QuestionPoolMessages");
 	  private static final ResourceLoader re = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.EvaluationMessages");
 	  private static final ResourceLoader rc = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.CommonMessages");
@@ -236,6 +235,8 @@ public class QuestionPoolBean implements Serializable {
 
   @Autowired
   private SecurityService securityService;
+  @Autowired
+  private LocaleService localeService;
 
   /**
    * Creates a new QuestionPoolBean object.
@@ -327,8 +328,13 @@ public class QuestionPoolBean implements Serializable {
 		  if (i2.getTitle() == null && i1.getTitle() == null) {
 			  return 0;
 		  }
-		  return COLLATOR.compare(i1.getTitle(), i2.getTitle());
+		  return getCollator().compare(i1.getTitle(), i2.getTitle());
 	  }
+  }
+
+  private Collator getCollator() {
+	  return SakaiCollators.getCollatorWithUnderscoreAfterSpace(
+			  localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
   }
 
   class QuestionSizeComparator implements Comparator<QuestionPoolFacade> {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/questionpool/QuestionPoolBean.java
@@ -26,8 +26,6 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.text.Collator;
 import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -115,6 +113,7 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.comparator.SakaiCollators;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
@@ -126,6 +125,8 @@ public class QuestionPoolBean implements Serializable {
 	
 	  /** Use serialVersionUID for interoperability. */
 	  private final static long serialVersionUID = 418920360211039758L;
+	  private static final Collator COLLATOR = SakaiCollators
+			  .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
 	  private static final ResourceLoader rb = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.QuestionPoolMessages");
 	  private static final ResourceLoader re = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.EvaluationMessages");
 	  private static final ResourceLoader rc = new ResourceLoader("org.sakaiproject.tool.assessment.bundle.CommonMessages");
@@ -326,12 +327,7 @@ public class QuestionPoolBean implements Serializable {
 		  if (i2.getTitle() == null && i1.getTitle() == null) {
 			  return 0;
 		  }
-		  RuleBasedCollator collator_ini = (RuleBasedCollator)Collator.getInstance();
-		  try {
-			RuleBasedCollator collator= new RuleBasedCollator(collator_ini.getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-			return collator.compare(i1.getTitle(), i2.getTitle());
-		  } catch (ParseException e) {}
-		  return Collator.getInstance().compare(i1.getTitle(), i2.getTitle());
+		  return COLLATOR.compare(i1.getTitle(), i2.getTitle());
 	  }
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
@@ -104,6 +104,7 @@ import org.sakaiproject.util.comparator.UserSortNameComparator;
   private BeanSort bs;
 
   private RubricsService rubricsService = ComponentManager.get(RubricsService.class);
+  private LocaleService localeService = ComponentManager.get(LocaleService.class);
 
   //private SectionAwareness sectionAwareness;
   // private List availableSections;
@@ -803,6 +804,9 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
     if ((sortProperty).equals("totalOverrideScore")) bs.toNumericSort();
     if ((sortProperty).equals("finalScore")) bs.toNumericSort();
     if ((sortProperty).equals("timeElapsed")) bs.toNumericSort();
+
+    UserSortNameComparator userComparator = sortProperty.equals("lastName")
+        ? new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()) : null;
     
     if (sortAscending) {
     	log.debug("TotalScoreListener: setRoleAndSortSection() :: sortAscending");
@@ -810,7 +814,6 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
     		agents = (List)bs.sort();
     	} else {
     		if (!agents.isEmpty()) {
-			UserSortNameComparator userComparator = new UserSortNameComparator(ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser());
     			Collections.sort(agents, new Comparator<AgentResults>() {
     				public int compare(AgentResults a1, AgentResults a2) {
     					return userComparator.compare(getUser(a1.getAgentId()), getUser(a2.getAgentId()));
@@ -825,7 +828,6 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
     		agents = (List)bs.sortDesc();
     	} else {
     		if (!agents.isEmpty()) {
-			UserSortNameComparator userComparator = new UserSortNameComparator(ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser());
     			Collections.sort(agents, new Comparator<AgentResults>() {
     				public int compare(AgentResults a1, AgentResults a2) {
     					return userComparator.compare(getUser(a2.getAgentId()), getUser(a1.getAgentId()));

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
@@ -83,6 +83,7 @@ import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
@@ -809,9 +810,9 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
     		agents = (List)bs.sort();
     	} else {
     		if (!agents.isEmpty()) {
+			UserSortNameComparator userComparator = new UserSortNameComparator(ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser());
     			Collections.sort(agents, new Comparator<AgentResults>() {
     				public int compare(AgentResults a1, AgentResults a2) {
-    					UserSortNameComparator userComparator = new UserSortNameComparator();
     					return userComparator.compare(getUser(a1.getAgentId()), getUser(a2.getAgentId()));
     				}
     			});
@@ -824,9 +825,9 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
     		agents = (List)bs.sortDesc();
     	} else {
     		if (!agents.isEmpty()) {
+			UserSortNameComparator userComparator = new UserSortNameComparator(ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser());
     			Collections.sort(agents, new Comparator<AgentResults>() {
     				public int compare(AgentResults a1, AgentResults a2) {
-    					UserSortNameComparator userComparator = new UserSortNameComparator();
     					return userComparator.compare(getUser(a2.getAgentId()), getUser(a1.getAgentId()));
     				}
     			});

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/BeanSortComparator.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/BeanSortComparator.java
@@ -32,6 +32,7 @@ import java.text.Collator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
+import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
@@ -45,6 +46,7 @@ public class BeanSortComparator
   implements Comparator
 {
   private Collator collator;
+  private Locale locale;
 
   private String propertyName;
 
@@ -56,12 +58,13 @@ public class BeanSortComparator
    */
   public BeanSortComparator(String propertyName)
   {
-    this(propertyName, Locale.getDefault());
+    this(propertyName, new ResourceLoader().getLocale());
   }
 
   public BeanSortComparator(String propertyName, Locale locale)
   {
     this.propertyName = propertyName;
+    this.locale = locale;
     this.collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
   }
 
@@ -120,18 +123,18 @@ public class BeanSortComparator
 	  }
 
 	  // Deal with n/a case
-	  if (s1.toLowerCase().startsWith("n/a")
-			  && !s2.toLowerCase().startsWith("n/a"))
+	  if (s1.toLowerCase(locale).startsWith("n/a")
+			  && !s2.toLowerCase(locale).startsWith("n/a"))
 		  return 1;
 
-	  if (s2.toLowerCase().startsWith("n/a") &&
-			  !s1.toLowerCase().startsWith("n/a"))
+	  if (s2.toLowerCase(locale).startsWith("n/a") &&
+			  !s1.toLowerCase(locale).startsWith("n/a"))
 		  return -1;
 
 
 	  String finalS1 = s1.replaceAll("<.*?>", "");
 	  String finalS2 = s2.replaceAll("<.*?>", "");
-        return collator.compare(finalS1.toLowerCase(), finalS2.toLowerCase());
+        return collator.compare(finalS1.toLowerCase(locale), finalS2.toLowerCase(locale));
   }
   
   /**

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/BeanSortComparator.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/BeanSortComparator.java
@@ -25,14 +25,14 @@ package org.sakaiproject.tool.assessment.util;
 import java.io.Serializable;
 
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.HashMap;
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.BeanUtils;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
  * DOCUMENTATION PENDING
@@ -41,9 +41,11 @@ import org.apache.commons.beanutils.BeanUtils;
  * @version $Id$
  */
 @Slf4j
- public class BeanSortComparator
+public class BeanSortComparator
   implements Comparator
 {
+  private Collator collator;
+
   private String propertyName;
 
   /**
@@ -54,7 +56,13 @@ import org.apache.commons.beanutils.BeanUtils;
    */
   public BeanSortComparator(String propertyName)
   {
+    this(propertyName, Locale.getDefault());
+  }
+
+  public BeanSortComparator(String propertyName, Locale locale)
+  {
     this.propertyName = propertyName;
+    this.collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
   }
 
   /**
@@ -123,12 +131,7 @@ import org.apache.commons.beanutils.BeanUtils;
 
 	  String finalS1 = s1.replaceAll("<.*?>", "");
 	  String finalS2 = s2.replaceAll("<.*?>", "");
-	  RuleBasedCollator collator_ini = (RuleBasedCollator)Collator.getInstance();
-	  try {
-		RuleBasedCollator collator= new RuleBasedCollator(collator_ini.getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-		return collator.compare(finalS1.toLowerCase(), finalS2.toLowerCase());
-	  } catch (ParseException e) {}
-	  return Collator.getInstance().compare(finalS1.toLowerCase(), finalS2.toLowerCase());	  
+        return collator.compare(finalS1.toLowerCase(), finalS2.toLowerCase());
   }
   
   /**

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -57,6 +57,7 @@ import org.hibernate.query.Query;
 import org.sakaiproject.antivirus.api.VirusFoundException;
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.content.api.ContentCollection;
 import org.sakaiproject.content.api.ContentCollectionEdit;
 import org.sakaiproject.content.api.ContentHostingService;
@@ -102,6 +103,7 @@ import org.sakaiproject.tool.assessment.services.ItemService;
 import org.sakaiproject.tool.assessment.services.PersistenceHelper;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.SakaiCollators;
 import org.springframework.orm.hibernate5.HibernateCallback;
 import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
@@ -2619,7 +2621,9 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
                 dataList.add(responseList);
             }
         }
-        Collections.sort(dataList, new ResponsesComparator(anonymous));
+        Collator collator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(
+                ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
+        Collections.sort(dataList, new ResponsesComparator(anonymous, collator));
         finalList.add(dataList);
         finalList.add(headerList);
         return finalList;
@@ -2794,13 +2798,12 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	 published question
 	 */
     private static class ResponsesComparator implements Comparator {
-        private static final Collator COLLATOR = SakaiCollators
-                .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
-
+        private final Collator collator;
         boolean anonymous;
 
-        public ResponsesComparator(boolean anony) {
+        public ResponsesComparator(boolean anony, Collator collator) {
             anonymous = anony;
+            this.collator = collator;
         }
 
 		public int compare(Object a, Object b) {
@@ -2820,23 +2823,23 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 			else {
 				String aFirstElement = (String) ((ArrayList) a).get(0);
 				String bFirstElement = (String) ((ArrayList) b).get(0);
-				if (COLLATOR.compare(aFirstElement, bFirstElement) < 0)
+				if (collator.compare(aFirstElement, bFirstElement) < 0)
 					return -1;
-				else if (COLLATOR.compare(aFirstElement, bFirstElement) > 0)
+				else if (collator.compare(aFirstElement, bFirstElement) > 0)
 					return 1;
 				else {
 					String aSecondElement = (String) ((ArrayList) a).get(1);
 					String bSecondElement = (String) ((ArrayList) b).get(1);
-					if (COLLATOR.compare(aSecondElement,bSecondElement) < 0)
+					if (collator.compare(aSecondElement,bSecondElement) < 0)
 						return -1;
-					else if (COLLATOR.compare(aSecondElement,bSecondElement) > 0)
+					else if (collator.compare(aSecondElement,bSecondElement) > 0)
 						return 1;
 					else {
 						String aThirdElement = (String) ((ArrayList) a).get(2);
 						String bThirdElement = (String) ((ArrayList) b).get(2);
-						if (COLLATOR.compare(aThirdElement,bThirdElement) < 0)
+						if (collator.compare(aThirdElement,bThirdElement) < 0)
 							return -1;
-						else if (COLLATOR.compare(aThirdElement,bThirdElement) > 0)
+						else if (collator.compare(aThirdElement,bThirdElement) > 0)
 							return 1;
 					}
 				}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueries.java
@@ -20,8 +20,6 @@ import java.io.File;
 import java.text.Collator;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -104,6 +102,7 @@ import org.sakaiproject.tool.assessment.services.ItemService;
 import org.sakaiproject.tool.assessment.services.PersistenceHelper;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.comparator.SakaiCollators;
 import org.springframework.orm.hibernate5.HibernateCallback;
 import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 
@@ -2794,8 +2793,10 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
 	 separate with each user, so we need to use the hash to find the
 	 published question
 	 */
-    @Slf4j
     private static class ResponsesComparator implements Comparator {
+        private static final Collator COLLATOR = SakaiCollators
+                .getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
+
         boolean anonymous;
 
         public ResponsesComparator(boolean anony) {
@@ -2803,51 +2804,44 @@ public class AssessmentGradingFacadeQueries extends HibernateDaoSupport implemen
         }
 
 		public int compare(Object a, Object b) {
-			RuleBasedCollator collator_ini = (RuleBasedCollator)Collator.getInstance();
-			try{
-				RuleBasedCollator collator = new RuleBasedCollator(collator_ini.getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				// For anonymous, it should return after the first element comparison
-				if (anonymous) {
-					Long aFirstElement = (Long) ((ArrayList) a).get(0);
-					Long bFirstElement = (Long) ((ArrayList) b).get(0);
-					if (aFirstElement.compareTo(bFirstElement) < 0)
-						return -1;
-					else if (aFirstElement.compareTo(bFirstElement) > 0)
-						return 1;
-					else
-						return 0;
-				}
-				// For non-anonymous, it compares last names first, if it is the same,
-				// compares first name, and then Eid
+			// For anonymous, it should return after the first element comparison
+			if (anonymous) {
+				Long aFirstElement = (Long) ((ArrayList) a).get(0);
+				Long bFirstElement = (Long) ((ArrayList) b).get(0);
+				if (aFirstElement.compareTo(bFirstElement) < 0)
+					return -1;
+				else if (aFirstElement.compareTo(bFirstElement) > 0)
+					return 1;
+				else
+					return 0;
+			}
+			// For non-anonymous, it compares last names first, if it is the same,
+			// compares first name, and then Eid
+			else {
+				String aFirstElement = (String) ((ArrayList) a).get(0);
+				String bFirstElement = (String) ((ArrayList) b).get(0);
+				if (COLLATOR.compare(aFirstElement, bFirstElement) < 0)
+					return -1;
+				else if (COLLATOR.compare(aFirstElement, bFirstElement) > 0)
+					return 1;
 				else {
-					String aFirstElement = (String) ((ArrayList) a).get(0);
-					String bFirstElement = (String) ((ArrayList) b).get(0);
-					if (collator.compare(aFirstElement, bFirstElement) < 0)
+					String aSecondElement = (String) ((ArrayList) a).get(1);
+					String bSecondElement = (String) ((ArrayList) b).get(1);
+					if (COLLATOR.compare(aSecondElement,bSecondElement) < 0)
 						return -1;
-					else if (collator.compare(aFirstElement, bFirstElement) > 0)
+					else if (COLLATOR.compare(aSecondElement,bSecondElement) > 0)
 						return 1;
 					else {
-						String aSecondElement = (String) ((ArrayList) a).get(1);
-						String bSecondElement = (String) ((ArrayList) b).get(1);
-						if (collator.compare(aSecondElement,bSecondElement) < 0)
+						String aThirdElement = (String) ((ArrayList) a).get(2);
+						String bThirdElement = (String) ((ArrayList) b).get(2);
+						if (COLLATOR.compare(aThirdElement,bThirdElement) < 0)
 							return -1;
-						else if (collator.compare(aSecondElement,bSecondElement) > 0)
+						else if (COLLATOR.compare(aThirdElement,bThirdElement) > 0)
 							return 1;
-						else {
-							String aThirdElement = (String) ((ArrayList) a).get(2);
-							String bThirdElement = (String) ((ArrayList) b).get(2);
-							if (collator.compare(aThirdElement,bThirdElement) < 0)
-								return -1;
-							else if (collator.compare(aThirdElement,bThirdElement) > 0)
-								return 1;
-						}
 					}
-					return 0;
 				}
-			} catch (ParseException e) {
-	  			log.error("ERROR compare: ",e);
-	  		}
-			return Collator.getInstance().compare(a, b);	
+				return 0;
+			}
 		}
 	}
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/FacadeUtils.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/FacadeUtils.java
@@ -24,16 +24,15 @@ package org.sakaiproject.tool.assessment.integration.helper.integrated;
 import java.util.*;
 import java.text.Collator;
 
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
  * borrowed gradebook's FacadeUtils class
  */
 public class FacadeUtils {
-
-	private static final Collator COLLATOR = SakaiCollators
-			.getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
 
 	// Enforce noninstantiability.
 	private FacadeUtils() {
@@ -44,7 +43,7 @@ public class FacadeUtils {
      */
     public static final Comparator ENROLLMENT_NAME_COMPARATOR = new Comparator() {
 		public int compare(Object o1, Object o2) {
-			return COLLATOR.compare(((EnrollmentRecord)o1).getUser().getSortName(),((EnrollmentRecord)o2).getUser().getSortName());
+			return getCollator().compare(((EnrollmentRecord)o1).getUser().getSortName(),((EnrollmentRecord)o2).getUser().getSortName());
 		}
 	};
 
@@ -54,7 +53,7 @@ public class FacadeUtils {
      */
     public static final Comparator ENROLLMENT_DISPLAY_UID_COMPARATOR = new Comparator() {
         public int compare(Object o1, Object o2) {
-			return COLLATOR.compare(((EnrollmentRecord)o1).getUser().getDisplayId(),((EnrollmentRecord)o2).getUser().getDisplayId());
+			return getCollator().compare(((EnrollmentRecord)o1).getUser().getDisplayId(),((EnrollmentRecord)o2).getUser().getDisplayId());
         }
     };
 
@@ -80,5 +79,10 @@ public class FacadeUtils {
             studentUids.add(enr.getUser().getUserUid());
         }
 		return studentUids;
+	}
+
+	private static Collator getCollator() {
+		return SakaiCollators.getCollatorWithUnderscoreAfterSpace(
+				ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
 	}
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/FacadeUtils.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/FacadeUtils.java
@@ -23,15 +23,17 @@ package org.sakaiproject.tool.assessment.integration.helper.integrated;
 
 import java.util.*;
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
  * borrowed gradebook's FacadeUtils class
  */
 public class FacadeUtils {
+
+	private static final Collator COLLATOR = SakaiCollators
+			.getCollatorWithUnderscoreAfterSpace(java.util.Locale.getDefault(), Collator.TERTIARY);
 
 	// Enforce noninstantiability.
 	private FacadeUtils() {
@@ -42,12 +44,7 @@ public class FacadeUtils {
      */
     public static final Comparator ENROLLMENT_NAME_COMPARATOR = new Comparator() {
 		public int compare(Object o1, Object o2) {
-			try{
-				RuleBasedCollator r_collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				return r_collator.compare(((EnrollmentRecord)o1).getUser().getSortName(),((EnrollmentRecord)o2).getUser().getSortName());
-			}catch(ParseException e){
-				  return Collator.getInstance().compare(((EnrollmentRecord)o1).getUser().getSortName(),((EnrollmentRecord)o2).getUser().getSortName());
-			}
+			return COLLATOR.compare(((EnrollmentRecord)o1).getUser().getSortName(),((EnrollmentRecord)o2).getUser().getSortName());
 		}
 	};
 
@@ -57,12 +54,7 @@ public class FacadeUtils {
      */
     public static final Comparator ENROLLMENT_DISPLAY_UID_COMPARATOR = new Comparator() {
         public int compare(Object o1, Object o2) {
-			try{
-				RuleBasedCollator r_collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				return r_collator.compare(((EnrollmentRecord)o1).getUser().getDisplayId(),((EnrollmentRecord)o2).getUser().getDisplayId());
-			}catch(ParseException e){
-				  return Collator.getInstance().compare(((EnrollmentRecord)o1).getUser().getDisplayId(),((EnrollmentRecord)o2).getUser().getDisplayId());
-			}
+			return COLLATOR.compare(((EnrollmentRecord)o1).getUser().getDisplayId(),((EnrollmentRecord)o2).getUser().getDisplayId());
         }
     };
 

--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
@@ -20,9 +20,8 @@ import java.util.Properties;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.Strings;
 
-public class Learner implements Serializable, Comparable<Learner>
+public class Learner implements Serializable
 {
 	private static final long serialVersionUID = 1L;
 
@@ -44,12 +43,4 @@ public class Learner implements Serializable, Comparable<Learner>
 		this.displayId = displayId;
 	}
 
-	@Override
-	public int compareTo(Learner learner)
-	{
-		// Replace spaces to handle sorting scenarios where surname has space
-		String prop1 = Strings.CS.replace(sortName, " ", "+");
-		String prop2 = Strings.CS.replace(learner.sortName, " ", "+");
-		return prop1.compareTo(prop2);
-	}
 }

--- a/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
+++ b/scormplayer/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
@@ -17,11 +17,12 @@ package org.sakaiproject.scorm.model.api.comparator;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Locale;
 
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import org.sakaiproject.scorm.model.api.LearnerExperience;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 /**
  * Custom comparator for LearnerExperience objects; used for sorting data tables.
@@ -39,6 +40,12 @@ public class LearnerExperienceComparator implements Comparator<LearnerExperience
 
     public static final CompType DEFAULT_COMP = CompType.Learner;
     private CompType compType = DEFAULT_COMP;
+    private final UserSortNameComparator userSortNameComparator;
+
+    public LearnerExperienceComparator(Locale locale)
+    {
+        userSortNameComparator = new UserSortNameComparator(locale);
+    }
 
     /**
      * Sets the comparison type the comparator will use. This determines which field of LearnerExperience is used for comparisons.
@@ -60,33 +67,9 @@ public class LearnerExperienceComparator implements Comparator<LearnerExperience
         {
             case Learner:
             {
-                // Use proper sorting logic similar to UserSortNameComparator
-                String sortName1 = le1.getSortName();
-                String sortName2 = le2.getSortName();
-                
-                if (sortName1 != null && sortName2 != null) {
-                    // Replace spaces to handle sorting scenarios where surname has space
-                    String prop1 = StringUtils.replace(sortName1, " ", "+");
-                    String prop2 = StringUtils.replace(sortName2, " ", "+");
-                    
-                    // Primary comparison on sort name
-                    int result = prop1.compareToIgnoreCase(prop2);
-                    if (result == 0) {
-                        // Secondary comparison on displayId if sort names are identical (matches UserSortNameComparator behavior)
-                        String displayId1 = le1.getDisplayId();
-                        String displayId2 = le2.getDisplayId();
-                        if (displayId1 != null && displayId2 != null) {
-                            result = displayId1.compareToIgnoreCase(displayId2);
-                        } else {
-                            // Fall back to learner name if displayIds are not available
-                            result = le1.getLearnerName().compareToIgnoreCase(le2.getLearnerName());
-                        }
-                    }
-                    return result;
-                }
-                
-                // Fall back to learner name comparison if sort names are not available
-                return le1.getLearnerName().compareToIgnoreCase(le2.getLearnerName());
+                String sortName1 = le1.getSortName() != null ? le1.getSortName() : le1.getLearnerName();
+                String sortName2 = le2.getSortName() != null ? le2.getSortName() : le2.getLearnerName();
+                return userSortNameComparator.compareSortNames(sortName1, le1.getDisplayId(), sortName2, le2.getDisplayId());
             }
             case AttemptDate:
             {

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package org.sakaiproject.scorm.service.impl;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,6 +50,8 @@ import org.sakaiproject.scorm.model.api.Progress;
 import org.sakaiproject.scorm.model.api.Score;
 import org.sakaiproject.scorm.service.api.LearningManagementSystem;
 import org.sakaiproject.scorm.service.api.ScormResultService;
+import org.sakaiproject.util.api.LocaleService;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -62,6 +63,7 @@ public class ScormResultServiceImpl implements ScormResultService {
 	@Setter protected AttemptDao attemptDao;
 	@Setter protected DataManagerDao dataManagerDao;
 	@Setter protected LearnerDao learnerDao;
+	@Setter protected LocaleService localeService;
 	@Setter protected LearningManagementSystem lms; // Dependency injection method lookup signatures
 
 	@Override
@@ -453,7 +455,9 @@ public class ScormResultServiceImpl implements ScormResultService {
 			// We just have the above ids
 			String context = lms.currentContext();
 			List<Learner> learners = filterLearnersByVisibility(learnerDao.find(context), context);
-			Collections.sort(learners);
+			UserSortNameComparator userSortNameComparator = new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser());
+			learners.sort((learner1, learner2) -> userSortNameComparator.compareSortNames(learner1.getSortName(), learner1.getDisplayId(),
+					learner2.getSortName(), learner2.getDisplayId()));
 
 			for (int i = 0; i < learners.size(); i++)
 			{

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
@@ -20,6 +20,7 @@
 		<property name="attemptDao" ref="org.sakaiproject.scorm.dao.api.AttemptDao"/>
 		<property name="dataManagerDao" ref="org.sakaiproject.scorm.dao.api.DataManagerDao"/>
 		<property name="learnerDao" ref="org.sakaiproject.scorm.dao.LearnerDao"/>
+		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
 	</bean>
 
 	<bean id="org.sakaiproject.scorm.service.api.ScormContentService"

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -63,6 +63,7 @@ import org.sakaiproject.scorm.ui.console.components.AttemptNumberAction;
 import org.sakaiproject.scorm.ui.console.components.ContentPackageDetailPanel;
 import org.sakaiproject.scorm.ui.console.components.DecoratedDatePropertyColumn;
 import org.sakaiproject.scorm.ui.console.pages.ConsoleBasePage;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.wicket.ajax.markup.html.table.SakaiDataTable;
 import org.sakaiproject.wicket.markup.html.repeater.data.table.Action;
 import org.sakaiproject.wicket.markup.html.repeater.data.table.ActionColumn;
@@ -81,6 +82,9 @@ public class ResultsListPage extends ConsoleBasePage
 
 	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormResultService")
 	ScormResultService resultService;
+
+	@SpringBean(name="org.sakaiproject.util.api.LocaleService")
+	LocaleService localeService;
 
 	private static final String NEW_LINE			= "\n";
 	private static final String DOUBLE_QUOTE		= "\"";
@@ -376,10 +380,11 @@ public class ResultsListPage extends ConsoleBasePage
 	{
 		private static final long serialVersionUID = 1L;
 		private final List<LearnerExperience> learnerExperiences;
-		private final LearnerExperienceComparator comp = new LearnerExperienceComparator();
+		private final LearnerExperienceComparator comp;
 
 		public AttemptDataProvider(long contentPackageId, Date dueOn)
 		{
+			comp = new LearnerExperienceComparator(localeService.getLocaleForCurrentSiteAndUser());
 			this.learnerExperiences = resultService.getLearnerExperiences(contentPackageId);
 			if (dueOn != null)
 			{

--- a/scormplayer/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/AbstractSCORM13APBase.java
+++ b/scormplayer/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/AbstractSCORM13APBase.java
@@ -32,6 +32,7 @@ import org.sakaiproject.scorm.service.api.ScormSequencingService;
 import org.sakaiproject.scorm.service.impl.ScormLaunchServiceImpl;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.util.api.LocaleService;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +40,8 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+
+import java.util.Locale;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -145,6 +148,14 @@ public abstract class AbstractSCORM13APBase extends AbstractTransactionalJUnit4S
 		public org.sakaiproject.grading.api.GradingService gradingService()
 		{
 			return mock(org.sakaiproject.grading.api.GradingService.class);
+		}
+
+		@Bean(name = "org.sakaiproject.util.api.LocaleService")
+		public LocaleService localeService()
+		{
+			LocaleService localeService = mock(LocaleService.class);
+			when(localeService.getLocaleForCurrentSiteAndUser()).thenReturn(Locale.US);
+			return localeService;
 		}
 	
 }

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/decorator/EnrollmentDecorator.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/decorator/EnrollmentDecorator.java
@@ -21,9 +21,6 @@
 package org.sakaiproject.tool.section.decorator;
 
 import java.io.Serializable;
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.Map;
@@ -31,9 +28,8 @@ import java.util.Map;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
 import org.sakaiproject.section.api.coursemanagement.User;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Decorates an EnrollmentRecord for display in the UI.
@@ -41,7 +37,6 @@ import lombok.extern.slf4j.Slf4j;
  * @author <a href="mailto:jholtzman@berkeley.edu">Josh Holtzman</a>
  *
  */
-@Slf4j
 public class EnrollmentDecorator implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -53,23 +48,6 @@ public class EnrollmentDecorator implements Serializable {
     public EnrollmentDecorator(EnrollmentRecord enrollment, Map categoryToSectionMap) {
         this.enrollment = enrollment;
         this.categoryToSectionMap = categoryToSectionMap;
-    }
-
-    private static Collator createCollator(Locale locale) {
-        Collator fallback = Collator.getInstance(locale);
-        fallback.setStrength(Collator.TERTIARY);
-        try {
-            Collator base = Collator.getInstance(locale);
-            if (!(base instanceof RuleBasedCollator)) {
-                return fallback;
-            }
-            Collator c = new RuleBasedCollator(((RuleBasedCollator) base).getRules().replaceAll("<'_'", "<' '<'_'"));
-            c.setStrength(Collator.TERTIARY);
-            return c;
-        } catch (ParseException e) {
-            log.warn("Failed to create RuleBasedCollator for EnrollmentDecorator", e);
-            return fallback;
-        }
     }
 
     public static final Comparator<EnrollmentDecorator> getNameComparator(final boolean sortAscending, final Locale locale) {
@@ -92,9 +70,8 @@ public class EnrollmentDecorator implements Serializable {
     }
 
     public static final Comparator<EnrollmentDecorator> getCategoryComparator(final String categoryId, final boolean sortAscending, final Locale locale) {
-        log.debug("Comparing enrollment decorators by {}", categoryId);
-        final Collator collator = createCollator(locale);
-        final UserSortNameComparator userComparator = new UserSortNameComparator(false, locale);
+        final AlphaNumericComparator titleComparator = new AlphaNumericComparator(locale);
+        final Comparator<EnrollmentDecorator> nameComparator = getNameComparator(true, locale);
         return new Comparator<EnrollmentDecorator>() {
             public int compare(EnrollmentDecorator enr1, EnrollmentDecorator enr2) {
                 CourseSection section1 = (CourseSection)enr1.getCategoryToSectionMap().get(categoryId);
@@ -107,11 +84,11 @@ public class EnrollmentDecorator implements Serializable {
                 }
                 int comparison;
                 if(section1 == null && section2 == null) {
-                    comparison = compareUsers(enr1.getUser(), enr2.getUser(), userComparator);
+                    comparison = nameComparator.compare(enr1, enr2);
                 } else {
-                    int titleComparison = collator.compare(section1.getTitle(), section2.getTitle());
+                    int titleComparison = titleComparator.compare(section1.getTitle(), section2.getTitle());
                     if (titleComparison == 0) {
-                        comparison = compareUsers(enr1.getUser(), enr2.getUser(), userComparator);
+                        comparison = nameComparator.compare(enr1, enr2);
                     } else {
                         comparison = titleComparison;
                     }

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/decorator/EnrollmentDecorator.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/decorator/EnrollmentDecorator.java
@@ -28,10 +28,10 @@ import java.util.Comparator;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
 import org.sakaiproject.section.api.coursemanagement.EnrollmentRecord;
 import org.sakaiproject.section.api.coursemanagement.User;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,11 +74,9 @@ public class EnrollmentDecorator implements Serializable {
 
     public static final Comparator<EnrollmentDecorator> getNameComparator(final boolean sortAscending, final Locale locale) {
         return new Comparator<EnrollmentDecorator>() {
-            private final Collator collator = createCollator(locale);
+            private final UserSortNameComparator userComparator = new UserSortNameComparator(false, locale);
             public int compare(EnrollmentDecorator enr1, EnrollmentDecorator enr2) {
-                int comparison = new CompareToBuilder()
-                        .append(enr1.getUser().getSortName(), enr2.getUser().getSortName(), this.collator)
-                        .toComparison();
+                int comparison = compareUsers(enr1.getUser(), enr2.getUser(), userComparator);
                 return sortAscending ? comparison : (-1 * comparison);
             }
         };
@@ -96,6 +94,7 @@ public class EnrollmentDecorator implements Serializable {
     public static final Comparator<EnrollmentDecorator> getCategoryComparator(final String categoryId, final boolean sortAscending, final Locale locale) {
         log.debug("Comparing enrollment decorators by {}", categoryId);
         final Collator collator = createCollator(locale);
+        final UserSortNameComparator userComparator = new UserSortNameComparator(false, locale);
         return new Comparator<EnrollmentDecorator>() {
             public int compare(EnrollmentDecorator enr1, EnrollmentDecorator enr2) {
                 CourseSection section1 = (CourseSection)enr1.getCategoryToSectionMap().get(categoryId);
@@ -108,11 +107,11 @@ public class EnrollmentDecorator implements Serializable {
                 }
                 int comparison;
                 if(section1 == null && section2 == null) {
-                    comparison = collator.compare(enr1.getUser().getSortName(), enr2.getUser().getSortName());
+                    comparison = compareUsers(enr1.getUser(), enr2.getUser(), userComparator);
                 } else {
                     int titleComparison = collator.compare(section1.getTitle(), section2.getTitle());
                     if (titleComparison == 0) {
-                        comparison = collator.compare(enr1.getUser().getSortName(), enr2.getUser().getSortName());
+                        comparison = compareUsers(enr1.getUser(), enr2.getUser(), userComparator);
                     } else {
                         comparison = titleComparison;
                     }
@@ -120,6 +119,11 @@ public class EnrollmentDecorator implements Serializable {
                 return sortAscending ? comparison : (-1 * comparison);
             }
         };
+    }
+
+    private static int compareUsers(User user1, User user2, UserSortNameComparator userComparator) {
+        return userComparator.compareSortNames(user1.getSortName(), user1.getDisplayId(),
+                user2.getSortName(), user2.getDisplayId());
     }
 
     public String getStatus() {

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/decorator/EnrollmentDecorator.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/decorator/EnrollmentDecorator.java
@@ -22,7 +22,10 @@ package org.sakaiproject.tool.section.decorator;
 
 import java.io.Serializable;
 import java.text.Collator;
+import java.text.ParseException;
+import java.text.RuleBasedCollator;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.builder.CompareToBuilder;
@@ -52,17 +55,30 @@ public class EnrollmentDecorator implements Serializable {
         this.categoryToSectionMap = categoryToSectionMap;
     }
 
-    public static final Comparator<EnrollmentDecorator> getNameComparator(final boolean sortAscending) {
-        return new Comparator<EnrollmentDecorator>() {
-            private final Collator collator = Collator.getInstance();        	
-            private int compareUsers(final User u1, final User u2) {
-        	    this.collator.setStrength(Collator.PRIMARY);
-        	    return new CompareToBuilder()
-        		        .append(u1.getSortName(), u2.getSortName(), this.collator)        				
-        		        .toComparison();
+    private static Collator createCollator(Locale locale) {
+        Collator fallback = Collator.getInstance(locale);
+        fallback.setStrength(Collator.TERTIARY);
+        try {
+            Collator base = Collator.getInstance(locale);
+            if (!(base instanceof RuleBasedCollator)) {
+                return fallback;
             }
+            Collator c = new RuleBasedCollator(((RuleBasedCollator) base).getRules().replaceAll("<'_'", "<' '<'_'"));
+            c.setStrength(Collator.TERTIARY);
+            return c;
+        } catch (ParseException e) {
+            log.warn("Failed to create RuleBasedCollator for EnrollmentDecorator", e);
+            return fallback;
+        }
+    }
+
+    public static final Comparator<EnrollmentDecorator> getNameComparator(final boolean sortAscending, final Locale locale) {
+        return new Comparator<EnrollmentDecorator>() {
+            private final Collator collator = createCollator(locale);
             public int compare(EnrollmentDecorator enr1, EnrollmentDecorator enr2) {
-                int comparison = compareUsers(enr1.getUser(), enr2.getUser());
+                int comparison = new CompareToBuilder()
+                        .append(enr1.getUser().getSortName(), enr2.getUser().getSortName(), this.collator)
+                        .toComparison();
                 return sortAscending ? comparison : (-1 * comparison);
             }
         };
@@ -77,8 +93,9 @@ public class EnrollmentDecorator implements Serializable {
         };
     }
 
-    public static final Comparator<EnrollmentDecorator> getCategoryComparator(final String categoryId, final boolean sortAscending) {
-        if(log.isDebugEnabled()) log.debug("Comparing enrollment decorators by " + categoryId);
+    public static final Comparator<EnrollmentDecorator> getCategoryComparator(final String categoryId, final boolean sortAscending, final Locale locale) {
+        log.debug("Comparing enrollment decorators by {}", categoryId);
+        final Collator collator = createCollator(locale);
         return new Comparator<EnrollmentDecorator>() {
             public int compare(EnrollmentDecorator enr1, EnrollmentDecorator enr2) {
                 CourseSection section1 = (CourseSection)enr1.getCategoryToSectionMap().get(categoryId);
@@ -89,17 +106,16 @@ public class EnrollmentDecorator implements Serializable {
                 if(section1 != null && section2 == null) {
                     return sortAscending ? 1 : -1;
                 }
+                int comparison;
                 if(section1 == null && section2 == null) {
-                    return getNameComparator(sortAscending).compare(enr1, enr2);
-                }
-
-                int comparison = 0;
-                if(section1.getTitle().equals(section2.getTitle())) {
-                    // Use the student name for comparison if the titles are equal
-                    comparison = enr1.getUser().getSortName().compareTo(enr2.getUser().getSortName());
+                    comparison = collator.compare(enr1.getUser().getSortName(), enr2.getUser().getSortName());
                 } else {
-                    // Use the section title for comparison if the titles are different
-                    comparison = section1.getTitle().compareTo(section2.getTitle());
+                    int titleComparison = collator.compare(section1.getTitle(), section2.getTitle());
+                    if (titleComparison == 0) {
+                        comparison = collator.compare(enr1.getUser().getSortName(), enr2.getUser().getSortName());
+                    } else {
+                        comparison = titleComparison;
+                    }
                 }
                 return sortAscending ? comparison : (-1 * comparison);
             }

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/CourseBean.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/CourseBean.java
@@ -27,6 +27,7 @@ import org.sakaiproject.section.api.coursemanagement.Course;
 import org.sakaiproject.section.api.facade.manager.Authn;
 import org.sakaiproject.section.api.facade.manager.Authz;
 import org.sakaiproject.section.api.facade.manager.Context;
+import org.sakaiproject.util.api.LocaleService;
 
 /**
  * Provides the current course uuid for a given user session.  This is also the
@@ -46,6 +47,7 @@ public class CourseBean implements Serializable {
     protected Authz authz;
     protected Context context;
     protected PreferencesBean prefs;
+    protected LocaleService localeService;
 
 	protected String getCourseUuid() {
 		Course course = sectionManager.getCourse(context.getContext(null));
@@ -81,6 +83,10 @@ public class CourseBean implements Serializable {
 	public void setPrefs(PreferencesBean prefs) {
 		this.prefs = prefs;
 	}
-	
+
+    public void setLocaleService(LocaleService localeService) {
+        this.localeService = localeService;
+    }
+
 }
 

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/CourseDependentBean.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/CourseDependentBean.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.sakaiproject.jsf2.util.LocaleUtil;
 import org.sakaiproject.section.api.SectionManager;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.section.api.SectionManager.ExternalIntegrationConfig;
 import org.sakaiproject.section.api.coursemanagement.Course;
 import org.sakaiproject.section.api.coursemanagement.CourseSection;
@@ -119,6 +120,10 @@ public class CourseDependentBean extends InitializableBean implements Serializab
 
 	protected Set getEnrolledSections(String userUid) {
 		return getCourseBean().sectionManager.getSectionEnrollments(userUid, getCourse().getUuid());
+	}
+
+	protected Locale getLocale() {
+		return getCourseBean().localeService.getLocaleForCurrentSiteAndUser();
 	}
 
 	protected String getCategoryName(String categoryId) {

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/EditManagersBean.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/EditManagersBean.java
@@ -21,9 +21,6 @@
 package org.sakaiproject.tool.section.jsf.backingbean;
 
 import java.io.Serializable;
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -43,6 +40,7 @@ import org.sakaiproject.section.api.exception.RoleConfigurationException;
 import org.sakaiproject.section.api.facade.Role;
 import org.sakaiproject.tool.section.decorator.SectionDecorator;
 import org.sakaiproject.tool.section.jsf.JsfUtil;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -68,26 +66,6 @@ public class EditManagersBean extends CourseDependentBean implements Serializabl
 	protected String sectionDescription;
 	
 	protected boolean externallyManaged;
-
-	/**
-	 * Compares ParticipationRecords by users' sortNames.
-	 */
-	static Comparator sortNameComparator = new Comparator() {
-		public int compare(Object o1, Object o2) {
-			ParticipationRecord manager1 = (ParticipationRecord)o1;
-			ParticipationRecord manager2 = (ParticipationRecord)o2;
-			Collator collator;
-			try {
-				collator = new RuleBasedCollator(((RuleBasedCollator) Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-			} catch (ParseException e) {
-				// error with init RuleBasedCollator with rules
-				// use the default Collator
-				collator = Collator.getInstance();
-				log.warn("{} sortNameComparator cannot init RuleBasedCollator. Will use the default Collator instead. {}", this, e);
-			}
-			return collator.compare(manager1.getUser().getSortName(), manager2.getUser().getSortName());
-		}
-	};
 
 	protected SectionDecorator initializeFields() {
 		// Determine whether this course is externally managed
@@ -128,6 +106,7 @@ public class EditManagersBean extends CourseDependentBean implements Serializabl
 
 	public void init() {
 		initializeFields();
+		Comparator<ParticipationRecord> sortNameComparator = getSortNameComparator();
 
 		// Get the current users in the manager role for this section
 		List<ParticipationRecord> selectedManagers = getSectionManager().getSectionTeachingAssistants(sectionUuid);
@@ -156,6 +135,13 @@ public class EditManagersBean extends CourseDependentBean implements Serializabl
 				availableUsers.add(new SelectItem(manager.getUserUid(), manager.getSortName()));
 			}
 		}
+	}
+
+	protected Comparator<ParticipationRecord> getSortNameComparator() {
+		UserSortNameComparator userComparator = new UserSortNameComparator(false, getLocale());
+		return (ParticipationRecord manager1, ParticipationRecord manager2) -> userComparator.compareSortNames(
+				manager1.getUser().getSortName(), manager1.getUser().getDisplayId(),
+				manager2.getUser().getSortName(), manager2.getUser().getDisplayId());
 	}
 	
 	public String update() {

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/EditStudentsBean.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/EditStudentsBean.java
@@ -23,6 +23,7 @@ package org.sakaiproject.tool.section.jsf.backingbean;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -67,10 +68,11 @@ public class EditStudentsBean extends EditManagersBean implements Serializable {
 	public void init() {
 		SectionDecorator currentSection = initializeFields();
 		sectionMax = currentSection.getMaxEnrollments();
+		Comparator<ParticipationRecord> sortNameComparator = getSortNameComparator();
 		
 		// Get the current users
 		List enrollments = getSectionManager().getSectionEnrollments(currentSection.getUuid());
-		Collections.sort(enrollments, EditManagersBean.sortNameComparator);
+		Collections.sort(enrollments, sortNameComparator);
 
 		populateSelectedUsers(enrollments);
 
@@ -121,29 +123,31 @@ public class EditStudentsBean extends EditManagersBean implements Serializable {
 			List available2= getSectionManager().getSectionEnrollments(availableSectionUuid);
 			available=new ArrayList();
 			
-			Collections.sort(available1, EditManagersBean.sortNameComparator);
-			Collections.sort(available2, EditManagersBean.sortNameComparator);
-			
-			int k1 = 0; int k2 = 0;
-			while (k1<available1.size() && k2 < available2.size()) {
-				ParticipationRecord p1=(ParticipationRecord)available1.get(k1);
-				ParticipationRecord p2=(ParticipationRecord)available2.get(k2);
-				String a1=p1.getUser().getSortName();
-				String a2=p2.getUser().getSortName();
-				if (a1.compareTo(a2)==0) {
+				Collections.sort(available1, sortNameComparator);
+				Collections.sort(available2, sortNameComparator);
+
+				// This walks two sorted lists to keep only students present in both lists.
+				int unsectionedIndex = 0;
+				int sectionIndex = 0;
+			while (unsectionedIndex < available1.size() && sectionIndex < available2.size()) {
+				ParticipationRecord p1 = (ParticipationRecord) available1.get(unsectionedIndex);
+				ParticipationRecord p2 = (ParticipationRecord) available2.get(sectionIndex);
+				int comparison = sortNameComparator.compare(p1, p2);
+				if (comparison == 0) {
 				   available.add(p2);
-				   k1++; k2++;
-				} else if (a1.compareTo(a2) < 0) {
-				   k1++;
+				   unsectionedIndex++;
+				   sectionIndex++;
+				} else if (comparison < 0) {
+				   unsectionedIndex++;
 				} else {
-				   k2++;
+				   sectionIndex++;
 			   }
 			}
 		}
 		else {
 			available = getSectionManager().getSectionEnrollments(availableSectionUuid);
 		}
-		Collections.sort(available, EditManagersBean.sortNameComparator);
+		Collections.sort(available, sortNameComparator);
 
 		availableUsers = new ArrayList();
 		for(Iterator iter = available.iterator(); iter.hasNext();) {

--- a/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/RosterBean.java
+++ b/sections/sections-app/src/java/org/sakaiproject/tool/section/jsf/backingbean/RosterBean.java
@@ -253,11 +253,11 @@ public class RosterBean extends CourseDependentBean implements Serializable {
 		boolean sortAscending = getPrefs().isRosterSortAscending();
 
 		if("studentName".equals(sortColumn)) {
-			return EnrollmentDecorator.getNameComparator(sortAscending);
+			return EnrollmentDecorator.getNameComparator(sortAscending, getLocale());
 		} else if("displayId".equals(sortColumn)) {
 			return EnrollmentDecorator.getDisplayIdComparator(sortAscending);
 		} else {
-			return EnrollmentDecorator.getCategoryComparator(sortColumn, sortAscending);
+			return EnrollmentDecorator.getCategoryComparator(sortColumn, sortAscending, getLocale());
 		}
 	}
 

--- a/sections/sections-app/src/webapp/WEB-INF/faces-beans.xml
+++ b/sections/sections-app/src/webapp/WEB-INF/faces-beans.xml
@@ -40,6 +40,11 @@
             <property-name>prefs</property-name>
             <value>#{preferencesBean}</value>
         </managed-property>
+        <managed-property>
+            <description>Locale Service</description>
+            <property-name>localeService</property-name>
+            <value>#{org_sakaiproject_util_api_LocaleService}</value>
+        </managed-property>
     </managed-bean>
 
     <managed-bean>

--- a/signup/impl/src/main/java/org/sakaiproject/signup/impl/SakaiFacadeImpl.java
+++ b/signup/impl/src/main/java/org/sakaiproject/signup/impl/SakaiFacadeImpl.java
@@ -82,6 +82,7 @@ import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import lombok.Getter;
@@ -116,6 +117,7 @@ public class SakaiFacadeImpl implements SakaiFacade {
 	private TimeService timeService;
 	private ContentHostingService contentHostingService;
     private Optional<CalendarService> additionalCalendarService;
+	private LocaleService localeService;
 
 	// Returns Google calendar if the calendar has been created in Google
 	public Calendar getAdditionalCalendar(String siteId) throws PermissionException {
@@ -458,7 +460,7 @@ public class SakaiFacadeImpl implements SakaiFacade {
 		}
 		
 		List<User> sakaiUsers = userDirectoryService.getUsers(userIdsHasPermissionToCreate);
-		Collections.sort(sakaiUsers, new UserSortNameComparator());
+		Collections.sort(sakaiUsers, new UserSortNameComparator(localeService.getLocaleForCurrentSiteAndUser()));
 		for (User user : sakaiUsers) {
 			SignupUser signupUser = new SignupUser(user.getEid(), user.getId(), user.getFirstName(), user.getLastName(), 
 					null, "", true);
@@ -681,7 +683,7 @@ public class SakaiFacadeImpl implements SakaiFacade {
 	private void addAndPopulateSignupUsersInfo(List<SignupUser> signupUsers, Map<String,Role> memberRoleMap, List<String> userIds, Site site){
 		//it should filter out non-existing userIds
 		List<User> sakaiUsers = userDirectoryService.getUsers(userIds);
-		Collections.sort(sakaiUsers, new UserSortNameComparator());
+		Collections.sort(sakaiUsers, new UserSortNameComparator(localeService.getLocaleForSiteAndUser(site.getId(), sessionManager.getCurrentSessionUserId())));
 		
 		if(sakaiUsers !=null){
 			for (User user : sakaiUsers) {

--- a/signup/impl/src/main/webapp/WEB-INF/components.xml
+++ b/signup/impl/src/main/webapp/WEB-INF/components.xml
@@ -37,6 +37,7 @@
         <property name="calendarService" ref="org.sakaiproject.calendar.api.CalendarService"/>
         <property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
         <property name="formattedText" ref="org.sakaiproject.util.api.FormattedText"/>
+        <property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
         <property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
         <property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
         <property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager"/>

--- a/signup/impl/src/test/java/org/sakaiproject/signup/test/SignupMeetingServiceTestConfiguration.java
+++ b/signup/impl/src/test/java/org/sakaiproject/signup/test/SignupMeetingServiceTestConfiguration.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.signup.test;
 
 import java.util.Optional;
+import java.util.Locale;
 
 import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
@@ -38,6 +39,7 @@ import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.util.api.LocaleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -126,6 +128,14 @@ public class SignupMeetingServiceTestConfiguration extends SakaiTestConfiguratio
         FormattedText formattedText = Mockito.mock(FormattedText.class);
         Mockito.when(formattedText.convertFormattedTextToPlaintext(Mockito.any())).thenAnswer(AdditionalAnswers.returnsFirstArg());
         return formattedText;
+    }
+
+    @Bean(name = "org.sakaiproject.util.api.LocaleService")
+    public LocaleService localeService() {
+        LocaleService localeService = Mockito.mock(LocaleService.class);
+        Mockito.when(localeService.getLocaleForCurrentSiteAndUser()).thenReturn(Locale.US);
+        Mockito.when(localeService.getLocaleForSiteAndUser(Mockito.any(), Mockito.any())).thenReturn(Locale.US);
+        return localeService;
     }
 
     @Bean(name = "org.sakaiproject.api.app.scheduler.SchedulerManager")

--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/GroupController.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/GroupController.java
@@ -196,7 +196,8 @@ public class GroupController {
         }
         //Sort the members of the site by sort name.
         List<User> siteMemberList = new ArrayList<>(siteMemberSet);
-        Collections.sort(siteMemberList, new UserSortNameComparator());
+        Collections.sort(siteMemberList, new UserSortNameComparator(
+                sakaiService.getLocaleForCurrentSiteAndUser()));
         selectableMemberList = new ArrayList<>(siteMemberList);
 
         // Get all the joinable sets from all the site groups.

--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/GroupController.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/GroupController.java
@@ -218,7 +218,7 @@ public class GroupController {
             }
         });
         List<String> joinableSetList = new ArrayList<>(groupJoinableSet);
-        Collections.sort(joinableSetList, new AlphaNumericComparator());
+        Collections.sort(joinableSetList, new AlphaNumericComparator(sakaiService.getLocaleForCurrentSiteAndUser()));
 
         // Add the attributes to the model
         model.addAttribute("groupForm", groupForm);

--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/MainController.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/MainController.java
@@ -116,7 +116,7 @@ public class MainController {
                     groupMemberList.add(memberUserOptional.get());
                 }
             });
-            Collections.sort(groupMemberList, new UserSortNameComparator());
+            Collections.sort(groupMemberList, new UserSortNameComparator(locale));
             groupMemberList.forEach(u -> stringJoiner.add(u.getDisplayName()));
             groupMemberMap.put(group.getId(), stringJoiner.toString());
             // Get the joinable sets and add them to the Map

--- a/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/MainController.java
+++ b/site-manage/site-group-manager/src/main/java/org/sakaiproject/groupmanager/controller/MainController.java
@@ -96,7 +96,7 @@ public class MainController {
         // List of groups of the site, excluding the ones which GROUP_PROP_WSETUP_CREATED property is false.
         List<Group> groupList = site.getGroups().stream().filter(group -> group.getProperties().getProperty(Group.GROUP_PROP_WSETUP_CREATED) != null && Boolean.valueOf(group.getProperties().getProperty(Group.GROUP_PROP_WSETUP_CREATED)).booleanValue()).collect(Collectors.toList());
         // Sort the group list by title.
-        Collections.sort(groupList, new GroupTitleComparator());
+        Collections.sort(groupList, new GroupTitleComparator(locale));
 
         // Control the groups that are locked by entities
         boolean anyGroupLocked = false;

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -203,6 +203,7 @@ import org.sakaiproject.util.SortedIterator;
 import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.api.LinkMigrationHelper;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.AlphaNumericComparator;
 import org.sakaiproject.util.comparator.GroupTitleComparator;
 import org.sakaiproject.util.comparator.ToolTitleComparator;
@@ -816,7 +817,7 @@ public class SiteAction extends PagedResourceActionII {
 	private Cache m_userSiteCache;
 	private ImportService importService;
 	private List prefLocales;
-	private Locale comparator_locale;
+	private Locale dateFormattingLocale;
 	private String libraryPath;
 	private String moreInfoPath;
 	private String showOrphanedMembers;
@@ -836,6 +837,7 @@ public class SiteAction extends PagedResourceActionII {
 	private IdManager idManager;
 	private LTIService ltiService;
 	private LinkMigrationHelper linkMigrationHelper;
+	private LocaleService localeService;
 	private MemoryService memoryService;
 	private PreferencesService preferencesService;
 	private PrivacyManager privacyManager;
@@ -875,6 +877,7 @@ public class SiteAction extends PagedResourceActionII {
 		groupProvider = ComponentManager.get(GroupProvider.class);
 		idManager = ComponentManager.get(IdManager.class);
 		linkMigrationHelper = (LinkMigrationHelper) ComponentManager.get("org.sakaiproject.util.api.LinkMigrationHelper");
+		localeService = ComponentManager.get(LocaleService.class);
 		ltiService = (LTIService) ComponentManager.get("org.sakaiproject.lti.api.LTIService");
 		memoryService = ComponentManager.get(MemoryService.class);
 		preferencesService = ComponentManager.get(PreferencesService.class);
@@ -903,7 +906,7 @@ public class SiteAction extends PagedResourceActionII {
 		siteTypeUtil = new SiteTypeUtil(siteService, serverConfigurationService);
 
 		importService = org.sakaiproject.importer.cover.ImportService.getInstance();
-		comparator_locale = rb.getLocale();
+		dateFormattingLocale = rb.getLocale();
 		prefLocales = new ArrayList<>();
 
 		SITE_DEFAULT_LIST = serverConfigurationService.getString("site.types");
@@ -5517,7 +5520,8 @@ public class SiteAction extends PagedResourceActionII {
 			String sortedAsc = (String) state.getAttribute(SORTED_ASC);
 			Iterator sortedParticipants;
 			if (sortedBy != null) {
-				sortedParticipants = new SortedIterator(participants.iterator(), new SiteComparator(sortedBy,sortedAsc,comparator_locale));
+				sortedParticipants = new SortedIterator(participants.iterator(), new SiteComparator(sortedBy,
+						sortedAsc, localeService.getLocaleForCurrentSiteAndUser()));
 				participants.clear();
 				while (sortedParticipants.hasNext()) {
 					participants.add(sortedParticipants.next());
@@ -16890,7 +16894,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 	}
 
 	private String getDateFormat(Date date) {
-		String f = userTimeService.shortPreciseLocalizedTimestamp(date.toInstant(), userTimeService.getLocalTimeZone(), comparator_locale);
+		String f = userTimeService.shortPreciseLocalizedTimestamp(date.toInstant(), userTimeService.getLocalTimeZone(), dateFormattingLocale);
 		return f;
 	}
 }

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -2317,10 +2317,11 @@ public class SiteAction extends PagedResourceActionII {
 
 					context.put("viewMembershipGroups", viewMembershipGroups);
 
-					Collections.sort(filteredGroups, new GroupTitleComparator());
+					GroupTitleComparator groupTitleComparator = new GroupTitleComparator(localeService.getLocaleForCurrentSiteAndUser());
+					Collections.sort(filteredGroups, groupTitleComparator);
 					context.put("groups", filteredGroups);
 
-					Collections.sort(filteredSections, new GroupTitleComparator());
+					Collections.sort(filteredSections, groupTitleComparator);
 					context.put("sections", filteredSections);
 				}
 
@@ -2419,8 +2420,9 @@ public class SiteAction extends PagedResourceActionII {
 				}
 				context.put("joinedJoinableGroups", new ArrayList<>(joinedGroups));
 
+				AlphaNumericComparator joinableGroupTitleComparator = new AlphaNumericComparator(localeService.getLocaleForCurrentSiteAndUser());
 				List<JoinableGroup> sortedJoinableGroups = joinableGroups.stream()
-						.sorted((g1, g2) -> new AlphaNumericComparator().compare(g1.getTitle(), g2.getTitle()))
+						.sorted((g1, g2) -> joinableGroupTitleComparator.compare(g1.getTitle(), g2.getTitle()))
 						.collect(Collectors.toList());
 				context.put("joinableGroups", sortedJoinableGroups);
 				
@@ -3520,7 +3522,7 @@ public class SiteAction extends PagedResourceActionII {
 			// Sort the course offerings if necessary
 			List<CourseObject> courseList = (List) state.getAttribute(STATE_TERM_COURSE_LIST);
 			if (CollectionUtils.isNotEmpty(courseList)) {
-				courseList.sort(Comparator.comparing(CourseObject::getTitle, new AlphaNumericComparator()));
+				courseList.sort(Comparator.comparing(CourseObject::getTitle, new AlphaNumericComparator(localeService.getLocaleForCurrentSiteAndUser())));
 				state.setAttribute(STATE_TERM_COURSE_LIST, courseList);
 			}
 			context.put("termCourseList", state.getAttribute(STATE_TERM_COURSE_LIST));

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
@@ -17,6 +17,7 @@ package org.sakaiproject.site.util;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Set;
 
 import org.sakaiproject.user.api.User;
@@ -170,6 +171,14 @@ public class Participant {
 	}
 
 	public int compareTo(Participant participantB) {
+		return compareTo(participantB, new UserSortNameComparator());
+	}
+
+	public int compareTo(Participant participantB, Locale locale) {
+		return compareTo(participantB, new UserSortNameComparator(locale));
+	}
+
+	private int compareTo(Participant participantB, UserSortNameComparator comparator) {
 		User userA = null;
 		User userB = null;
 		String uniqnameB = participantB.getUniqname();
@@ -194,7 +203,7 @@ public class Participant {
 			return 1;
 		}
 
-		return new UserSortNameComparator().compare(userA, userB);
+		return comparator.compare(userA, userB);
 	}
 
 } // Participant

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
@@ -17,7 +17,6 @@ package org.sakaiproject.site.util;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Set;
 
 import org.sakaiproject.user.api.User;
@@ -168,10 +167,6 @@ public class Participant {
 		} catch (UserNotDefinedException e) {
 			return uniqname;
 		}
-	}
-
-	public int compareTo(Participant participantB, Locale locale) {
-		return compareTo(participantB, new UserSortNameComparator(locale));
 	}
 
 	public int compareTo(Participant participantB, UserSortNameComparator comparator) {

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
@@ -20,9 +20,11 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 public class Participant {
@@ -171,7 +173,7 @@ public class Participant {
 	}
 
 	public int compareTo(Participant participantB) {
-		return compareTo(participantB, new UserSortNameComparator());
+		return compareTo(participantB, ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser());
 	}
 
 	public int compareTo(Participant participantB, Locale locale) {

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/Participant.java
@@ -20,11 +20,9 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 
-import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.user.cover.UserDirectoryService;
-import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 public class Participant {
@@ -172,15 +170,11 @@ public class Participant {
 		}
 	}
 
-	public int compareTo(Participant participantB) {
-		return compareTo(participantB, ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser());
-	}
-
 	public int compareTo(Participant participantB, Locale locale) {
 		return compareTo(participantB, new UserSortNameComparator(locale));
 	}
 
-	private int compareTo(Participant participantB, UserSortNameComparator comparator) {
+	public int compareTo(Participant participantB, UserSortNameComparator comparator) {
 		User userA = null;
 		User userB = null;
 		String uniqnameB = participantB.getUniqname();

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteComparator.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteComparator.java
@@ -17,7 +17,6 @@
 package org.sakaiproject.site.util;
 
 import java.text.Collator;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Locale;
@@ -31,14 +30,12 @@ import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService.SortType;
 import org.sakaiproject.user.cover.UserDirectoryService;
+import org.sakaiproject.util.comparator.SakaiCollators;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * The comparator to be used in Worksite Setup/Site Info tool
  */
-@Slf4j
 public class SiteComparator implements Comparator {
 
 	Collator collator = Collator.getInstance();
@@ -62,8 +59,8 @@ public class SiteComparator implements Comparator {
 	 *            otherwise.
 	 */
 	public SiteComparator(String criterion, String asc) {
-		if (SiteConstants.SORTED_BY_PARTICIPANT_NAME.equals(criterion)) {
-			throw new IllegalArgumentException("Participant name sorting requires a locale");
+		if (isParticipantCriterion(criterion)) {
+			throw new IllegalArgumentException("Participant sorting requires a locale");
 		}
 		m_criterion = criterion;
 		m_asc = asc;
@@ -72,23 +69,14 @@ public class SiteComparator implements Comparator {
 
 	
 
-	// create a locale-sensitive comparator; on error keep localeCollator set to null so it's not used
+	// create a locale-sensitive comparator
 	public SiteComparator(String criterion, String asc, Locale locale) {
 		m_criterion = criterion;
 		m_asc = asc;
 
 		m_loc = Objects.requireNonNull(locale, "locale");
 		userSortNameComparator = new UserSortNameComparator(locale);
-
-		try {
-			RuleBasedCollator defaultCollator = (RuleBasedCollator) Collator.getInstance(locale);
-			String rules = defaultCollator.getRules();
-			localeCollator = new RuleBasedCollator(rules.replaceAll("<'\u005f'", "<' '<'\u005f'"));
-			localeCollator.setStrength(Collator.TERTIARY);
-		} catch (Exception e) {
-			log.warn("SiteComparator failed to create RuleBasedCollator for locale " + locale.toString(), e);
-			localeCollator = null;
-		}
+		localeCollator = SakaiCollators.getCollatorWithUnderscoreAfterSpace(locale, Collator.TERTIARY);
 	}
 	
 	
@@ -342,6 +330,16 @@ public class SiteComparator implements Comparator {
 	 */
 	private int compareParticipantName(Participant  o1, Participant o2) {
 		return o1.compareTo(o2, userSortNameComparator);
+	}
+
+	private boolean isParticipantCriterion(String criterion) {
+		return SiteConstants.SORTED_BY_PARTICIPANT_NAME.equals(criterion)
+				|| SiteConstants.SORTED_BY_PARTICIPANT_UNIQNAME.equals(criterion)
+				|| SiteConstants.SORTED_BY_PARTICIPANT_ROLE.equals(criterion)
+				|| SiteConstants.SORTED_BY_PARTICIPANT_COURSE.equals(criterion)
+				|| SiteConstants.SORTED_BY_PARTICIPANT_ID.equals(criterion)
+				|| SiteConstants.SORTED_BY_PARTICIPANT_CREDITS.equals(criterion)
+				|| SiteConstants.SORTED_BY_PARTICIPANT_STATUS.equals(criterion);
 	}
 
 	private int compareBoolean(boolean b1, boolean b2) {

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteComparator.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteComparator.java
@@ -66,32 +66,22 @@ public class SiteComparator implements Comparator {
 
 	
 
-        // create a locale-sensitive comparator; on error keep localeCollator set to null so it's not used 
-	
-        public SiteComparator(String criterion, String asc, Locale locale) {
-	
-                this(criterion, asc);
-	
-                m_loc = locale;
-	
-                try {
-	
-        	RuleBasedCollator defaultCollator = (RuleBasedCollator) Collator.getInstance(locale); 
-	
-               String rules = defaultCollator.getRules();
-	
-               localeCollator = new RuleBasedCollator(rules.replaceAll("<'\u005f'", "<' '<'\u005f'"));
-	
-               localeCollator.setStrength(Collator.TERTIARY);
-	
-                } catch (Exception e) {
-	
-                	log.warn("SiteComparator failed to create RuleBasedCollator for locale " + locale.toString(), e);
-                	localeCollator = null;
-	
-                }
-	
-        }	
+	// create a locale-sensitive comparator; on error keep localeCollator set to null so it's not used
+	public SiteComparator(String criterion, String asc, Locale locale) {
+		this(criterion, asc);
+
+		m_loc = locale;
+
+		try {
+			RuleBasedCollator defaultCollator = (RuleBasedCollator) Collator.getInstance(locale);
+			String rules = defaultCollator.getRules();
+			localeCollator = new RuleBasedCollator(rules.replaceAll("<'\u005f'", "<' '<'\u005f'"));
+			localeCollator.setStrength(Collator.TERTIARY);
+		} catch (Exception e) {
+			log.warn("SiteComparator failed to create RuleBasedCollator for locale " + locale.toString(), e);
+			localeCollator = null;
+		}
+	}
 	
 	
 	/**
@@ -152,7 +142,7 @@ public class SiteComparator implements Comparator {
 		} else if (m_criterion.equals(SiteConstants.SORTED_BY_PARTICIPANT_NAME)) {
 			// Defer to the UserSortNameComparator if possible
 			if (o1.getClass().equals(Participant.class) && o2.getClass().equals(Participant.class)) {
-				result = ((Participant) o1).compareTo((Participant) o2);
+				result = ((Participant) o1).compareTo((Participant) o2, m_loc);
 			} else if (o1.getClass().equals(Participant.class)) {
 				result = compareString(((Participant) o1).getName(), null);
 			} else if (o2.getClass().equals(Participant.class)) {
@@ -343,7 +333,7 @@ public class SiteComparator implements Comparator {
 	 * @return
 	 */
 	private int compareParticipantName(Participant  o1, Participant o2) {
-		return compareString(o1.getName(), o2.getName());
+		return o1.compareTo(o2, m_loc);
 	}
 
 	private int compareBoolean(boolean b1, boolean b2) {

--- a/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteComparator.java
+++ b/site-manage/site-manage-util/util/src/java/org/sakaiproject/site/util/SiteComparator.java
@@ -21,6 +21,7 @@ import java.text.RuleBasedCollator;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.entity.api.EntityPropertyNotDefinedException;
@@ -30,6 +31,7 @@ import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService.SortType;
 import org.sakaiproject.user.cover.UserDirectoryService;
+import org.sakaiproject.util.comparator.UserSortNameComparator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,6 +43,7 @@ public class SiteComparator implements Comparator {
 
 	Collator collator = Collator.getInstance();
 	Collator localeCollator = null;
+	UserSortNameComparator userSortNameComparator = null;
 	
 	/**
 	 * the criteria
@@ -59,6 +62,9 @@ public class SiteComparator implements Comparator {
 	 *            otherwise.
 	 */
 	public SiteComparator(String criterion, String asc) {
+		if (SiteConstants.SORTED_BY_PARTICIPANT_NAME.equals(criterion)) {
+			throw new IllegalArgumentException("Participant name sorting requires a locale");
+		}
 		m_criterion = criterion;
 		m_asc = asc;
 
@@ -68,9 +74,11 @@ public class SiteComparator implements Comparator {
 
 	// create a locale-sensitive comparator; on error keep localeCollator set to null so it's not used
 	public SiteComparator(String criterion, String asc, Locale locale) {
-		this(criterion, asc);
+		m_criterion = criterion;
+		m_asc = asc;
 
-		m_loc = locale;
+		m_loc = Objects.requireNonNull(locale, "locale");
+		userSortNameComparator = new UserSortNameComparator(locale);
 
 		try {
 			RuleBasedCollator defaultCollator = (RuleBasedCollator) Collator.getInstance(locale);
@@ -142,7 +150,7 @@ public class SiteComparator implements Comparator {
 		} else if (m_criterion.equals(SiteConstants.SORTED_BY_PARTICIPANT_NAME)) {
 			// Defer to the UserSortNameComparator if possible
 			if (o1.getClass().equals(Participant.class) && o2.getClass().equals(Participant.class)) {
-				result = ((Participant) o1).compareTo((Participant) o2, m_loc);
+				result = ((Participant) o1).compareTo((Participant) o2, userSortNameComparator);
 			} else if (o1.getClass().equals(Participant.class)) {
 				result = compareString(((Participant) o1).getName(), null);
 			} else if (o2.getClass().equals(Participant.class)) {
@@ -333,7 +341,7 @@ public class SiteComparator implements Comparator {
 	 * @return
 	 */
 	private int compareParticipantName(Participant  o1, Participant o2) {
-		return o1.compareTo(o2, m_loc);
+		return o1.compareTo(o2, userSortNameComparator);
 	}
 
 	private int compareBoolean(boolean b1, boolean b2) {

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
@@ -57,7 +57,7 @@ public class ReportDefsProvider implements IDataProvider {
 	private boolean 				includeHidden;
 	private List<ReportDef>			data;
 	@SpringBean(name = "org.sakaiproject.util.api.LocaleService")
-	private transient LocaleService localeService;
+	private LocaleService localeService;
 
 	public ReportDefsProvider(String siteId, int mode, boolean filterWithToolsInSite, boolean includeHidden) {
 		Injector.get().inject(this);		

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
@@ -187,9 +187,8 @@ public class ReportDefsProvider implements IDataProvider {
 	}
 	
 	public final Comparator<ReportDef> getReportDefComparator() {
+		Comparator<String> comparator = new AlphaNumericComparator(localeService.getLocaleForCurrentSiteAndUser());
 		return new Comparator<ReportDef>() {
-			private transient Comparator<String> comparator = new AlphaNumericComparator(localeService.getLocaleForCurrentSiteAndUser());
-			
 			public int compare(ReportDef o1, ReportDef o2) {
 				String title1 = null;
 				String title2 = null;

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
@@ -26,11 +26,11 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.wicket.Session;
 import org.apache.wicket.injection.Injector;
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
@@ -41,6 +41,7 @@ import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.tool.facade.Locator;
 import org.sakaiproject.sitestats.tool.wicket.models.ReportDefModel;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.AlphaNumericComparator;
 
 @Slf4j
@@ -55,6 +56,8 @@ public class ReportDefsProvider implements IDataProvider {
 	private boolean 				filterWithToolsInSite;
 	private boolean 				includeHidden;
 	private List<ReportDef>			data;
+	@SpringBean(name = "org.sakaiproject.util.api.LocaleService")
+	private transient LocaleService localeService;
 
 	public ReportDefsProvider(String siteId, int mode, boolean filterWithToolsInSite, boolean includeHidden) {
 		Injector.get().inject(this);		
@@ -185,7 +188,7 @@ public class ReportDefsProvider implements IDataProvider {
 	
 	public final Comparator<ReportDef> getReportDefComparator() {
 		return new Comparator<ReportDef>() {
-			private transient Comparator<String> comparator = new AlphaNumericComparator(Session.get().getLocale());
+			private transient Comparator<String> comparator = new AlphaNumericComparator(localeService.getLocaleForCurrentSiteAndUser());
 			
 			public int compare(ReportDef o1, ReportDef o2) {
 				String title1 = null;

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportDefsProvider.java
@@ -18,9 +18,6 @@
  */
 package org.sakaiproject.sitestats.tool.wicket.providers;
 
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.wicket.Session;
 import org.apache.wicket.injection.Injector;
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
@@ -43,6 +41,7 @@ import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.tool.facade.Locator;
 import org.sakaiproject.sitestats.tool.wicket.models.ReportDefModel;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
 
 @Slf4j
 public class ReportDefsProvider implements IDataProvider {
@@ -186,14 +185,7 @@ public class ReportDefsProvider implements IDataProvider {
 	
 	public final Comparator<ReportDef> getReportDefComparator() {
 		return new Comparator<ReportDef>() {
-			private transient Collator		collator = Collator.getInstance();
-			{
-				try{
-					collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				}catch(ParseException e){
-				    log.error("Unable to create RuleBasedCollator");
-				}		
-			}
+			private transient Comparator<String> comparator = new AlphaNumericComparator(Session.get().getLocale());
 			
 			public int compare(ReportDef o1, ReportDef o2) {
 				String title1 = null;
@@ -208,7 +200,7 @@ public class ReportDefsProvider implements IDataProvider {
 				}else{
 					title2 = o2.getTitle();
 				}
-				return collator.compare(title1, title2);
+				return comparator.compare(title1, title2);
 			}
 			
 		};

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportsDataProvider.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/providers/ReportsDataProvider.java
@@ -19,14 +19,12 @@
 package org.sakaiproject.sitestats.tool.wicket.providers;
 
 import java.io.Serializable;
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.wicket.Session;
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder;
 import org.apache.wicket.injection.Injector;
 import org.apache.wicket.model.IModel;
@@ -45,6 +43,7 @@ import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.tool.facade.Locator;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
 
 @Slf4j
 public class ReportsDataProvider extends SortableSearchableDataProvider {
@@ -142,20 +141,13 @@ public class ReportsDataProvider extends SortableSearchableDataProvider {
 	public final Comparator<Stat> getReportDataComparator(final String fieldName, final boolean sortAscending, 
 			final StatsManager SST_sm, final EventRegistryService SST_ers, final UserDirectoryService M_uds) {
 		return new Comparator<Stat>() {
-			private transient Collator collator= Collator.getInstance();
-			{
-				try{
-					collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-				}catch(ParseException e){
-				    log.error("Unable to create RuleBasedCollator");
-				}		
-			}			
+			private transient Comparator<String> comparator = new AlphaNumericComparator(Session.get().getLocale());
 			
 			public int compare(Stat r1, Stat r2) {
 				if(fieldName.equals(COL_SITE)){
 					String s1 = Locator.getFacade().getSiteService().getSiteDisplay(r1.getSiteId()).toLowerCase();
 					String s2 = Locator.getFacade().getSiteService().getSiteDisplay(r2.getSiteId()).toLowerCase();
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;
@@ -172,14 +164,14 @@ public class ReportsDataProvider extends SortableSearchableDataProvider {
 					}catch(UserNotDefinedException e){
 						s2 = "-";
 					}
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;
 				}else if(fieldName.equals(COL_USERNAME)){
 					String s1 = Locator.getFacade().getStatsManager().getUserNameForDisplay(r1.getUserId()).toLowerCase();
 					String s2 = Locator.getFacade().getStatsManager().getUserNameForDisplay(r2.getUserId()).toLowerCase();
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;
@@ -188,7 +180,7 @@ public class ReportsDataProvider extends SortableSearchableDataProvider {
 					EventStat es2 = (EventStat) r2;
 					String s1 = SST_ers.getEventName(es1.getEventId()).toLowerCase();
 					String s2 = SST_ers.getEventName(es2.getEventId()).toLowerCase();
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;
@@ -197,7 +189,7 @@ public class ReportsDataProvider extends SortableSearchableDataProvider {
 					EventStat es2 = (EventStat) r2;
 					String s1 = SST_ers.getToolName(es1.getToolId()).toLowerCase();
 					String s2 = SST_ers.getToolName(es2.getToolId()).toLowerCase();
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;
@@ -206,7 +198,7 @@ public class ReportsDataProvider extends SortableSearchableDataProvider {
 					ResourceStat rs2 = (ResourceStat) r2;
 					String s1 = SST_sm.getResourceName(rs1.getResourceRef()).toLowerCase();
 					String s2 = SST_sm.getResourceName(rs2.getResourceRef()).toLowerCase();
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;
@@ -215,7 +207,7 @@ public class ReportsDataProvider extends SortableSearchableDataProvider {
 					ResourceStat rs2 = (ResourceStat) r2;
 					String s1 = ((String) rs1.getResourceAction()).toLowerCase();
 					String s2 = ((String) rs2.getResourceAction()).toLowerCase();
-					int res = collator.compare(s1, s2);
+					int res = comparator.compare(s1, s2);
 					if(sortAscending)
 						return res;
 					else return -res;

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/util/Comparators.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/wicket/util/Comparators.java
@@ -15,38 +15,26 @@
  */
 package org.sakaiproject.sitestats.tool.wicket.util;
 
-import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.Comparator;
-
-import lombok.extern.slf4j.Slf4j;
 
 import org.apache.wicket.extensions.markup.html.form.select.IOptionRenderer;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.Session;
 
 import org.sakaiproject.sitestats.api.event.ToolInfo;
 import org.sakaiproject.sitestats.tool.facade.Locator;
 import org.sakaiproject.sitestats.tool.wicket.models.LoadableDisplayUserListModel.DisplayUser;
+import org.sakaiproject.util.comparator.AlphaNumericComparator;
 
 /**
- * Utility class to house Comparators using a common RuleBasedCollator
+ * Utility class to house comparators using the current Wicket session locale.
  * @author plukasew
  */
-@Slf4j
 public class Comparators
 {
-	private static Collator collator = Collator.getInstance();
-	static
+	private static Comparator<String> getStringComparatorForLocale()
 	{
-		try
-		{
-			collator = new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-		}
-		catch (ParseException e)
-		{
-			log.error("Unable to create RuleBasedCollator", e);
-		}
+		return new AlphaNumericComparator(Session.get().getLocale());
 	}
 
 	/**
@@ -55,7 +43,7 @@ public class Comparators
 	 */
 	public static final Comparator<String> getStringComparator()
 	{
-		return (String o1, String o2) -> collator.compare(o1, o2);
+		return getStringComparatorForLocale();
 	}
 
 	/**
@@ -64,11 +52,12 @@ public class Comparators
 	 */
 	public static final Comparator<ToolInfo> getToolInfoComparator()
 	{
+		Comparator<String> comparator = getStringComparatorForLocale();
 		return (ToolInfo o1, ToolInfo o2) ->
 		{
 			String toolName1 = Locator.getFacade().getEventRegistryService().getToolName(o1.getToolId());
 			String toolName2 = Locator.getFacade().getEventRegistryService().getToolName(o2.getToolId());
-			return collator.compare(toolName1, toolName2);
+			return comparator.compare(toolName1, toolName2);
 		};
 	}
 
@@ -79,7 +68,8 @@ public class Comparators
 	 */
 	public static final Comparator<Object> getOptionRendererComparator(final IOptionRenderer renderer)
 	{
-		return (Object o1, Object o2) -> collator.compare(renderer.getDisplayValue(o1), renderer.getDisplayValue(o2));
+		Comparator<String> comparator = getStringComparatorForLocale();
+		return (Object o1, Object o2) -> comparator.compare(String.valueOf(renderer.getDisplayValue(o1)), String.valueOf(renderer.getDisplayValue(o2)));
 	}
 
 	/**
@@ -89,7 +79,8 @@ public class Comparators
 	 */
 	public static final Comparator<Object> getChoiceRendererComparator(final IChoiceRenderer renderer)
 	{
-		return (Object o1, Object o2) -> collator.compare(renderer.getDisplayValue(o1), renderer.getDisplayValue(o2));
+		Comparator<String> comparator = getStringComparatorForLocale();
+		return (Object o1, Object o2) -> comparator.compare(String.valueOf(renderer.getDisplayValue(o1)), String.valueOf(renderer.getDisplayValue(o2)));
 	}
 
 	/**
@@ -98,6 +89,7 @@ public class Comparators
 	 */
 	public static final Comparator<DisplayUser> getDisplayUserComparator()
 	{
-		return (DisplayUser d1, DisplayUser d2) -> collator.compare(d1.display, d2.display);
+		Comparator<String> comparator = getStringComparatorForLocale();
+		return (DisplayUser d1, DisplayUser d2) -> comparator.compare(d1.display, d2.display);
 	}
 }

--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
@@ -27,8 +27,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -67,6 +65,8 @@ import org.sakaiproject.umem.api.Authz;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.api.LocaleService;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 /**
  * @author <a href="mailto:nuno@ufp.pt">Nuno Fernandes</a>
@@ -103,8 +103,10 @@ public class SiteListBean {
 	private AuthzGroupService			authzGroupService	= (AuthzGroupService) ComponentManager.get( AuthzGroupService.class.getName() );
 	private UserDirectoryService		userDirectoryService= (UserDirectoryService) ComponentManager.get( UserDirectoryService.class.getName() );
 	private ServerConfigurationService			M_scf				= (ServerConfigurationService) ComponentManager.get(ServerConfigurationService.class.getName());
+	private LocaleService				localeService		= ComponentManager.get(LocaleService.class);
 	/** Private vars */
-	private RuleBasedCollator					collator;
+	private Collator					collator			= SakaiCollators
+			.getCollatorWithUnderscoreAfterSpace(localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
 	private long						timeSpentInGroups	= 0;
 	private String						portalURL			= M_scf.getPortalUrl();
 	private String						message				= "";
@@ -133,13 +135,6 @@ public class SiteListBean {
 		private String				siteTerm;
 		private boolean				selected;
 
-		{
-			try{
-				collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-			}catch(ParseException e){
-				collator = (RuleBasedCollator)Collator.getInstance();
-			}
-		}
 		public UserSitesRow() {
 			this.selected = false;
 		}

--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
@@ -221,37 +221,37 @@ public class SiteListBean {
 						if(fieldName.equals(SORT_SITE_NAME)){
 							String s1 = r1.getSiteTitle();
 							String s2 = r2.getSiteTitle();
-							int res = collator.compare(s1!=null? s1.toLowerCase():"", s2!=null? s2.toLowerCase():"");
+							int res = collator.compare(s1!=null? s1:"", s2!=null? s2:"");
 							if(sortAscending) return res;
 							else return -res;
 						}else if(fieldName.equals(SORT_SITE_TYPE)){
 							String s1 = r1.getSiteType();
 							String s2 = r2.getSiteType();
-							int res = collator.compare(s1!=null? s1.toLowerCase():"", s2!=null? s2.toLowerCase():"");
+							int res = collator.compare(s1!=null? s1:"", s2!=null? s2:"");
 							if(sortAscending) return res;
 							else return -res;
 						}else if(fieldName.equals(SORT_SITE_RID)){
 							String s1 = r1.getRoleName();
 							String s2 = r2.getRoleName();
-							int res = collator.compare(s1!=null? s1.toLowerCase():"", s2!=null? s2.toLowerCase():"");
+							int res = collator.compare(s1!=null? s1:"", s2!=null? s2:"");
 							if(sortAscending) return res;
 							else return -res;
 						}else if(fieldName.equals(SORT_SITE_PV)){
 							String s1 = r1.getPubView();
 							String s2 = r2.getPubView();
-							int res = collator.compare(s1!=null? s1.toLowerCase():"", s2!=null? s2.toLowerCase():"");
+							int res = collator.compare(s1!=null? s1:"", s2!=null? s2:"");
 							if(sortAscending) return res;
 							else return -res;
 						}else if(fieldName.equals(SORT_USER_STATUS)){
 							String s1 = r1.getUserStatus();
 							String s2 = r2.getUserStatus();
-							int res = collator.compare(s1!=null? s1.toLowerCase():"", s2!=null? s2.toLowerCase():"");
+							int res = collator.compare(s1!=null? s1:"", s2!=null? s2:"");
 							if(sortAscending) return res;
 							else return -res;
 						}else if(fieldName.equals(SORT_SITE_TERM)){
 							String s1 = r1.getSiteTerm();
 							String s2 = r2.getSiteTerm();
-							int res = collator.compare(s1!=null? s1.toLowerCase():"", s2!=null? s2.toLowerCase():"");
+							int res = collator.compare(s1!=null? s1:"", s2!=null? s2:"");
 							if(sortAscending) return res;
 							else return -res;
 						}

--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/SiteListBean.java
@@ -105,8 +105,6 @@ public class SiteListBean {
 	private ServerConfigurationService			M_scf				= (ServerConfigurationService) ComponentManager.get(ServerConfigurationService.class.getName());
 	private LocaleService				localeService		= ComponentManager.get(LocaleService.class);
 	/** Private vars */
-	private Collator					collator			= SakaiCollators
-			.getCollatorWithUnderscoreAfterSpace(localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
 	private long						timeSpentInGroups	= 0;
 	private String						portalURL			= M_scf.getPortalUrl();
 	private String						message				= "";
@@ -289,9 +287,13 @@ public class SiteListBean {
 				refreshQuery = false;
 			}
 			
-			if(userSitesRows != null && userSitesRows.size() > 0) Collections.sort(userSitesRows, getUserSitesRowComparator(sitesSortColumn, sitesSortAscending, collator));
+			if(userSitesRows != null && userSitesRows.size() > 0) Collections.sort(userSitesRows, getUserSitesRowComparator(sitesSortColumn, sitesSortAscending, getCollator()));
 		}
 		return "";
+	}
+
+	private Collator getCollator() {
+		return SakaiCollators.getCollatorWithUnderscoreAfterSpace(localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
 	}
 	
 	/**
@@ -552,7 +554,7 @@ public class SiteListBean {
 	}
 
 	public List getUserSitesRows() {		
-		if(userSitesRows != null && userSitesRows.size() > 0) Collections.sort(userSitesRows, getUserSitesRowComparator(sitesSortColumn, sitesSortAscending, collator));
+		if(userSitesRows != null && userSitesRows.size() > 0) Collections.sort(userSitesRows, getUserSitesRowComparator(sitesSortColumn, sitesSortAscending, getCollator()));
 		return userSitesRows;
 	}
 

--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/UserListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/UserListBean.java
@@ -116,8 +116,6 @@ public class UserListBean {
 	private LocaleService localeService = ComponentManager.get(LocaleService.class);
 
 	/** Private vars */
-	private Collator						collator			= SakaiCollators
-			.getCollatorWithUnderscoreAfterSpace(localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
 	private String							message				= "";
 	// system
 	
@@ -287,10 +285,14 @@ public class UserListBean {
 		
 		if(userRows != null){
 			// Sort resulting list
-			Collections.sort(userRows, getUserRowComparator(userSortColumn, userSortAscending, collator));
+			Collections.sort(userRows, getUserRowComparator(userSortColumn, userSortAscending, getCollator()));
 		}
 		
 		return "";
+	}
+
+	private Collator getCollator() {
+		return SakaiCollators.getCollatorWithUnderscoreAfterSpace(localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
 	}
 	
 	public TimeZone getUserTimeZone() {

--- a/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/UserListBean.java
+++ b/usermembership/tool/src/java/org/sakaiproject/umem/tool/ui/UserListBean.java
@@ -27,8 +27,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.Collator;
-import java.text.ParseException;
-import java.text.RuleBasedCollator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -54,6 +52,8 @@ import org.sakaiproject.umem.api.Authz;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.api.LocaleService;
+import org.sakaiproject.util.comparator.SakaiCollators;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -107,16 +107,19 @@ public class UserListBean {
 	private String							newUserType			= null;
 	private String							newAuthority		= USER_AUTH_ALL;
 
-	/** Private vars */
-	private static RuleBasedCollator				collator;																// use
-	private String							message				= "";
-	// system
 	/** Sakai services vars */
 	private transient UserDirectoryService	M_uds				= (UserDirectoryService) ComponentManager.get(UserDirectoryService.class.getName());
 	private transient ToolManager			M_tm				= (ToolManager) ComponentManager.get(ToolManager.class.getName());
 	private transient SqlService			M_sql				= (SqlService) ComponentManager.get(SqlService.class.getName());
 	private transient Authz					authz				= (Authz) ComponentManager.get(Authz.class.getName());
 	private UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
+	private LocaleService localeService = ComponentManager.get(LocaleService.class);
+
+	/** Private vars */
+	private Collator						collator			= SakaiCollators
+			.getCollatorWithUnderscoreAfterSpace(localeService.getLocaleForCurrentSiteAndUser(), Collator.TERTIARY);
+	private String							message				= "";
+	// system
 	
 	// ######################################################################################
 	// UserRow, UserSitesRow CLASS
@@ -132,14 +135,6 @@ public class UserListBean {
 		private String				authority;
 		private Date              createdOn;
 		private Date              modifiedOn;
-
-		static {
-			try{
-				collator= new RuleBasedCollator(((RuleBasedCollator)Collator.getInstance()).getRules().replaceAll("<'\u005f'", "<' '<'\u005f'"));
-			}catch(ParseException e){
-				collator = (RuleBasedCollator)Collator.getInstance();
-			}
-		}
 
 		public UserRow() {
 		}

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/CardGameController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/CardGameController.java
@@ -28,6 +28,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.util.comparator.UserSortNameComparator;
 import org.sakaiproject.webapi.beans.CardGameUserRestBean;
 import org.sakaiproject.webapi.beans.SimpleGroup;
@@ -88,6 +89,9 @@ public class CardGameController extends AbstractSakaiApiController {
     @Autowired
     private ProfileService profileService;
 
+    @Autowired
+    private LocaleService localeService;
+
     private int minAttempts;
     private double minHitRatio;
     private boolean showOfficialPhoto;
@@ -128,7 +132,7 @@ public class CardGameController extends AbstractSakaiApiController {
             log.debug("Not skipping any users for having default images");
         }
 
-        Set<User> visibleUsers = userDirectoryService.getUsers(getVisibleUsersIds(currentUserId, site)).stream()
+        List<User> visibleUsers = userDirectoryService.getUsers(getVisibleUsersIds(currentUserId, site)).stream()
                 .filter(Objects::nonNull)
                 .filter(user -> {
                     boolean skipUser = skipNoImageUsers && hasDefaultImage(user.getId(), siteId, showOfficialPhoto);
@@ -138,8 +142,9 @@ public class CardGameController extends AbstractSakaiApiController {
 
                     return !skipUser;
                 })
-                .sorted(new UserSortNameComparator(true, true))
-                .collect(Collectors.toSet());
+                .sorted(new UserSortNameComparator(true, true,
+                        localeService.getLocaleForSiteAndUser(siteId, currentUserId)))
+                .collect(Collectors.toList());
 
         return visibleUsers.stream()
                 .map(user -> CardGameUserRestBean.of(user, statItems.get(user.getId())))


### PR DESCRIPTION
CC: @danielmerino 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide locale-aware sorting for user lists, groups, rosters, announcements, learners, grade/assignment exports, ZIP/grade-sheet exports, reports and UI lists.
  * New shared locale-aware collation utility improving underscore-vs-space and alphanumeric ordering for natural, locale-correct name, title and group sorting.

* **Tests**
  * Added locale-specific sorting tests covering multiple locales and numeric ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->