### PR TITLE
SAK-51816 SCORM Add status translations and improve localization in reporting components

### DIFF
--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool.properties
@@ -5,3 +5,20 @@ paging.display.viewing = Viewing
 paging.display.to = to
 paging.display.of = of
 paging.display.suffix = Items
+
+# SCORM interaction result values (cmi.interactions.n.result)
+result.correct = Correct
+result.incorrect = Incorrect
+result.neutral = Neutral
+result.unanticipated = Unanticipated
+
+# SCORM success status values (cmi.success_status)
+success.status.passed = Passed
+success.status.failed = Failed
+success.status.unknown = Unknown
+
+# SCORM completion status values (cmi.completion_status)
+completion.status.completed = Completed
+completion.status.incomplete = Incomplete
+completion.status.not_attempted = Not Attempted
+completion.status.unknown = Unknown

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
@@ -5,3 +5,20 @@ paging.display.viewing=Visualizaci\u00f3n
 paging.display.to=para
 paging.display.of=por
 paging.display.suffix=\u00cdtems
+
+# SCORM interaction result values (cmi.interactions.n.result)
+result.correct=Correcto
+result.incorrect=Incorrecto
+result.neutral=Neutral
+result.unanticipated=Imprevisto
+
+# SCORM success status values (cmi.success_status)
+success.status.passed=Aprobado
+success.status.failed=No superado
+success.status.unknown=Desconocido
+
+# SCORM completion status values (cmi.completion_status)
+completion.status.completed=Completado
+completion.status.incomplete=Incompleto
+completion.status.not_attempted=No intentado
+completion.status.unknown=Desconocido

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
@@ -19,6 +19,6 @@ success.status.unknown=Desconocido
 
 # SCORM completion status values (cmi.completion_status)
 completion.status.completed=Completado
-completion.status.incomplete=Incompleto
+completion.status.incomplete=No completado
 completion.status.not_attempted=Sin intentos
 completion.status.unknown=Desconocido

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
@@ -20,5 +20,5 @@ success.status.unknown=Desconocido
 # SCORM completion status values (cmi.completion_status)
 completion.status.completed=Completado
 completion.status.incomplete=Incompleto
-completion.status.not_attempted=No intentado
+completion.status.not_attempted=Sin intentos
 completion.status.unknown=Desconocido

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_es.properties
@@ -10,7 +10,7 @@ paging.display.suffix=\u00cdtems
 result.correct=Correcto
 result.incorrect=Incorrecto
 result.neutral=Neutral
-result.unanticipated=Imprevisto
+result.unanticipated=Inesperado
 
 # SCORM success status values (cmi.success_status)
 success.status.passed=Aprobado

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_eu.properties
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool_eu.properties
@@ -5,3 +5,20 @@ paging.display.viewing=Bista
 paging.display.to=to
 paging.display.of=of
 paging.display.suffix=Itemak
+
+# SCORM interaction result values (cmi.interactions.n.result)
+result.correct=Zuzena
+result.incorrect=Okerra
+result.neutral=Neutroa
+result.unanticipated=Aurreikusi gabea
+
+# SCORM success status values (cmi.success_status)
+success.status.passed=Gaindituta
+success.status.failed=Ez gaindituta
+success.status.unknown=Ezezaguna
+
+# SCORM completion status values (cmi.completion_status)
+completion.status.completed=Osatuta
+completion.status.incomplete=Osatu gabe
+completion.status.not_attempted=Saiatu gabe
+completion.status.unknown=Ezezaguna

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormWebApplication.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormWebApplication.java
@@ -30,7 +30,7 @@ import org.sakaiproject.scorm.service.api.ScormResourceService;
 import org.sakaiproject.scorm.ui.ContentPackageResourceReference;
 import org.sakaiproject.scorm.ui.player.pages.ScormCompletionPage;
 import org.sakaiproject.scorm.ui.player.pages.ScormPlayerPage;
