### PR TITLE
SAK-52604 Announcements tool hides future announcements from instructors who can edit them

### DIFF
--- a/announcement/announcement-api/api/src/bundle/announcement.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement.properties
@@ -19,6 +19,8 @@ java.alert.youpermi.subject = You don't have permissions to create this announce
 java.alert.youdel = you don't have permission to delete the messages.
 # {0} is a reference
 java.alert.youdelann.ref = you don't have permissions to delete this announcement - {0}
+# {0} is a reference
+java.alert.youreorder.ref = you don't have permissions to reorder this announcement - {0}
 java.alert.youdelann2 = you don't have permissions to delete this announcement!
 java.alert.thisitem = This item is being edited by another user. Please try again later.
 java.alert.youacc.pes = You don't have permissions to access the message(s) - {0}

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementChannelEdit.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementChannelEdit.java
@@ -21,6 +21,10 @@
 
 package org.sakaiproject.announcement.api;
 
+import java.util.List;
+
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.javax.Filter;
 import org.sakaiproject.message.api.MessageChannelEdit;
 
 /**
@@ -30,4 +34,9 @@ import org.sakaiproject.message.api.MessageChannelEdit;
  */
 public interface AnnouncementChannelEdit extends AnnouncementChannel<AnnouncementMessageEdit>, MessageChannelEdit<AnnouncementMessageEdit>
 {
+	/**
+	 * Return all stored messages in this channel for instructor management actions.
+	 * This bypasses announcement view filters; callers must have annc.revise.any.
+	 */
+	public List<AnnouncementMessage> getMessagesForInstructors(Filter filter, boolean ascending) throws PermissionException;
 }

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
@@ -225,6 +225,15 @@ public interface AnnouncementService extends MessageService
 												boolean isSynopticTool, String siteId, Integer maxAgeInDays) throws PermissionException;
 
 	/**
+	 * Return announcement messages for the Announcements tool instructor view.
+	 * Users with annc.revise.any on a channel receive all stored messages from that channel,
+	 * including future, retracted, draft, grouped, and role-targeted messages.
+	 */
+	public List<AnnouncementMessage> getChannelMessagesForInstructors(String channelReference, Filter filter, boolean ascending,
+												String mergedChannelDelimitedList, boolean allUserSites,
+												boolean isSynopticTool, String siteId, Integer maxAgeInDays) throws PermissionException;
+
+	/**
 	 * Returns visible MOTD announcements from the MOTD channel.
 	 * Visibility is enforced by {@link #isMessageViewable(org.sakaiproject.message.api.Message)}.
 	 *

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/cover/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/cover/AnnouncementService.java
@@ -539,6 +539,17 @@ public class AnnouncementService
 		return service.getMessages(channelReference,filter, order, merged);	
 	}
 
+	public static java.util.List<AnnouncementMessage> getChannelMessagesForInstructors(String channelReference, Filter filter, boolean ascending,
+			String mergedChannelDelimitedList, boolean allUserSites, boolean isSynopticTool, String siteId, Integer maxAgeInDays)
+			throws org.sakaiproject.exception.PermissionException
+	{
+		org.sakaiproject.announcement.api.AnnouncementService service = getInstance();
+		if (service == null) return null;
+
+		return service.getChannelMessagesForInstructors(channelReference, filter, ascending, mergedChannelDelimitedList,
+				allUserSites, isSynopticTool, siteId, maxAgeInDays);
+	}
+
 	/**
 	 * Returns visible MOTD announcements from the MOTD channel.
 	 * @param afterDate Optional lower-bound date filter.

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -2001,7 +2001,8 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 
 		private List<AnnouncementMessage> findStoredMessages(Filter filter, boolean ascending)
 		{
-			return ((List<AnnouncementMessage>) findSortedMessages(ascending)).stream()
+			return findSortedMessages(ascending).stream()
+				.map(AnnouncementMessage.class::cast)
 				.filter(m -> filter == null || filter.accept(m))
 				.collect(Collectors.toList());
 		}

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -1468,7 +1468,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 
 		RoleAccessFilter roleFilter = new RoleAccessFilter(currentUserId);
 		return messageList.stream()
-			.filter(m -> (instructorView && canManageAllAnnouncements(m.getReference())) || roleFilter.accept(m))
+			.filter(m -> (instructorView && canManageAllAnnouncements(m.getOriginChannel())) || roleFilter.accept(m))
 			.collect(Collectors.toList());
 	}
 

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -107,6 +107,7 @@ import org.sakaiproject.time.api.Time;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.user.api.User;
 import org.sakaiproject.util.api.LinkMigrationHelper;
 import org.sakaiproject.util.MergedList;
 import org.sakaiproject.util.MergedListEntryProviderBase;
@@ -1292,6 +1293,19 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 	public List<AnnouncementMessage> getChannelMessages(String channelReference, Filter filter, boolean ascending,
 			String mergedChannelDelimitedList, boolean allUsersSites, boolean isSynopticTool, String siteId, Integer maxAgeInDays) throws PermissionException {
 
+		return getChannelMessages(channelReference, filter, ascending, mergedChannelDelimitedList, allUsersSites, isSynopticTool, siteId, maxAgeInDays, false);
+	}
+
+	@Override
+	public List<AnnouncementMessage> getChannelMessagesForInstructors(String channelReference, Filter filter, boolean ascending,
+			String mergedChannelDelimitedList, boolean allUsersSites, boolean isSynopticTool, String siteId, Integer maxAgeInDays) throws PermissionException {
+
+		return getChannelMessages(channelReference, filter, ascending, mergedChannelDelimitedList, allUsersSites, isSynopticTool, siteId, maxAgeInDays, true);
+	}
+
+	private List<AnnouncementMessage> getChannelMessages(String channelReference, Filter filter, boolean ascending,
+			String mergedChannelDelimitedList, boolean allUsersSites, boolean isSynopticTool, String siteId, Integer maxAgeInDays, boolean instructorView) throws PermissionException {
+
 		if (filter == null && maxAgeInDays != null) {
 			filter = getMaxAgeInDaysAndAmountFilter(maxAgeInDays, Integer.MAX_VALUE);
 		}
@@ -1427,12 +1441,20 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 				AnnouncementChannel curChannel = (AnnouncementChannel) getChannel(curEntry.getReference());
 				if (curChannel != null) {
 					if (allowGetChannel(curChannel.getReference())) {
-						messageList.addAll(((List<AnnouncementMessage>) curChannel.getMessages(filter, ascending)).stream().map(m -> {
+						List<AnnouncementMessage> channelMessages;
+						if (instructorView && canManageAllAnnouncements(curChannel.getReference()) && curChannel instanceof AnnouncementChannelEdit) {
+							channelMessages = ((AnnouncementChannelEdit) curChannel).getMessagesForInstructors(filter, ascending);
+						} else {
+							// Channels loaded by this service are AnnouncementChannelEdit; this fallback
+							// preserves the viewer-filtered contract if another implementation is supplied.
+							channelMessages = (List<AnnouncementMessage>) curChannel.getMessages(filter, ascending);
+						}
+						messageList.addAll(channelMessages.stream().map(m -> {
 
-								m.setOriginChannel(curEntry.getReference());
-								m.setOriginSite(curChannel.getContext());
-								return m;
-							}).collect(Collectors.toList()));
+							m.setOriginChannel(curEntry.getReference());
+							m.setOriginSite(curChannel.getContext());
+							return m;
+						}).collect(Collectors.toList()));
 					}
 				}
 			} catch (IdUnusedException e) {
@@ -1446,8 +1468,12 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 
 		RoleAccessFilter roleFilter = new RoleAccessFilter(currentUserId);
 		return messageList.stream()
-			.filter(roleFilter::accept)
+			.filter(m -> (instructorView && canManageAllAnnouncements(m.getReference())) || roleFilter.accept(m))
 			.collect(Collectors.toList());
+	}
+
+	private boolean canManageAllAnnouncements(String reference) {
+		return unlockCheck(SECURE_UPDATE_ANY, reference);
 	}
 
 	/**
@@ -1512,10 +1538,10 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 
 		// get the channel associated with this site
 		String oChannelRef = channelReference(fromContext, SiteService.MAIN_CONTAINER);
-		AnnouncementChannel oChannel = null;
+		BaseAnnouncementChannelEdit oChannel = null;
 		try
 		{
-			oChannel = (AnnouncementChannel) getChannel(oChannelRef);
+			oChannel = (BaseAnnouncementChannelEdit) getChannel(oChannelRef);
 			// the "to" message channel
 			String nChannelRef = channelReference(toContext, SiteService.MAIN_CONTAINER);
 			AnnouncementChannel nChannel = null;
@@ -1547,14 +1573,14 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 			if (nChannel != null)
 			{
 				// pass the DOM to get new message ids, record the mapping from old to new, and adjust attachments
-				List oMessageList = oChannel.getMessages(null, true);
+				List<AnnouncementMessage> oMessageList = oChannel.getMessagesForImport(true);
 				AnnouncementMessage oMessage = null;
 				AnnouncementMessageHeader oMessageHeader = null;
 				AnnouncementMessageEdit nMessage = null;
 				for (int i = 0; i < oMessageList.size(); i++)
 				{
 					// the "from" message
-					oMessage = (AnnouncementMessage) oMessageList.get(i);
+					oMessage = oMessageList.get(i);
 					String oMessageId = oMessage.getId();
 
 					boolean toBeImported = true;
@@ -1599,7 +1625,10 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 							nMessageHeader.setDraft(oMessageHeader.getDraft());
 						}
 
-						nMessageHeader.setFrom(oMessageHeader.getFrom());
+						// Imported announcements belong to the user performing the import in the
+						// destination site, so revise-own workflows such as bulk publish still work.
+						User importingUser = userDirectoryService.getCurrentUser();
+						nMessageHeader.setFrom(importingUser);
 						nMessageHeader.setSubject(oMessageHeader.getSubject());
 						// attachment
 						List oAttachments = oMessageHeader.getAttachments();
@@ -1711,13 +1740,16 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 		// get the channel associated with this site
 		String oChannelRef = channelReference(fromContext, SiteService.MAIN_CONTAINER);
 		try {
-			AnnouncementChannel oChannel = (AnnouncementChannel) getChannel(oChannelRef);
-			return ((List<AnnouncementMessage>) oChannel.getMessages(null, true)).stream()
+			BaseAnnouncementChannelEdit oChannel = (BaseAnnouncementChannelEdit) getChannel(oChannelRef);
+			// The selectable import picker uses the same stored-message inventory that
+			// transferCopyEntities uses, so a partial import can select anything a full
+			// tool import would copy.
+			return oChannel.getMessagesForImport(true).stream()
 				.map(ann -> Map.of("id", ann.getId(), "title", ann.getAnnouncementHeader().getSubject())).collect(Collectors.toList());
 		} catch (Exception e) {
 			log.warn("Failed to get channel for ref {}", e.toString());
 		}
-		return Collections.EMPTY_LIST;
+		return Collections.emptyList();
 	}
 
 
@@ -1732,8 +1764,8 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 		// get the channel associated with this site
 		String oChannelRef = channelReference(siteId, SiteService.MAIN_CONTAINER);
 		try {
-			AnnouncementChannel oChannel = (AnnouncementChannel) getChannel(oChannelRef);
-			return !oChannel.getMessages(null, true).isEmpty();
+			BaseAnnouncementChannelEdit oChannel = (BaseAnnouncementChannelEdit) getChannel(oChannelRef);
+			return !oChannel.getMessagesForImport(true).isEmpty();
 		} catch (Exception e) {
 			log.warn("Failed to get channel for ref {}", e.toString());
 		}
@@ -1759,14 +1791,13 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 					channelId = channelReference(toSiteId, SiteService.MAIN_CONTAINER);
 					try
 					{
-						AnnouncementChannel aChannel = getAnnouncementChannel(channelId);
+						BaseAnnouncementChannelEdit aChannel = (BaseAnnouncementChannelEdit) getAnnouncementChannel(channelId);
 						//need to clear the cache to grab the newly saved messages
 						threadLocalManager.set(aChannel.getReference() + ".msgs", null);
-						List mList = aChannel.getMessages(null, true);
+						List<AnnouncementMessage> mList = aChannel.getMessagesForImport(true);
 
-						for(Iterator iter = mList.iterator(); iter.hasNext();)
+						for (AnnouncementMessage msg : mList)
 						{
-							AnnouncementMessage msg = (AnnouncementMessage) iter.next();
 							String msgBody = msg.getBody();
 							boolean updated = false;
 							Iterator<Entry<String, String>> entryItr = entrySet.iterator();
@@ -1786,7 +1817,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 							}
 						}
 					}
-					catch(Exception e)
+					catch (Exception e)
 					{
 						log.debug("Unable to remove Announcements ", e.getMessage(), e);
 					}
@@ -1906,20 +1937,22 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 		{
 			AnnouncementMessage msg = (AnnouncementMessage) getMessage(messageId);
 
+			// Single-message reads use allowEditMessage(), which permits revise-own as well
+			// as revise-any; list/management paths require channel-wide revise-any.
 			// Apply the privacy filter to check draft permissions
 			PrivacyFilter filter = new PrivacyFilter(null);
-			if (!filter.accept(msg)) {
+			if (!filter.accept(msg) && !allowEditMessage(messageId)) {
 				throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_READ, msg.getReference());
 			}
 
 			// Check group access permissions: empty list returned means no permission to view
-			if (filterGroupAccess(List.of(msg)).isEmpty()) {
+			if (filterGroupAccess(List.of(msg)).isEmpty() && !allowEditMessage(messageId)) {
 				throw new PermissionException(sessionManager.getCurrentSessionUserId(), SECURE_READ, msg.getReference());
 			}
 
 			String currentUserId = sessionManager.getCurrentSessionUserId();
 			RoleAccessFilter roleFilter = new RoleAccessFilter(currentUserId);
-			if (!roleFilter.accept(msg)) {
+			if (!roleFilter.accept(msg) && !allowEditMessage(messageId)) {
 				throw new PermissionException(currentUserId, SECURE_READ, msg.getReference());
 			}
 
@@ -1945,6 +1978,33 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 			return super.getMessages(filter, ascending);
 
 		} // getMessages
+
+		public List<AnnouncementMessage> getMessagesForImport(boolean ascending) throws PermissionException
+		{
+			unlock(SECURE_READ, getReference());
+
+			// Site Import is an administrative copy path. Return all stored announcements,
+			// sorted, without PrivacyFilter or group visibility filtering.
+			return findStoredMessages(null, ascending);
+		}
+
+		@Override
+		public List<AnnouncementMessage> getMessagesForInstructors(Filter filter, boolean ascending) throws PermissionException
+		{
+			unlock(SECURE_UPDATE_ANY, getReference());
+
+			// The Announcements tool is an instructor management surface. Users who can edit all
+			// announcements in this channel need all stored messages, not only currently
+			// viewable messages.
+			return findStoredMessages(filter, ascending);
+		}
+
+		private List<AnnouncementMessage> findStoredMessages(Filter filter, boolean ascending)
+		{
+			return ((List<AnnouncementMessage>) findSortedMessages(ascending)).stream()
+				.filter(m -> filter == null || filter.accept(m))
+				.collect(Collectors.toList());
+		}
 
 		
 		/**
@@ -2473,20 +2533,20 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 				String channelId = serverConfigurationService.getString(ANNOUNCEMENT_CHANNEL_PROPERTY, null);
 				
 				String toSiteId = toContext;
-				
+
 				if (channelId == null)
 				{
 					channelId = channelReference(toSiteId, SiteService.MAIN_CONTAINER);
 					try
 					{
-						AnnouncementChannel aChannel = getAnnouncementChannel(channelId);
-						
-						List mList = aChannel.getMessages(null, true);
-						
+						BaseAnnouncementChannelEdit aChannel = (BaseAnnouncementChannelEdit) getAnnouncementChannel(channelId);
+
+						List<AnnouncementMessage> mList = aChannel.getMessagesForImport(true);
+
 						for(Iterator iter = mList.iterator(); iter.hasNext();)
 						{
 							AnnouncementMessage msg = (AnnouncementMessage) iter.next();
-							
+
 							aChannel.removeMessage(msg.getId());
 						}
 					}

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1460,7 +1459,7 @@ public class AnnouncementAction extends PagedResourceActionII
 
 	private boolean canManageAnnouncement(AnnouncementMessage msg)
 	{
-		return m_securityService.unlock(AnnouncementService.SECURE_ANNC_UPDATE_ANY, msg.getReference());
+		return m_securityService.unlock(AnnouncementService.SECURE_ANNC_UPDATE_ANY, getChannelIdFromReference(msg.getReference()));
 	}
 	
 	/**
@@ -4051,36 +4050,42 @@ public class AnnouncementAction extends PagedResourceActionII
 					// Reorder is part of the full Announcements management surface, so it must
 					// operate on the same unfiltered local-channel message set the instructor can manage.
 					AnnouncementChannelEdit channel = (AnnouncementChannelEdit) announcementService.getChannel(state.getChannelId());
-					List<AnnouncementMessage> allMessages = channel.getMessagesForInstructors(null, true);
-					int msgCount = allMessages.size(); //used to find msg order number
-					//store the updated message ids so we know which ones didn't get updated
-					List<String> updatedMessageIds = new ArrayList<String>();
-					Vector v2 = new Vector();
-
-					//find starting message index (0 - x) based on number of messages displayed per page
-					int j= allMessages.size();
-					if ((sstate.getAttribute(STATE_TOP_PAGE_MESSAGE) != null) && (sstate.getAttribute(STATE_PAGESIZE) != null))
+					List<AnnouncementMessage> allMessages = channel.getMessagesForInstructors(null, false);
+					List<String> finalMessageIds = new ArrayList<String>();
+					for (AnnouncementMessage message : allMessages)
 					{
-						j = ((Integer) sstate.getAttribute(STATE_TOP_PAGE_MESSAGE)).intValue();
+						finalMessageIds.add(message.getId());
 					}
 
-					for (int i = 0; i < messageReferences2.length; i++, j++)
+					List<String> reorderedMessageIds = new ArrayList<String>();
+					for (String messageReference : messageReferences2)
 					{
-						// get the updated/reordered message object through service
+						String messageId = getMessageIDFromReference(messageReference);
+						if (finalMessageIds.contains(messageId) && !reorderedMessageIds.contains(messageId))
+						{
+							reorderedMessageIds.add(messageId);
+						}
+					}
+
+					//find starting message index (0 - x) based on number of messages displayed per page
+					int insertAt = finalMessageIds.size();
+					if ((sstate.getAttribute(STATE_TOP_PAGE_MESSAGE) != null) && (sstate.getAttribute(STATE_PAGESIZE) != null))
+					{
+						insertAt = ((Integer) sstate.getAttribute(STATE_TOP_PAGE_MESSAGE)).intValue();
+					}
+					finalMessageIds.removeAll(reorderedMessageIds);
+					insertAt = Math.min(insertAt, finalMessageIds.size());
+					finalMessageIds.addAll(insertAt, reorderedMessageIds);
+
+					int messageOrder = finalMessageIds.size();
+					for (String messageId : finalMessageIds)
+					{
 						try
 						{
-							// get the channel id throught announcement service
-							AnnouncementChannel channel2 = announcementService.getAnnouncementChannel(this
-									.getChannelIdFromReference(messageReferences2[i]));
-							// get the message object through service
-							AnnouncementMessage message2 = channel2.getAnnouncementMessage(this
-									.getMessageIDFromReference(messageReferences2[i]));
-							AnnouncementMessageEdit msg =(AnnouncementMessageEdit)message2;
+							AnnouncementMessageEdit msg = (AnnouncementMessageEdit) channel.getAnnouncementMessage(messageId);
 							AnnouncementMessageHeaderEdit header2 = msg.getAnnouncementHeaderEdit();
-							header2.setMessage_order(msgCount - j);
-							channel2.commitMessage_order(msg);
-							updatedMessageIds.add(msg.getId());
-							//v2.addElement(message2);
+							header2.setMessage_order(messageOrder--);
+							channel.commitMessage_order(msg);
 						}
 						catch (IdUnusedException e)
 						{
@@ -4090,32 +4095,7 @@ public class AnnouncementAction extends PagedResourceActionII
 						catch (PermissionException e)
 						{
 							if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
-							addAlert(sstate, rb.getFormattedMessage("java.alert.youdelann.ref", messageReferences2[i]));
-						}
-					}
-					if(allMessages.size() > messageReferences2.length){
-						//need to update the message order of the remaining untouched messages (only sorts the top 10)
-
-						//order by message order:
-						Comparator<AnnouncementMessage> comparing = Comparator.comparing(o -> (o.getAnnouncementHeader().getMessage_order()));
-						SortedIterator<AnnouncementMessage> messagesSorted = new SortedIterator<>(allMessages.iterator(), comparing);
-						//start at last message and increment up
-						int messageOrder = 1;
-						while(messagesSorted.hasNext()){
-							Message message = messagesSorted.next();
-							if(!updatedMessageIds.contains(message.getId())){
-								//since this list is ordered, we can assign the message order in order:
-								AnnouncementChannel channel2 = announcementService.getAnnouncementChannel(this
-										.getChannelIdFromReference(message.getReference()));
-								// get the message object through service
-								AnnouncementMessage message2 = channel2.getAnnouncementMessage(this
-										.getMessageIDFromReference(message.getReference()));
-								AnnouncementMessageEdit msg =(AnnouncementMessageEdit)message2;
-								AnnouncementMessageHeaderEdit header2 = msg.getAnnouncementHeaderEdit();
-								header2.setMessage_order(messageOrder);
-								channel2.commitMessage_order(msg);
-							}
-							messageOrder++;
+							addAlert(sstate, rb.getFormattedMessage("java.alert.youdelann.ref", messageId));
 						}
 					}
 				} catch (PermissionException | IdUnusedException e1) {

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -4082,24 +4082,29 @@ public class AnnouncementAction extends PagedResourceActionII
 					{
 						try
 						{
-							AnnouncementMessageEdit msg = (AnnouncementMessageEdit) channel.getAnnouncementMessage(messageId);
-							AnnouncementMessageHeaderEdit header2 = msg.getAnnouncementHeaderEdit();
-							header2.setMessage_order(messageOrder--);
-							channel.commitMessage_order(msg);
+							AnnouncementMessageEdit messageEdit = channel.editAnnouncementMessage(messageId);
+							AnnouncementMessageHeaderEdit headerEdit = messageEdit.getAnnouncementHeaderEdit();
+							headerEdit.setMessage_order(messageOrder--);
+							channel.commitMessage_order(messageEdit);
 						}
 						catch (IdUnusedException e)
 						{
-							if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
+							log.debug("Unable to reorder announcement message {} because it no longer exists", messageId, e);
 							// addAlert(sstate, e.toString());
 						}
 						catch (PermissionException e)
 						{
-							if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
-							addAlert(sstate, rb.getFormattedMessage("java.alert.youdelann.ref", messageId));
+							log.debug("Permission denied while reordering announcement message {}", messageId, e);
+							addAlert(sstate, rb.getFormattedMessage("java.alert.youreorder.ref", messageId));
+						}
+						catch (InUseException e)
+						{
+							log.debug("Unable to reorder announcement message {} because it is being edited", messageId, e);
+							addAlert(sstate, rb.getString("java.alert.thisitem"));
 						}
 					}
-				} catch (PermissionException | IdUnusedException e1) {
-					log.error(e1.getMessage());
+				} catch (PermissionException | IdUnusedException e) {
+					log.error("Unable to load announcement channel {} while reordering announcements", state.getChannelId(), e);
 				}
 			}
 		}

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1205,11 +1205,19 @@ public class AnnouncementAction extends PagedResourceActionII
 	{
 		List<AnnouncementWrapper> wrappedMessageList = new ArrayList<>();
 
-        String siteId = ToolManager.getCurrentPlacement().getContext();
+		String siteId = ToolManager.getCurrentPlacement().getContext();
+		String mergedChannelDelimitedList = portlet.getPortletConfig().getInitParameter(getPortletConfigParameterNameForLoadOnly(portlet));
+		List<AnnouncementMessage> messageList;
+		if (isOnWorkspaceTab() || isSynopticTool()) {
+			messageList = announcementService.getChannelMessages(state.getChannelId(), filter, ascending,
+					mergedChannelDelimitedList, isOnWorkspaceTab(), isSynopticTool(), siteId, null);
+		} else {
+			messageList = announcementService.getChannelMessagesForInstructors(state.getChannelId(), filter, ascending,
+					mergedChannelDelimitedList, false, false, siteId, null);
+		}
 
-		List<AnnouncementMessage> messageList = announcementService.getChannelMessages(state.getChannelId(), filter, ascending, portlet.getPortletConfig().getInitParameter(
-								getPortletConfigParameterNameForLoadOnly(portlet)), isOnWorkspaceTab(), isSynopticTool(), siteId, null);
-
+		// The instructor API returns management candidates. This display pass still
+		// preserves the viewer policy for synoptic/workspace and non-revise-any users.
 		messageList = getViewableMessages(messageList, siteId);
 
 		wrappedMessageList.addAll(AnnouncementWrapper.wrapList(messageList, defaultChannel, state.getDisplayOptions()));
@@ -1422,8 +1430,8 @@ public class AnnouncementAction extends PagedResourceActionII
 	}
 	
 	/**
-	 * Determines if use has draft (UI: hidden) permission or site.upd
-	 * If so, they will be able to view messages that are hidden
+	 * Determines if the current user can manage announcements that are hidden
+	 * or outside their normal view window in the full Announcements tool.
 	 */
 	private boolean canViewHidden(AnnouncementMessage msg, String siteId) 
 	{
@@ -1439,7 +1447,8 @@ public class AnnouncementAction extends PagedResourceActionII
 				break;
 		}
 
