### PR TITLE
SAK-50885 SCORM support cc+ archive import/merge

### DIFF
--- a/common/archive-impl/impl2/src/webapp/WEB-INF/components.xml
+++ b/common/archive-impl/impl2/src/webapp/WEB-INF/components.xml
@@ -35,6 +35,7 @@
 				<value>LessonBuilderEntityProducer</value>
 				<value>PollsService</value>
 				<value>rubrics</value>
+				<value>scorm</value>
 			</list>
 		</property>
 		<property name="mergeFilteredSakaiRoles">

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -533,7 +533,7 @@
 # archive.merge.filter.services=false
 
 # List of data service types that can merge in data from an archive
-# DEFAULT: AnnouncementService,AssignmentService,ContentHostingService,CalendarService,ChatEntityProducer,DiscussionService,MailArchiveService,SyllabusService,RWikiObjectService,DiscussionForumService,WebService,LessonBuilderEntityProducer,RubricsService
+# DEFAULT: AnnouncementService,AssignmentService,ContentHostingService,CalendarService,ChatEntityProducer,DiscussionService,MailArchiveService,SyllabusService,RWikiObjectService,DiscussionForumService,WebService,LessonBuilderEntityProducer,RubricsService,scorm
 # archive.merge.filtered.services={list of service names}
 
 # Controls if user role filtering is enabled. If enabled, any user roles not in the list cannot archive or merge data

--- a/scormplayer/scorm-impl/service/pom.xml
+++ b/scormplayer/scorm-impl/service/pom.xml
@@ -72,6 +72,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <!-- Test-only: GradingService signatures reference CourseSection; grading-api is provided-scope
+             so its transitive sections-api is absent at test time, which breaks mocking GradingService. -->
+        <dependency>
+            <groupId>org.sakaiproject.edu-services.sections</groupId>
+            <artifactId>sections-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scormplayer/scorm-impl/service/pom.xml
+++ b/scormplayer/scorm-impl/service/pom.xml
@@ -75,12 +75,10 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <!-- GradingService signatures reference CourseSection (from sections-api); grading-api is
              provided so this transitive must be declared here for compilation and tests. -->

--- a/scormplayer/scorm-impl/service/pom.xml
+++ b/scormplayer/scorm-impl/service/pom.xml
@@ -72,12 +72,21 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-        <!-- Test-only: GradingService signatures reference CourseSection; grading-api is provided-scope
-             so its transitive sections-api is absent at test time, which breaks mocking GradingService. -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- GradingService signatures reference CourseSection (from sections-api); grading-api is
+             provided so this transitive must be declared here for compilation and tests. -->
         <dependency>
             <groupId>org.sakaiproject.edu-services.sections</groupId>
             <artifactId>sections-api</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormEntityProducer.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormEntityProducer.java
@@ -15,6 +15,10 @@
  */
 package org.sakaiproject.scorm.service.impl;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
@@ -24,15 +28,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import org.sakaiproject.authz.api.SecurityAdvisor;
 import org.sakaiproject.authz.api.SecurityAdvisor.SecurityAdvice;
@@ -41,20 +49,20 @@ import org.sakaiproject.content.api.ContentCollection;
 import org.sakaiproject.content.api.ContentCollectionEdit;
 import org.sakaiproject.content.api.ContentEntity;
 import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.content.api.ContentResource;
 import org.adl.validator.contentpackage.LaunchData;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.EntityTransferrer;
+import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.entity.api.HardDeleteAware;
+import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.IdUsedException;
-import org.sakaiproject.exception.InUseException;
-import org.sakaiproject.exception.PermissionException;
-import org.sakaiproject.exception.ServerOverloadException;
-import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.grading.api.GradingService;
 import org.sakaiproject.scorm.api.ScormConstants;
@@ -66,10 +74,16 @@ import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.model.api.ContentPackageManifest;
 import org.sakaiproject.scorm.service.api.ScormContentService;
 import org.sakaiproject.scorm.service.api.ScormResourceService;
-import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.util.MergeConfig;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
- * Entity producer enabling Import from Site for SCORM Player.
+ * Entity producer for the SCORM Player, supporting Import from Site (transfer/copy),
+ * CC+ archive/merge (export and re-import), and hard delete of a site's SCORM content.
  */
 @Setter
 @Slf4j
@@ -88,6 +102,18 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     );
     private static final String SCORM_REFERENCE_PREFIX = ContentHostingService.REFERENCE_ROOT + ScormConstants.ROOT_DIRECTORY;
 
+    // Archive/merge (CC+ archive) constants
+    private static final String ARCHIVE_ELEMENT = "contentpackage";
+    private static final String ATTR_TITLE = "title";
+    private static final String ATTR_ARCHIVE = "archive";
+    private static final String ATTR_RESOURCE_ID = "resourceId";
+    private static final String ATTR_NUMBER_OF_TRIES = "numberOfTries";
+    private static final String ATTR_SHOW_TOC = "showToc";
+    private static final String ATTR_SHOW_NAV_BAR = "showNavBar";
+    private static final String ATTR_RELEASE_ON = "releaseOn";
+    private static final String ATTR_DUE_ON = "dueOn";
+    private static final String ATTR_ACCEPT_UNTIL = "acceptUntil";
+
     private EntityManager entityManager;
     private ScormContentService scormContentService;
     private ContentPackageDao contentPackageDao;
@@ -95,8 +121,8 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     private ScormResourceService scormResourceService;
     private ContentHostingService contentHostingService;
     private SecurityService securityService;
-    private SessionManager sessionManager;
     private GradingService gradingService;
