### PR TITLE
SAK-52617 Calendar allow Sakai-to-Sakai iCal subscriptions with circular loop detection

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -158,6 +158,10 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
    	private PDFExportService pdfExportService;
 
 	private GroupComparator groupComparator = new GroupComparator();
+
+	// Carries the comma-separated siteId chain for the current ICS request thread.
+	// Set in handleAccessIcalCommon, read by loadCalendarSubscriptionFromUrl to propagate the chain.
+	static final ThreadLocal<String> calendarSubscriptionChain = new ThreadLocal<>();
 	
 	public static final String UI_SERVICE = "ui.service";
 	
@@ -383,6 +387,28 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 
 					allEvents.addAll(new CalendarEventVector(calEvent));
 				}
+			}
+
+			// When Sakai-to-Sakai subscriptions are enabled, remove subscription events that
+			// duplicate another subscription event already seen (same display name and start
+			// time).  Because generateICal only exports primary events and appends the
+			// originating site name via X-SAKAI-SITE-NAME, events from different source sites
+			// have distinct display names and are not collapsed — only genuine duplicates
+			// (same event arriving via multiple subscription paths) are removed.
+			// Primary (non-subscription) events are always kept.
+			// This block is intentionally skipped when the feature is disabled so that
+			// pre-existing external (non-Sakai) subscriptions are not affected.
+			if (serverConfigurationService.getBoolean("calendar.subscription.sakai.enabled", false)) {
+				Set<String> seenSubscriptionKeys = new HashSet<>();
+				allEvents.removeIf(e -> {
+					CalendarEvent ce = (CalendarEvent) e;
+					if (REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
+							entityManager.newReference(ce.getCalendarReference()).getSubType())) {
+						String key = ce.getDisplayName() + "|" + ce.getRange().firstTime().getTime();
+						return !seenSubscriptionKeys.add(key);
+					}
+					return false;
+				});
 			}
 
 			// Do a sort since each of the events implements the Comparable interface.
@@ -5086,19 +5112,41 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		CalendarEventVector calendarEventVector = getEvents(calRefs, currentTimeRange);
 		Iterator itEvent = calendarEventVector.iterator();
 
+		// When Sakai-to-Sakai subscriptions are enabled (calendar.subscription.sakai.enabled=true)
+		// we only export primary events and tag them with the originating site name.
+		boolean sakaiToSakaiEnabled = serverConfigurationService.getBoolean("calendar.subscription.sakai.enabled", false);
+
 		// Generate XML for all the events.
 		while (itEvent.hasNext())
 		{
 			CalendarEvent event = (CalendarEvent) itEvent.next();
 
+			// Only export events that originate in this site's own calendar.
+			// Re-exporting subscription events (imported from other sites) causes
+			// cascading duplicates and wrong site attribution for subscribers.
+			if (sakaiToSakaiEnabled && REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
+					entityManager.newReference(event.getCalendarReference()).getSubType())) {
+				continue;
+			}
+
 			DateTime icalStartDate = new DateTime(event.getRange().firstTime().getTime());
-			
-			long seconds = event.getRange().duration() / 1000;
-			VEvent icalEvent = new VEvent(icalStartDate, Duration.ofSeconds(seconds), event.getDisplayName() );
-			
+			DateTime icalEndDate = new DateTime(event.getRange().lastTime().getTime());
+			VEvent icalEvent = new VEvent(icalStartDate, icalEndDate, event.getDisplayName() );
+
+			// Tag the event with the originating site name so that subscribers can
+			// display it with the correct attribution in their calendar view.
+			if (sakaiToSakaiEnabled) {
+				String siteName = event.getSiteName();
+				if (siteName != null && !siteName.isEmpty()) {
+					icalEvent.getProperties().add(new XProperty("X-SAKAI-SITE-NAME", siteName));
+				}
+			}
+
 			net.fortuna.ical4j.model.parameter.TzId tzId = new net.fortuna.ical4j.model.parameter.TzId( timeService.getLocalTimeZone().getID() );
 			icalEvent.getProperty(Property.DTSTART).getParameters().add(tzId);
 			icalEvent.getProperty(Property.DTSTART).getParameters().add(Value.DATE_TIME);