-import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.api.LocaleService;
 import org.sakaiproject.wicket.protocol.http.SakaiWebApplication;
 
 /**
@@ -47,6 +47,9 @@ public abstract class ScormWebApplication extends SakaiWebApplication
     @Getter @Setter
     private ContentHostingService contentHostingService;
 
+    @Getter @Setter
+    private LocaleService localeService;
+
     @Override
     public void init()
     {
@@ -55,6 +58,7 @@ public abstract class ScormWebApplication extends SakaiWebApplication
         mountPage( "scormCompletionPage", ScormCompletionPage.class );
         Objects.requireNonNull(serverConfigurationService, "serverConfigurationService must be set before init()");
         Objects.requireNonNull(contentHostingService, "contentHostingService must be set before init()");
+        Objects.requireNonNull(localeService, "localeService must be set before init()");
 
         mountResource( "/contentpackages/resourceName/private/scorm/${resourceID}/${resourceName}",
             new ContentPackageResourceReference(serverConfigurationService, contentHostingService) );
@@ -70,7 +74,7 @@ public abstract class ScormWebApplication extends SakaiWebApplication
     public Session newSession( Request request, Response response )
     {
         Session session = super.newSession( request, response );
-        session.setLocale( new ResourceLoader().getLocale() );
+        session.setLocale( localeService.getLocaleForCurrentSiteAndUser() );
         return session;
     }
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormWebApplication.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormWebApplication.java
@@ -20,12 +20,17 @@ import lombok.Setter;
 
 import java.util.Objects;
 
+import org.apache.wicket.Session;
+import org.apache.wicket.request.Request;
+import org.apache.wicket.request.Response;
+
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.scorm.service.api.ScormResourceService;
 import org.sakaiproject.scorm.ui.ContentPackageResourceReference;
 import org.sakaiproject.scorm.ui.player.pages.ScormCompletionPage;
 import org.sakaiproject.scorm.ui.player.pages.ScormPlayerPage;
+import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.wicket.protocol.http.SakaiWebApplication;
 
 /**
@@ -53,5 +58,19 @@ public abstract class ScormWebApplication extends SakaiWebApplication
 
         mountResource( "/contentpackages/resourceName/private/scorm/${resourceID}/${resourceName}",
             new ContentPackageResourceReference(serverConfigurationService, contentHostingService) );
+    }
+
+    /**
+     * Align the Wicket session locale with the user's Sakai language preference so that the tool's
+     * i18n bundles resolve to the same language as the surrounding Sakai portal. Without this, Wicket
+     * defaults to the browser's Accept-Language header and the tool can render in a different language
+     * than the rest of Sakai.
+     */
+    @Override
+    public Session newSession( Request request, Response response )
+    {
+        Session session = super.newSession( request, response );
+        session.setLocale( new ResourceLoader().getLocale() );
+        return session;
     }
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.java
@@ -15,6 +15,8 @@
  */
 package org.sakaiproject.scorm.ui.reporting.components;
 
+import java.util.Locale;
+
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -58,12 +60,12 @@ public class InteractionPanel extends Panel
 		add(new Label("weighting", String.valueOf(interaction.getWeighting())));
 		add(new Label("timestamp"));
 		add(new Label("latency"));
-		add(new Label("result"));
 
 		boolean showIcon = true;
 		boolean isNeutral = false;
 		ResourceReference resultIconReference = BLANK_ICON;
 		String result = interaction.getResult();
+		Label resultLabel;
 		if (result != null)
 		{
 			if (result.equalsIgnoreCase("correct"))
@@ -87,11 +89,16 @@ public class InteractionPanel extends Panel
 			{
 				showIcon = false;
 			}
+
+			// Translate the known result values, falling back to the raw value for anything unexpected
+			resultLabel = new Label("result", new ResourceModel("result." + result.toLowerCase(Locale.ROOT), result));
 		}
 		else
 		{
 			showIcon = false;
+			resultLabel = new Label("result", "");
 		}
+		add(resultLabel);
 
 		Icon resultIcon = new Icon("resultIcon", resultIconReference);
 		resultIcon.setVisible(showIcon);

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.java
@@ -16,16 +16,13 @@
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.List;
-import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.CompoundPropertyModel;
-import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.Model;
-import org.apache.wicket.model.ResourceModel;
 
 import org.sakaiproject.scorm.model.api.Objective;
 