+    private ServerConfigurationService serverConfigurationService;
 
     public void init() {
         try {
@@ -132,7 +158,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
         try {
             return scormContentService.getContentPackages(fromContext).stream()
                     .map(cp -> Map.of("id", String.valueOf(cp.getContentPackageId()), "title", cp.getTitle()))
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (ResourceStorageException e) {
             log.warn("Unable to build SCORM entity map for {}: {}", fromContext, e.getMessage());
             return Collections.emptyList();
@@ -295,21 +321,18 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                 return null;
             }
 
-            // Create a deep copy that is completely detached from Hibernate session
+            // Deep copy fully detached from the Hibernate session, including each LaunchData
             ContentPackageManifest clone = SerializationUtils.clone(manifest);
             clone.setId(null);
 
-            // Get the launch data list from the clone
-            List<LaunchData> launchDataList = clone.getLaunchData();
-            if (launchDataList != null) {
-                // Create a new list with cloned LaunchData objects to ensure complete detachment
-                List<LaunchData> newLaunchDataList = new java.util.ArrayList<>();
-                for (LaunchData ld : launchDataList) {
-                    LaunchData ldClone = SerializationUtils.clone(ld);
-                    ldClone.setId(null);
-                    newLaunchDataList.add(ldClone);
-                }
-                clone.setLaunchData(newLaunchDataList);
+            if (clone.getLaunchData() != null) {
+                clone.setLaunchData(clone.getLaunchData().stream()
+                        .map(ld -> {
+                            LaunchData ldClone = SerializationUtils.clone(ld);
+                            ldClone.setId(null);
+                            return ldClone;
+                        })
+                        .collect(Collectors.toList()));
             }
 
             return contentPackageManifestDao.save(clone);
@@ -464,10 +487,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     private String fallbackDisplayName(String displayName, String collectionId) {
-        if (displayName == null || displayName.trim().isEmpty()) {
-            return getDisplayName(collectionId);
-        }
-        return displayName;
+        return StringUtils.isBlank(displayName) ? getDisplayName(collectionId) : displayName;
     }
 
     private void removeCollectionQuietly(String collectionId) {
@@ -518,15 +538,237 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
         }
     }
 
-    private String extractResourceId(String collectionId) {
-        if (collectionId == null) {
+    @Override
+    public boolean willArchiveMerge() {
+        return true;
+    }
+
+    /**
+     * Archive the SCORM content packages for a site as part of a CC+ (Common Cartridge plus archive) export.
+     * Each package is written as a self-contained zip alongside the archive XML so it can be re-imported via {@link #merge}.
+     */
+    @Override
+    public String archive(String siteId, Document doc, Stack<Element> stack, String archivePath, List<Reference> attachments) {
+        StringBuilder results = new StringBuilder();
+
+        // The element tag must be the producer label ("scorm"): SiteArchiver writes this producer's
+        // output to "{label}.xml" and SiteMerger dispatches/filters merge by the element's tag name
+        // (matched against the archive.merge.filtered.services list, see getLabel()).
+        Element root = doc.createElement(getLabel());
+        ((Element) stack.peek()).appendChild(root);
+        stack.push(root);
+
+        int archived = 0;
+        try {
+            List<ContentPackage> packages = scormContentService.getContentPackages(siteId);
+            for (ContentPackage pkg : packages) {
+                try {
+                    String zipName = "scorm_" + pkg.getResourceId() + ".zip";
+                    if (writePackageArchive(pkg.getResourceId(), archivePath + zipName)) {
+                        Element element = doc.createElement(ARCHIVE_ELEMENT);
+                        element.setAttribute(ATTR_TITLE, StringUtils.trimToEmpty(pkg.getTitle()));
+                        element.setAttribute(ATTR_RESOURCE_ID, StringUtils.trimToEmpty(pkg.getResourceId()));
+                        element.setAttribute(ATTR_ARCHIVE, zipName);
+                        element.setAttribute(ATTR_NUMBER_OF_TRIES, String.valueOf(pkg.getNumberOfTries()));
+                        element.setAttribute(ATTR_SHOW_TOC, String.valueOf(pkg.isShowTOC()));
+                        element.setAttribute(ATTR_SHOW_NAV_BAR, String.valueOf(pkg.isShowNavBar()));
+                        setDateAttribute(element, ATTR_RELEASE_ON, pkg.getReleaseOn());
+                        setDateAttribute(element, ATTR_DUE_ON, pkg.getDueOn());
+                        setDateAttribute(element, ATTR_ACCEPT_UNTIL, pkg.getAcceptUntil());
+                        root.appendChild(element);
+                        archived++;
+                    }
+                } catch (Exception e) {
+                    log.warn("Unable to archive SCORM package {} for site {}: {}", pkg.getContentPackageId(), siteId, e.getMessage());
+                }
+            }
+        } catch (ResourceStorageException e) {
+            log.warn("Unable to list SCORM packages while archiving site {}: {}", siteId, e.getMessage());
+        }
+
+        stack.pop();
+        results.append("archiving ").append(archived).append(" SCORM content package(s).\n");
+        return results.toString();
+    }
+
+    /**
+     * Re-import the SCORM content packages produced by {@link #archive} into the destination site.
+     */
+    @Override
+    public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
+        StringBuilder results = new StringBuilder();
+
+        if (StringUtils.isBlank(siteId)) {
+            return "SCORM merge stopped, no siteId provided\n";
+        }
+
+        Set<String> reservedTitles = new HashSet<>();
+        try {
+            scormContentService.getContentPackages(siteId).forEach(cp -> reservedTitles.add(cp.getTitle()));
+        } catch (ResourceStorageException e) {
+            log.debug("Unable to preload SCORM titles for {}: {}", siteId, e.getMessage());
+        }
+
+        // On merge, archivePath is the path to this producer's archive file (e.g. ".../sakai_archive/scorm.xml"),
+        // not a directory (unlike archive()). The package zips live alongside it, so resolve against its parent.
+        File archiveFile = new File(archivePath);
+        File archiveDir = archiveFile.isDirectory() ? archiveFile : archiveFile.getParentFile();
+
+        NodeList packages = root.getElementsByTagName(ARCHIVE_ELEMENT);
+        int merged = 0;
+        for (int i = 0; i < packages.getLength(); i++) {
+            Node node = packages.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element element = (Element) node;
+            String title = element.getAttribute(ATTR_TITLE);
+
+            if (StringUtils.isNotBlank(title) && reservedTitles.contains(title)) {
+                log.debug("Skipping SCORM package '{}', a package with that title already exists in {}", title, siteId);
+                continue;
+            }
+
+            File zip = new File(archiveDir, element.getAttribute(ATTR_ARCHIVE));
+            if (!zip.isFile()) {
+                log.warn("SCORM archive zip {} not found while merging into {}", zip.getPath(), siteId);
+                continue;
+            }
+
+            try {
+                ContentPackage created = importPackageArchive(siteId, zip, title);
+                if (created != null) {
+                    restoreSettings(created, element);
+                    reservedTitles.add(created.getTitle());
+                    merged++;
+                }
+            } catch (Exception e) {
+                log.warn("Unable to merge SCORM package '{}' into {}: {}", title, siteId, e.getMessage(), e);
+            }
+        }
+
+        results.append("merging ").append(merged).append(" SCORM content package(s).\n");
+        return results.toString();
+    }
+
+    /**
+     * Stream the unpacked SCORM content collection at {@code /private/scorm/{uuid}/} into a zip archive,
+     * preserving paths relative to the package root (so {@code imsmanifest.xml} lands at the zip root).
+     */
+    private boolean writePackageArchive(String resourceId, String zipPath) throws Exception {
+        if (StringUtils.isBlank(resourceId)) {
+            return false;
+        }
+
+        final String collectionId = buildCollectionPath(resourceId);
+
+        Callable<Boolean> task = () -> {
+            ContentCollection collection;
+            try {
+                collection = contentHostingService.getCollection(collectionId);
+            } catch (IdUnusedException e) {
+                log.warn("SCORM content collection {} not found, skipping archive", collectionId);
+                return false;
+            }
+
+            try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipPath))) {
+                zipCollection(collection, collectionId, zos);
+            }
+            return true;
+        };
+
+        return runWithAdvisor(task);
+    }
+
+    private void zipCollection(ContentCollection collection, String rootCollectionId, ZipOutputStream zos) throws Exception {
+        for (ContentEntity member : collection.getMemberResources()) {
+            if (member.isCollection()) {
+                zipCollection((ContentCollection) member, rootCollectionId, zos);
+            } else {
+                String entryName = StringUtils.removeStart(member.getId(), rootCollectionId);
+                zos.putNextEntry(new ZipEntry(entryName));
+                try (InputStream in = ((ContentResource) member).streamContent()) {
+                    in.transferTo(zos);
+                } finally {
+                    zos.closeEntry();
+                }
+            }
+        }
+    }
+
+    /**
+     * Recreate a SCORM content package from an archived zip, mirroring the interactive upload flow
+     * ({@code putArchive} followed by {@code storeAndValidate}). Returns the newly created package.
+     */
+    private ContentPackage importPackageArchive(String siteId, File zip, String title) throws Exception {
+        Set<Long> existingIds = collectPackageIds(siteId);
+
+        Callable<ContentPackage> task = () -> {
+            String name = StringUtils.isNotBlank(title) ? title + ".zip" : zip.getName();
+            try (InputStream in = new FileInputStream(zip)) {
+                String resourceId = scormResourceService.putArchive(in, name, "application/zip", false, NotificationService.NOTI_NONE);
+                String encoding = serverConfigurationService.getString("scorm.zip.encoding", "UTF-8");
+                scormContentService.storeAndValidate(resourceId, false, encoding);
+            }
+            return findNewPackage(siteId, existingIds);
+        };
+
+        return runWithAdvisor(task);
+    }
+
+    private Set<Long> collectPackageIds(String siteId) {
+        return contentPackageDao.find(siteId).stream()
+                .map(ContentPackage::getContentPackageId)
+                .collect(Collectors.toSet());
+    }
+
+    private ContentPackage findNewPackage(String siteId, Set<Long> existingIds) {
+        return contentPackageDao.find(siteId).stream()
+                .filter(cp -> !existingIds.contains(cp.getContentPackageId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void restoreSettings(ContentPackage pkg, Element element) {
+        // storeAndValidate() derives the title from the manifest, which loses any rename made in the UI.
+        // Restore the archived title so the package matches what Lessons references when relinking SCORM items.
+        String title = element.getAttribute(ATTR_TITLE);
+        if (StringUtils.isNotBlank(title)) {
+            pkg.setTitle(title);
+        }
+        pkg.setNumberOfTries(NumberUtils.toInt(element.getAttribute(ATTR_NUMBER_OF_TRIES), pkg.getNumberOfTries()));
+        pkg.setShowTOC(parseBoolean(element.getAttribute(ATTR_SHOW_TOC), pkg.isShowTOC()));
+        pkg.setShowNavBar(parseBoolean(element.getAttribute(ATTR_SHOW_NAV_BAR), pkg.isShowNavBar()));
+
+        Date releaseOn = parseDate(element.getAttribute(ATTR_RELEASE_ON));
+        if (releaseOn != null) {
+            pkg.setReleaseOn(releaseOn);
+        }
+        pkg.setDueOn(parseDate(element.getAttribute(ATTR_DUE_ON)));
+        pkg.setAcceptUntil(parseDate(element.getAttribute(ATTR_ACCEPT_UNTIL)));
+
+        contentPackageDao.save(pkg);
+    }
+
+    private void setDateAttribute(Element element, String name, Date date) {
+        if (date != null) {
+            element.setAttribute(name, String.valueOf(date.getTime()));
+        }
+    }
+
+    private Date parseDate(String value) {
+        if (StringUtils.isBlank(value)) {
             return null;
         }
-        String trimmed = collectionId.endsWith(Entity.SEPARATOR) ? collectionId.substring(0, collectionId.length() - 1) : collectionId;
-        if (trimmed.startsWith(ScormConstants.ROOT_DIRECTORY)) {
-            return trimmed.substring(ScormConstants.ROOT_DIRECTORY.length());
+        try {
+            return new Date(Long.parseLong(value));
+        } catch (NumberFormatException e) {
+            return null;
         }
-        return trimmed;
+    }
+
+    private boolean parseBoolean(String value, boolean fallback) {
+        return StringUtils.isBlank(value) ? fallback : Boolean.parseBoolean(value);
     }
 
     private String buildPackageReference(String context, Long contentPackageId) {

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormEntityProducer.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormEntityProducer.java
@@ -113,6 +113,13 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     private static final String ATTR_RELEASE_ON = "releaseOn";
     private static final String ATTR_DUE_ON = "dueOn";
     private static final String ATTR_ACCEPT_UNTIL = "acceptUntil";
+    private static final String SCO_TYPE = "sco";
+    // Per-SCO Gradebook binding persisted within each <contentpackage>
+    private static final String GRADEBOOK_ELEMENT = "gradebookitem";
+    private static final String ATTR_ITEM_IDENTIFIER = "itemIdentifier";
+    private static final String ATTR_GB_NAME = "name";
+    private static final String ATTR_GB_POINTS = "points";
+    private static final String ATTR_GB_CATEGORY_ID = "categoryId";
 
     private EntityManager entityManager;
     private ScormContentService scormContentService;
@@ -398,31 +405,113 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
         }
 
         for (LaunchData launchData : manifest.getLaunchData()) {
-            if (!"sco".equalsIgnoreCase(launchData.getSCORMType())) {
+            if (!SCO_TYPE.equalsIgnoreCase(launchData.getSCORMType())) {
                 continue;
             }
 
             String itemIdentifier = launchData.getItemIdentifier();
-            String sourceExternalId = source.getContentPackageId() + ":" + itemIdentifier;
-            String destExternalId = copy.getContentPackageId() + ":" + itemIdentifier;
+            String sourceExternalId = scoExternalId(source.getContentPackageId(), itemIdentifier);
+            String destExternalId = scoExternalId(copy.getContentPackageId(), itemIdentifier);
 
             if (!gradingService.isExternalAssignmentDefined(fromContext, sourceExternalId)) {
                 continue;
             }
 
+            Assignment sourceAssignment = gradingService.getExternalAssignment(fromContext, sourceExternalId);
+            if (sourceAssignment == null) {
+                log.warn("Skipping gradebook copy for SCO {} - source assignment not found", itemIdentifier);
+                continue;
+            }
+
+            recreateScoAssessment(toContext, destExternalId, sourceAssignment.getName(),
+                    sourceAssignment.getPoints(), copy.getDueOn(), sourceAssignment.getCategoryId());
+        }
+    }
+
+    /** External assessment id for a SCO, as used by the SCORM Gradebook integration: "{contentPackageId}:{itemIdentifier}". */
+    private String scoExternalId(Long contentPackageId, String itemIdentifier) {
+        return contentPackageId + ":" + itemIdentifier;
+    }
+
+    /**
+     * Create (remap) a SCO's Gradebook external assessment in the given site. Shared by site-copy and archive merge.
+     * Failures (e.g. duplicate or invalid category in the destination) are logged and skipped so one SCO can't abort the rest.
+     */
+    private void recreateScoAssessment(String context, String externalId, String name, Double points, Date dueOn, Long categoryId) {
+        try {
+            gradingService.addExternalAssessment(context, context, externalId, null, name, points, dueOn,
+                    ScormConstants.SCORM_DFLT_TOOL_NAME, null, false, categoryId, null);
+        } catch (Exception e) {
+            log.warn("Could not create gradebook item {} in {}: {}", externalId, context, e.toString());
+        }
+    }
+
+    /**
+     * Persist each SCO's Gradebook binding (external assessment name/points/category) for the package into the archive XML,
+     * so {@link #mergeGradebookBindings} can re-create them against the new contentPackageId on import.
+     */
+    private void archiveGradebookBindings(Document doc, Element element, String siteId, ContentPackage pkg) {
+        if (pkg.getManifestId() == null) {
+            return;
+        }
+        ContentPackageManifest manifest = contentPackageManifestDao.load(pkg.getManifestId());
+        if (manifest == null || manifest.getLaunchData() == null) {
+            return;
+        }
+
+        for (LaunchData launchData : manifest.getLaunchData()) {
+            if (!SCO_TYPE.equalsIgnoreCase(launchData.getSCORMType())) {
+                continue;
+            }
+            String itemIdentifier = launchData.getItemIdentifier();
+            String externalId = scoExternalId(pkg.getContentPackageId(), itemIdentifier);
+            if (!gradingService.isExternalAssignmentDefined(siteId, externalId)) {
+                continue;
+            }
             try {
-                Assignment sourceAssignment = gradingService.getExternalAssignment(fromContext, sourceExternalId);
-                if (sourceAssignment == null) {
-                    log.warn("Skipping gradebook copy for SCO {} - source assignment not found", itemIdentifier);
+                Assignment assignment = gradingService.getExternalAssignment(siteId, externalId);
+                if (assignment == null) {
                     continue;
                 }
-
-                gradingService.addExternalAssessment(toContext, toContext, destExternalId, null, sourceAssignment.getName(),
-                        sourceAssignment.getPoints(), copy.getDueOn(), ScormConstants.SCORM_DFLT_TOOL_NAME,
-                        null, false, sourceAssignment.getCategoryId(), null);
+                Element gb = doc.createElement(GRADEBOOK_ELEMENT);
+                gb.setAttribute(ATTR_ITEM_IDENTIFIER, StringUtils.trimToEmpty(itemIdentifier));
+                gb.setAttribute(ATTR_GB_NAME, StringUtils.trimToEmpty(assignment.getName()));
+                if (assignment.getPoints() != null) {
+                    gb.setAttribute(ATTR_GB_POINTS, String.valueOf(assignment.getPoints()));
+                }
+                if (assignment.getCategoryId() != null) {
+                    gb.setAttribute(ATTR_GB_CATEGORY_ID, String.valueOf(assignment.getCategoryId()));
+                }
+                element.appendChild(gb);
             } catch (Exception e) {
-                log.warn("Could not copy gradebook item for SCO {}: {}", itemIdentifier, e.toString());
+                log.warn("Unable to archive gradebook binding for SCO {} in {}: {}", itemIdentifier, siteId, e.getMessage());
             }
+        }
+    }
+
+    /**
+     * Re-create the SCO Gradebook bindings captured by {@link #archiveGradebookBindings} against the merged package's
+     * new contentPackageId.
+     */
+    private void mergeGradebookBindings(String siteId, ContentPackage pkg, Element element) {
+        NodeList items = element.getElementsByTagName(GRADEBOOK_ELEMENT);
+        for (int i = 0; i < items.getLength(); i++) {
+            Node node = items.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element gb = (Element) node;
+            String itemIdentifier = gb.getAttribute(ATTR_ITEM_IDENTIFIER);
+            if (StringUtils.isBlank(itemIdentifier)) {
+                continue;
+            }
+            String externalId = scoExternalId(pkg.getContentPackageId(), itemIdentifier);
+            if (gradingService.isExternalAssignmentDefined(siteId, externalId)) {
+                continue;
+            }
+            Double points = gb.hasAttribute(ATTR_GB_POINTS) ? NumberUtils.toDouble(gb.getAttribute(ATTR_GB_POINTS)) : null;
+            Long categoryId = gb.hasAttribute(ATTR_GB_CATEGORY_ID) ? NumberUtils.toLong(gb.getAttribute(ATTR_GB_CATEGORY_ID)) : null;
+            recreateScoAssessment(siteId, externalId, gb.getAttribute(ATTR_GB_NAME), points, pkg.getDueOn(), categoryId);
         }
     }
 
@@ -575,6 +664,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                         setDateAttribute(element, ATTR_RELEASE_ON, pkg.getReleaseOn());
                         setDateAttribute(element, ATTR_DUE_ON, pkg.getDueOn());
                         setDateAttribute(element, ATTR_ACCEPT_UNTIL, pkg.getAcceptUntil());
+                        archiveGradebookBindings(doc, element, siteId, pkg);
                         root.appendChild(element);
                         archived++;
                     }
@@ -639,6 +729,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                 ContentPackage created = importPackageArchive(siteId, zip, title);
                 if (created != null) {
                     restoreSettings(created, element);
+                    mergeGradebookBindings(siteId, created, element);
                     reservedTitles.add(created.getTitle());
                     merged++;
                 }

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormEntityProducer.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormEntityProducer.java
@@ -167,7 +167,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                     .map(cp -> Map.of("id", String.valueOf(cp.getContentPackageId()), "title", cp.getTitle()))
                     .toList();
         } catch (ResourceStorageException e) {
-            log.warn("Unable to build SCORM entity map for {}: {}", fromContext, e.getMessage());
+            log.warn("Unable to build SCORM entity map for {}: {}", fromContext, e.toString());
             return Collections.emptyList();
         }
     }
@@ -187,14 +187,14 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
         try {
             scormContentService.getContentPackages(toContext).forEach(cp -> reservedTitles.add(cp.getTitle()));
         } catch (ResourceStorageException e) {
-            log.debug("Unable to preload destination SCORM titles for {}: {}", toContext, e.getMessage());
+            log.debug("Unable to preload destination SCORM titles for {}: {}", toContext, e.toString());
         }
 
         List<ContentPackage> sourcePackages;
         try {
             sourcePackages = scormContentService.getContentPackages(fromContext);
         } catch (ResourceStorageException e) {
-            log.warn("Unable to fetch SCORM packages from {} for site copy: {}", fromContext, e.getMessage());
+            log.warn("Unable to fetch SCORM packages from {} for site copy: {}", fromContext, e.toString());
             return transversalMap;
         }
 
@@ -239,7 +239,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                     purgeContentPackage(pkg);
                 }
             } catch (ResourceStorageException e) {
-                log.warn("Unable to cleanup SCORM content in {} prior to import: {}", toContext, e.getMessage());
+                log.warn("Unable to cleanup SCORM content in {} prior to import: {}", toContext, e.toString());
             }
         }
 