+			icalEvent.getProperty(Property.DTEND).getParameters().add(new net.fortuna.ical4j.model.parameter.TzId( timeService.getLocalTimeZone().getID() ));
+			icalEvent.getProperty(Property.DTEND).getParameters().add(Value.DATE_TIME);
 			icalEvent.getProperties().add(new Uid(event.getId()));
 			// build the description, adding links to attachments if necessary
 			StringBuffer description = new StringBuffer("");
@@ -5581,66 +5629,86 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 	protected void handleAccessIcalCommon(HttpServletRequest req, HttpServletResponse res, Reference ref, String calRef)
 			throws EntityPermissionException, PermissionException, IOException {
 
-		// Ok so we need to check to see if we've handled this reference before.
-		// This is to prevent loops when including calendars
-		// that currently includes other calendars we only do the check in here.
-		if (getUserAgent().equals(req.getHeader("User-Agent"))) {
-			res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-			log.warn("Reject internal request for: "+ calRef);
-			return;
-		}
-
-		// Extract the alias name to use for the filename.
-		List<Alias> alias =  aliasService.getAliases(calRef);
-		String aliasName = "schedule.ics";
-		if ( ! alias.isEmpty() )
-			aliasName =  alias.get(0).getId();
-		
-		List<String> referenceList = getCalendarReferences(ref.getContext());
-		Time modDate = timeService.newTime(0);
-
-		// update date/time reference
-		for (String curCalRef: referenceList)
-		{
-			Calendar curCal = findCalendar(curCalRef);
-			/*
-			 * TODO: This null check is required to handle the references 
-			 * pertaining to external calendar subscriptions as they are 
-			 * currently broken in (at least) the 2 following ways:
-			 * 
-			 * (i) findCalendar will return null rather than a calendar object.
-			 * (ii) getCalendar(String) will return a calendar object that is 
-			 * not null, but the corresponding getModified() method returns a
-			 * date than can not be parsed.  
-			 *  
-			 * Clearly such references to need to be improved to make them 
-			 * consistent with other types as at the moment they have to be
-			 * excluded as part of this process to find the most recent modified
-			 * date. 
-			 */
-			if (curCal == null)
-			{	
-				continue;
+		if (serverConfigurationService.getBoolean("calendar.subscription.sakai.enabled", false)) {
+			// Sakai-to-Sakai subscriptions enabled: use chain-based circular detection.
+			// X-Sakai-Calendar-Chain carries the comma-separated siteId path accumulated
+			// so far. If this site is already in the chain, a circular subscription exists.
+			String incomingChain = req.getHeader("X-Sakai-Calendar-Chain");
+			String currentSiteId = ref.getContext();
+			if (incomingChain != null && Arrays.asList(incomingChain.split(",")).contains(currentSiteId)) {
+				res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+				log.warn("Circular calendar subscription detected for site: {} in chain: {}", currentSiteId, incomingChain);
+				return;
 			}
-			Time curModDate = curCal.getModified();
-			if ( curModDate != null && curModDate.after(modDate))
-			{
-				modDate = curModDate;
+			// Build the outgoing chain and store it so outbound subscription fetches can include it.
+			String outgoingChain = incomingChain != null ? incomingChain + "," + currentSiteId : currentSiteId;
+			calendarSubscriptionChain.set(outgoingChain);
+		} else {
+			// Legacy behavior: reject ICS requests that come from another Sakai instance
+			// to prevent infinite subscription loops.  Enable Sakai-to-Sakai subscriptions
+			// with loop detection by setting calendar.subscription.sakai.enabled=true in
+			// sakai.properties.
+			String userAgent = req.getHeader("User-Agent");
+			if (userAgent != null && userAgent.contains("Sakai")) {
+				res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+				return;
 			}
 		}
-		res.addHeader("Content-Disposition", "inline; filename=\"" + aliasName + "\"");
-		res.setContentType(ICAL_MIME_TYPE);
-		res.setDateHeader("Last-Modified", modDate.getTime() );
-		String calendarName = "";
 		try {
-			calendarName = siteService.getSite(ref.getContext()).getTitle();
-			boolean isMyDashboard = siteService.isUserSite(ref.getContext());
-			if (isMyDashboard){
-				calendarName = serverConfigurationService.getString(UI_SERVICE, SAKAI);
+			// Extract the alias name to use for the filename.
+			List<Alias> alias =  aliasService.getAliases(calRef);
+			String aliasName = "schedule.ics";
+			if ( ! alias.isEmpty() )
+				aliasName =  alias.get(0).getId();
+
+			List<String> referenceList = getCalendarReferences(ref.getContext());
+			Time modDate = timeService.newTime(0);
+
+			// update date/time reference
+			for (String curCalRef: referenceList)
+			{
+				Calendar curCal = findCalendar(curCalRef);
+				/*
+				 * TODO: This null check is required to handle the references
+				 * pertaining to external calendar subscriptions as they are
+				 * currently broken in (at least) the 2 following ways:
+				 *
+				 * (i) findCalendar will return null rather than a calendar object.
+				 * (ii) getCalendar(String) will return a calendar object that is
+				 * not null, but the corresponding getModified() method returns a
+				 * date than can not be parsed.
+				 *
+				 * Clearly such references to need to be improved to make them
+				 * consistent with other types as at the moment they have to be
+				 * excluded as part of this process to find the most recent modified
+				 * date.
+				 */
+				if (curCal == null)
+				{
+					continue;
+				}
+				Time curModDate = curCal.getModified();
+				if ( curModDate != null && curModDate.after(modDate))
+				{
+					modDate = curModDate;
+				}
 			}
-		} catch (IdUnusedException e) {
+			res.addHeader("Content-Disposition", "inline; filename=\"" + aliasName + "\"");
+			res.setContentType(ICAL_MIME_TYPE);
+			res.setDateHeader("Last-Modified", modDate.getTime() );
+			String calendarName = "";
+			try {
+				calendarName = siteService.getSite(ref.getContext()).getTitle();
+				boolean isMyDashboard = siteService.isUserSite(ref.getContext());
+				if (isMyDashboard){
+					calendarName = serverConfigurationService.getString(UI_SERVICE, SAKAI);
+				}
+			} catch (IdUnusedException e) {
+			}
+			printICalSchedule(calendarName, referenceList, res.getOutputStream());
+		} finally {
+			calendarSubscriptionChain.remove();
 		}
-		printICalSchedule(calendarName, referenceList, res.getOutputStream());
 	}
 	
 	protected void handleAccessIcal(HttpServletRequest req, HttpServletResponse res, Reference ref, String calRef)

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -404,7 +404,10 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 					CalendarEvent ce = (CalendarEvent) e;
 					if (REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
 							entityManager.newReference(ce.getCalendarReference()).getSubType())) {
-						String key = ce.getDisplayName() + "|" + ce.getRange().firstTime().getTime();
+						String key = ce.getDisplayName()
+								+ "|" + ce.getRange().firstTime().getTime()
+								+ "|" + ce.getRange().lastTime().getTime()
+								+ "|" + Objects.toString(ce.getLocation(), "");
 						return !seenSubscriptionKeys.add(key);
 					}
 					return false;
@@ -5113,7 +5116,10 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		Iterator itEvent = calendarEventVector.iterator();
 
 		// When Sakai-to-Sakai subscriptions are enabled (calendar.subscription.sakai.enabled=true)
-		// we only export primary events and tag them with the originating site name.
+		// primary events are tagged with X-SAKAI-SITE-NAME so that subscribers can display
+		// the originating site name.  Subscription events (from external or Sakai sources)
+		// are exported as-is; circular loops are prevented by X-Sakai-Calendar-Chain detection
+		// and multi-path duplicates are collapsed by the dedup in getEvents().
 		boolean sakaiToSakaiEnabled = serverConfigurationService.getBoolean("calendar.subscription.sakai.enabled", false);
 
 		// Generate XML for all the events.
@@ -5121,21 +5127,16 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		{
 			CalendarEvent event = (CalendarEvent) itEvent.next();
 
-			// Only export events that originate in this site's own calendar.
-			// Re-exporting subscription events (imported from other sites) causes
-			// cascading duplicates and wrong site attribution for subscribers.
-			if (sakaiToSakaiEnabled && REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
-					entityManager.newReference(event.getCalendarReference()).getSubType())) {
-				continue;
-			}
-
 			DateTime icalStartDate = new DateTime(event.getRange().firstTime().getTime());
 			DateTime icalEndDate = new DateTime(event.getRange().lastTime().getTime());
 			VEvent icalEvent = new VEvent(icalStartDate, icalEndDate, event.getDisplayName() );
 
-			// Tag the event with the originating site name so that subscribers can
-			// display it with the correct attribution in their calendar view.
-			if (sakaiToSakaiEnabled) {
+			// Tag primary events with the originating site name so that subscribers can
+			// display the correct attribution.  Subscription events already carry the
+			// site name baked into their display name by IcalendarReader, so they are
+			// exported without an additional X-SAKAI-SITE-NAME property.
+			if (sakaiToSakaiEnabled && !REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
+					entityManager.newReference(event.getCalendarReference()).getSubType())) {
 				String siteName = event.getSiteName();
 				if (siteName != null && !siteName.isEmpty()) {
 					icalEvent.getProperties().add(new XProperty("X-SAKAI-SITE-NAME", siteName));

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseCalendarService.java
@@ -5116,10 +5116,11 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		Iterator itEvent = calendarEventVector.iterator();
 
 		// When Sakai-to-Sakai subscriptions are enabled (calendar.subscription.sakai.enabled=true)
-		// primary events are tagged with X-SAKAI-SITE-NAME so that subscribers can display
-		// the originating site name.  Subscription events (from external or Sakai sources)
-		// are exported as-is; circular loops are prevented by X-Sakai-Calendar-Chain detection
-		// and multi-path duplicates are collapsed by the dedup in getEvents().
+		// primary events are tagged with X-SAKAI-SITE-NAME so that subscribers display the
+		// originating site name.  Subscription events imported from other Sakai instances are
+		// skipped to prevent cascading re-export and duplicate titles with site-name suffixes.
+		// Subscription events from external providers (Google, Outlook, etc.) are exported
+		// as-is so they remain visible to downstream subscribers.
 		boolean sakaiToSakaiEnabled = serverConfigurationService.getBoolean("calendar.subscription.sakai.enabled", false);
 
 		// Generate XML for all the events.
@@ -5127,14 +5128,24 @@ public abstract class BaseCalendarService implements CalendarService, DoubleStor
 		{
 			CalendarEvent event = (CalendarEvent) itEvent.next();
 
+			if (sakaiToSakaiEnabled && REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
+					entityManager.newReference(event.getCalendarReference()).getSubType())) {
+				// Skip events imported from other Sakai instances to avoid cascading re-export
+				// and duplicate titles.  External feeds (no Sakai ICS path) are still included.
+				String subUrl = externalCalendarSubscriptionService.getSubscriptionUrlFromId(
+						entityManager.newReference(event.getCalendarReference()).getId());
+				if (subUrl != null && subUrl.contains("/access/calendar/ical/")) {
+					continue;
+				}
+			}
+
 			DateTime icalStartDate = new DateTime(event.getRange().firstTime().getTime());
 			DateTime icalEndDate = new DateTime(event.getRange().lastTime().getTime());
 			VEvent icalEvent = new VEvent(icalStartDate, icalEndDate, event.getDisplayName() );
 
 			// Tag primary events with the originating site name so that subscribers can
 			// display the correct attribution.  Subscription events already carry the
-			// site name baked into their display name by IcalendarReader, so they are
-			// exported without an additional X-SAKAI-SITE-NAME property.
+			// site name baked into their display name by IcalendarReader.
 			if (sakaiToSakaiEnabled && !REF_TYPE_CALENDAR_SUBSCRIPTION.equals(
 					entityManager.newReference(event.getCalendarReference()).getSubType())) {
 				String siteName = event.getSiteName();

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
@@ -728,9 +728,10 @@ public class BaseExternalCalendarSubscriptionService implements
 			// connect
 			URLConnection conn = _url.openConnection();
 			conn.addRequestProperty("User-Agent", m_calendarService.getUserAgent());
-			// Propagate the subscription chain so the remote Sakai can detect circular references.
+			// Propagate the subscription chain only to Sakai ICS endpoints so that internal
+			// site IDs are not leaked to third-party calendar providers (Google, Outlook, etc.).
 			String chain = BaseCalendarService.calendarSubscriptionChain.get();
-			if (chain != null) {
+			if (chain != null && url.contains("/access/calendar/ical/")) {
 				conn.addRequestProperty("X-Sakai-Calendar-Chain", chain);
 			}
 			conn.setConnectTimeout(TIMEOUT);

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/BaseExternalCalendarSubscriptionService.java
@@ -727,8 +727,12 @@ public class BaseExternalCalendarSubscriptionService implements
 
 			// connect
 			URLConnection conn = _url.openConnection();
-			// Must set user agent so we can detect loops.
 			conn.addRequestProperty("User-Agent", m_calendarService.getUserAgent());
+			// Propagate the subscription chain so the remote Sakai can detect circular references.
+			String chain = BaseCalendarService.calendarSubscriptionChain.get();
+			if (chain != null) {
+				conn.addRequestProperty("X-Sakai-Calendar-Chain", chain);
+			}
 			conn.setConnectTimeout(TIMEOUT);
 			conn.setReadTimeout(TIMEOUT);
 			// Now make the connection.

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
@@ -129,8 +129,9 @@ public class IcalendarReader extends Reader {
 				// sites get distinct display names and survive deduplication.
 				Property sakaiSiteName = event.getProperty("X-SAKAI-SITE-NAME");
 				String effectiveSummary = summary.getValue();
-				if (sakaiSiteName != null && !sakaiSiteName.getValue().isEmpty()) {
-					effectiveSummary = effectiveSummary + " (" + sakaiSiteName.getValue() + ")";
+				String sakaiSiteNameValue = sakaiSiteName != null ? sakaiSiteName.getValue() : null;
+				if (sakaiSiteNameValue != null && !sakaiSiteNameValue.isBlank()) {
+					effectiveSummary = effectiveSummary + " (" + sakaiSiteNameValue + ")";
 				}
 
 				if ( start == null || end == null) {

--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/readers/IcalendarReader.java
@@ -123,6 +123,16 @@ public class IcalendarReader extends Reader {
 					continue;
 				}
 
+				// If the ICS was exported by Sakai it will carry X-SAKAI-SITE-NAME.
+				// Append the site name to the summary so that the event is displayed
+				// with its originating site, and so that same-name events from different
+				// sites get distinct display names and survive deduplication.
+				Property sakaiSiteName = event.getProperty("X-SAKAI-SITE-NAME");
+				String effectiveSummary = summary.getValue();
+				if (sakaiSiteName != null && !sakaiSiteName.getValue().isEmpty()) {
+					effectiveSummary = effectiveSummary + " (" + sakaiSiteName.getValue() + ")";
+				}
+
 				if ( start == null || end == null) {
 					log.warn("Defer importing this calendar event as it has no START or END, [{}]", event);
 					continue;
@@ -143,7 +153,7 @@ public class IcalendarReader extends Reader {
 					Period period = new Period(new DateTime(startDate), new DateTime(endDate));
 
 					processRow(handler,
-							summary.getValue(),
+							effectiveSummary,
 							description != null ? description.getValue() : "",
 							columnDescriptionArray,
 							location != null ? location.getValue() : "",
@@ -158,7 +168,7 @@ public class IcalendarReader extends Reader {
 					PeriodList periods = event.calculateRecurrenceSet(range);
 					for (Period period : periods) {
 						processRow(handler,
-								summary.getValue(),
+								effectiveSummary,
 								description != null ? description.getValue() : "",
 								columnDescriptionArray,
 								location != null ? location.getValue() : "",

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2500,6 +2500,13 @@
 # calendar.external.subscriptions.user.cacheentries=32
 # calendar.external.subscriptions.user.cachetime=120
 
+# Allow Sakai-to-Sakai iCal subscriptions (site A subscribing to site B's ICS URL).
+# When enabled, circular subscription loops are detected via the X-Sakai-Calendar-Chain
+# HTTP header instead of the legacy User-Agent block, and imported events show the
+# originating site name in their title.
+# DEFAULT: false (legacy behavior: any ICS request from another Sakai instance is rejected)
+# calendar.subscription.sakai.enabled=false
+
 # Determine the range for calendar export
 # Number of months from the past required in the export
 # DEFAULT: 6


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Sakai-to-Sakai calendar subscriptions with loop detection to prevent circular chains.
  * Deduplication of imported subscription events to avoid duplicates.
  * Originating site name shown on imported primary events; subscription-sourced events are not labeled.
  * Improved iCal start/end time and timezone handling for exports.
  * New configuration option to enable cross-Sakai subscriptions (disabled by default).

* **Bug Fixes**
  * Prevents circular subscription requests between Sakai instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->