### PR TITLE
SAK-52605 gradebook incorrect syntax initializing studentNumberCellTemplate

### DIFF
--- a/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-gbgrade-table.js
@@ -211,7 +211,7 @@ $(document).ready(function() {
     studentNumberHeader: TrimPath.parseTemplate(
         $("#studentNumberHeaderTemplate").html().trim().toString()),
     studentNumberCell: new TrimPathFragmentCache('studentNumberCell', TrimPath.parseTemplate(
-        $("#studentNumberCellTemplate").html().trim(),toString())),
+        $("#studentNumberCellTemplate").html().trim().toString())),
     sectionsHeader: TrimPath.parseTemplate(
         $("#sectionsHeaderTemplate").html().trim().toString()),
     sectionsCell: new TrimPathFragmentCache('sectionsCell', TrimPath.parseTemplate(


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the student number cell display in the gradebook table caused by a malformed template expression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->