@@ -344,7 +344,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
 
             return contentPackageManifestDao.save(clone);
         } catch (Exception e) {
-            log.warn("Unable to clone manifest {}: {}", manifestId, e.getMessage());
+            log.warn("Unable to clone manifest {}: {}", manifestId, e.toString());
             return null;
         }
     }
@@ -376,7 +376,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                 return;
             }
         } catch (Exception e) {
-            log.debug("Unable to read collection properties for {}: {}", resourceId, e.getMessage());
+            log.debug("Unable to read collection properties for {}: {}", resourceId, e.toString());
             return;
         }
 
@@ -389,7 +389,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
             if (edit != null && edit.isActiveEdit()) {
                 contentHostingService.cancelCollection(edit);
             }
-            log.debug("Unable to update collection display name for {}: {}", resourceId, e.getMessage());
+            log.debug("Unable to update collection display name for {}: {}", resourceId, e.toString());
         }
     }
 
@@ -434,8 +434,16 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     /**
-     * Create (remap) a SCO's Gradebook external assessment in the given site. Shared by site-copy and archive merge.
-     * Failures (e.g. duplicate or invalid category in the destination) are logged and skipped so one SCO can't abort the rest.
+     * Creates (remaps) a SCO's Gradebook external assessment in the given site, shared by site-copy and
+     * archive merge. Failures (for example a duplicate or invalid category in the destination) are logged
+     * and skipped so one SCO cannot abort the rest.
+     *
+     * @param context    the destination site id, used as both the gradebook uid and the context
+     * @param externalId the SCO external assessment id, as produced by {@link #scoExternalId}
+     * @param name       the gradebook item name
+     * @param points     the maximum points for the item, or {@code null} if not set
+     * @param dueOn      the due date for the item, or {@code null} if not set
+     * @param categoryId the destination gradebook category id, or {@code null} for no category
      */
     private void recreateScoAssessment(String context, String externalId, String name, Double points, Date dueOn, Long categoryId) {
         try {
@@ -447,8 +455,14 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     /**
-     * Persist each SCO's Gradebook binding (external assessment name/points/category) for the package into the archive XML,
-     * so {@link #mergeGradebookBindings} can re-create them against the new contentPackageId on import.
+     * Persists each SCO's Gradebook binding (external assessment name, points and category) for the package
+     * into the archive XML, so {@link #mergeGradebookBindings} can re-create them against the new
+     * contentPackageId on import.
+     *
+     * @param doc     the archive document used to create elements
+     * @param element the package element the gradebook bindings are appended to
+     * @param siteId  the source site id whose gradebook is read
+     * @param pkg     the content package whose SCO bindings are archived
      */
     private void archiveGradebookBindings(Document doc, Element element, String siteId, ContentPackage pkg) {
         if (pkg.getManifestId() == null) {
@@ -484,14 +498,18 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                 }
                 element.appendChild(gb);
             } catch (Exception e) {
-                log.warn("Unable to archive gradebook binding for SCO {} in {}: {}", itemIdentifier, siteId, e.getMessage());
+                log.warn("Unable to archive gradebook binding for SCO {} in {}: {}", itemIdentifier, siteId, e.toString());
             }
         }
     }
 
     /**
-     * Re-create the SCO Gradebook bindings captured by {@link #archiveGradebookBindings} against the merged package's
-     * new contentPackageId.
+     * Re-creates the SCO Gradebook bindings captured by {@link #archiveGradebookBindings} against the
+     * merged package's new contentPackageId.
+     *
+     * @param siteId  the destination site id whose gradebook is written
+     * @param pkg     the newly merged content package providing the new contentPackageId
+     * @param element the archived package element holding the gradebook bindings
      */
     private void mergeGradebookBindings(String siteId, ContentPackage pkg, Element element) {
         NodeList items = element.getElementsByTagName(GRADEBOOK_ELEMENT);
@@ -598,7 +616,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
             try {
                 contentPackageDao.remove(pkg);
             } catch (Exception e) {
-                log.warn("Unable to mark SCORM package {} as deleted: {}", pkg.getContentPackageId(), e.getMessage());
+                log.warn("Unable to mark SCORM package {} as deleted: {}", pkg.getContentPackageId(), e.toString());
             }
 
             try {
@@ -606,7 +624,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                     scormResourceService.removeResources(pkg.getResourceId());
                 }
             } catch (ResourceNotDeletedException e) {
-                log.warn("Unable to remove SCORM resources for {}: {}", pkg.getContentPackageId(), e.getMessage());
+                log.warn("Unable to remove SCORM resources for {}: {}", pkg.getContentPackageId(), e.toString());
             }
         } finally {
             securityService.popAdvisor(advisor);
@@ -623,7 +641,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
             List<ContentPackage> packages = scormContentService.getContentPackages(siteId);
             packages.forEach(this::purgeContentPackage);
         } catch (ResourceStorageException e) {
-            log.warn("Unable to hard delete SCORM content for {}: {}", siteId, e.getMessage());
+            log.warn("Unable to hard delete SCORM content for {}: {}", siteId, e.toString());
         }
     }
 
