### PR TITLE
SAK-52613 Kernel DropboxAuthzHandler canMaintainEntity Null-check currentUser

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DropboxAuthzHandler.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/DropboxAuthzHandler.java
@@ -206,7 +206,7 @@ public class DropboxAuthzHandler
 		String dropboxOwner = getDropboxOwner(entityId);
 
 		// Return true if the current user has dropbox.maintain.own.groups and they share a group with the dropbox owner
-		if (contentService.isDropboxGroups(siteId))
+		if (currentUser != null && contentService.isDropboxGroups(siteId))
 		{
 			try
 			{
@@ -225,7 +225,7 @@ public class DropboxAuthzHandler
 			}
 		}
 
-		return currentUser.equals(dropboxOwner) && securityService.unlock(ContentHostingService.AUTH_DROPBOX_OWN, siteService.siteReference(siteId));
+		return currentUser != null && currentUser.equals(dropboxOwner) && securityService.unlock(ContentHostingService.AUTH_DROPBOX_OWN, siteService.siteReference(siteId));
 	}
 
 	/**


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when accessing Dropbox features under certain session conditions where the session user was missing.
  * Ensured Dropbox permission checks are evaluated only when a valid session user is present, improving stability and access behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakaiproject/sakai/pull/14644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->