### PR TITLE
SAK-52644 Portal more sites should render when clicked vs every page load

### DIFF
--- a/library/src/webapp/js/portal/portal.all.sites.js
+++ b/library/src/webapp/js/portal/portal.all.sites.js
@@ -298,7 +298,14 @@ document.addEventListener("DOMContentLoaded", () => {
       if (drawerLoaded) return;
 
       const content = document.getElementById("moresites-content");
+      const loading = document.getElementById("moresites-loading");
+      const errorBanner = document.getElementById("moresites-error");
       const siteId = sidebar.dataset.currentSiteId || "";
+
+      // Show the spinner (and clear any previous error) until the drawer content has fully loaded.
+      // This also resets the UI when the drawer is reopened after a failed attempt.
+      loading?.style.removeProperty("display");
+      errorBanner?.style.setProperty("display", "none");
 
       try {
         const response = await fetch(`/portal/sites-drawer/${siteId}`, { credentials: "include" });
@@ -307,14 +314,15 @@ document.addEventListener("DOMContentLoaded", () => {
           throw new Error(`Network error while loading the sites drawer from ${response.url}`);
         }
 
+        // Replacing the content removes the spinner once the drawer is completely loaded.
         content.innerHTML = await response.text();
         drawerLoaded = true;
         allsites.setup();
       } catch (error) {
         // Leave drawerLoaded false so reopening the drawer retries the fetch.
         console.error(error);
-        document.getElementById("moresites-loading")?.style.setProperty("display", "none");
-        document.getElementById("moresites-error")?.style.setProperty("display", "block");
+        loading?.style.setProperty("display", "none");
+        errorBanner?.style.setProperty("display", "block");
       }
     });
   }