@@ -633,8 +651,16 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     /**
-     * Archive the SCORM content packages for a site as part of a CC+ (Common Cartridge plus archive) export.
-     * Each package is written as a self-contained zip alongside the archive XML so it can be re-imported via {@link #merge}.
+     * Archives the SCORM content packages for a site as part of a CC+ (Common Cartridge plus archive)
+     * export. Each package is written as a self-contained zip alongside the archive XML so it can be
+     * re-imported via {@link #merge}.
+     *
+     * @param siteId      the id of the site being archived
+     * @param doc         the archive document used to create elements
+     * @param stack       the element stack; this producer's element is pushed and popped around its content
+     * @param archivePath the directory the package zips are written into
+     * @param attachments collected attachment references (unused by this producer)
+     * @return a human-readable summary of how many packages were archived
      */
     @Override
     public String archive(String siteId, Document doc, Stack<Element> stack, String archivePath, List<Reference> attachments) {
@@ -669,11 +695,11 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                         archived++;
                     }
                 } catch (Exception e) {
-                    log.warn("Unable to archive SCORM package {} for site {}: {}", pkg.getContentPackageId(), siteId, e.getMessage());
+                    log.warn("Unable to archive SCORM package {} for site {}: {}", pkg.getContentPackageId(), siteId, e.toString());
                 }
             }
         } catch (ResourceStorageException e) {
-            log.warn("Unable to list SCORM packages while archiving site {}: {}", siteId, e.getMessage());
+            log.warn("Unable to list SCORM packages while archiving site {}: {}", siteId, e.toString());
         }
 
         stack.pop();
@@ -682,7 +708,14 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     /**
-     * Re-import the SCORM content packages produced by {@link #archive} into the destination site.
+     * Re-imports the SCORM content packages produced by {@link #archive} into the destination site.
+     *
+     * @param siteId      the id of the destination site
+     * @param root        this producer's archived root element
+     * @param archivePath the path to this producer's archive file; the package zips live alongside it
+     * @param fromSiteId  the id of the originating site (unused by this producer)
+     * @param mcx         the merge configuration (unused by this producer)
+     * @return a human-readable summary of how many packages were merged
      */
     @Override
     public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {
@@ -696,7 +729,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
         try {
             scormContentService.getContentPackages(siteId).forEach(cp -> reservedTitles.add(cp.getTitle()));
         } catch (ResourceStorageException e) {
-            log.debug("Unable to preload SCORM titles for {}: {}", siteId, e.getMessage());
+            log.debug("Unable to preload SCORM titles for {}: {}", siteId, e.toString());
         }
 
         // On merge, archivePath is the path to this producer's archive file (e.g. ".../sakai_archive/scorm.xml"),
@@ -734,7 +767,7 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
                     merged++;
                 }
             } catch (Exception e) {
-                log.warn("Unable to merge SCORM package '{}' into {}: {}", title, siteId, e.getMessage(), e);
+                log.warn("Unable to merge SCORM package '{}' into {}: {}", title, siteId, e.toString(), e);
             }
         }
 
@@ -743,8 +776,13 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     /**
-     * Stream the unpacked SCORM content collection at {@code /private/scorm/{uuid}/} into a zip archive,
+     * Streams the unpacked SCORM content collection at {@code /private/scorm/{uuid}/} into a zip archive,
      * preserving paths relative to the package root (so {@code imsmanifest.xml} lands at the zip root).
+     *
+     * @param resourceId the package resource uuid identifying the content collection
+     * @param zipPath    the filesystem path the zip is written to
+     * @return {@code true} if a zip was written, {@code false} if {@code resourceId} was blank
+     * @throws Exception if the collection cannot be read or the zip cannot be written
      */
     private boolean writePackageArchive(String resourceId, String zipPath) throws Exception {
         if (StringUtils.isBlank(resourceId)) {
@@ -788,8 +826,14 @@ public class ScormEntityProducer implements EntityProducer, EntityTransferrer, H
     }
 
     /**
-     * Recreate a SCORM content package from an archived zip, mirroring the interactive upload flow
-     * ({@code putArchive} followed by {@code storeAndValidate}). Returns the newly created package.
+     * Recreates a SCORM content package from an archived zip, mirroring the interactive upload flow
+     * ({@code putArchive} followed by {@code storeAndValidate}).
+     *
+     * @param siteId the destination site id
+     * @param zip    the archived package zip
+     * @param title  the archived package title, used as the upload name; falls back to the zip file name when blank
+     * @return the newly created content package, or {@code null} if it could not be found after import
+     * @throws Exception if storing or validating the archive fails
      */
     private ContentPackage importPackageArchive(String siteId, File zip, String title) throws Exception {
         Set<Long> existingIds = collectPackageIds(siteId);

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-entityproducer.xml
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-entityproducer.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<!-- SCORM Import from Site / archive-merge entity producer. Kept in its own file so the
+	     production wiring can be reused verbatim by ScormEntityProducerTest. -->
+	<bean id="org.sakaiproject.scorm.service.impl.ScormEntityProducer"
+		class="org.sakaiproject.scorm.service.impl.ScormEntityProducer"
+		init-method="init">
+		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
+		<property name="scormContentService" ref="org.sakaiproject.scorm.service.api.ScormContentService" />
+		<property name="contentPackageDao" ref="org.sakaiproject.scorm.dao.api.ContentPackageDao" />
+		<property name="contentPackageManifestDao" ref="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
+		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
+		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
+		<property name="scormResourceService" ref="org.sakaiproject.scorm.service.api.ScormResourceService" />
+		<property name="gradingService" ref="org.sakaiproject.grading.api.GradingService" />
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
+	</bean>
+</beans>

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
@@ -60,17 +60,6 @@
 		<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
 	</bean>
 
-	<bean id="org.sakaiproject.scorm.service.impl.ScormEntityProducer"
-		class="org.sakaiproject.scorm.service.impl.ScormEntityProducer"
-		init-method="init">
-		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
-		<property name="scormContentService" ref="org.sakaiproject.scorm.service.api.ScormContentService" />
-		<property name="contentPackageDao" ref="org.sakaiproject.scorm.dao.api.ContentPackageDao" />
-		<property name="contentPackageManifestDao" ref="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
-		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
-		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
-		<property name="scormResourceService" ref="org.sakaiproject.scorm.service.api.ScormResourceService" />
-		<property name="gradingService" ref="org.sakaiproject.grading.api.GradingService" />
-		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
-	</bean>
+	<!-- The SCORM entity producer lives in its own file so the test can load the same wiring -->
+	<import resource="classpath:org/sakaiproject/scorm/service/impl/spring-scorm-entityproducer.xml" />
 </beans>

--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
@@ -69,8 +69,8 @@
 		<property name="contentPackageManifestDao" ref="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
 		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService" />
 		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
-		<property name="sessionManager" ref="org.sakaiproject.tool.api.SessionManager" />
 		<property name="scormResourceService" ref="org.sakaiproject.scorm.service.api.ScormResourceService" />
 		<property name="gradingService" ref="org.sakaiproject.grading.api.GradingService" />
+		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
 	</bean>
 </beans>

--- a/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormEntityProducerTest.java
+++ b/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormEntityProducerTest.java
@@ -18,9 +18,11 @@ package org.sakaiproject.scorm.service.impl;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Stack;
@@ -33,6 +35,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,11 +44,14 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.mockito.ArgumentCaptor;
+
 import org.adl.validator.contentpackage.LaunchData;
-import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentCollection;
 import org.sakaiproject.content.api.ContentEntity;
@@ -62,10 +68,15 @@ import org.sakaiproject.scorm.service.api.ScormContentService;
 import org.sakaiproject.scorm.service.api.ScormResourceService;
 import org.sakaiproject.util.MergeConfig;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = ScormTestConfiguration.class)
 public class ScormEntityProducerTest
 {
     private static final String SITE_ID = "site-a";
@@ -77,16 +88,14 @@ public class ScormEntityProducerTest
     private Path tempRoot;
     private String archivePath;
 
-    private ScormContentService scormContentService;
-    private ScormResourceService scormResourceService;
-    private ContentHostingService contentHostingService;
-    private ContentPackageDao contentPackageDao;
-    private ContentPackageManifestDao contentPackageManifestDao;
-    private SecurityService securityService;
-    private ServerConfigurationService serverConfigurationService;
-    private GradingService gradingService;
-
-    private ScormEntityProducer producer;
+    @Autowired private ScormEntityProducer producer;
+    @Autowired private ScormContentService scormContentService;
+    @Autowired private ScormResourceService scormResourceService;
+    @Autowired private ContentHostingService contentHostingService;
+    @Autowired private ContentPackageDao contentPackageDao;
+    @Autowired private ContentPackageManifestDao contentPackageManifestDao;
+    @Autowired private ServerConfigurationService serverConfigurationService;
+    @Autowired private GradingService gradingService;
 
     @Before
     public void setUp() throws Exception
@@ -94,24 +103,9 @@ public class ScormEntityProducerTest
         tempRoot = Files.createTempDirectory("scorm-archive-tests-" + UUID.randomUUID());
         archivePath = tempRoot.toString() + File.separator;
 
-        scormContentService = mock(ScormContentService.class);
-        scormResourceService = mock(ScormResourceService.class);
-        contentHostingService = mock(ContentHostingService.class);
-        contentPackageDao = mock(ContentPackageDao.class);
-        contentPackageManifestDao = mock(ContentPackageManifestDao.class);
-        securityService = mock(SecurityService.class);
-        serverConfigurationService = mock(ServerConfigurationService.class);
-        gradingService = mock(GradingService.class);
-
-        producer = new ScormEntityProducer();
-        producer.setScormContentService(scormContentService);
-        producer.setScormResourceService(scormResourceService);
-        producer.setContentHostingService(contentHostingService);
-        producer.setContentPackageDao(contentPackageDao);
-        producer.setContentPackageManifestDao(contentPackageManifestDao);
-        producer.setSecurityService(securityService);
-        producer.setServerConfigurationService(serverConfigurationService);
-        producer.setGradingService(gradingService);
+        // Context (and its mock beans) is shared across test methods, so reset to isolate each test
+        reset(scormContentService, scormResourceService, contentHostingService, contentPackageDao,
+                contentPackageManifestDao, serverConfigurationService, gradingService);
     }
 
     @After
@@ -141,23 +135,9 @@ public class ScormEntityProducerTest
         pkg.setReleaseOn(new Date(1000L));
         pkg.setDueOn(new Date(2000L));
         when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(pkg));
