### PR TITLE
SAK-52626 Portal portal.google.universal_analytics_id should be null by default according to sakai.properties

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -291,7 +291,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
         timeoutDialogWarningSeconds = serverConfigurationService.getInt(PROP_PORTAL_TIMEOUT_DIALOG_WARN_SECONDS, 600);
         toolUrlPrefix = serverConfigurationService.getToolUrl();
         topLogin = serverConfigurationService.getBoolean(PROP_TOP_LOGIN, true);
-        universalAnalyticsId = serverConfigurationService.getString(PROP_GOOGLE_ANALYTICS_ID);
+        universalAnalyticsId = serverConfigurationService.getString(PROP_GOOGLE_ANALYTICS_ID, null);
         useBullhornAlerts = serverConfigurationService.getBoolean(PROP_BULLHORN_ALERTS_ENABLED, true);
 
         poweredBy = new ArrayList<>();


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google Analytics configuration handling to ensure it only loads when explicitly configured, preventing unintended initialization when the setting is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->