--- a/library/src/webapp/js/portal/portal.all.sites.js
+++ b/library/src/webapp/js/portal/portal.all.sites.js
@@ -308,7 +308,7 @@ document.addEventListener("DOMContentLoaded", () => {
       errorBanner?.style.setProperty("display", "none");
 
       try {
-        const response = await fetch(`/portal/sites-drawer/${siteId}`, { credentials: "include" });
+        const response = await fetch(`/portal/sites-drawer/${encodeURIComponent(siteId)}`, { credentials: "include" });
 
         if (!response.ok) {
           throw new Error(`Network error while loading the sites drawer from ${response.url}`);

--- a/library/src/webapp/js/portal/portal.all.sites.js
+++ b/library/src/webapp/js/portal/portal.all.sites.js
@@ -252,8 +252,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const newState = e.detail.pinned ? "pinned" : "unpinned";
     const button = document.querySelector(`#selectSite button.site-favorite-btn[data-site-id='${e.detail.siteId}']`);
-    allsites.updateButton(button, newState);
-    allsites.setAllOrNoneStarStates();
+    if (button) {
+      // The "other sites" term panes are loaded lazily; their pin buttons only exist once the
+      // drawer has been opened. The organize-favorites list below is rendered eagerly, so it is
+      // always updated.
+      allsites.updateButton(button, newState);
+      allsites.setAllOrNoneStarStates();
+    }
 
     if (!e.detail.pinned) {
       document.querySelector(`#organize-favorites-list li.organize-favorite-item[data-site-id='${e.detail.siteId}']`)?.remove();
@@ -280,10 +285,39 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  document.getElementById("select-site-sidebar")?.addEventListener("shown.bs.offcanvas", function() {
+  const sidebar = document.getElementById("select-site-sidebar");
 
-    allsites.setup();
-  });
+  if (sidebar) {
+
+    let drawerLoaded = false;
+
+    // The term-grouped list of every accessible site is expensive to build, and the drawer is
+    // hidden until opened, so we fetch its content on demand the first time it is shown.
+    sidebar.addEventListener("show.bs.offcanvas", async () => {
+
+      if (drawerLoaded) return;
+
+      const content = document.getElementById("moresites-content");
+      const siteId = sidebar.dataset.currentSiteId || "";
+
+      try {
+        const response = await fetch(`/portal/sites-drawer/${siteId}`, { credentials: "include" });
+
+        if (!response.ok) {
+          throw new Error(`Network error while loading the sites drawer from ${response.url}`);
+        }
+
+        content.innerHTML = await response.text();
+        drawerLoaded = true;
+        allsites.setup();
+      } catch (error) {
+        // Leave drawerLoaded false so reopening the drawer retries the fetch.
+        console.error(error);
+        document.getElementById("moresites-loading")?.style.setProperty("display", "none");
+        document.getElementById("moresites-error")?.style.setProperty("display", "block");
+      }
+    });
+  }
 
   const organizeTab = document.getElementById('allsites-organize-favourites-tab');
   const refreshNotification = document.getElementById("allsites-refresh-notification");

--- a/portal/portal-impl/impl/src/bundle/sitenav.properties
+++ b/portal/portal-impl/impl/src/bundle/sitenav.properties
@@ -168,6 +168,8 @@ moresite_toggle_all_as_favorites = Toggle as pinned all sites in {0} term
 moresite_toggle_all_as_favorites_no_term = Toggle as pinned all sites without term
 moresite_favorites_on = On
 moresite_favorites_off = Off
+moresite_loading = Loading sites...
+moresite_loading_error = Sites could not be loaded. Please try again.
 
 timeout_dialog_title = Timeout Alert
 timeout_dialog_warning_message = Your session will timeout in <span>{0}</span> minutes.

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -75,6 +75,7 @@ import org.sakaiproject.portal.charon.handlers.ErrorReportHandler;
 import org.sakaiproject.portal.charon.handlers.FavoritesHandler;
 import org.sakaiproject.portal.charon.handlers.GenerateBugReportHandler;
 import org.sakaiproject.portal.charon.handlers.HelpHandler;
+import org.sakaiproject.portal.charon.handlers.MoreSitesHandler;
 import org.sakaiproject.portal.charon.handlers.JoinHandler;
 import org.sakaiproject.portal.charon.handlers.LoginHandler;
 import org.sakaiproject.portal.charon.handlers.LogoutHandler;
@@ -358,6 +359,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
         addHandler(new TimeoutDialogHandler());
         addHandler(new JoinHandler());
         addHandler(new FavoritesHandler());
+        addHandler(new MoreSitesHandler());
         addHandler(new GenerateBugReportHandler());
     }
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -541,16 +541,6 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
             }
         }
 
-        SiteView siteView = siteHelper.getSitesView(SiteView.View.ALL_SITES_VIEW, req, session, siteId);
-        siteView.setPrefix(prefix);
-        siteView.setResetTools(resetTools);
-        siteView.setToolContextPath(toolContextPath);
-        siteView.setIncludeSummary(includeSummary);
-        siteView.setDoPages(doPages);
-        siteView.setExpandSite(expandSite);
-
-        rcontext.put("allSites", siteView.getRenderContextObject());
-
         includeLogin(rcontext, req, session);
         includeBottom(rcontext, site);
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/MoreSitesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/MoreSitesHandler.java
@@ -70,10 +70,10 @@ public class MoreSitesHandler extends BasePortalHandler {
             return NEXT;
         }
 
-        try {
-            // /portal/sites-drawer/{siteId} - siteId identifies the current site for highlighting
-            String siteId = (parts.length >= 3) ? parts[2] : null;
+        // /portal/sites-drawer/{siteId} - siteId identifies the current site for highlighting
+        String siteId = (parts.length >= 3) ? parts[2] : null;
 
+        try {
             SiteView siteView = portal.getSiteHelper().getSitesView(SiteView.View.DHTML_MORE_VIEW, req, session, siteId);
             siteView.setToolContextPath(null);
             Map<String, Object> drawerContext = ((MoreSiteViewImpl) siteView).getMoreSitesDrawerContext();
@@ -88,6 +88,7 @@ public class MoreSitesHandler extends BasePortalHandler {
             portal.sendResponse(rcontext, res, "moresites-drawer", "text/html; charset=UTF-8");
             return END;
         } catch (Exception e) {
+            log.warn("Failed to render the More Sites drawer for site [{}]", siteId, e);
             throw new PortalHandlerException(e);
         }
     }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/MoreSitesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/MoreSitesHandler.java
@@ -1,0 +1,94 @@
+/**********************************************************************************
+ * $URL$
+ * $Id$
+ ***********************************************************************************
+ *
+ * Copyright (c) 2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+
+package org.sakaiproject.portal.charon.handlers;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.portal.api.PortalHandlerException;
+import org.sakaiproject.portal.api.PortalRenderContext;
+import org.sakaiproject.portal.api.PortalRenderEngine;
+import org.sakaiproject.portal.api.SiteView;
+import org.sakaiproject.portal.charon.site.MoreSiteViewImpl;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.util.ResourceLoader;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Renders the "More Sites" drawer content (the term-grouped list of every site the user can access)
+ * on demand. The drawer is hidden until the user opens it, so building this list on every page
+ * render was wasteful - for users in hundreds of sites it dominated render time. The morpheus
+ * JS (portal.all.sites.js) fetches this fragment when the offcanvas is opened.
+ */
+@Slf4j
+public class MoreSitesHandler extends BasePortalHandler {
+
+    private static final String URL_FRAGMENT = "sites-drawer";
+
+    private static final ResourceLoader rloader = new ResourceLoader("sitenav");
+
+    private final PreferencesService preferencesService;
+
+    public MoreSitesHandler() {
+        setUrlFragment(URL_FRAGMENT);
+        preferencesService = ComponentManager.get(PreferencesService.class);
+    }
+
+    @Override
+    public int doGet(String[] parts, HttpServletRequest req, HttpServletResponse res, Session session)
+            throws PortalHandlerException {
+
+        if ((parts.length < 2) || !parts[1].equals(URL_FRAGMENT)) {
+            return NEXT;
+        }
+
+        if (session == null || session.getUserId() == null) {
+            return NEXT;
+        }
+
+        try {
+            // /portal/sites-drawer/{siteId} - siteId identifies the current site for highlighting
+            String siteId = (parts.length >= 3) ? parts[2] : null;
+
+            SiteView siteView = portal.getSiteHelper().getSitesView(SiteView.View.DHTML_MORE_VIEW, req, session, siteId);
+            siteView.setToolContextPath(null);
+            Map<String, Object> drawerContext = ((MoreSiteViewImpl) siteView).getMoreSitesDrawerContext();
+
+            PortalRenderEngine rengine = portalService.getRenderEngine(portal.getPortalContext(), req);
+            PortalRenderContext rcontext = rengine.newRenderContext(req);
+            rcontext.put("rloader", rloader);
+            rcontext.put("userIsLoggedIn", Boolean.TRUE);
+            rcontext.put("tabDisplayLabel", preferencesService.getSiteTitleDisplayPreference());
+            rcontext.put("tabsSites", drawerContext);
+
+            portal.sendResponse(rcontext, res, "moresites-drawer", "text/html; charset=UTF-8");
+            return END;
+        } catch (Exception e) {
+            throw new PortalHandlerException(e);
+        }
+    }
+}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -53,6 +53,7 @@ import org.sakaiproject.event.api.Event;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.javax.PagingPosition;
 import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.api.PortalConstants;
 import org.sakaiproject.portal.api.PortalHandlerException;
@@ -60,7 +61,6 @@ import org.sakaiproject.portal.api.PortalRenderContext;
 import org.sakaiproject.portal.api.PortalService;
 import org.sakaiproject.portal.api.SiteView;
 import org.sakaiproject.portal.api.StoredState;
-import org.sakaiproject.portal.charon.site.AllSitesViewImpl;
 import org.sakaiproject.portal.util.ByteArrayServletResponse;
 import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.portal.util.URLUtils;
@@ -329,11 +329,13 @@ public class SiteHandler extends WorksiteHandler
 			}
 			else
 			{
-				// TODO Should maybe switch to portal.getSiteHelper().getMyWorkspace()
-				AllSitesViewImpl allSites = (AllSitesViewImpl) portal.getSiteHelper().getSitesView(SiteView.View.ALL_SITES_VIEW, req, session, siteId);
-				List<Map> sites = (List<Map>) allSites.getRenderContextObject();
-				if (sites.size() > 0) {
-					siteId = (String) sites.get(0).get("siteId");
+				// We only need the first accessible site id to use as the default landing site, so
+				// fetch ids with getSiteIds rather than hydrating (and converting to maps) every
+				// site the user can access.
+				List<String> siteIds = siteService.getSiteIds(SiteService.SelectionType.MEMBER, null, null, null,
+						SiteService.SortType.NONE, new PagingPosition(1, 1));
+				if (!siteIds.isEmpty()) {
+					siteId = siteIds.get(0);
 				} else {
 					siteId = siteService.getUserSiteId(userId);
 				}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/AbstractSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/AbstractSiteViewImpl.java
@@ -57,6 +57,7 @@ public abstract class AbstractSiteViewImpl implements SiteView
 	protected boolean loggedIn;
 	protected ArrayList<Site> moreSites;
 	protected List<Site> mySites;
+	protected boolean showMyWorkspace;
 	protected String myWorkspaceSiteId;
 	@Setter protected String prefix;
 	protected Map<String, Object> renderContextMap;
@@ -79,8 +80,7 @@ public abstract class AbstractSiteViewImpl implements SiteView
 		this.request = request;
 		this.currentSiteId = currentSiteId;
 		this.session = session;
-		boolean showMyWorkspace = serverConfigurationService.getBoolean("myworkspace.show", true);
-		mySites = siteNeighbourhoodService.getSitesAtNode(request, session, showMyWorkspace);
+		showMyWorkspace = serverConfigurationService.getBoolean("myworkspace.show", true);
 
 		loggedIn = session.getUserId() != null;
 		Site myWorkspaceSite = siteHelper.getMyWorkspace(session);
@@ -91,9 +91,23 @@ public abstract class AbstractSiteViewImpl implements SiteView
 	}
 
 
+	/**
+	 * Lazily loads the full list of every site the user can access. The first caller pays the cost
+	 * of {@link SiteNeighbourhoodService#getSitesAtNode}; subsequent calls reuse the loaded list.
+	 */
+	protected List<Site> getMySites() {
+		if (mySites == null) {
+			mySites = siteNeighbourhoodService.getSitesAtNode(request, session, showMyWorkspace);
+		}
+		return mySites;
+	}
+
 	@Override
 	public boolean isEmpty() {
-		return mySites.isEmpty();
+		// Only need to know whether the user has any accessible sites
+		// without hydrating every Site (and its realm/properties/pages/tools) like getMySites does.
+		return siteService.getSiteIds(SiteService.SelectionType.ACCESS, null, null, null,
+				SiteService.SortType.NONE, null).isEmpty();
 	}
 
 }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/AllSitesViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/AllSitesViewImpl.java
@@ -47,7 +47,7 @@ public class AllSitesViewImpl extends AbstractSiteViewImpl
 	 */
 	public Object getRenderContextObject()
 	{
-		List l = siteHelper.convertSitesToMaps(request, mySites, prefix, currentSiteId, myWorkspaceSiteId,
+		List l = siteHelper.convertSitesToMaps(request, getMySites(), prefix, currentSiteId, myWorkspaceSiteId,
 			includeSummary, expandSite, resetTools, doPages, toolContextPath,
 			loggedIn);
 		return l;

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
@@ -65,26 +65,17 @@ public class DefaultSiteViewImpl extends AbstractSiteViewImpl
 		// My WorkSpace will be the first in the list
 
 		// if public workgroup/gateway site is not included, add to list
+		List<Site> mySites = getMySites();
 		boolean siteFound = false;
-		for (int i = 0; i < mySites.size(); i++)
-		{
-			if (((Site) mySites.get(i)).getId().equals(currentSiteId))
-			{
-				siteFound = true;
-			}
-		}
+        for (Site mySite : mySites) {
+            if (mySite.getId().equals(currentSiteId)) {
+                siteFound = true;
+            }
+        }
 
-		try
-		{
-			if (!siteFound)
-			{
-				mySites.add(siteService.getSite(currentSiteId));
-			}
+		if (!siteFound) {
+			siteService.getOptionalSite(currentSiteId).ifPresent(mySites::add);
 		}
-		catch (IdUnusedException e)
-		{
-
-		} // ignore
 
 		// we allow one site in the drawer - that is OK
 		moreSites = new ArrayList<Site>();
@@ -180,7 +171,7 @@ public class DefaultSiteViewImpl extends AbstractSiteViewImpl
 	 */
 	public boolean isEmpty()
 	{
-		return mySites.isEmpty();
+		return getMySites().isEmpty();
 	}
 
 	/*

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
@@ -139,13 +139,9 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 		int favoritesBarSize = tabsToDisplay + 1;
 
 		Set<String> pinnedSiteIds = new HashSet<>(siteHelper.getPinnedSites());
-		List<Site> sitesForFavorites = new ArrayList<>();
-		for (int position = 0; position < favoritesSites.size(); position++) {
-			Site site = favoritesSites.get(position);
-			if (position < favoritesBarSize || pinnedSiteIds.contains(site.getId()) || site.getId().equals(currentSiteId)) {
-				sitesForFavorites.add(site);
-			}
-		}
+		List<Site> sitesForFavorites = favoritesSites.stream()
+				.filter(site -> favoritesSites.indexOf(site) < favoritesBarSize || pinnedSiteIds.contains(site.getId()) || site.getId().equals(currentSiteId))
+				.toList();
 
 		List<Map<String, Object>> l = siteHelper.convertSitesToMaps(request, sitesForFavorites, prefix, currentSiteId, myWorkspaceSiteId, false, false,
 				serverConfigurationService.getBoolean(Portal.CONFIG_AUTO_RESET, false), true, null, loggedIn);
@@ -304,6 +300,8 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 				term = siteProperties.getProperty("term");
 				if(null==term) {
 					term = rb.getString("moresite_unknown_term");
+				} else {
+					term = StringEscapeUtils.escapeHtml4(term);
 				}
 
 			}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
@@ -71,8 +71,19 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 	public Object getRenderContextObject()
 	{
 		// Get the list of sites in the right order,
-		// My WorkSpace will be the first in the list
-		ensureCurrentSiteIncluded();
+		// My WorkSpace will be the first in the list.
+		// The favorites bar / organize-favorites list only needs pinned + recent (+ workspace +
+		// current) sites - loading every site the user can access on every page render is what made
+		// this slow. The full list is only built when the More Sites drawer is opened.
+		List<Site> favoritesSites;
+		if (loggedIn) {
+			favoritesSites = getPinnedAndRecentFavorites();
+		} else {
+			// Gateway: the public site list is small; keep the prior behavior of ensuring the
+			// current site is represented and rendering the full tab list (includeGatewayNav.vm).
+			ensureCurrentSiteIncluded();
+			favoritesSites = getMySites();
+		}
 
 		// we allow one site in the drawer - that is OK
 		moreSites = new ArrayList<>();
@@ -86,7 +97,7 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
  		String mrphs_worksiteToolUrl = null;
  		String mrphs_worksiteUrl = null;
         if ( myWorkspaceSiteId != null ) {
-            for (Site s : mySites) {
+            for (Site s : favoritesSites) {
                 if (myWorkspaceSiteId.equals(s.getId()) ) {
                     mrphs_worksiteUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)));
                     List<SitePage> pages = siteHelper.getPermittedPagesInOrder(s);
@@ -129,8 +140,8 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 
 		Set<String> pinnedSiteIds = new HashSet<>(siteHelper.getPinnedSites());
 		List<Site> sitesForFavorites = new ArrayList<>();
-		for (int position = 0; position < mySites.size(); position++) {
-			Site site = mySites.get(position);
+		for (int position = 0; position < favoritesSites.size(); position++) {
+			Site site = favoritesSites.get(position);
 			if (position < favoritesBarSize || pinnedSiteIds.contains(site.getId()) || site.getId().equals(currentSiteId)) {
 				sitesForFavorites.add(site);
 			}
@@ -212,18 +223,51 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 	}
 
 	/**
-	 * Ensure the current site is part of mySites so it is represented in the rendered lists.
+	 * Ensure the current site is part of the (full) mySites list so it is represented in the
+	 * rendered lists. Used by the gateway favorites path and the More Sites drawer.
 	 */
 	private void ensureCurrentSiteIncluded() {
-		if (mySites.stream().noneMatch(s -> s.getId().equals(currentSiteId))) {
-			siteService.getOptionalSite(currentSiteId).ifPresent(mySites::add);
+		List<Site> all = getMySites();
+		if (all.stream().noneMatch(s -> s.getId().equals(currentSiteId))) {
+			siteService.getOptionalSite(currentSiteId).ifPresent(all::add);
 		}
+	}
+
+	/**
+	 * Build the limited set of sites the favorites bar / organize-favorites list needs for a
+	 * logged-in user: the workspace, the user's pinned sites (in pinned order), the recent sites,
+	 * and the current site. Each is loaded individually (cached) instead of loading every site the
+	 * user can access, mirroring {@link PortalSiteHelperImpl#getContextSitesWithPages}.
+	 */
+	private List<Site> getPinnedAndRecentFavorites() {
+		List<Site> favorites = new ArrayList<>();
+		Set<String> seen = new HashSet<>();
+		// Match getSitesAtNode(showMyWorkspace): only include the workspace when it is configured
+		// to be shown - it provides the leading slot and the worksite/calendar tool URLs.
+		if (showMyWorkspace) {
+			addSiteById(myWorkspaceSiteId, favorites, seen);
+		}
+		siteHelper.getPinnedSites().forEach(id -> addSiteById(id, favorites, seen));
+		siteHelper.getRecentSites(session.getUserId()).forEach(id -> addSiteById(id, favorites, seen));
+		addSiteById(currentSiteId, favorites, seen);
+		return favorites;
+	}
+
+	/**
+	 * Add the site with the given id to {@code sites}, skipping ids already seen (or null) so each
+	 * site is loaded at most once.
+	 */
+	private void addSiteById(String siteId, List<Site> sites, Set<String> seen) {
+		if (siteId == null || !seen.add(siteId)) {
+			return;
+		}
+		siteService.getOptionalSite(siteId).ifPresent(sites::add);
 	}
 
 	protected void processMySites()
 	{
 		List<Site> allSites = new ArrayList<>();
-		allSites.addAll(mySites);
+		allSites.addAll(getMySites());
 		allSites.addAll(moreSites);
 		// get Sections
 		Map<String, List<Site>> termsToSites = new HashMap<>();

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
@@ -26,9 +26,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -36,7 +38,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.sakaiproject.entity.api.ResourceProperties;
-import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.portal.api.Portal;
 import org.sakaiproject.portal.util.PortalUtils;
 import org.sakaiproject.site.api.Site;
@@ -71,33 +72,10 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 	{
 		// Get the list of sites in the right order,
 		// My WorkSpace will be the first in the list
-
-		// if public workgroup/gateway site is not included, add to list
-		boolean siteFound = false;
-		for (int i = 0; i < mySites.size(); i++)
-		{
-			if (((Site) mySites.get(i)).getId().equals(currentSiteId))
-			{
-				siteFound = true;
-			}
-		}
-
-		try
-		{
-			if (!siteFound)
-			{
-				mySites.add(siteService.getSite(currentSiteId));
-			}
-		}
-		catch (IdUnusedException e)
-		{
-
-		} // ignore
+		ensureCurrentSiteIncluded();
 
 		// we allow one site in the drawer - that is OK
 		moreSites = new ArrayList<>();
-		
-		processMySites();
 
 		String calendarToolId = serverConfigurationService.getString("portal.calendartool","sakai.schedule");
 		String preferencesToolId = serverConfigurationService.getString("portal.preferencestool","sakai.preferences");
@@ -145,24 +123,31 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 
 		renderContextMap.put("themeSwitcher", serverConfigurationService.getBoolean("portal.themes.switcher", true));
 
-		List<Map<String, Object>> l = siteHelper.convertSitesToMaps(request, mySites, prefix, currentSiteId, myWorkspaceSiteId, false, false,
+		int tabsToDisplay = serverConfigurationService.getInt(Portal.CONFIG_DEFAULT_TABS, 15);
+		// The favorites bar shows tabsToDisplay sites plus one leading slot for the user's workspace.
+		int favoritesBarSize = tabsToDisplay + 1;
+
+		Set<String> pinnedSiteIds = new HashSet<>(siteHelper.getPinnedSites());
+		List<Site> sitesForFavorites = new ArrayList<>();
+		for (int position = 0; position < mySites.size(); position++) {
+			Site site = mySites.get(position);
+			if (position < favoritesBarSize || pinnedSiteIds.contains(site.getId()) || site.getId().equals(currentSiteId)) {
+				sitesForFavorites.add(site);
+			}
+		}
+
+		List<Map<String, Object>> l = siteHelper.convertSitesToMaps(request, sitesForFavorites, prefix, currentSiteId, myWorkspaceSiteId, false, false,
 				serverConfigurationService.getBoolean(Portal.CONFIG_AUTO_RESET, false), true, null, loggedIn);
 
-		int tabsToDisplay = serverConfigurationService.getInt(Portal.CONFIG_DEFAULT_TABS, 15);
-
 		renderContextMap.put("maxFavoritesShown", tabsToDisplay);
-
 		List<Map<String, Object>> pinned
 			= l.stream().filter(map -> map.containsKey("isPinned") && (Boolean) map.get("isPinned"))
 				.collect(Collectors.toList());
 
 		renderContextMap.put("pinned", pinned);
 
-		// Bump it up by one to make room for the user's workspace
-		tabsToDisplay++;
-
-		if (l.size() > tabsToDisplay) {
-			List<Map<String, Object>> sublist = l.subList(0, tabsToDisplay);
+		if (l.size() > favoritesBarSize) {
+			List<Map<String, Object>> sublist = l.subList(0, favoritesBarSize);
 
 			boolean listContainsCurrentSite = false;
 			for (Map<String, Object> entry : sublist) {
@@ -179,7 +164,7 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 
 				for (Map<String, Object> entry : l) {
 					if (entry.get("isCurrentSite") instanceof Boolean ? (Boolean) entry.get("isCurrentSite") : false) {
-						modifiedList.set(tabsToDisplay - 1, entry);
+						modifiedList.set(favoritesBarSize - 1, entry);
 						break;
 					}
 				}
@@ -209,6 +194,30 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
 		}
 
 		return renderContextMap;
+	}
+
+	/**
+	 * Builds the term-grouped "More Sites" drawer content on demand. This is the expensive part of
+	 * the view (it converts every member site), so it is only invoked when the drawer is actually
+	 * opened - see {@link org.sakaiproject.portal.charon.handlers.MoreSitesHandler}.
+	 *
+	 * @return the render context map populated with the {@code tabsMore*} keys consumed by
+	 *         moresites-drawer.vm
+	 */
+	public Map<String, Object> getMoreSitesDrawerContext() {
+		ensureCurrentSiteIncluded();
+		moreSites = new ArrayList<>();
+		processMySites();
+		return renderContextMap;
+	}
+
+	/**
+	 * Ensure the current site is part of mySites so it is represented in the rendered lists.
+	 */
+	private void ensureCurrentSiteIncluded() {
+		if (mySites.stream().noneMatch(s -> s.getId().equals(currentSiteId))) {
+			siteService.getOptionalSite(currentSiteId).ifPresent(mySites::add);
+		}
 	}
 
 	protected void processMySites()

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -603,6 +603,13 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 	}
 
 	/**
+	 * The recent site ids for the given user.
+	 */
+	public List<String> getRecentSites(String userId) {
+		return portalService.getRecentSites(userId);
+	}
+
+	/**
 	* Get all provider IDs for the given site.
 	*
 	* @param site the site to retrieve all provider IDs

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -596,6 +596,13 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 	}
 
 	/**
+	 * The pinned site ids for the current user.
+	 */
+	public List<String> getPinnedSites() {
+		return portalService.getPinnedSites();
+	}
+
+	/**
 	* Get all provider IDs for the given site.
 	*
 	* @param site the site to retrieve all provider IDs

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites-drawer.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites-drawer.vm
@@ -1,0 +1,107 @@
+## "More Sites" drawer content. Rendered on demand by MoreSitesHandler when the offcanvas is
+## opened (fetched by portal.all.sites.js), so the term-grouped list of every accessible site is
+## not built on every page render.
+#macro( displaySite $site )
+<li class="fav-sites-entry #if (${site.isCurrentSite})is-selected #end #if (${site.isMyWorkspace})my-workspace #end">
+
+  <div class="fav-title #if (${site.isMyWorkspace}) fav-title-myworkspace #end">
+    <a href="${site.siteUrl}" title="${site.siteTitle}">
+      #if (${site.isMyWorkspace})
+        <span class="bi-house-fill" aria-hidden="true"></span><span class="fullTitle">${site.siteTitle}</span>
+      #elseif ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )
+        <span class="fullTitle">${site.shortDescription}</span>
+      #else
+        <span class="fullTitle">${site.siteTitleTrunc}</span>
+      #end
+    </a>
+  </div>
+
+  #if (!${site.isMyWorkspace})
+    <button class="site-favorite-btn icon-button float-end"
+            data-site-id="${site.siteId}"
+            title="$rloader.getFormattedMessage("site_fav_toggle", $site.siteTitle)"
+            aria-pressed="#if ($site.isPinned)true#else false#end"
+            data-pinned-state="#if ($site.isPinned)pinned#else unpinned#end"
+            aria-label="$rloader.getFormattedMessage("site_fav_toggle", $site.siteTitle)">
+      <i class="si si-pin" style="display: #if ($site.isPinned) none #else inline #end"></i>
+      <i class="si si-pin-fill" style="display:#if ($site.isPinned) inline #else none #end"></i>
+    </button>
+  #end
+</li>
+#end
+
+<div class="moresites-left-col">
+  #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
+    #if ($tabsSites.tabsMoreTermsLeftPane.get($termKey).size() > 0)
+      <div class="fav-sites-term fav-sites-card card mb-2">
+        <div class="card-header">
+          #if ( !$termKey || $termKey == "" )
+            <h3 class="card-title">
+              <span>${rloader.sit_notermkey}</span>
+              <button class="favorites-select-all-none icon-button ms-1"
+                      title="${rloader.moresite_toggle_all_as_favorites_no_term}"
+                      aria-label="${rloader.moresite_toggle_all_as_favorites_no_term}">
+                <i class="si si-pin-fill" style="display: none"></i>
+                <i class="si si-pin" style="display: none"></i>
+              </button>
+            </h3>
+          #else
+            <h3 class="card-title">
+              <span>$termKey</span>
+              <button class="favorites-select-all-none icon-button ms-1"
+                      title="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)"
+                      aria-label="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)">
+                <i class="si si-pin-fill" style="display: none"></i>
+                <i class="si si-pin" style="display: none"></i>
+              </button>
+            </h3>
+          #end
+        </div>
+
+        <div class="card-body">
+          <ul class="other-sites-category-list favorite-site-list" role="presentation">
+            #foreach( $site in $tabsSites.tabsMoreTermsLeftPane.get($termKey))
+                #displaySite($site)
+              #end
+          </ul>
+        </div>
+      </div>
+    #end
+  #end
+</div>
+
+<div class="moresites-right-col">
+  #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
+    #if ($tabsSites.tabsMoreTermsRightPane.get($termKey).size() > 0)
+      <div class="fav-sites-card card mb-2">
+        <div class="card-header">
+          <h3 class="card-title">
+            <span>$termKey</span>
+            <button class="favorites-select-all-none icon-button ms-1"
+                    title="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)"
+                    aria-label="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)">
+              <i class="si si-pin-fill" style="display: none"></i>
+              <i class="si si-pin" style="display: none"></i>
+            </button>
+          </h3>
+        </div>
+        <div class="card-body">
+          <ul class="other-sites-category-list favorite-site-list" role="presentation">
+            <!-- anchor "my workspace" to the top of the list -->
+            #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
+              #if (${site.isMyWorkspace})
+                #displaySite($site)
+              #end
+            #end
+
+            #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
+              #if ($site.siteType != "course" && !$site.isMyWorkspace)
+                #displaySite($site)
+              #end
+            #end
+          </ul>
+        </div>
+      </div>
+    #end
+  #end
+</div>

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/moresites.vm
@@ -1,31 +1,3 @@
-#macro( displaySite $site )
-  <li class="fav-sites-entry #if (${site.isCurrentSite})is-selected #end #if (${site.isMyWorkspace})my-workspace #end">
-
-    <div class="fav-title #if (${site.isMyWorkspace}) fav-title-myworkspace #end">
-      <a href="${site.siteUrl}" title="${site.siteTitle}">
-        #if (${site.isMyWorkspace})
-          <span class="bi-house-fill" aria-hidden="true"></span><span class="fullTitle">${site.siteTitle}</span>
-        #elseif ( ( ${tabDisplayLabel} == 2 ) && ( ${site.shortDescription} ) )
-          <span class="fullTitle">${site.shortDescription}</span>
-        #else
-          <span class="fullTitle">${site.siteTitleTrunc}</span>
-        #end
-      </a>
-    </div>
-
-    #if (!${site.isMyWorkspace})
-      <button class="site-favorite-btn icon-button float-end"
-          data-site-id="${site.siteId}"
-          title="$rloader.getFormattedMessage("site_fav_toggle", $site.siteTitle)"
-          aria-pressed="#if ($site.isPinned)true#else false#end"
-          data-pinned-state="#if ($site.isPinned)pinned#else unpinned#end"
-          aria-label="$rloader.getFormattedMessage("site_fav_toggle", $site.siteTitle)">
-        <i class="si si-pin" style="display: #if ($site.isPinned) none #else inline #end"></i>
-        <i class="si si-pin-fill" style="display:#if ($site.isPinned) inline #else none #end"></i>
-      </button>
-    #end
-  </li>
-#end
 #if (${userIsLoggedIn})
   <div id="maxToolsText" style="display: none">${rloader.sit_alltools}</div>
   <div id="maxToolsInt" style="display: none">${maxToolsInt}</div>
@@ -35,6 +7,7 @@
   <div id="select-site-sidebar"
       class="offcanvas offcanvas-end"
       tabindex="-1"
+      data-current-site-id="${currentSiteId}"
       aria-labelledby="select-site-label">
     <div class="offcanvas-header">
       <h2 class="offcanvas-title" id="select-site-label">${rloader.sit_allsites}</h2>
@@ -103,80 +76,13 @@
             </div>
             <div id="all-sites-no-search-results" class="is-hidden">${rloader.sit_search_none}</div>
 
-            <div class="moresites-left-col">
-              #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
-                #if ($tabsSites.tabsMoreTermsLeftPane.get($termKey).size() > 0)
-                  <div class="fav-sites-term fav-sites-card card mb-2">
-                    <div class="card-header">
-                    #if ( !$termKey || $termKey == "" )
-                      <h3 class="card-title">
-                        <span>${rloader.sit_notermkey}</span>
-                        <button class="favorites-select-all-none icon-button ms-1"
-                            title="${rloader.moresite_toggle_all_as_favorites_no_term}"
-                            aria-label="${rloader.moresite_toggle_all_as_favorites_no_term}">
-                          <i class="si si-pin-fill" style="display: none"></i>
-                          <i class="si si-pin" style="display: none"></i>
-                        </button>
-                      </h3>
-                    #else
-                      <h3 class="card-title">
-                        <span>$termKey</span>
-                        <button class="favorites-select-all-none icon-button ms-1"
-                            title="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)"
-                            aria-label="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)">
-                          <i class="si si-pin-fill" style="display: none"></i>
-                          <i class="si si-pin" style="display: none"></i>
-                        </button>
-                      </h3>
-                    #end
-                    </div>
-
-                    <div class="card-body">
-                        <ul class="other-sites-category-list favorite-site-list" role="presentation">
-                          #foreach( $site in $tabsSites.tabsMoreTermsLeftPane.get($termKey))
-                            #displaySite($site)
-                          #end
-                        </ul>
-                    </div>
-                  </div>
-                #end
-              #end
-            </div>
-
-            <div class="moresites-right-col">
-              #foreach( $termKey in $tabsSites.tabsMoreSortedTermList )
-                #if ($tabsSites.tabsMoreTermsRightPane.get($termKey).size() > 0)
-                  <div class="fav-sites-card card mb-2">
-                    <div class="card-header">
-                      <h3 class="card-title">
-                        <span>$termKey</span>
-                        <button class="favorites-select-all-none icon-button ms-1"
-                            title="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)"
-                            aria-label="$rloader.getFormattedMessage("moresite_toggle_all_as_favorites", $termKey)">
-                          <i class="si si-pin-fill" style="display: none"></i>
-                          <i class="si si-pin" style="display: none"></i>
-                        </button>
-                      </h3>
-                    </div>
-                    <div class="card-body">
-                      <ul class="other-sites-category-list favorite-site-list" role="presentation">
-                        <!-- anchor "my workspace" to the top of the list -->
-                        #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
-                          #if (${site.isMyWorkspace})
-                            #displaySite($site)
-                          #end
-                        #end
-
-                        #foreach( $site in $tabsSites.tabsMoreTermsRightPane.get($termKey))
-                          #if (${site.siteType} != #"course" && !${site.isMyWorkspace})
-                            #displaySite($site)
-                          #end
-                        #end
-                      </ul>
-                    </div>
-                  </div>
-                #end
-              #end
+            ## "More Sites" drawer content is now rendered on demand by MoreSitesHandler
+            <div id="moresites-content">
+              <div id="moresites-loading" class="text-center my-3">
+                <span class="spinner-border" role="status" aria-hidden="true"></span>
+                <span class="ms-2">${rloader.moresite_loading}</span>
+              </div>
+              <div id="moresites-error" class="sak-banner-error" style="display: none">${rloader.moresite_loading_error}</div>
             </div>
 
           </div><!--  end of #other-sites-category-wrap -->


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand loading for the “More Sites” drawer, with a loading indicator and a retryable error state.
* **Improvements**
  * Drawer content is fetched only when the sidebar is opened to improve initial page performance.
  * “More Sites” favorites now consistently include and correctly position the current site.
* **Bug Fixes**
  * Pin/unpin updates now refresh only when the related pin control exists, preventing incorrect all/none star state behavior.
* **Localization**
  * Added “Loading sites...” and “Sites could not be loaded. Please try again.” messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->