+        stubContentCollection(COLLECTION_ID, "imsmanifest.xml");
 
-        ContentResource manifest = mock(ContentResource.class);
-        when(manifest.getId()).thenReturn(COLLECTION_ID + "imsmanifest.xml");
-        when(manifest.isCollection()).thenReturn(false);
-        when(manifest.streamContent()).thenReturn(new ByteArrayInputStream("<manifest/>".getBytes(StandardCharsets.UTF_8)));
-
-        ContentCollection collection = mock(ContentCollection.class);
-        when(collection.getMemberResources()).thenReturn(List.<ContentEntity>of(manifest));
-        when(contentHostingService.getCollection(COLLECTION_ID)).thenReturn(collection);
-
-        Document doc = newDocument();
-        Element root = doc.createElement("archive");
-        doc.appendChild(root);
-        Stack<Element> stack = new Stack<>();
-        stack.push(root);
-
-        producer.archive(SITE_ID, doc, stack, archivePath, null);
+        Element root = archive();
 
         // The zip was written next to the archive XML and contains the manifest at the zip root
         File zip = new File(archivePath + ZIP_NAME);
@@ -166,9 +146,9 @@ public class ScormEntityProducerTest
 
         // Metadata element captured the package settings. The element tag must be the producer
         // label ("scorm") so SiteMerger dispatches/filters the merge correctly.
-        Element scormRoot = (Element) root.getElementsByTagName("scorm").item(0);
+        Element scormRoot = firstChild(root, "scorm");
         assertNotNull(scormRoot);
-        Element cp = (Element) scormRoot.getElementsByTagName("contentpackage").item(0);
+        Element cp = firstChild(scormRoot, "contentpackage");
         assertNotNull(cp);
         assertEquals("My Package", cp.getAttribute("title"));
         assertEquals(UUID_1, cp.getAttribute("resourceId"));
@@ -182,40 +162,26 @@ public class ScormEntityProducerTest
     @Test
     public void mergeRecreatesPackageAndRestoresSettings() throws Exception
     {
-        // A real zip waiting in the archive folder, as archive() would have produced
         writeZip(new File(archivePath + ZIP_NAME), "imsmanifest.xml", "<manifest/>");
 
         Document doc = newDocument();
-        Element scormRoot = doc.createElement("scorm");
-        doc.appendChild(scormRoot);
-        Element cp = doc.createElement("contentpackage");
-        cp.setAttribute("title", "My Package");
+        Element cp = packageElement(doc, "My Package", ZIP_NAME);
         cp.setAttribute("resourceId", UUID_1);
-        cp.setAttribute("archive", ZIP_NAME);
         cp.setAttribute("numberOfTries", "5");
         cp.setAttribute("showToc", "true");
         cp.setAttribute("showNavBar", "true");
         cp.setAttribute("releaseOn", "1000");
         cp.setAttribute("dueOn", "2000");
-        scormRoot.appendChild(cp);
+        Element scormRoot = scormRootWith(doc, cp);
 
-        // No existing packages in the destination, so nothing is skipped as a duplicate
-        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of());
-        when(serverConfigurationService.getString("scorm.zip.encoding", "UTF-8")).thenReturn("UTF-8");
-        when(scormResourceService.putArchive(any(), any(), eq("application/zip"), anyBoolean(), anyInt())).thenReturn("res-1");
-        when(scormContentService.storeAndValidate(eq("res-1"), anyBoolean(), eq("UTF-8"))).thenReturn(0);
-
-        // Snapshot before import is empty; after storeAndValidate the new package appears.
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of()); // no duplicate titles
         // storeAndValidate derives the title from the manifest, so start from a different title
         // to prove merge() restores the archived one.
         ContentPackage created = new ContentPackage("Manifest Title", UUID_1);
         created.setContentPackageId(42L);
-        when(contentPackageDao.find(SITE_ID)).thenReturn(List.of()).thenReturn(List.of(created));
+        stubSuccessfulImport(created);
 
-        // SiteMerger passes the path to the producer's archive file (scorm.xml), not the directory;
-        // merge() must resolve the zip against the file's parent directory.
-        String scormXmlPath = archivePath + "scorm.xml";
-        producer.merge(SITE_ID, scormRoot, scormXmlPath, FROM_SITE_ID, new MergeConfig());
+        merge(scormRoot);
 
         verify(scormResourceService).putArchive(any(), any(), eq("application/zip"), anyBoolean(), anyInt());
         verify(scormContentService).storeAndValidate(eq("res-1"), anyBoolean(), eq("UTF-8"));
@@ -236,21 +202,14 @@ public class ScormEntityProducerTest
         writeZip(new File(archivePath + ZIP_NAME), "imsmanifest.xml", "<manifest/>");
 
         Document doc = newDocument();
-        Element scormRoot = doc.createElement("scorm");
-        doc.appendChild(scormRoot);
-        Element cp = doc.createElement("contentpackage");
-        cp.setAttribute("title", "My Package");
-        cp.setAttribute("archive", ZIP_NAME);
-        scormRoot.appendChild(cp);
+        Element scormRoot = scormRootWith(doc, packageElement(doc, "My Package", ZIP_NAME));
 
-        ContentPackage existing = new ContentPackage("My Package", UUID_1);
-        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(existing));
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(new ContentPackage("My Package", UUID_1)));
 
-        producer.merge(SITE_ID, scormRoot, archivePath, FROM_SITE_ID, new MergeConfig());
+        merge(scormRoot);
 
         // Nothing imported because the title collides
-        verify(scormResourceService, org.mockito.Mockito.never())
-                .putArchive(any(), any(), any(), anyBoolean(), anyInt());
+        verify(scormResourceService, never()).putArchive(any(), any(), any(), anyBoolean(), anyInt());
     }
 
     @Test
@@ -260,41 +219,14 @@ public class ScormEntityProducerTest
         pkg.setContentPackageId(100L);
         pkg.setManifestId(7L);
         when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(pkg));
+        stubContentCollection(COLLECTION_ID, "imsmanifest.xml");
+        stubManifestWithSco(7L, "ITEM-1");
+        stubGradebookAssignment("100:ITEM-1", "Quiz", 10.0, 5L);
 
-        // Minimal content collection so writePackageArchive() succeeds and the element is emitted
-        ContentResource manifestFile = mock(ContentResource.class);
-        when(manifestFile.getId()).thenReturn(COLLECTION_ID + "imsmanifest.xml");
-        when(manifestFile.isCollection()).thenReturn(false);
-        when(manifestFile.streamContent()).thenReturn(new ByteArrayInputStream("<manifest/>".getBytes(StandardCharsets.UTF_8)));
-        ContentCollection collection = mock(ContentCollection.class);
-        when(collection.getMemberResources()).thenReturn(List.<ContentEntity>of(manifestFile));
-        when(contentHostingService.getCollection(COLLECTION_ID)).thenReturn(collection);
+        Element root = archive();
 
-        // One SCO in the manifest with a gradebook external assessment defined
-        LaunchData sco = mock(LaunchData.class);
-        when(sco.getSCORMType()).thenReturn("sco");
-        when(sco.getItemIdentifier()).thenReturn("ITEM-1");
-        ContentPackageManifest manifest = mock(ContentPackageManifest.class);
-        when(manifest.getLaunchData()).thenReturn(List.of(sco));
-        when(contentPackageManifestDao.load(7L)).thenReturn(manifest);
-
-        when(gradingService.isExternalAssignmentDefined(SITE_ID, "100:ITEM-1")).thenReturn(true);
-        Assignment assignment = mock(Assignment.class);
-        when(assignment.getName()).thenReturn("Quiz");
-        when(assignment.getPoints()).thenReturn(10.0);
-        when(assignment.getCategoryId()).thenReturn(5L);
-        when(gradingService.getExternalAssignment(SITE_ID, "100:ITEM-1")).thenReturn(assignment);
-
-        Document doc = newDocument();
-        Element root = doc.createElement("archive");
-        doc.appendChild(root);
-        Stack<Element> stack = new Stack<>();
-        stack.push(root);
-
-        producer.archive(SITE_ID, doc, stack, archivePath, null);
-
-        Element cp = (Element) root.getElementsByTagName("contentpackage").item(0);
-        Element gb = (Element) cp.getElementsByTagName("gradebookitem").item(0);
+        Element cp = firstChild(firstChild(root, "scorm"), "contentpackage");
+        Element gb = firstChild(cp, "gradebookitem");
         assertNotNull("expected a gradebookitem element", gb);
         assertEquals("ITEM-1", gb.getAttribute("itemIdentifier"));
         assertEquals("Quiz", gb.getAttribute("name"));
