### PR TITLE
SAK-52607 Portal subsites remove the sakai.properties configuration

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -848,12 +848,6 @@
 # DEFAULT: site
 # portal.handler.default=site
 
-# Whether or not to include subsites in the portal. If set to never, subsites will never be included. 
-# If set to false, subsites may be included depending on the site preferences. 
-# If set to any other value, subsites will always be included. 
-# DEFAULT= none (null) = always include
-# portal.includesubsites=never
-
 # DEFAULT: - (a dash)
 # portal.mutable.pagename=
 
@@ -3938,13 +3932,6 @@
 # user.type.selector.1=registered
 # user.type.selector.2=maintain
 # user.type.selector.3=guest
-
-## SAK-22703 - Optionally group subsites into flyout menu
-## Default changed to true in SAK-32499
-# The flyout subsites menu is off by default. Grouping the subsites into a flyout menu can be very 
-# useful if you have a wide and shallow site hierarchy. To turn it on, set the following property to true. 
-# DEFAULT: true
-# portal.showSubsitesAsFlyout=false
 
 # ########################################################################
 # MSGCNTR

--- a/library/src/skins/default/src/sass/modules/_toolmenu.scss
+++ b/library/src/skins/default/src/sass/modules/_toolmenu.scss
@@ -140,7 +140,6 @@ body.is-logged-out{
 					}
 				}
 			}
-			// Properties for portal.showSubsitesAsFlyout=true
 			&.floating {
 				ul {
 					li {
@@ -167,17 +166,6 @@ body.is-logged-out{
 				}
 			}
 		}
-	}
-}
-
-// One cannot use @extend within a media query so this has been pulled out from
-// the showSubsitesAsFlyouts properties above.  This may change with a Sass upgrade.
-#subSites.floating a.#{$namespace}toolsNav__menuitem--link.is-invisible {
-	&:after {
-		@extend .fa-lg;
-		@extend .fa;
-		content: '\f070';
-		margin-left: auto;	// push it to the far side
 	}
 }
 

--- a/library/src/webapp/bundled-js/sakai.morpheus.toggletools.js
+++ b/library/src/webapp/bundled-js/sakai.morpheus.toggletools.js
@@ -19,9 +19,6 @@ portal.toggleMinimizeNav = function () {
 
   $PBJQ("body").toggleClass("Mrphs-toolMenu-collapsed");
 
-  // Remove any popout div for subsites.  Popout only displayed when portal.showSubsitesAsFlyout is set to true.
-  $PBJQ('#subSites.floating').css({'display': 'none'});
-
   var el = $PBJQ("#toolsNav-toggle-li button");
   el.toggleClass('min max').parent().toggleClass('min max');
 
@@ -35,38 +32,3 @@ portal.toggleMinimizeNav = function () {
     el.attr('aria-pressed', true);
   }
 };
-
-$PBJQ(document).ready(function () {
-//Shows or hides the subsites in a popout div. This isn't used unless
-// portal.showSubsitesAsFlyout is set to true in sakai.properties.
-
-    $PBJQ("#toolsNav-toggle-li button").on("click", portal.toggleMinimizeNav);
-    $PBJQ("#toggleSubsitesLink").click(function (e) {
-        var subsitesLink = $PBJQ(this);
-        if ($PBJQ('#subSites').css('display') == 'block') {
-            $PBJQ('#subSites').hide();
-            $PBJQ('#subSites').removeClass('floating');
-        } else {
-            var position = subsitesLink.position();
-            var _top = ( -1 * ( $PBJQ('#toolMenu').height() - position.top ) );
-            var subsitesPosition = ( MorpheusViewportHelper.isPhone() ) ? {
-            	'display': 'block',
-            	'top': 0,
-            	'overflow' : 'hidden'
-            }:{
-            	'display': 'block',
-            	'left': $PBJQ('#toolMenu').width() + 7 + 'px',	// width of arrow border
-            	'top': _top + 'px'
-            }
-            $PBJQ('#subSites').css(subsitesPosition);
-            $PBJQ('#subSites').addClass('floating');
-
-            // focus on first subsite for accessibility recommendations
-            $PBJQ('#subSites').find('li a').first().focus();
-
-            if ($PBJQ("#toggleSubsitesLink").position().top < 240) {
-                $PBJQ("#subSites.floating").addClass('ontop');
-            }
-        }
-    });
-});

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -342,18 +342,15 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		return siteMap;
 	}
 
