### PR TITLE
SAK-52619 Gradebook fix grade preview in dark mode

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -19,11 +19,18 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <axe.core.version>4.11.3</axe.core.version>
     <junit.jupiter.version>5.12.1</junit.jupiter.version>
     <playwright.version>1.58.0</playwright.version>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.deque.html.axe-core</groupId>
+      <artifactId>playwright</artifactId>
+      <version>${axe.core.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.microsoft.playwright</groupId>
       <artifactId>playwright</artifactId>

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GradebookTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GradebookTest.java
@@ -18,9 +18,14 @@ package org.sakaiproject.e2e.tests;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.deque.html.axecore.playwright.AxeBuilder;
+import com.deque.html.axecore.results.AxeResults;
+import com.deque.html.axecore.results.CheckedNode;
+import com.deque.html.axecore.results.Rule;
 import com.microsoft.playwright.Locator;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -108,7 +113,7 @@ class GradebookTest extends SakaiUiTestBase {
 
     @Test
     @Order(4)
-    void courseGradePreviewIsReadableInDarkMode() {
+    void courseGradePreviewHasAccessibleContrast() {
         sakai.login("instructor1");
         page.navigate(sakaiUrl);
         sakai.toolClick("Gradebook");
@@ -143,30 +148,33 @@ class GradebookTest extends SakaiUiTestBase {
 
         page.evaluate("() => document.documentElement.classList.add('sakaiUserTheme-dark')");
         assertThat(preview).isVisible();
-        assertTrue(contrastRatio(preview) >= 4.5,
-            "Course grade preview should have readable contrast in dark mode");
+        assertNoAxeContrastViolations("dark mode");
 
         page.evaluate("() => document.documentElement.classList.remove('sakaiUserTheme-dark')");
-        assertTrue(contrastRatio(preview) >= 4.5,
-            "Course grade preview should have readable contrast in light mode");
+        assertNoAxeContrastViolations("light mode");
     }
 
-    private double contrastRatio(Locator locator) {
-        Number contrast = (Number) locator.evaluate("el => {"
-            + "const style = getComputedStyle(el);"
-            + "const rgb = value => value.match(/\\d+(\\.\\d+)?/g).slice(0, 3).map(Number);"
-            + "const channel = value => {"
-            + "  const normalized = value / 255;"
-            + "  return normalized <= 0.03928 ? normalized / 12.92 : Math.pow((normalized + 0.055) / 1.055, 2.4);"
-            + "};"
-            + "const luminance = values => 0.2126 * channel(values[0])"
-            + "  + 0.7152 * channel(values[1]) + 0.0722 * channel(values[2]);"
-            + "const foreground = luminance(rgb(style.color));"
-            + "const background = luminance(rgb(style.backgroundColor));"
-            + "const light = Math.max(foreground, background);"
-            + "const dark = Math.min(foreground, background);"
-            + "return (light + 0.05) / (dark + 0.05);"
-            + "}");
-        return contrast.doubleValue();
+    private void assertNoAxeContrastViolations(String theme) {
+        AxeResults results = new AxeBuilder(page)
+            .include("#settingsGradeRelease")
+            .withRules(List.of("color-contrast"))
+            .analyze();
+
+        assertTrue(results.violationFree(),
+            "Grade Release Rules should have no axe color-contrast violations in " + theme
+                + System.lineSeparator() + formatAxeViolations(results.getViolations()));
+    }
+
+    private String formatAxeViolations(List<Rule> violations) {
+        return violations.stream()
+            .map(rule -> rule.getId() + ": " + rule.getHelp() + System.lineSeparator()
+                + rule.getNodes().stream()
+                    .map(this::formatAxeNode)
+                    .collect(Collectors.joining(System.lineSeparator())))
+            .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private String formatAxeNode(CheckedNode node) {
+        return "  " + node.getTarget() + " - " + node.getFailureSummary();
     }
 }

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GradebookTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GradebookTest.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.e2e.tests;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.microsoft.playwright.Locator;
 import java.util.List;
@@ -103,5 +104,69 @@ class GradebookTest extends SakaiUiTestBase {
         if (cancelButton.count() > 0) {
             cancelButton.click(new Locator.ClickOptions().setForce(true));
         }
+    }
+
+    @Test
+    @Order(4)
+    void courseGradePreviewIsReadableInDarkMode() {
+        sakai.login("instructor1");
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Gradebook");
+
+        page.locator(".navIntraTool a")
+            .filter(new Locator.FilterOptions().setHasText("Settings"))
+            .first()
+            .click(new Locator.ClickOptions().setForce(true));
+
+        Locator gradeReleaseButton = page.locator(".accordion button")
+            .filter(new Locator.FilterOptions().setHasText("Grade Release Rules"))
+            .first();
+        assertThat(gradeReleaseButton).isVisible();
+        if (!"true".equals(gradeReleaseButton.getAttribute("aria-expanded"))) {
+            gradeReleaseButton.click(new Locator.ClickOptions().setForce(true));
+        }
+
+        Locator displayCourseGrade = page.locator("label")
+            .filter(new Locator.FilterOptions().setHasText("Display final course grade to students"))
+            .locator("input[type=\"checkbox\"]")
+            .first();
+        assertThat(displayCourseGrade).isVisible();
+        if (!displayCourseGrade.isChecked()) {
+            displayCourseGrade.check(new Locator.CheckOptions().setForce(true));
+        }
+
+        Locator preview = page.locator("#settingsGradeRelease .form-group")
+            .filter(new Locator.FilterOptions().setHasText("Preview"))
+            .locator("span")
+            .nth(1);
+        assertThat(preview).isVisible();
+
+        page.evaluate("() => document.documentElement.classList.add('sakaiUserTheme-dark')");
+        assertThat(preview).isVisible();
+        assertTrue(contrastRatio(preview) >= 4.5,
+            "Course grade preview should have readable contrast in dark mode");
+
+        page.evaluate("() => document.documentElement.classList.remove('sakaiUserTheme-dark')");
+        assertTrue(contrastRatio(preview) >= 4.5,
+            "Course grade preview should have readable contrast in light mode");
+    }
+
+    private double contrastRatio(Locator locator) {
+        Number contrast = (Number) locator.evaluate("el => {"
+            + "const style = getComputedStyle(el);"
+            + "const rgb = value => value.match(/\\d+(\\.\\d+)?/g).slice(0, 3).map(Number);"
+            + "const channel = value => {"
+            + "  const normalized = value / 255;"
+            + "  return normalized <= 0.03928 ? normalized / 12.92 : Math.pow((normalized + 0.055) / 1.055, 2.4);"
+            + "};"
+            + "const luminance = values => 0.2126 * channel(values[0])"
+            + "  + 0.7152 * channel(values[1]) + 0.0722 * channel(values[2]);"
+            + "const foreground = luminance(rgb(style.color));"
+            + "const background = luminance(rgb(style.backgroundColor));"
+            + "const light = Math.max(foreground, background);"
+            + "const dark = Math.min(foreground, background);"
+            + "return (light + 0.05) / (dark + 0.05);"
+            + "}");
+        return contrast.doubleValue();
     }
 }

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/SettingsGradeReleasePanel.html
@@ -69,9 +69,9 @@
 					
 				</div>
 				
-				<div class="form-group" wicket:id="courseGradePreview">
+				<div class="form-group d-flex align-items-center gap-2 flex-wrap" wicket:id="courseGradePreview">
 					<span><wicket:message key="settingspage.displaycoursegrade.preview" /></span>
-					<span class="bg-info text-dark" wicket:id="preview">X+ 99%</span>
+					<span class="badge bg-info" wicket:id="preview">X+ 99%</span>
 				</div>
 				
 				<div class="checkbox" wicket:id="allowStudentsToCompareGradesContainer">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured course grade preview meets color-contrast requirements in both light and dark modes.

* **Style**
  * Improved layout and spacing of the course grade preview component and adjusted its badge styling.

* **Tests**
  * Added an automated accessibility test that checks the grade preview for color-contrast violations across themes and fails on any violations.

* **Chores**
  * Updated test configuration to include an accessibility analysis tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->