@@ -308,37 +240,128 @@ public class ScormEntityProducerTest
         writeZip(new File(archivePath + ZIP_NAME), "imsmanifest.xml", "<manifest/>");
 
         Document doc = newDocument();
-        Element scormRoot = doc.createElement("scorm");
-        doc.appendChild(scormRoot);
-        Element cp = doc.createElement("contentpackage");
-        cp.setAttribute("title", "My Package");
-        cp.setAttribute("archive", ZIP_NAME);
+        Element cp = packageElement(doc, "My Package", ZIP_NAME);
         cp.setAttribute("dueOn", "2000");
-        Element gb = doc.createElement("gradebookitem");
-        gb.setAttribute("itemIdentifier", "ITEM-1");
-        gb.setAttribute("name", "Quiz");
-        gb.setAttribute("points", "10.0");
-        gb.setAttribute("categoryId", "5");
-        cp.appendChild(gb);
-        scormRoot.appendChild(cp);
+        cp.appendChild(gradebookItemElement(doc, "ITEM-1", "Quiz", "10.0", "5"));
+        Element scormRoot = scormRootWith(doc, cp);
 
         when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of());
+        ContentPackage created = new ContentPackage("My Package", UUID_1);
+        created.setContentPackageId(42L);
+        stubSuccessfulImport(created);
+        when(gradingService.isExternalAssignmentDefined(SITE_ID, "42:ITEM-1")).thenReturn(false);
+
+        merge(scormRoot);
+
+        // External assessment recreated against the NEW contentPackageId, carrying the archived settings
+        ArgumentCaptor<String> externalId = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Double> points = ArgumentCaptor.forClass(Double.class);
+        ArgumentCaptor<Long> categoryId = ArgumentCaptor.forClass(Long.class);
+        verify(gradingService).addExternalAssessment(eq(SITE_ID), eq(SITE_ID), externalId.capture(),
+                isNull(), eq("Quiz"), points.capture(), eq(new Date(2000L)), eq(ScormConstants.SCORM_DFLT_TOOL_NAME),
+                isNull(), eq(false), categoryId.capture(), isNull());
+        assertEquals("42:ITEM-1", externalId.getValue());
+        assertEquals(Double.valueOf(10.0), points.getValue());
+        assertEquals(Long.valueOf(5L), categoryId.getValue());
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    /** Run archive() against a fresh {@code <archive>} root and return it. */
+    private Element archive() throws Exception
+    {
+        Document doc = newDocument();
+        Element root = doc.createElement("archive");
+        doc.appendChild(root);
+        Stack<Element> stack = new Stack<>();
+        stack.push(root);
+        producer.archive(SITE_ID, doc, stack, archivePath, null);
+        return root;
+    }
+
+    /** Run merge() with the standard SiteMerger contract: archivePath points at the scorm.xml file. */
+    private void merge(Element scormRoot)
+    {
+        producer.merge(SITE_ID, scormRoot, archivePath + "scorm.xml", FROM_SITE_ID, new MergeConfig());
+    }
+
+    private void stubContentCollection(String collectionId, String... fileNames) throws Exception
+    {
+        List<ContentEntity> members = new ArrayList<>();
+        for (String name : fileNames)
+        {
+            ContentResource resource = mock(ContentResource.class);
+            when(resource.getId()).thenReturn(collectionId + name);
+            when(resource.isCollection()).thenReturn(false);
+            when(resource.streamContent()).thenReturn(new ByteArrayInputStream(("<" + name + "/>").getBytes(StandardCharsets.UTF_8)));
+            members.add(resource);
+        }
+        ContentCollection collection = mock(ContentCollection.class);
+        when(collection.getMemberResources()).thenReturn(members);
+        when(contentHostingService.getCollection(collectionId)).thenReturn(collection);
+    }
+
+    private void stubManifestWithSco(Serializable manifestId, String itemIdentifier)
+    {
+        LaunchData sco = mock(LaunchData.class);
+        when(sco.getSCORMType()).thenReturn("sco");
+        when(sco.getItemIdentifier()).thenReturn(itemIdentifier);
+        ContentPackageManifest manifest = mock(ContentPackageManifest.class);
+        when(manifest.getLaunchData()).thenReturn(List.of(sco));
+        when(contentPackageManifestDao.load(manifestId)).thenReturn(manifest);
+    }
+
+    private void stubGradebookAssignment(String externalId, String name, Double points, Long categoryId)
+    {
+        when(gradingService.isExternalAssignmentDefined(SITE_ID, externalId)).thenReturn(true);
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getName()).thenReturn(name);
+        when(assignment.getPoints()).thenReturn(points);
+        when(assignment.getCategoryId()).thenReturn(categoryId);
+        when(gradingService.getExternalAssignment(SITE_ID, externalId)).thenReturn(assignment);
+    }
+
+    /** Stub the interactive-upload import flow (putArchive -> storeAndValidate) and the before/after find snapshot. */
+    private void stubSuccessfulImport(ContentPackage created) throws Exception
+    {
         when(serverConfigurationService.getString("scorm.zip.encoding", "UTF-8")).thenReturn("UTF-8");
         when(scormResourceService.putArchive(any(), any(), eq("application/zip"), anyBoolean(), anyInt())).thenReturn("res-1");
         when(scormContentService.storeAndValidate(eq("res-1"), anyBoolean(), eq("UTF-8"))).thenReturn(0);
-
-        ContentPackage created = new ContentPackage("My Package", UUID_1);
-        created.setContentPackageId(42L);
         when(contentPackageDao.find(SITE_ID)).thenReturn(List.of()).thenReturn(List.of(created));
-        // No existing assessment under the new contentPackageId yet
-        when(gradingService.isExternalAssignmentDefined(SITE_ID, "42:ITEM-1")).thenReturn(false);
+    }
 
-        producer.merge(SITE_ID, scormRoot, archivePath + "scorm.xml", FROM_SITE_ID, new MergeConfig());
+    private Element scormRootWith(Document doc, Element... contentPackages)
+    {
+        Element scorm = doc.createElement("scorm");
+        doc.appendChild(scorm);
+        for (Element cp : contentPackages)
+        {
+            scorm.appendChild(cp);
+        }
+        return scorm;
+    }
 
-        // External assessment recreated against the NEW contentPackageId, with the archived settings
-        verify(gradingService).addExternalAssessment(eq(SITE_ID), eq(SITE_ID), eq("42:ITEM-1"),
-                isNull(), eq("Quiz"), eq(10.0), eq(new Date(2000L)), eq(ScormConstants.SCORM_DFLT_TOOL_NAME),
-                isNull(), eq(false), eq(5L), isNull());
+    private Element packageElement(Document doc, String title, String archiveName)
+    {
+        Element cp = doc.createElement("contentpackage");
+        cp.setAttribute("title", title);
+        cp.setAttribute("archive", archiveName);
+        return cp;
+    }
+
+    private Element gradebookItemElement(Document doc, String itemIdentifier, String name, String points, String categoryId)
+    {
+        Element gb = doc.createElement("gradebookitem");
+        gb.setAttribute("itemIdentifier", itemIdentifier);
+        gb.setAttribute("name", name);
+        gb.setAttribute("points", points);
+        gb.setAttribute("categoryId", categoryId);
+        return gb;
+    }
+
+    private static Element firstChild(Element parent, String tag)
+    {
+        return (Element) parent.getElementsByTagName(tag).item(0);
     }
 
     private static Document newDocument() throws Exception