-	private List<Map<String, Object>> getSiteMaps(Collection<Site> sites, String currentSiteId, String userId, boolean pinned, boolean hidden) {
+	private Map<String, String> getChildSiteMap(Site site) {
+		Map<String, String> childSiteMap = new HashMap<>();
+		childSiteMap.put("id", site.getId());
+		childSiteMap.put("title", site.getTitle());
+		childSiteMap.put("url", site.getUrl());
+		return childSiteMap;
+	}
 
-		// Precompute a mapping from parent site IDs to child site IDs.
-		Map<String, List<Map<String, String>>> parentToChildSites;
-		parentToChildSites = siteService.getSites(org.sakaiproject.site.api.SiteService.SelectionType.ACCESS,
-				null, null, null, org.sakaiproject.site.api.SiteService.SortType.TITLE_ASC, null).stream()
-				.filter(site -> site.getProperties().getProperty(PROP_PARENT_ID) != null)
-				.collect(Collectors.groupingBy(
-						site -> site.getProperties().getProperty(PROP_PARENT_ID),
-						Collectors.mapping(site -> Map.of("id", site.getId(), "title", site.getTitle()), Collectors.toList())
-				));
-
+	private List<Map<String, Object>> getSiteMaps(Collection<Site> sites, String currentSiteId, String userId, boolean pinned, boolean hidden, Map<String, List<Map<String, String>>> parentToChildSites) {
 		return sites.stream()
 			.map(site -> getSiteMap(site, currentSiteId, userId, pinned, hidden, parentToChildSites))
 			.collect(Collectors.toList());
@@ -457,12 +454,21 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 	public Map<String, Object> getContextSitesWithPages(HttpServletRequest req, String currentSiteId, String toolContextPath, boolean loggedIn) {
 
 		Map<String, Object> contextSites = new HashMap<>();
+		String userId = loggedIn ? sessionManager.getCurrentSessionUserId() : null;
+		List<String> excludedSiteIds = loggedIn ? getExcludedSiteIds(userId) : Collections.emptyList();
+		Map<String, List<Map<String, String>>> parentToChildSites = siteService.getSites(org.sakaiproject.site.api.SiteService.SelectionType.ACCESS,
+				null, null, null, org.sakaiproject.site.api.SiteService.SortType.TITLE_ASC, null).stream()
+				.filter(site -> !excludedSiteIds.contains(site.getId()))
+				.filter(site -> site.getProperties().getProperty(PROP_PARENT_ID) != null)
+				.collect(Collectors.groupingBy(
+						site -> site.getProperties().getProperty(PROP_PARENT_ID),
+						Collectors.mapping(this::getChildSiteMap, Collectors.toList())
+				));
+
 		if (loggedIn) {
             // Put Home site in context
-			String userId = sessionManager.getCurrentSessionUserId();
-			contextSites.put("homeSite", getSiteMap(getSite(siteService.getUserSiteId(userId)), currentSiteId, userId,false, false, null));
+			contextSites.put("homeSite", getSiteMap(getSite(siteService.getUserSiteId(userId)), currentSiteId, userId,false, false, parentToChildSites));
 
-			List<String> excludedSiteIds = getExcludedSiteIds(userId);
 			// Get pinned sites, excluded sites never appear in the pinned list including current site
             Collection<String> pinnedSiteIds = portalService.getPinnedSites(userId);
             Collection<Site> pinnedSites = pinnedSiteIds.stream()
@@ -470,7 +476,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					.map(this::getSite)
 					.filter(Objects::nonNull)
 					.collect(Collectors.toList());
-            List<Map<String, Object>> pinnedSiteMaps = getSiteMaps(pinnedSites, currentSiteId, userId,true, true);
+			List<Map<String, Object>> pinnedSiteMaps = getSiteMaps(pinnedSites, currentSiteId, userId,true, true, parentToChildSites);
             contextSites.put("pinnedSites", pinnedSiteMaps);
 
 			// Get most recent sites
@@ -494,11 +500,11 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					.map(this::getSite)
 					.filter(Objects::nonNull)
 					.collect(Collectors.toList());
-            List<Map<String, Object>> recentSitesMaps = getSiteMaps(recentSites, currentSiteId, userId, false, false);
+			List<Map<String, Object>> recentSitesMaps = getSiteMaps(recentSites, currentSiteId, userId, false, false, parentToChildSites);
 
 			// If the current site is excluded it should appear in recent as hidden
 			if (excludedSiteIds.contains(currentSiteId)) {
-				recentSitesMaps.add(getSiteMap(getSite(currentSiteId), currentSiteId, userId, false, true, null));
+				recentSitesMaps.add(getSiteMap(getSite(currentSiteId), currentSiteId, userId, false, true, parentToChildSites));
 			}
             contextSites.put("recentSites", recentSitesMaps);
 
@@ -512,7 +518,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			//Get gateway site
 			Site gatewaySite = getSite(currentSiteId);
 			if (!gatewaySite.isEmpty()) {
-				contextSites.put("gatewaySite", getSiteMap(gatewaySite, currentSiteId, null,false, false, null));
+				contextSites.put("gatewaySite", getSiteMap(gatewaySite, currentSiteId, null,false, false, parentToChildSites));
 			}
 		}
 		return contextSites;

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -40,7 +40,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -63,15 +62,15 @@ import org.sakaiproject.alias.api.Alias;
 import org.sakaiproject.alias.api.AliasService;
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.SecurityService;
-import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.entity.api.Entity;
+import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityProducer;
 import org.sakaiproject.entity.api.EntitySummary;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.Summary;
-import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.portal.api.Portal;
@@ -305,7 +304,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				.collect(Collectors.joining());
     }
 
-	private Map<String, Object> getSiteMap(Site site, String currentSiteId, String userId, boolean pinned, boolean hidden, boolean includePages, Map<String, List<Map<String, String>>> parentToChildSites) {
+	private Map<String, Object> getSiteMap(Site site, String currentSiteId, String userId, boolean pinned, boolean hidden, Map<String, List<Map<String, String>>> parentToChildSites) {
 
 		Map<String, Object> siteMap = new HashMap<>();
 		siteMap.put("id", site.getId());
@@ -329,40 +328,34 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		siteMap.put("isCurrent", site.getId().equals(currentSiteId));
 		siteMap.put("isHidden", hidden);
 		siteMap.put("currentSiteId", currentSiteId);
-		if (includePages) {
-			List<SitePage> pageList = getPermittedPagesInOrder(site);
-			siteMap.put("pages", getPageMaps(pageList, site));
+		List<SitePage> pageList = getPermittedPagesInOrder(site);
+		siteMap.put("pages", getPageMaps(pageList, site));
 
-			if (Boolean.parseBoolean(site.getProperties().getProperty("subpagenav")) && !pageList.isEmpty()) {
-				siteMap.put("subPages", getSubPages(userId, site.getId(), pageList));
-			}
-			if (parentToChildSites != null) {
-				// Add the childSiteIds: these are the IDs of sites whose parent is the current site.
-				siteMap.put("childSites", parentToChildSites.get(site.getId()));
-				siteMap.put("parentSiteId", site.getProperties().getProperty(PROP_PARENT_ID));
-			}
+		if (Boolean.parseBoolean(site.getProperties().getProperty("subpagenav")) && !pageList.isEmpty()) {
+			siteMap.put("subPages", getSubPages(userId, site.getId(), pageList));
+		}
+		if (parentToChildSites != null) {
+			// Add the childSiteIds: these are the IDs of sites whose parent is the current site.
+			siteMap.put("childSites", parentToChildSites.get(site.getId()));
+			siteMap.put("parentSiteId", site.getProperties().getProperty(PROP_PARENT_ID));
 		}
 		return siteMap;
 	}
 
-	private List<Map<String, Object>> getSiteMaps(Collection<Site> sites, String currentSiteId, String userId, boolean pinned, boolean hidden, boolean includePages) {
+	private List<Map<String, Object>> getSiteMaps(Collection<Site> sites, String currentSiteId, String userId, boolean pinned, boolean hidden) {
 
 		// Precompute a mapping from parent site IDs to child site IDs.
 		Map<String, List<Map<String, String>>> parentToChildSites;
-		if (!Arrays.asList("false", "never").contains(serverConfigurationService.getString("portal.includesubsites", "false"))) {
-			parentToChildSites = siteService.getSites(org.sakaiproject.site.api.SiteService.SelectionType.ACCESS,
-					null, null, null, org.sakaiproject.site.api.SiteService.SortType.TITLE_ASC, null).stream()
-					.filter(site -> site.getProperties().getProperty(PROP_PARENT_ID) != null)
-					.collect(Collectors.groupingBy(
-							site -> site.getProperties().getProperty(PROP_PARENT_ID),
-							Collectors.mapping(site -> Map.of("id", site.getId(), "title", site.getTitle()), Collectors.toList())
-					));
-		} else {
-			parentToChildSites = null;
-		}
+		parentToChildSites = siteService.getSites(org.sakaiproject.site.api.SiteService.SelectionType.ACCESS,
+				null, null, null, org.sakaiproject.site.api.SiteService.SortType.TITLE_ASC, null).stream()
+				.filter(site -> site.getProperties().getProperty(PROP_PARENT_ID) != null)
+				.collect(Collectors.groupingBy(
+						site -> site.getProperties().getProperty(PROP_PARENT_ID),
+						Collectors.mapping(site -> Map.of("id", site.getId(), "title", site.getTitle()), Collectors.toList())
+				));
 
 		return sites.stream()
-			.map(site -> getSiteMap(site, currentSiteId, userId, pinned, hidden, includePages, parentToChildSites))
+			.map(site -> getSiteMap(site, currentSiteId, userId, pinned, hidden, parentToChildSites))
 			.collect(Collectors.toList());
 	}
 
@@ -467,7 +460,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		if (loggedIn) {
             // Put Home site in context
 			String userId = sessionManager.getCurrentSessionUserId();
-			contextSites.put("homeSite", getSiteMap(getSite(siteService.getUserSiteId(userId)), currentSiteId, userId,false, false, true, null));
+			contextSites.put("homeSite", getSiteMap(getSite(siteService.getUserSiteId(userId)), currentSiteId, userId,false, false, null));
 
 			List<String> excludedSiteIds = getExcludedSiteIds(userId);
 			// Get pinned sites, excluded sites never appear in the pinned list including current site
@@ -477,7 +470,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					.map(this::getSite)
 					.filter(Objects::nonNull)
 					.collect(Collectors.toList());
-            List<Map<String, Object>> pinnedSiteMaps = getSiteMaps(pinnedSites, currentSiteId, userId,true, false, true);
+            List<Map<String, Object>> pinnedSiteMaps = getSiteMaps(pinnedSites, currentSiteId, userId,true, true);
             contextSites.put("pinnedSites", pinnedSiteMaps);
 
 			// Get most recent sites
@@ -501,11 +494,11 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					.map(this::getSite)
 					.filter(Objects::nonNull)
 					.collect(Collectors.toList());
-            List<Map<String, Object>> recentSitesMaps = getSiteMaps(recentSites, currentSiteId, userId, false, false, true);
+            List<Map<String, Object>> recentSitesMaps = getSiteMaps(recentSites, currentSiteId, userId, false, false);
 
 			// If the current site is excluded it should appear in recent as hidden
 			if (excludedSiteIds.contains(currentSiteId)) {
-				recentSitesMaps.add(getSiteMap(getSite(currentSiteId), currentSiteId, userId, false, true, true, null));
+				recentSitesMaps.add(getSiteMap(getSite(currentSiteId), currentSiteId, userId, false, true, null));
 			}
             contextSites.put("recentSites", recentSitesMaps);
 
@@ -519,7 +512,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			//Get gateway site
 			Site gatewaySite = getSite(currentSiteId);
 			if (!gatewaySite.isEmpty()) {
-				contextSites.put("gatewaySite", getSiteMap(gatewaySite, currentSiteId, null,false, false, true, null));
+				contextSites.put("gatewaySite", getSiteMap(gatewaySite, currentSiteId, null,false, false, null));
 			}
 		}
 		return contextSites;

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -1,4 +1,4 @@
-#macro(siteListItem $type $site $isExpanded)
+#macro(siteListItem $type $site $isExpanded $indentation)
 
     ## Remove those special site chars. They don't play well with html attributes.
     #set ($safeSiteId = $site.id.replace("!", "").replace("~", "").replace(".",""))
@@ -73,21 +73,33 @@
                 #pageListItem ($page, $pageUrl, "${page.icon}", 4)
             #end
             #if ($site.childSites)
-                <li class="nav-item">
-                    <div class="ps-2">
-                        <div class="dropdown">
-                            <button class="btn btn-nav w-100 dropdown-toggle pe-3 d-flex align-items-center justify-content-between" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <div class="d-flex align-items-center">
-                                    <span class="me-1 bi bi-diagram-2" aria-hidden="true"></span>
-                                    <span>$rloader.sitenav_sub_sites</span>
-                                </div>
-                            </button>
-                            <ul class="dropdown-menu w-100">
-                                #foreach($childSite in $site.childSites)
-                                    <li><a class="dropdown-item px-3 py-2" href="/portal/site/$childSite.id">$ftext.escapeHtml(${childSite.title})</a></li>
-                                #end
-                            </ul>
+                #set($subsiteCollapseId = "${type}-site-${safeSiteId}-subsites")
+
+                <li class="nav-item ms-${indentation}">
+                    <button class="btn btn-nav w-100 ps-3 collapsed"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#${subsiteCollapseId}"
+                            aria-expanded="false"
+                            aria-controls="${subsiteCollapseId}">
+                        <div class="d-flex text-start align-items-center">
+                            <div class="d-flex w-100">
+                                <span class="bi bi-diagram-3 me-1" aria-hidden="true"></span>
+                                <span>$rloader.sitenav_sub_sites</span>
+                            </div>
                         </div>
+                    </button>
+
+                    <div id="${subsiteCollapseId}" class="pt-1 collapse">
+                        <ul class="nav flex-column">
+                            #foreach($childSite in $site.childSites)
+                                <li class="nav-item">
+                                    <a class="btn btn-nav w-100 rounded-end text-start ps-5" href="/portal/site/$childSite.id">
+                                        <span class="me-2 bi bi-arrow-return-right" aria-hidden="true"></span>
+                                        <span>$ftext.escapeHtml(${childSite.title})</span>
+                                    </a>
+                                </li>
+                            #end
+                        </ul>
                     </div>
                 </li>
             #end
@@ -136,14 +148,14 @@
         #if (${userIsLoggedIn})
             <div id="sites-section-first" class="sites-section">
                 <ul class="mb-0">
-                    #siteListItem("home", $sidebarSites.homeSite, false)
+                    #siteListItem("home", $sidebarSites.homeSite, false, 3)
                 </ul>
             </div>
             <div class="sites-section pinned-site-section">
                 <h3 class="sites-section-heading #if (! $showSiteLabels) d-none #end">${rloader.sitenav_title_pinned}</h3>
                 <ul id="pinned-site-list" class="mb-0 #if ($sidebarSites.pinnedSites.empty)d-none#end">
                     #foreach ($site in $sidebarSites.pinnedSites)
-                        #siteListItem("pinned", $site, false)
+                        #siteListItem("pinned", $site, false, 3)
                     #end
                 </ul>
                 #if (${showSiteLabels})
@@ -156,7 +168,7 @@
                 <h3 class="sites-section-heading #if (! $showSiteLabels) d-none #end">${rloader.sitenav_title_recent}</h3>
                 <ul id="recent-site-list" class="mb-0">
                     #foreach ($site in $sidebarSites.recentSites)
-                        #siteListItem("recent", $site, false)
+                        #siteListItem("recent", $site, false, 3)
                     #end
                 </ul>
             </div>
@@ -165,7 +177,7 @@
                 <div class="sites-section">
                     <h3 class="visually-hidden sites-section-heading">${rloader.sitenav_title_current}</h3>
                     <ul class="pt-2 mb-0">
-                        #siteListItem("gateway", $sidebarSites.gatewaySite, true)
+                        #siteListItem("gateway", $sidebarSites.gatewaySite, true, 3)
                     </ul>
                 </div>
             #end

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -93,7 +93,7 @@
                         <ul class="nav flex-column">
                             #foreach($childSite in $site.childSites)
                                 <li class="nav-item">
-                                    <a class="btn btn-nav w-100 rounded-end text-start ps-5" href="/portal/site/$childSite.id">
+                                    <a class="btn btn-nav w-100 rounded-end text-start ps-5" href="$!{childSite.url}">
                                         <span class="me-2 bi bi-arrow-return-right" aria-hidden="true"></span>
                                         <span>$ftext.escapeHtml(${childSite.title})</span>
                                     </a>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subsites now display as collapsible, indented nested lists in site navigation instead of a flyout.

* **Chores**
  * Removed obsolete commented configuration and outdated UI event wiring related to the previous subsites menu.
  * Simplified site-context generation logic to always include page information and streamline parent/child site handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->