### PR TITLE
SAK-52629 DateManager hide unused bulk fields

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/support/SakaiHelper.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/support/SakaiHelper.java
@@ -218,9 +218,11 @@ public class SakaiHelper {
         }
 
         Map<String, String> toolLabelFallbacks = toolLabelFallbacks();
+        List<String> requestedToolIds = normalizedToolIds(toolIds);
 
-        for (String rawToolId : toolIds) {
-            String toolId = normalizeToolId(rawToolId);
+        uncheckUnrequestedToolCheckboxes(requestedToolIds);
+
+        for (String toolId : requestedToolIds) {
             Locator checkbox = page.locator("input#" + cssEscape(toolId)).first();
             boolean selected = false;
             if (checkbox.count() > 0 && checkbox.isVisible()) {
@@ -245,7 +247,9 @@ public class SakaiHelper {
             }
         }
 
-        if (toolIds.stream().map(this::normalizeToolId).anyMatch("sakai.lessonbuildertool"::equals)) {
+        uncheckUnrequestedToolCheckboxes(requestedToolIds);
+
+        if (requestedToolIds.stream().anyMatch("sakai.lessonbuildertool"::equals)) {
             Locator lessonContinue = page.locator("#btnContinue").first();
             if (lessonContinue.count() > 0 && lessonContinue.isVisible()) {
                 lessonContinue.click(new Locator.ClickOptions().setForce(true));
@@ -660,15 +664,35 @@ public class SakaiHelper {
     }
 
     private String courseCacheKey(String username, List<String> toolIds) {
+        List<String> normalizedToolIds = normalizedToolIds(toolIds);
+        Collections.sort(normalizedToolIds);
+        String toolKey = String.join(",", normalizedToolIds);
+        return username + "|" + toolKey;
+    }
+
+    private List<String> normalizedToolIds(List<String> toolIds) {
         List<String> normalizedToolIds = new ArrayList<>();
         if (toolIds != null) {
             for (String toolId : toolIds) {
                 normalizedToolIds.add(normalizeToolId(toolId));
             }
         }
-        Collections.sort(normalizedToolIds);
-        String toolKey = String.join(",", normalizedToolIds);
-        return username + "|" + toolKey;
+        return normalizedToolIds;
+    }
+
+    private void uncheckUnrequestedToolCheckboxes(List<String> requestedToolIds) {
+        Locator checkboxes = page.locator("input[type=\"checkbox\"][name=\"selectedTools\"]");
+        int count = checkboxes.count();
+
+        for (int index = 0; index < count; index++) {
+            Locator checkbox = checkboxes.nth(index);
+            String toolId = checkbox.getAttribute("value");
+            if (toolId == null || requestedToolIds.contains(toolId) || !checkbox.isChecked() || checkbox.isDisabled()) {
+                continue;
+            }
+
+            checkbox.uncheck(new Locator.UncheckOptions().setForce(true));
+        }
     }
 
     private String toDateTimeLocal(String value) {

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.options.AriaRole;
 import com.microsoft.playwright.options.SelectOption;
 import java.time.LocalDate;
@@ -279,13 +280,14 @@ class AssignmentTest extends SakaiUiTestBase {
         assignmentRow.locator("input[type=\"checkbox\"]").first().check(new Locator.CheckOptions().setForce(true));
         page.locator("#btnPublish").click(new Locator.ClickOptions().setForce(true));
         page.locator("input[name=\"eventSubmit_doPublish_assignment\"]").click(new Locator.ClickOptions().setForce(true));
-        assertThat(page.locator("body")).containsText(bulkPublishTitle);
+        page.waitForLoadState(com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED);
+        assertAssignmentRowVisible(bulkPublishTitle);
 
         sakai.toolClick("Calendar");
-        assertThat(page.locator("body")).containsText(bulkPublishTitle);
+        assertVisibleCalendarEntry(bulkPublishTitle);
 
         sakai.toolClick("Announcements");
-        assertThat(page.locator("body")).containsText(bulkPublishTitle);
+        assertVisibleAnnouncement(bulkPublishTitle);
     }
 
     private void openAddAssignmentForm() {
@@ -373,5 +375,20 @@ class AssignmentTest extends SakaiUiTestBase {
         } catch (RuntimeException e) {
             return false;
         }
+    }
+
+    private void assertAssignmentRowVisible(String title) {
+        assertThat(page.locator("tr").filter(new Locator.FilterOptions().setHasText(title)).first())
+            .isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+    }
+
+    private void assertVisibleCalendarEntry(String title) {
+        assertThat(page.locator("a, td, span").filter(new Locator.FilterOptions().setHasText(title)).first())
+            .isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+    }
+
+    private void assertVisibleAnnouncement(String title) {
+        assertThat(page.locator("table a").filter(new Locator.FilterOptions().setHasText(title)).first())
+            .isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
     }
 }

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.microsoft.playwright.Locator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+class DateManagerTest extends SakaiUiTestBase {
+
+    @Test
+    void bulkSetterOnlyShowsFieldsForSiteTools() {
+        sakai.login("instructor1");
+
+        String gradebookResourcesSite = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng", "sakai\\.resources"));
+        page.navigate(gradebookResourcesSite);
+        openDateManager();
+
+        assertBulkDateFieldVisible("bulk-open-date");
+        assertBulkDateFieldVisible("bulk-due-date");
+        assertBulkDateFieldHidden("bulk-accept-until");
+        assertBulkDateFieldHidden("bulk-feedback-start");
+        assertBulkDateFieldHidden("bulk-feedback-end");
+        assertBulkDateFieldHidden("bulk-signup-begins");
+        assertBulkDateFieldHidden("bulk-signup-deadline");
+
+        String assignmentsSite = sakai.createCourse("instructor1",
+            List.of("sakai\\.gradebookng", "sakai\\.resources", "sakai\\.assignment\\.grades"));
+        page.navigate(assignmentsSite);
+        openDateManager();
+
+        assertBulkDateFieldVisible("bulk-open-date");
+        assertBulkDateFieldVisible("bulk-due-date");
+        assertBulkDateFieldVisible("bulk-accept-until");
+        assertBulkDateFieldHidden("bulk-feedback-start");
+        assertBulkDateFieldHidden("bulk-feedback-end");
+        assertBulkDateFieldHidden("bulk-signup-begins");
+        assertBulkDateFieldHidden("bulk-signup-deadline");
+
+        String gradebookOnlySite = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng"));
+        page.navigate(gradebookOnlySite);
+        openDateManager();
+
+        assertBulkDateFieldVisible("bulk-due-date");
+        assertBulkDateFieldHidden("bulk-open-date");
+        assertBulkDateFieldHidden("bulk-accept-until");
+
+        String assessmentsSite = sakai.createCourse("instructor1", List.of("sakai\\.samigo"));
+        page.navigate(assessmentsSite);
+        openDateManager();
+
+        assertBulkDateFieldVisible("bulk-open-date");
+        assertBulkDateFieldVisible("bulk-due-date");
+        assertBulkDateFieldVisible("bulk-accept-until");
+        assertBulkDateFieldVisible("bulk-feedback-start");
+        assertBulkDateFieldVisible("bulk-feedback-end");
+        assertBulkDateFieldHidden("bulk-signup-begins");
+        assertBulkDateFieldHidden("bulk-signup-deadline");
+
+        String signupSite = sakai.createCourse("instructor1", List.of("sakai\\.signup"));
+        page.navigate(signupSite);
+        openDateManager();
+
+        assertBulkDateFieldVisible("bulk-open-date");
+        assertBulkDateFieldVisible("bulk-due-date");
+        assertBulkDateFieldVisible("bulk-signup-begins");
+        assertBulkDateFieldVisible("bulk-signup-deadline");
+        assertBulkDateFieldHidden("bulk-accept-until");
+        assertBulkDateFieldHidden("bulk-feedback-start");
+        assertBulkDateFieldHidden("bulk-feedback-end");
+
+        String lessonsSite = sakai.createCourse("instructor1", List.of("sakai\\.lessonbuildertool"));
+        page.navigate(lessonsSite);
+        openDateManager();
+
+        assertBulkDateFieldVisible("bulk-open-date");
+        assertBulkDateFieldHidden("bulk-due-date");
+        assertBulkDateFieldHidden("bulk-accept-until");
+
+        String dashboardOnlySite = sakai.createCourse("instructor1", List.of("sakai\\.dashboard"));
+        page.navigate(dashboardOnlySite);
+        openDateManager();
+
+        assertThat(page.locator(".date-manager-setter")).hasCount(0);
+    }
+
+    private void openDateManager() {
+        sakai.toolClick("Site Info");
+        Locator dateManager = page.locator(".navIntraTool a, .navIntraTool button")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Date Manager$", Pattern.CASE_INSENSITIVE)))
+            .first();
+        assertThat(dateManager).isVisible();
+        dateManager.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+        assertNoTemplateRenderingError();
+    }
+
+    private void assertBulkDateFieldVisible(String id) {
+        assertThat(page.locator("#" + id)).isVisible();
+    }
+
+    private void assertBulkDateFieldHidden(String id) {
+        assertThat(page.locator("#" + id)).hasCount(0);
+    }
+
+    private void assertNoTemplateRenderingError() {
+        String bodyText = page.locator("body").textContent();
+        Pattern templateError = Pattern.compile(
+            "TemplateProcessingException|TemplateOutputException|An error happened during template rendering",
+            Pattern.CASE_INSENSITIVE
+        );
+        assertFalse(templateError.matcher(bodyText == null ? "" : bodyText).find(), "Date Manager rendered a Thymeleaf error");
+    }
+}

--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerConstants.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerConstants.java
@@ -15,6 +15,8 @@
  */
 package org.sakaiproject.datemanager.api;
 
+import java.util.Map;
+
 public class DateManagerConstants {
 	public static final String COMMON_ID_ASSIGNMENTS = "sakai.assignment.grades";
 	public static final String COMMON_ID_ASSESSMENTS = "sakai.samigo";
@@ -51,4 +53,13 @@ public class DateManagerConstants {
 
 	public static final String DATEPICKER_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 	public static final int LIST_VIEW_YEAR_RANGE = 18;
+
+	public static final Map<String, String> BULK_DATE_FIELD_LABEL_KEYS = Map.of(
+			JSON_OPENDATE_PARAM_NAME, "column.open.date",
+			JSON_DUEDATE_PARAM_NAME, "column.due.date",
+			JSON_ACCEPTUNTIL_PARAM_NAME, "column.accept.until",
+			JSON_FEEDBACKSTART_PARAM_NAME, "column.feedback.start.date",
+			JSON_FEEDBACKEND_PARAM_NAME, "column.feedback.end.date",
+			JSON_SIGNUPBEGINS_PARAM_NAME, "column.signup.begins.date",
+			JSON_SIGNUPDEADLINE_PARAM_NAME, "column.signup.deadline.date");
 }

--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
@@ -49,6 +49,7 @@ public interface DateManagerService {
 	public String getMessage(String messageId);
 	public boolean currentSiteContainsTool(String commonId);
 	public String getToolTitle(String commonId);
+	public List<String> getBulkDateFieldsForCurrentSite();
 
 	// Assignments methods
 	public JSONArray getAssignmentsForContext(String siteId);
@@ -99,6 +100,7 @@ public interface DateManagerService {
 	public void updateLessons(DateManagerValidation lessonsValidation) throws Exception;
 
 	public DateManagerValidation validateTool(String toolId, int idx, String[][] columnsNames, String[] toolColumnsAux);
+	public DateManagerValidation validateTool(String toolId, int idx, String[] toolColumnsAux);
 	public void updateTool(String toolId, DateManagerValidation dateManagerValidation);
 
 	public boolean isChanged(String toolId, String[] columns);

--- a/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -36,11 +36,13 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.opencsv.CSVReader;
@@ -264,6 +266,39 @@ public class DateManagerServiceImpl implements DateManagerService {
 			toolTitle = tool.getTitle();
 		}
 		return toolTitle;
+	}
+
+	@Override
+	public List<String> getBulkDateFieldsForCurrentSite() {
+		Set<String> fields = new LinkedHashSet<>();
+
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_ASSIGNMENTS, columnsNames[0]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_ASSESSMENTS, columnsNames[1]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_GRADEBOOK, columnsNames[2]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_SIGNUP, columnsNames[3]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_RESOURCES, columnsNames[5]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_CALENDAR, columnsNames[4]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_FORUMS, columnsNames[5]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_ANNOUNCEMENTS, columnsNames[4]);
+		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_LESSONS, columnsNames[6]);
+
+		return new ArrayList<>(fields);
+	}
+
+	private void addBulkDateFieldsForTool(Set<String> fields, String commonId, String[] toolColumnsNames) {
+		if (!currentSiteContainsTool(commonId)) {
+			return;
+		}
+
+		Arrays.stream(toolColumnsNames)
+			.filter(this::isBulkDateField)
+			.forEach(fields::add);
+	}
+
+	private boolean isBulkDateField(String fieldName) {
+		return !DateManagerConstants.JSON_ID_PARAM_NAME.equals(fieldName)
+				&& !DateManagerConstants.JSON_TITLE_PARAM_NAME.equals(fieldName)
+				&& !DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME.equals(fieldName);
 	}
 
 	private String getUrlForTool(String tool) {
@@ -1787,6 +1822,11 @@ public class DateManagerServiceImpl implements DateManagerService {
 	 * 
 	 * @return DateManagerValidation
 	 */
+	@Override
+	public DateManagerValidation validateTool(String toolId, int idx, String[] columns) {
+		return validateTool(toolId, idx, columnsNames, columns);
+	}
+
 	@Override
 	public DateManagerValidation validateTool(String toolId, int idx, String[][] columnsNames, String[] columns) {
 		String siteId = getCurrentSiteId();

--- a/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
+++ b/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
@@ -123,6 +123,7 @@ public class MainController {
     public String showIndex(@RequestParam(required=false) String code, Model model, HttpServletRequest request, HttpServletResponse response) {
 		String siteId = dateManagerService.getCurrentSiteId();
 		model = getModelWithLocale(model, request, response);
+		model.addAttribute("bulkDateFields", dateManagerService.getBulkDateFieldsForCurrentSite());
 
 		if (dateManagerService.currentSiteContainsTool(DateManagerConstants.COMMON_ID_ASSIGNMENTS)) {
 			JSONArray assignmentsJson = dateManagerService.getAssignmentsForContext(siteId);
@@ -409,16 +410,7 @@ public class MainController {
 			int idx = data.index;
 			String[] toolColumnsAux = data.columns;
 			
-			// Note: columnsNames would need to be retrieved from service or made accessible
-			String[][] columnsNames = {{"id", "title", "open_date", "due_date", "accept_until"},
-					{"id", "title", "open_date", "due_date", "accept_until", "feedback_start", "feedback_end"},
-					{"id", "title", "due_date"}, 
-					{"id", "title", "open_date", "due_date", "signup_begins", "signup_deadline"},
-					{"id", "title", "open_date", "due_date"},
-					{"id", "title", "open_date", "due_date", "extraInfo"},
-					{"id", "title", "open_date"}};
-			
-			DateManagerValidation dateValidation = dateManagerService.validateTool(currentToolId, idx, columnsNames, toolColumnsAux);
+			DateManagerValidation dateValidation = dateManagerService.validateTool(currentToolId, idx, toolColumnsAux);
 			if (dateValidation != null) {
 				if (!dateValidation.getErrors().isEmpty()) {
 					List<Object> error = new ArrayList<>();

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -2,7 +2,7 @@ var DTMN = DTMN || {};
 
 DTMN.toolList = [ "assignments", "assessments", "signup", "gradebook", "resources", "calendar", "forums", "announcements", "lessons" ];
 DTMN.collapseElements = [ ];
-DTMN.bulkFields = [ "open_date", "due_date", "accept_until", "feedback_start", "feedback_end", "signup_begins", "signup_deadline" ];
+DTMN.bulkFields = DTMN.bulkFields || [];
 DTMN.nextIndex = -1;
 
 DTMN.initDatePicker = function(updates, notModified) {
@@ -78,6 +78,15 @@ DTMN.initBulkSetter = function(updates, notModified) {
   DTMN.bulkAllBtn = document.getElementById("applyAllDates");
   DTMN.bulkVisibleBtn = document.getElementById("applyVisibleDates");
   DTMN.bulkInputs = Array.from(document.querySelectorAll(".bulk-date-input"));
+
+  if (!DTMN.bulkAllBtn || !DTMN.bulkVisibleBtn) {
+    return;
+  }
+
+  if (DTMN.bulkFields.length === 0) {
+    DTMN.bulkFields = Array.from(document.querySelectorAll(".date-manager-setter [data-field]"))
+      .map(function(el) { return el.getAttribute("data-field"); });
+  }
 
   DTMN.initBulkDatePickers();
 

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -45,47 +45,19 @@
       <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
     </div>
 
-    <div class="date-manager-setter mb-3">
+    <div th:if="${bulkDateFields != null and !bulkDateFields.isEmpty()}" class="date-manager-setter mb-3">
       <div class="sak-banner-error d-none" id="dateBulkSetterError">
         <span data-error="empty" th:text="#{datesetter.error.empty}"></span>
         <span data-error="dateonly" class="d-none" th:text="#{datesetter.error.dateonly}"></span>
       </div>
       <p th:text="#{datesetter.instructions}">Enter one or more dates below, then apply them to all items or expanded sections only. Remember to click Save Changes at the bottom of the page to save your adjustments.</p>
       <div class="row g-3">
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-open-date" th:text="#{column.open.date}">Open Date</label>
-          <input id="bulk-open-date" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-open-date" type="hidden" data-field="open_date" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-due-date" th:text="#{column.due.date}">Due Date</label>
-          <input id="bulk-due-date" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-due-date" type="hidden" data-field="due_date" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-accept-until" th:text="#{column.accept.until}">Accept Until Date</label>
-          <input id="bulk-accept-until" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-accept-until" type="hidden" data-field="accept_until" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-feedback-start" th:text="#{column.feedback.start.date}">Show Feedback On</label>
-          <input id="bulk-feedback-start" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-feedback-start" type="hidden" data-field="feedback_start" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-feedback-end" th:text="#{column.feedback.end.date}">Show Feedback Until</label>
-          <input id="bulk-feedback-end" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-feedback-end" type="hidden" data-field="feedback_end" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-signup-begins" th:text="#{column.signup.begins.date}">Sign-up Begin Date</label>
-          <input id="bulk-signup-begins" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-signup-begins" type="hidden" data-field="signup_begins" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-          <label class="form-label" for="bulk-signup-deadline" th:text="#{column.signup.deadline.date}">Sign-up End Date</label>
-          <input id="bulk-signup-deadline" type="text" class="form-control bulk-date-input" />
-          <input id="bulk-hidden-signup-deadline" type="hidden" data-field="signup_deadline" />
+        <div th:each="field : ${bulkDateFields}" class="col-sm-6 col-lg-3"
+             th:with="inputId=${'bulk-' + #strings.replace(field, '_', '-')}">
+          <label class="form-label" th:for="${inputId}"
+                 th:text="#{${T(org.sakaiproject.datemanager.api.DateManagerConstants).BULK_DATE_FIELD_LABEL_KEYS.get(field)}}">Date</label>
+          <input th:id="${inputId}" type="text" class="form-control bulk-date-input" />
+          <input th:id="${'bulk-hidden-' + #strings.replace(field, '_', '-')}" type="hidden" th:attr="data-field=${field}" />
         </div>
       </div>
       <button class="btn btn-link m-2" id="applyAllDates" th:text="#{datesetter.all.button}" disabled></button>
@@ -317,6 +289,8 @@
           /*[/]*/
 
           var notModified = [];
+
+          DTMN.bulkFields = /*[[${bulkDateFields}]]*/ [];
 
           DTMN.initDatePicker(updates, notModified);
           DTMN.initShifter(updates, notModified);


### PR DESCRIPTION
- Derive bulk setter fields from Date Manager service field definitions for tools present in the site.

- Render bulk setter controls dynamically with shared label keys instead of hard-coded markup.

- Keep controller logic thin by delegating bulk field and import validation field-shape rules to the service.

- Add Playwright coverage for tool-specific bulk setter field visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date Manager now shows only relevant bulk date fields for your site's enabled tools and hides the bulk setter when no fields apply.

* **Improvements**
  * Bulk setter initialization streamlined to avoid unnecessary work and better expose the available fields.
  * Per-tool CSV validation improved to use site-aware column sets.

* **Tests**
  * Added end-to-end tests covering bulk date field visibility and related test helper enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->