@@ -60,31 +57,16 @@ public class ObjectivesPanel extends Panel
 		String completionStatus = objective.getCompletionStatus();
 
 		Label descLabel = new Label("description");
-		Label successLabel = new Label("successStatus", localizeStatus("success.status.", successStatus));
-		Label completionLabel = new Label("completionStatus", localizeStatus("completion.status.", completionStatus));
+		Label successLabel = new Label("successStatus", StatusLocalization.localizeStatus("success.status.", successStatus));
+		Label completionLabel = new Label("completionStatus", StatusLocalization.localizeStatus("completion.status.", completionStatus));
 
-		successLabel.setVisible(successStatus != null && successStatus.trim().length() != 0);
-		completionLabel.setVisible(completionStatus != null && completionStatus.trim().length() != 0);
+		successLabel.setVisible(StringUtils.isNotBlank(successStatus));
+		completionLabel.setVisible(StringUtils.isNotBlank(completionStatus));
 
 		item.add(descLabel);
 		item.add(new ScorePanel("score", objective.getScore()));
 		item.add(successLabel);
 		item.add(completionLabel);
 		container.add(item);
-	}
-
-	/**
-	 * Builds a model that translates a raw SCORM status value (e.g. "passed", "completed") via the
-	 * key "{keyPrefix}{value}", falling back to the raw value when no translation exists.
-	 */
-	private static IModel<String> localizeStatus(String keyPrefix, String value)
-	{
-		if (value == null || value.trim().isEmpty())
-		{
-			return Model.of("");
-		}
-
-		String key = keyPrefix + value.trim().toLowerCase(Locale.ROOT).replace(' ', '_');
-		return new ResourceModel(key, value);
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.java
@@ -16,12 +16,16 @@
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
 
 import org.sakaiproject.scorm.model.api.Objective;
 
@@ -52,17 +56,35 @@ public class ObjectivesPanel extends Panel
 		WebMarkupContainer item = new WebMarkupContainer(container.newChildId(), new CompoundPropertyModel(objective));
 		item.setRenderBodyOnly(true);
 
-		Label descLabel = new Label("description");
-		Label successLabel = new Label("successStatus");
-		Label completionLabel = new Label("completionStatus");
+		String successStatus = objective.getSuccessStatus();
+		String completionStatus = objective.getCompletionStatus();
 
-		successLabel.setVisible(objective.getSuccessStatus() != null && objective.getSuccessStatus().trim().length() != 0);
-		completionLabel.setVisible(objective.getCompletionStatus() != null && objective.getCompletionStatus().trim().length() != 0);
+		Label descLabel = new Label("description");
+		Label successLabel = new Label("successStatus", localizeStatus("success.status.", successStatus));
+		Label completionLabel = new Label("completionStatus", localizeStatus("completion.status.", completionStatus));
+
+		successLabel.setVisible(successStatus != null && successStatus.trim().length() != 0);
+		completionLabel.setVisible(completionStatus != null && completionStatus.trim().length() != 0);
 
 		item.add(descLabel);
 		item.add(new ScorePanel("score", objective.getScore()));
 		item.add(successLabel);
 		item.add(completionLabel);
 		container.add(item);
+	}
+
+	/**
+	 * Builds a model that translates a raw SCORM status value (e.g. "passed", "completed") via the
+	 * key "{keyPrefix}{value}", falling back to the raw value when no translation exists.
+	 */
+	private static IModel<String> localizeStatus(String keyPrefix, String value)
+	{
+		if (value == null || value.trim().isEmpty())
+		{
+			return Model.of("");
+		}
+
+		String key = keyPrefix + value.trim().toLowerCase(Locale.ROOT).replace(' ', '_');
+		return new ResourceModel(key, value);
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.java
@@ -17,14 +17,13 @@ package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
-import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.apache.wicket.model.ResourceModel;
 
 import org.sakaiproject.scorm.model.api.Progress;
 import org.sakaiproject.scorm.ui.reporting.util.ScormDurationFormatter;
@@ -67,10 +66,10 @@ public class ProgressPanel extends Panel
 
 		String successStatus = progress.getSuccessStatus();
 		String completionStatus = progress.getCompletionStatus();
-		Label successLabel = new Label("successStatus", localizeStatus("success.status.", successStatus));
-		Label completionLabel = new Label("completionStatus", localizeStatus("completion.status.", completionStatus));
-		successLabel.setVisible(successStatus != null && successStatus.trim().length() != 0);
-		completionLabel.setVisible(completionStatus != null && completionStatus.trim().length() != 0);
+		Label successLabel = new Label("successStatus", StatusLocalization.localizeStatus("success.status.", successStatus));
+		Label completionLabel = new Label("completionStatus", StatusLocalization.localizeStatus("completion.status.", completionStatus));
+		successLabel.setVisible(StringUtils.isNotBlank(successStatus));
+		completionLabel.setVisible(StringUtils.isNotBlank(completionStatus));
 		add(successLabel);
 		add(completionLabel);
 
@@ -79,20 +78,5 @@ public class ProgressPanel extends Panel
 		Label totalTimeLabel = new Label("totalTime", Model.of(formattedTotalTime != null ? formattedTotalTime : ""));
 		totalTimeLabel.setVisible(formattedTotalTime != null);
 		add(totalTimeLabel);
-	}
-
-	/**
-	 * Builds a model that translates a raw SCORM status value (e.g. "passed", "completed") via the
-	 * key "{keyPrefix}{value}", falling back to the raw value when no translation exists.
-	 */
-	private static IModel<String> localizeStatus(String keyPrefix, String value)
-	{
-		if (value == null || value.trim().isEmpty())
-		{
-			return Model.of("");
-		}
-
-		String key = keyPrefix + value.trim().toLowerCase(Locale.ROOT).replace(' ', '_');
-		return new ResourceModel(key, value);
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.java
@@ -22,7 +22,9 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
 
 import org.sakaiproject.scorm.model.api.Progress;
 import org.sakaiproject.scorm.ui.reporting.util.ScormDurationFormatter;
@@ -63,10 +65,12 @@ public class ProgressPanel extends Panel
 		}
 		add(percentBar);
 