--- a/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormEntityProducerTest.java
+++ b/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormEntityProducerTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.scorm.service.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.content.api.ContentCollection;
+import org.sakaiproject.content.api.ContentEntity;
+import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.scorm.dao.api.ContentPackageDao;
+import org.sakaiproject.scorm.model.api.ContentPackage;
+import org.sakaiproject.scorm.service.api.ScormContentService;
+import org.sakaiproject.scorm.service.api.ScormResourceService;
+import org.sakaiproject.util.MergeConfig;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class ScormEntityProducerTest
+{
+    private static final String SITE_ID = "site-a";
+    private static final String FROM_SITE_ID = "site-source";
+    private static final String UUID_1 = "uuid-1";
+    private static final String COLLECTION_ID = "/private/scorm/" + UUID_1 + "/";
+    private static final String ZIP_NAME = "scorm_" + UUID_1 + ".zip";
+
+    private Path tempRoot;
+    private String archivePath;
+
+    private ScormContentService scormContentService;
+    private ScormResourceService scormResourceService;
+    private ContentHostingService contentHostingService;
+    private ContentPackageDao contentPackageDao;
+    private SecurityService securityService;
+    private ServerConfigurationService serverConfigurationService;
+
+    private ScormEntityProducer producer;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        tempRoot = Files.createTempDirectory("scorm-archive-tests-" + UUID.randomUUID());
+        archivePath = tempRoot.toString() + File.separator;
+
+        scormContentService = mock(ScormContentService.class);
+        scormResourceService = mock(ScormResourceService.class);
+        contentHostingService = mock(ContentHostingService.class);
+        contentPackageDao = mock(ContentPackageDao.class);
+        securityService = mock(SecurityService.class);
+        serverConfigurationService = mock(ServerConfigurationService.class);
+
+        producer = new ScormEntityProducer();
+        producer.setScormContentService(scormContentService);
+        producer.setScormResourceService(scormResourceService);
+        producer.setContentHostingService(contentHostingService);
+        producer.setContentPackageDao(contentPackageDao);
+        producer.setSecurityService(securityService);
+        producer.setServerConfigurationService(serverConfigurationService);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if (tempRoot != null && Files.exists(tempRoot))
+        {
+            Files.walk(tempRoot)
+                .sorted((a, b) -> b.getNameCount() - a.getNameCount())
+                .forEach(path -> path.toFile().delete());
+        }
+    }
+
+    @Test
+    public void willArchiveMergeIsEnabled()
+    {
+        assertTrue(producer.willArchiveMerge());
+    }
+
+    @Test
+    public void archiveWritesPackageZipAndMetadata() throws Exception
+    {
+        ContentPackage pkg = new ContentPackage("My Package", UUID_1);
+        pkg.setNumberOfTries(3);
+        pkg.setShowTOC(true);
+        pkg.setShowNavBar(true);
+        pkg.setReleaseOn(new Date(1000L));
+        pkg.setDueOn(new Date(2000L));
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(pkg));
+
+        ContentResource manifest = mock(ContentResource.class);
+        when(manifest.getId()).thenReturn(COLLECTION_ID + "imsmanifest.xml");
+        when(manifest.isCollection()).thenReturn(false);
+        when(manifest.streamContent()).thenReturn(new ByteArrayInputStream("<manifest/>".getBytes(StandardCharsets.UTF_8)));
+
+        ContentCollection collection = mock(ContentCollection.class);
+        when(collection.getMemberResources()).thenReturn(List.<ContentEntity>of(manifest));
+        when(contentHostingService.getCollection(COLLECTION_ID)).thenReturn(collection);
+
+        Document doc = newDocument();
+        Element root = doc.createElement("archive");
+        doc.appendChild(root);
+        Stack<Element> stack = new Stack<>();
+        stack.push(root);
+
+        producer.archive(SITE_ID, doc, stack, archivePath, null);
+
+        // The zip was written next to the archive XML and contains the manifest at the zip root
+        File zip = new File(archivePath + ZIP_NAME);
+        assertTrue("expected SCORM zip to be written", zip.isFile());
+        assertEquals("imsmanifest.xml", firstZipEntryName(zip));
+
+        // Metadata element captured the package settings. The element tag must be the producer
+        // label ("scorm") so SiteMerger dispatches/filters the merge correctly.
+        Element scormRoot = (Element) root.getElementsByTagName("scorm").item(0);
+        assertNotNull(scormRoot);
+        Element cp = (Element) scormRoot.getElementsByTagName("contentpackage").item(0);
+        assertNotNull(cp);
+        assertEquals("My Package", cp.getAttribute("title"));
+        assertEquals(UUID_1, cp.getAttribute("resourceId"));
+        assertEquals(ZIP_NAME, cp.getAttribute("archive"));
+        assertEquals("3", cp.getAttribute("numberOfTries"));
+        assertEquals("true", cp.getAttribute("showToc"));
+        assertEquals("1000", cp.getAttribute("releaseOn"));
+        assertEquals("2000", cp.getAttribute("dueOn"));
+    }
+
+    @Test
+    public void mergeRecreatesPackageAndRestoresSettings() throws Exception
+    {
+        // A real zip waiting in the archive folder, as archive() would have produced
+        writeZip(new File(archivePath + ZIP_NAME), "imsmanifest.xml", "<manifest/>");
+
+        Document doc = newDocument();
+        Element scormRoot = doc.createElement("scorm");
+        doc.appendChild(scormRoot);
+        Element cp = doc.createElement("contentpackage");
+        cp.setAttribute("title", "My Package");
+        cp.setAttribute("resourceId", UUID_1);
+        cp.setAttribute("archive", ZIP_NAME);
+        cp.setAttribute("numberOfTries", "5");
+        cp.setAttribute("showToc", "true");
+        cp.setAttribute("showNavBar", "true");
+        cp.setAttribute("releaseOn", "1000");
+        cp.setAttribute("dueOn", "2000");
+        scormRoot.appendChild(cp);
+
+        // No existing packages in the destination, so nothing is skipped as a duplicate
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of());
+        when(serverConfigurationService.getString("scorm.zip.encoding", "UTF-8")).thenReturn("UTF-8");
+        when(scormResourceService.putArchive(any(), any(), eq("application/zip"), anyBoolean(), anyInt())).thenReturn("res-1");
+        when(scormContentService.storeAndValidate(eq("res-1"), anyBoolean(), eq("UTF-8"))).thenReturn(0);
+
+        // Snapshot before import is empty; after storeAndValidate the new package appears.
+        // storeAndValidate derives the title from the manifest, so start from a different title
+        // to prove merge() restores the archived one.
+        ContentPackage created = new ContentPackage("Manifest Title", UUID_1);
+        created.setContentPackageId(42L);
+        when(contentPackageDao.find(SITE_ID)).thenReturn(List.of()).thenReturn(List.of(created));
+
+        // SiteMerger passes the path to the producer's archive file (scorm.xml), not the directory;
+        // merge() must resolve the zip against the file's parent directory.
+        String scormXmlPath = archivePath + "scorm.xml";
+        producer.merge(SITE_ID, scormRoot, scormXmlPath, FROM_SITE_ID, new MergeConfig());
+
+        verify(scormResourceService).putArchive(any(), any(), eq("application/zip"), anyBoolean(), anyInt());
+        verify(scormContentService).storeAndValidate(eq("res-1"), anyBoolean(), eq("UTF-8"));
+        verify(contentPackageDao).save(created);
+
+        // Settings from the archive XML were applied to the recreated package
+        assertEquals("My Package", created.getTitle());
+        assertEquals(5, created.getNumberOfTries());
+        assertTrue(created.isShowTOC());
+        assertTrue(created.isShowNavBar());
+        assertEquals(new Date(1000L), created.getReleaseOn());
+        assertEquals(new Date(2000L), created.getDueOn());
+    }
+
+    @Test
+    public void mergeSkipsPackageWhenTitleAlreadyExists() throws Exception
+    {
+        writeZip(new File(archivePath + ZIP_NAME), "imsmanifest.xml", "<manifest/>");
+
+        Document doc = newDocument();
+        Element scormRoot = doc.createElement("scorm");
+        doc.appendChild(scormRoot);
+        Element cp = doc.createElement("contentpackage");
+        cp.setAttribute("title", "My Package");
+        cp.setAttribute("archive", ZIP_NAME);
+        scormRoot.appendChild(cp);
+
+        ContentPackage existing = new ContentPackage("My Package", UUID_1);
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(existing));
+
+        producer.merge(SITE_ID, scormRoot, archivePath, FROM_SITE_ID, new MergeConfig());
+
+        // Nothing imported because the title collides
+        verify(scormResourceService, org.mockito.Mockito.never())
+                .putArchive(any(), any(), any(), anyBoolean(), anyInt());
+    }
+
+    private static Document newDocument() throws Exception
+    {
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+    }
+
+    private static String firstZipEntryName(File zip) throws Exception
+    {
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zip)))
+        {
+            ZipEntry entry = zis.getNextEntry();
+            return entry == null ? null : entry.getName();
+        }
+    }
+
+    private static void writeZip(File file, String entryName, String content) throws Exception
+    {
+        try (java.util.zip.ZipOutputStream zos = new java.util.zip.ZipOutputStream(new java.io.FileOutputStream(file)))
+        {
+            zos.putNextEntry(new ZipEntry(entryName));
+            zos.write(content.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+    }
+}

--- a/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormEntityProducerTest.java
+++ b/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormEntityProducerTest.java
@@ -39,18 +39,25 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.adl.validator.contentpackage.LaunchData;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentCollection;
 import org.sakaiproject.content.api.ContentEntity;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.grading.api.Assignment;
+import org.sakaiproject.grading.api.GradingService;
+import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.dao.api.ContentPackageDao;
+import org.sakaiproject.scorm.dao.api.ContentPackageManifestDao;
 import org.sakaiproject.scorm.model.api.ContentPackage;
+import org.sakaiproject.scorm.model.api.ContentPackageManifest;
 import org.sakaiproject.scorm.service.api.ScormContentService;
 import org.sakaiproject.scorm.service.api.ScormResourceService;
 import org.sakaiproject.util.MergeConfig;
@@ -74,8 +81,10 @@ public class ScormEntityProducerTest
     private ScormResourceService scormResourceService;
     private ContentHostingService contentHostingService;
     private ContentPackageDao contentPackageDao;
+    private ContentPackageManifestDao contentPackageManifestDao;
     private SecurityService securityService;
     private ServerConfigurationService serverConfigurationService;
+    private GradingService gradingService;
 
     private ScormEntityProducer producer;
 
@@ -89,16 +98,20 @@ public class ScormEntityProducerTest
         scormResourceService = mock(ScormResourceService.class);
         contentHostingService = mock(ContentHostingService.class);
         contentPackageDao = mock(ContentPackageDao.class);
+        contentPackageManifestDao = mock(ContentPackageManifestDao.class);
         securityService = mock(SecurityService.class);
         serverConfigurationService = mock(ServerConfigurationService.class);
+        gradingService = mock(GradingService.class);
 
         producer = new ScormEntityProducer();
         producer.setScormContentService(scormContentService);
         producer.setScormResourceService(scormResourceService);
         producer.setContentHostingService(contentHostingService);
         producer.setContentPackageDao(contentPackageDao);
+        producer.setContentPackageManifestDao(contentPackageManifestDao);
         producer.setSecurityService(securityService);
         producer.setServerConfigurationService(serverConfigurationService);
+        producer.setGradingService(gradingService);
     }
 
     @After
@@ -238,6 +251,94 @@ public class ScormEntityProducerTest
         // Nothing imported because the title collides
         verify(scormResourceService, org.mockito.Mockito.never())
                 .putArchive(any(), any(), any(), anyBoolean(), anyInt());