-		boolean b = m_securityService.unlock(AnnouncementService.SECURE_ANNC_READ_DRAFT, msg.getReference())
+		boolean b = canManageAnnouncement(msg)
+							 || m_securityService.unlock(AnnouncementService.SECURE_ANNC_READ_DRAFT, msg.getReference())
 							 || m_securityService.unlock(SiteService.SECURE_UPDATE_SITE, "/site/"+ siteId);
 		if (roleswap==null)
 		{
@@ -1447,6 +1456,11 @@ public class AnnouncementAction extends PagedResourceActionII
 		} 
 		
 		return b;
+	}
+
+	private boolean canManageAnnouncement(AnnouncementMessage msg)
+	{
+		return m_securityService.unlock(AnnouncementService.SECURE_ANNC_UPDATE_ANY, msg.getReference());
 	}
 	
 	/**
@@ -4033,77 +4047,77 @@ public class AnnouncementAction extends PagedResourceActionII
 			String[] messageReferences2 = rundata.getParameters().getStrings("selectedMembers2");
 			if (messageReferences2 != null)
 			{
-				
-				
 				try {
-				//grab all messages before the order changes:	
-				List<AnnouncementMessage> allMessages = announcementService.getChannel(state.getChannelId()).getMessages(null, true);
-				int msgCount =  allMessages.size(); //used to find msg order number
-				//store the updated message ids so we know which ones didn't get updated
-				List<String> updatedMessageIds = new ArrayList<String>();
-				Vector v2 = new Vector();
-				
-				//find starting message index (0 - x) based on number of messages displayed per page
-				int j= allMessages.size();
-				if ((sstate.getAttribute(STATE_TOP_PAGE_MESSAGE) != null) && (sstate.getAttribute(STATE_PAGESIZE) != null))
-				{
-					j = ((Integer) sstate.getAttribute(STATE_TOP_PAGE_MESSAGE)).intValue();
-				}
-				
-				for (int i = 0; i < messageReferences2.length; i++, j++)
-				{
-					// get the updated/reordered message object through service
-					try
+					// Reorder is part of the full Announcements management surface, so it must
+					// operate on the same unfiltered local-channel message set the instructor can manage.
+					AnnouncementChannelEdit channel = (AnnouncementChannelEdit) announcementService.getChannel(state.getChannelId());
+					List<AnnouncementMessage> allMessages = channel.getMessagesForInstructors(null, true);
+					int msgCount = allMessages.size(); //used to find msg order number
+					//store the updated message ids so we know which ones didn't get updated
+					List<String> updatedMessageIds = new ArrayList<String>();
+					Vector v2 = new Vector();
+
+					//find starting message index (0 - x) based on number of messages displayed per page
+					int j= allMessages.size();
+					if ((sstate.getAttribute(STATE_TOP_PAGE_MESSAGE) != null) && (sstate.getAttribute(STATE_PAGESIZE) != null))
 					{
-						// get the channel id throught announcement service
-						AnnouncementChannel channel2 = announcementService.getAnnouncementChannel(this
-								.getChannelIdFromReference(messageReferences2[i]));
-						// get the message object through service
-						AnnouncementMessage message2 = channel2.getAnnouncementMessage(this
-								.getMessageIDFromReference(messageReferences2[i]));
-						AnnouncementMessageEdit msg =(AnnouncementMessageEdit)message2;
-						AnnouncementMessageHeaderEdit header2 = msg.getAnnouncementHeaderEdit();
-						header2.setMessage_order(msgCount - j);
-						channel2.commitMessage_order(msg);
-						updatedMessageIds.add(msg.getId());
-						//v2.addElement(message2);
+						j = ((Integer) sstate.getAttribute(STATE_TOP_PAGE_MESSAGE)).intValue();
 					}
-					catch (IdUnusedException e)
+
+					for (int i = 0; i < messageReferences2.length; i++, j++)
 					{
-						if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
-						// addAlert(sstate, e.toString());
-					}
-					catch (PermissionException e)
-					{
-						if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
-						addAlert(sstate, rb.getFormattedMessage("java.alert.youdelann.ref", messageReferences2[i]));
-					}
-				}
-				if(allMessages.size() > messageReferences2.length){
-					//need to update the message order of the remaining untouched messages (only sorts the top 10)
-				
-					//order by message order:
-					Comparator<AnnouncementMessage> comparing = Comparator.comparing(o -> (o.getAnnouncementHeader().getMessage_order()));
-					SortedIterator<AnnouncementMessage> messagesSorted = new SortedIterator<>(allMessages.iterator(), comparing);
-					//start at last message and increment up
-					int messageOrder = 1;
-					while(messagesSorted.hasNext()){
-						Message message = messagesSorted.next();
-						if(!updatedMessageIds.contains(message.getId())){
-							//since this list is ordered, we can assign the message order in order:
+						// get the updated/reordered message object through service
+						try
+						{
+							// get the channel id throught announcement service
 							AnnouncementChannel channel2 = announcementService.getAnnouncementChannel(this
-									.getChannelIdFromReference(message.getReference()));
+									.getChannelIdFromReference(messageReferences2[i]));
 							// get the message object through service
 							AnnouncementMessage message2 = channel2.getAnnouncementMessage(this
-									.getMessageIDFromReference(message.getReference()));
+									.getMessageIDFromReference(messageReferences2[i]));
 							AnnouncementMessageEdit msg =(AnnouncementMessageEdit)message2;
 							AnnouncementMessageHeaderEdit header2 = msg.getAnnouncementHeaderEdit();
-							header2.setMessage_order(messageOrder);						
+							header2.setMessage_order(msgCount - j);
 							channel2.commitMessage_order(msg);
+							updatedMessageIds.add(msg.getId());
+							//v2.addElement(message2);
 						}
-						messageOrder++;
+						catch (IdUnusedException e)
+						{
+							if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
+							// addAlert(sstate, e.toString());
+						}
+						catch (PermissionException e)
+						{
+							if (log.isDebugEnabled()) log.debug("{}.doDeleteannouncement()", this, e);
+							addAlert(sstate, rb.getFormattedMessage("java.alert.youdelann.ref", messageReferences2[i]));
+						}
 					}
-				}
+					if(allMessages.size() > messageReferences2.length){
+						//need to update the message order of the remaining untouched messages (only sorts the top 10)
+
+						//order by message order:
+						Comparator<AnnouncementMessage> comparing = Comparator.comparing(o -> (o.getAnnouncementHeader().getMessage_order()));
+						SortedIterator<AnnouncementMessage> messagesSorted = new SortedIterator<>(allMessages.iterator(), comparing);
+						//start at last message and increment up
+						int messageOrder = 1;
+						while(messagesSorted.hasNext()){
+							Message message = messagesSorted.next();
+							if(!updatedMessageIds.contains(message.getId())){
+								//since this list is ordered, we can assign the message order in order:
+								AnnouncementChannel channel2 = announcementService.getAnnouncementChannel(this
+										.getChannelIdFromReference(message.getReference()));
+								// get the message object through service
+								AnnouncementMessage message2 = channel2.getAnnouncementMessage(this
+										.getMessageIDFromReference(message.getReference()));
+								AnnouncementMessageEdit msg =(AnnouncementMessageEdit)message2;
+								AnnouncementMessageHeaderEdit header2 = msg.getAnnouncementHeaderEdit();
+								header2.setMessage_order(messageOrder);
+								channel2.commitMessage_order(msg);
+							}
+							messageOrder++;
+						}
+					}
 				} catch (PermissionException | IdUnusedException e1) {
 					log.error(e1.getMessage());
 				}

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -3140,14 +3140,13 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 			return msgs;
 		} // findMessages
 
-		protected List findSortedMessages(boolean ascending) {
-			List msgs = new Vector(findMessages());
-			if (msgs.size() == 0) return msgs;
+		protected List<Message> findSortedMessages(boolean ascending) {
+			List<Message> msgs = new ArrayList<>(findMessages());
+			if (msgs.isEmpty()) return msgs;
 
-			// sort - natural order is date ascending
+			// Natural message order is date ascending.
 			Collections.sort(msgs);
 
-			// reverse, if not ascending
 			if (!ascending)
 			{
 				Collections.reverse(msgs);

--- a/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
+++ b/message/message-util/util/src/java/org/sakaiproject/message/util/BaseMessage.java
@@ -3140,6 +3140,22 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 			return msgs;
 		} // findMessages
 
+		protected List findSortedMessages(boolean ascending) {
+			List msgs = new Vector(findMessages());
+			if (msgs.size() == 0) return msgs;
+
+			// sort - natural order is date ascending
+			Collections.sort(msgs);
+
+			// reverse, if not ascending
+			if (!ascending)
+			{
+				Collections.reverse(msgs);
+			}
+
+			return msgs;
+		}
+
 		/**
 		 * Find messages, sort, filter by group and the provided filter.
 		 * 
@@ -3151,17 +3167,8 @@ public abstract class BaseMessage implements MessageService, DoubleStorageUser
 		 */
 		public List findFilterMessages(Filter filter, boolean ascending)
 		{
-			List msgs = findMessages();
+			List msgs = findSortedMessages(ascending);
 			if (msgs.size() == 0) return msgs;
-			
-			// sort - natural order is date ascending
-			Collections.sort(msgs);
-
-			// reverse, if not ascending
-			if (!ascending)
-			{
-				Collections.reverse(msgs);
-			}
 
 			// filter out
 			List filtered = new Vector();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instructor view for announcements: authorized users can see all messages (drafts, future, retracted, grouped, role-targeted).

* **Bug Fixes & Enhancements**
  * Tighter hidden-message access checks for users with manage privileges.
  * Import/transfer now attributes imported announcements to the importer and preserves stored-message inventories.
  * Reordering now reliably operates on the instructor-visible message set.

* **Refactor**
  * Internal message sorting and retrieval simplified for consistent ordering.

* **Localization**
  * Added a permission-related i18n message for reorder permission errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->