-		Label successLabel = new Label("successStatus");
-		Label completionLabel = new Label("completionStatus");
-		successLabel.setVisible(progress.getSuccessStatus() != null && progress.getSuccessStatus().trim().length() != 0);
-		completionLabel.setVisible(progress.getCompletionStatus() != null && progress.getCompletionStatus().trim().length() != 0);
+		String successStatus = progress.getSuccessStatus();
+		String completionStatus = progress.getCompletionStatus();
+		Label successLabel = new Label("successStatus", localizeStatus("success.status.", successStatus));
+		Label completionLabel = new Label("completionStatus", localizeStatus("completion.status.", completionStatus));
+		successLabel.setVisible(successStatus != null && successStatus.trim().length() != 0);
+		completionLabel.setVisible(completionStatus != null && completionStatus.trim().length() != 0);
 		add(successLabel);
 		add(completionLabel);
 
@@ -75,5 +79,20 @@ public class ProgressPanel extends Panel
 		Label totalTimeLabel = new Label("totalTime", Model.of(formattedTotalTime != null ? formattedTotalTime : ""));
 		totalTimeLabel.setVisible(formattedTotalTime != null);
 		add(totalTimeLabel);
+	}
+
+	/**
+	 * Builds a model that translates a raw SCORM status value (e.g. "passed", "completed") via the
+	 * key "{keyPrefix}{value}", falling back to the raw value when no translation exists.
+	 */
+	private static IModel<String> localizeStatus(String keyPrefix, String value)
+	{
+		if (value == null || value.trim().isEmpty())
+		{
+			return Model.of("");
+		}
+
+		String key = keyPrefix + value.trim().toLowerCase(Locale.ROOT).replace(' ', '_');
+		return new ResourceModel(key, value);
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/StatusLocalization.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/StatusLocalization.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2007 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.scorm.ui.reporting.components;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
+
+public final class StatusLocalization
+{
+	private StatusLocalization()
+	{
+	}
+
+	public static IModel<String> localizeStatus(String keyPrefix, String value)
+	{
+		if (StringUtils.isBlank(value))
+		{
+			return Model.of("");
+		}
+
+		String trimmedValue = value.trim();
+		String key = keyPrefix + trimmedValue.toLowerCase(Locale.ROOT).replace(' ', '_');
+		return new ResourceModel(key, trimmedValue);
+	}
+}

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/BaseResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/BaseResultsPage.java
@@ -15,8 +15,11 @@
  */
 package org.sakaiproject.scorm.ui.reporting.pages;
 
+import java.util.Locale;
+
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.link.Link;
 import org.apache.wicket.markup.repeater.RepeatingView;
@@ -238,6 +241,37 @@ public abstract class BaseResultsPage extends ConsoleBasePage
 			}
 
 			return percentage;