+    }
+
+    @Test
+    public void archivePersistsScoGradebookBindings() throws Exception
+    {
+        ContentPackage pkg = new ContentPackage("My Package", UUID_1);
+        pkg.setContentPackageId(100L);
+        pkg.setManifestId(7L);
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of(pkg));
+
+        // Minimal content collection so writePackageArchive() succeeds and the element is emitted
+        ContentResource manifestFile = mock(ContentResource.class);
+        when(manifestFile.getId()).thenReturn(COLLECTION_ID + "imsmanifest.xml");
+        when(manifestFile.isCollection()).thenReturn(false);
+        when(manifestFile.streamContent()).thenReturn(new ByteArrayInputStream("<manifest/>".getBytes(StandardCharsets.UTF_8)));
+        ContentCollection collection = mock(ContentCollection.class);
+        when(collection.getMemberResources()).thenReturn(List.<ContentEntity>of(manifestFile));
+        when(contentHostingService.getCollection(COLLECTION_ID)).thenReturn(collection);
+
+        // One SCO in the manifest with a gradebook external assessment defined
+        LaunchData sco = mock(LaunchData.class);
+        when(sco.getSCORMType()).thenReturn("sco");
+        when(sco.getItemIdentifier()).thenReturn("ITEM-1");
+        ContentPackageManifest manifest = mock(ContentPackageManifest.class);
+        when(manifest.getLaunchData()).thenReturn(List.of(sco));
+        when(contentPackageManifestDao.load(7L)).thenReturn(manifest);
+
+        when(gradingService.isExternalAssignmentDefined(SITE_ID, "100:ITEM-1")).thenReturn(true);
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getName()).thenReturn("Quiz");
+        when(assignment.getPoints()).thenReturn(10.0);
+        when(assignment.getCategoryId()).thenReturn(5L);
+        when(gradingService.getExternalAssignment(SITE_ID, "100:ITEM-1")).thenReturn(assignment);
+
+        Document doc = newDocument();
+        Element root = doc.createElement("archive");
+        doc.appendChild(root);
+        Stack<Element> stack = new Stack<>();
+        stack.push(root);
+
+        producer.archive(SITE_ID, doc, stack, archivePath, null);
+
+        Element cp = (Element) root.getElementsByTagName("contentpackage").item(0);
+        Element gb = (Element) cp.getElementsByTagName("gradebookitem").item(0);
+        assertNotNull("expected a gradebookitem element", gb);
+        assertEquals("ITEM-1", gb.getAttribute("itemIdentifier"));
+        assertEquals("Quiz", gb.getAttribute("name"));
+        assertEquals("10.0", gb.getAttribute("points"));
+        assertEquals("5", gb.getAttribute("categoryId"));
+    }
+
+    @Test
+    public void mergeRecreatesScoGradebookBindings() throws Exception
+    {
+        writeZip(new File(archivePath + ZIP_NAME), "imsmanifest.xml", "<manifest/>");
+
+        Document doc = newDocument();
+        Element scormRoot = doc.createElement("scorm");
+        doc.appendChild(scormRoot);
+        Element cp = doc.createElement("contentpackage");
+        cp.setAttribute("title", "My Package");
+        cp.setAttribute("archive", ZIP_NAME);
+        cp.setAttribute("dueOn", "2000");
+        Element gb = doc.createElement("gradebookitem");
+        gb.setAttribute("itemIdentifier", "ITEM-1");
+        gb.setAttribute("name", "Quiz");
+        gb.setAttribute("points", "10.0");
+        gb.setAttribute("categoryId", "5");
+        cp.appendChild(gb);
+        scormRoot.appendChild(cp);
+
+        when(scormContentService.getContentPackages(SITE_ID)).thenReturn(List.of());
+        when(serverConfigurationService.getString("scorm.zip.encoding", "UTF-8")).thenReturn("UTF-8");
+        when(scormResourceService.putArchive(any(), any(), eq("application/zip"), anyBoolean(), anyInt())).thenReturn("res-1");
+        when(scormContentService.storeAndValidate(eq("res-1"), anyBoolean(), eq("UTF-8"))).thenReturn(0);
+
+        ContentPackage created = new ContentPackage("My Package", UUID_1);
+        created.setContentPackageId(42L);
+        when(contentPackageDao.find(SITE_ID)).thenReturn(List.of()).thenReturn(List.of(created));
+        // No existing assessment under the new contentPackageId yet
+        when(gradingService.isExternalAssignmentDefined(SITE_ID, "42:ITEM-1")).thenReturn(false);
+
+        producer.merge(SITE_ID, scormRoot, archivePath + "scorm.xml", FROM_SITE_ID, new MergeConfig());
+
+        // External assessment recreated against the NEW contentPackageId, with the archived settings
+        verify(gradingService).addExternalAssessment(eq(SITE_ID), eq(SITE_ID), eq("42:ITEM-1"),
+                isNull(), eq("Quiz"), eq(10.0), eq(new Date(2000L)), eq(ScormConstants.SCORM_DFLT_TOOL_NAME),
+                isNull(), eq(false), eq(5L), isNull());
     }
 
     private static Document newDocument() throws Exception

--- a/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormTestConfiguration.java
+++ b/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormTestConfiguration.java
@@ -29,12 +29,15 @@ import org.sakaiproject.scorm.service.api.ScormResourceService;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
 
 /**
- * Spring test context for {@link ScormEntityProducer}. Collaborators are supplied as mock beans and the
- * producer is wired exactly as it is in production (spring-scorm-services.xml), without a database.
+ * Spring test context for {@link ScormEntityProducer}. Collaborators are supplied as mock beans, and the
+ * producer itself is loaded from the production bean definition (spring-scorm-entityproducer.xml) so the
+ * test exercises the real wiring without duplicating it and without a database.
  */
 @Configuration
+@ImportResource("classpath:org/sakaiproject/scorm/service/impl/spring-scorm-entityproducer.xml")
 public class ScormTestConfiguration {
 
     @Bean(name = "org.sakaiproject.scorm.service.api.ScormContentService")
@@ -80,24 +83,5 @@ public class ScormTestConfiguration {
     @Bean(name = "org.sakaiproject.entity.api.EntityManager")
     public EntityManager entityManager() {
         return mock(EntityManager.class);
-    }
-
-    @Bean
-    public ScormEntityProducer scormEntityProducer(ScormContentService scormContentService,
-            ScormResourceService scormResourceService, ContentHostingService contentHostingService,
-            ContentPackageDao contentPackageDao, ContentPackageManifestDao contentPackageManifestDao,
-            SecurityService securityService, ServerConfigurationService serverConfigurationService,
-            GradingService gradingService, EntityManager entityManager) {
-        ScormEntityProducer producer = new ScormEntityProducer();
-        producer.setScormContentService(scormContentService);
-        producer.setScormResourceService(scormResourceService);
-        producer.setContentHostingService(contentHostingService);
-        producer.setContentPackageDao(contentPackageDao);
-        producer.setContentPackageManifestDao(contentPackageManifestDao);
-        producer.setSecurityService(securityService);
-        producer.setServerConfigurationService(serverConfigurationService);
-        producer.setGradingService(gradingService);
-        producer.setEntityManager(entityManager);
-        return producer;
     }
 }

--- a/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormTestConfiguration.java
+++ b/scormplayer/scorm-impl/service/src/test/java/org/sakaiproject/scorm/service/impl/ScormTestConfiguration.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.scorm.service.impl;
+
+import static org.mockito.Mockito.mock;
+
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.grading.api.GradingService;
+import org.sakaiproject.scorm.dao.api.ContentPackageDao;
+import org.sakaiproject.scorm.dao.api.ContentPackageManifestDao;
+import org.sakaiproject.scorm.service.api.ScormContentService;
+import org.sakaiproject.scorm.service.api.ScormResourceService;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring test context for {@link ScormEntityProducer}. Collaborators are supplied as mock beans and the
+ * producer is wired exactly as it is in production (spring-scorm-services.xml), without a database.
+ */
+@Configuration
+public class ScormTestConfiguration {
+
+    @Bean(name = "org.sakaiproject.scorm.service.api.ScormContentService")
+    public ScormContentService scormContentService() {
+        return mock(ScormContentService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.scorm.service.api.ScormResourceService")
+    public ScormResourceService scormResourceService() {
+        return mock(ScormResourceService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.content.api.ContentHostingService")
+    public ContentHostingService contentHostingService() {
+        return mock(ContentHostingService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.scorm.dao.api.ContentPackageDao")
+    public ContentPackageDao contentPackageDao() {
+        return mock(ContentPackageDao.class);
+    }
+
+    @Bean(name = "org.sakaiproject.scorm.dao.api.ContentPackageManifestDao")
+    public ContentPackageManifestDao contentPackageManifestDao() {
+        return mock(ContentPackageManifestDao.class);
+    }
+
+    @Bean(name = "org.sakaiproject.authz.api.SecurityService")
+    public SecurityService securityService() {
+        return mock(SecurityService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.component.api.ServerConfigurationService")
+    public ServerConfigurationService serverConfigurationService() {
+        return mock(ServerConfigurationService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.grading.api.GradingService")
+    public GradingService gradingService() {
+        return mock(GradingService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.entity.api.EntityManager")
+    public EntityManager entityManager() {
+        return mock(EntityManager.class);
+    }
+
+    @Bean
+    public ScormEntityProducer scormEntityProducer(ScormContentService scormContentService,
+            ScormResourceService scormResourceService, ContentHostingService contentHostingService,
+            ContentPackageDao contentPackageDao, ContentPackageManifestDao contentPackageManifestDao,
+            SecurityService securityService, ServerConfigurationService serverConfigurationService,
+            GradingService gradingService, EntityManager entityManager) {
+        ScormEntityProducer producer = new ScormEntityProducer();
+        producer.setScormContentService(scormContentService);
+        producer.setScormResourceService(scormResourceService);
+        producer.setContentHostingService(contentHostingService);
+        producer.setContentPackageDao(contentPackageDao);
+        producer.setContentPackageManifestDao(contentPackageManifestDao);
+        producer.setSecurityService(securityService);
+        producer.setServerConfigurationService(serverConfigurationService);
+        producer.setGradingService(gradingService);
+        producer.setEntityManager(entityManager);
+        return producer;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SCORM content packages can be archived and merged between sites; each package is exported as its own zip with metadata and restored on import (including settings, attempts, TOC/nav options, and dates).
  * SCO gradebook bindings are preserved in archives and recreated during merge.
* **Configuration**
  * SCORM has been added to the default list of services allowed for archive merge/import operations.
* **Tests**
  * Added coverage for SCORM archive/merge behavior and gradebook binding persistence/restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->