+		}
+	}
+
+	public class StatusPropertyColumn extends DecoratedPropertyColumn
+	{
+		private static final long serialVersionUID = 1L;
+
+		private final String keyPrefix;
+
+		public StatusPropertyColumn(IModel displayModel, String sortProperty, String propertyExpression, String keyPrefix)
+		{
+			super(displayModel, sortProperty, propertyExpression);
+			this.keyPrefix = keyPrefix;
+		}
+
+		@Override
+		public Object convertObject(Object object)
+		{
+			if (object == null)
+			{
+				return "";
+			}
+
+			String value = object.toString().trim();
+			if (StringUtils.isBlank(value))
+			{
+				return "";
+			}
+
+			String key = keyPrefix + value.toLowerCase(Locale.ROOT).replace(' ', '_');
+			return getLocalizer().getString(key, BaseResultsPage.this, value);
 		}
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
@@ -17,6 +17,7 @@ package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
@@ -38,6 +39,7 @@ import org.sakaiproject.scorm.ui.reporting.components.InteractionPanel;
 import org.sakaiproject.scorm.ui.reporting.util.ObjectiveProvider;
 import org.sakaiproject.wicket.ajax.markup.html.table.SakaiDataTable;
 import org.sakaiproject.wicket.markup.html.link.BookmarkablePageLabeledLink;
+import org.sakaiproject.wicket.markup.html.repeater.data.table.DecoratedPropertyColumn;
 
 public class InteractionResultsPage extends BaseResultsPage
 {
@@ -156,9 +158,44 @@ public class InteractionResultsPage extends BaseResultsPage
 
 		columns.add(new PropertyColumn(idHeader, "id", "id"));
 		columns.add(new PropertyColumn(descriptionHeader, "description", "description"));
-		columns.add(new PropertyColumn(completionStatusHeader, "completionStatus", "completionStatus"));
-		columns.add(new PropertyColumn(successStatusHeader, "successStatus", "successStatus"));
+		columns.add(new StatusPropertyColumn(completionStatusHeader, "completionStatus", "completionStatus", "completion.status."));
+		columns.add(new StatusPropertyColumn(successStatusHeader, "successStatus", "successStatus", "success.status."));
 
 		return columns;
+	}
+
+	/**
+	 * Translates a raw SCORM status value (e.g. "completed", "passed") via the key "{keyPrefix}{value}",
+	 * falling back to the raw value when no translation exists.
+	 */
+	private class StatusPropertyColumn extends DecoratedPropertyColumn
+	{
+		private static final long serialVersionUID = 1L;
+
+		private final String keyPrefix;
+
+		public StatusPropertyColumn(IModel displayModel, String sortProperty, String propertyExpression, String keyPrefix)
+		{
+			super(displayModel, sortProperty, propertyExpression);
+			this.keyPrefix = keyPrefix;
+		}
+
+		@Override
+		public Object convertObject(Object object)
+		{
+			if (object == null)
+			{
+				return "";
+			}
+
+			String value = object.toString().trim();
+			if (value.isEmpty())
+			{
+				return "";
+			}
+
+			String key = keyPrefix + value.toLowerCase(Locale.ROOT).replace(' ', '_');
+			return getLocalizer().getString(key, InteractionResultsPage.this, value);
+		}
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
@@ -17,7 +17,6 @@ package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
@@ -39,7 +38,6 @@ import org.sakaiproject.scorm.ui.reporting.components.InteractionPanel;
 import org.sakaiproject.scorm.ui.reporting.util.ObjectiveProvider;
 import org.sakaiproject.wicket.ajax.markup.html.table.SakaiDataTable;
 import org.sakaiproject.wicket.markup.html.link.BookmarkablePageLabeledLink;
-import org.sakaiproject.wicket.markup.html.repeater.data.table.DecoratedPropertyColumn;
 
 public class InteractionResultsPage extends BaseResultsPage
 {
@@ -162,40 +160,5 @@ public class InteractionResultsPage extends BaseResultsPage
 		columns.add(new StatusPropertyColumn(successStatusHeader, "successStatus", "successStatus", "success.status."));
 
 		return columns;
-	}
-
-	/**
-	 * Translates a raw SCORM status value (e.g. "completed", "passed") via the key "{keyPrefix}{value}",
-	 * falling back to the raw value when no translation exists.
-	 */
-	private class StatusPropertyColumn extends DecoratedPropertyColumn
-	{
-		private static final long serialVersionUID = 1L;
-
-		private final String keyPrefix;
-
-		public StatusPropertyColumn(IModel displayModel, String sortProperty, String propertyExpression, String keyPrefix)
-		{
-			super(displayModel, sortProperty, propertyExpression);
-			this.keyPrefix = keyPrefix;
-		}
-
-		@Override
-		public Object convertObject(Object object)
-		{
-			if (object == null)
-			{
-				return "";
-			}
-
-			String value = object.toString().trim();
-			if (value.isEmpty())
-			{
-				return "";
-			}
-
-			String key = keyPrefix + value.toLowerCase(Locale.ROOT).replace(' ', '_');
-			return getLocalizer().getString(key, InteractionResultsPage.this, value);
-		}
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
@@ -17,6 +17,7 @@ package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
@@ -40,6 +41,7 @@ import org.sakaiproject.wicket.ajax.markup.html.table.SakaiDataTable;
 import org.sakaiproject.wicket.markup.html.link.BookmarkablePageLabeledLink;
 import org.sakaiproject.wicket.markup.html.repeater.data.table.Action;
 import org.sakaiproject.wicket.markup.html.repeater.data.table.ActionColumn;
+import org.sakaiproject.wicket.markup.html.repeater.data.table.DecoratedPropertyColumn;
 
 public class LearnerResultsPage extends BaseResultsPage
 {
@@ -163,9 +165,44 @@ public class LearnerResultsPage extends BaseResultsPage
 		columns.add(actionColumn);
 
 		columns.add(new PercentageColumn(scoreHeader, "scaled", "scaled"));
-		columns.add(new PropertyColumn(completedHeader, "completionStatus", "completionStatus"));
-		columns.add(new PropertyColumn(successHeader, "successStatus", "successStatus"));
+		columns.add(new StatusPropertyColumn(completedHeader, "completionStatus", "completionStatus", "completion.status."));
+		columns.add(new StatusPropertyColumn(successHeader, "successStatus", "successStatus", "success.status."));
 
 		return columns;
+	}
+
+	/**
+	 * Translates a raw SCORM status value (e.g. "completed", "passed") via the key "{keyPrefix}{value}",
+	 * falling back to the raw value when no translation exists.
+	 */
+	private class StatusPropertyColumn extends DecoratedPropertyColumn
+	{
+		private static final long serialVersionUID = 1L;
+
+		private final String keyPrefix;
+
+		public StatusPropertyColumn(IModel displayModel, String sortProperty, String propertyExpression, String keyPrefix)
+		{
+			super(displayModel, sortProperty, propertyExpression);
+			this.keyPrefix = keyPrefix;
+		}
+
+		@Override
+		public Object convertObject(Object object)
+		{
+			if (object == null)
+			{
+				return "";
+			}
+
+			String value = object.toString().trim();
+			if (value.isEmpty())
+			{
+				return "";
+			}
+
+			String key = keyPrefix + value.toLowerCase(Locale.ROOT).replace(' ', '_');
+			return getLocalizer().getString(key, LearnerResultsPage.this, value);
+		}
 	}
 }

--- a/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
+++ b/scormplayer/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
@@ -17,7 +17,6 @@ package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
@@ -41,7 +40,6 @@ import org.sakaiproject.wicket.ajax.markup.html.table.SakaiDataTable;
 import org.sakaiproject.wicket.markup.html.link.BookmarkablePageLabeledLink;
 import org.sakaiproject.wicket.markup.html.repeater.data.table.Action;
 import org.sakaiproject.wicket.markup.html.repeater.data.table.ActionColumn;
-import org.sakaiproject.wicket.markup.html.repeater.data.table.DecoratedPropertyColumn;
 
 public class LearnerResultsPage extends BaseResultsPage
 {
@@ -169,40 +167,5 @@ public class LearnerResultsPage extends BaseResultsPage
 		columns.add(new StatusPropertyColumn(successHeader, "successStatus", "successStatus", "success.status."));
 
 		return columns;
-	}
-
-	/**
-	 * Translates a raw SCORM status value (e.g. "completed", "passed") via the key "{keyPrefix}{value}",
-	 * falling back to the raw value when no translation exists.
-	 */
-	private class StatusPropertyColumn extends DecoratedPropertyColumn
-	{
-		private static final long serialVersionUID = 1L;
-
-		private final String keyPrefix;
-
-		public StatusPropertyColumn(IModel displayModel, String sortProperty, String propertyExpression, String keyPrefix)
-		{
-			super(displayModel, sortProperty, propertyExpression);
-			this.keyPrefix = keyPrefix;
-		}
-
-		@Override
-		public Object convertObject(Object object)
-		{
-			if (object == null)
-			{
-				return "";
-			}
-
-			String value = object.toString().trim();
-			if (value.isEmpty())
-			{
-				return "";
-			}
-
-			String key = keyPrefix + value.toLowerCase(Locale.ROOT).replace(' ', '_');
-			return getLocalizer().getString(key, LearnerResultsPage.this, value);
-		}
 	}
 }

--- a/scormplayer/scorm-tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/scormplayer/scorm-tool/src/webapp/WEB-INF/applicationContext.xml
@@ -9,6 +9,7 @@
 		<property name="resourceService"><ref bean="org.sakaiproject.scorm.service.api.ScormResourceService"/></property>
 		<property name="serverConfigurationService"><ref bean="org.sakaiproject.component.api.ServerConfigurationService"/></property>
 		<property name="contentHostingService"><ref bean="org.sakaiproject.content.api.ContentHostingService"/></property>
+		<property name="localeService"><ref bean="org.sakaiproject.util.api.LocaleService"/></property>
 	</bean>
 
 	<!-- SCORM single-package player tool -->
@@ -16,5 +17,6 @@
 		<property name="resourceService"><ref bean="org.sakaiproject.scorm.service.api.ScormResourceService"/></property>
 		<property name="serverConfigurationService"><ref bean="org.sakaiproject.component.api.ServerConfigurationService"/></property>
 		<property name="contentHostingService"><ref bean="org.sakaiproject.content.api.ContentHostingService"/></property>
+		<property name="localeService"><ref bean="org.sakaiproject.util.api.LocaleService"/></property>
 	</bean>
 </beans>

--- a/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/DecoratedPropertyColumn.java
+++ b/scormplayer/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/DecoratedPropertyColumn.java
@@ -33,9 +33,10 @@ public abstract class DecoratedPropertyColumn extends PropertyColumn
 		super(displayModel, sortProperty, propertyExpression);
 	}
 
-	protected IModel createLabelModel(IModel embeddedModel)
+	@Override
+	public IModel<?> getDataModel(IModel rowModel)
 	{
-		return new PropertyModel(embeddedModel, getPropertyExpression())
+		return new PropertyModel(rowModel, getPropertyExpression())
 		{
 			private static final long serialVersionUID = 1L;
 
@@ -45,7 +46,7 @@ public abstract class DecoratedPropertyColumn extends PropertyColumn
 				Object object = super.getObject();
 				return convertObject(object);
 			}
-			
+
 		};
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status values (interaction result, success, completion) are now localized across reporting pages and panels instead of showing raw codes.
  * Added new status text translations for Spanish and Basque.
  * Updated the tool UI to use the platform/site language selection for consistent i18n.
* **Bug Fixes**
  * Improved handling of missing/blank status values by rendering empty output and hiding related icons/columns rather than displaying unlocalized values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->