### PR TITLE
SAK-52567 LTI handling of GB items with titles different from assignments

### DIFF
--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -2765,8 +2765,8 @@ public class SakaiLTIUtil {
 			String external_id = gradebookColumn.getExternalId();
 			// Check if the column was created in Gradebook and is associated with an assignment (assumes only one; cannot handle multiple yet)
 			org.sakaiproject.assignment.api.model.Assignment assignment = LineItemUtil.getAssignmentForGradebookLink(siteId, gradebookColumn.getId());
-			log.debug("external_id: {} assignment with GB item from GB={}", external_id, assignment);
-			if ( external_id != null && (LineItemUtil.isAssignmentColumn(external_id) || (assignment != null)) ) {
+			log.debug("external_id: {}; isAssignmentColumn={}; assignment with GB item from GB={}", external_id, LineItemUtil.isAssignmentColumn(external_id), assignment);
+			if ( (external_id != null && LineItemUtil.isAssignmentColumn(external_id)) || assignment != null ) {
 				pushAdvisor(); // Add security advisor to allow access to assignments
 				try {
 					org.sakaiproject.assignment.api.AssignmentService assignmentService = ComponentManager.get(org.sakaiproject.assignment.api.AssignmentService.class);

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/LineItemUtil.java
@@ -399,13 +399,17 @@ public class LineItemUtil {
 		}
 
 		boolean createNew = true;
+		boolean updateName = true;
 		for (Iterator i = assignments.iterator(); i.hasNext();) {
 			Assignment gbColumn = (Assignment) i.next();
-
-			if (lineItem.label.equals(gbColumn.getName())) {
+			org.sakaiproject.assignment.api.model.Assignment asn = getAssignmentForGradebookLink(context_id, gbColumn.getId());
+			boolean matchesAsnContentId = content_id != null && asn != null && asn.getContentId() != null &&
+			    NumberUtils.compare(content_id.longValue(), asn.getContentId().longValue()) == 0;
+			if (matchesAsnContentId || lineItem.label.equals(gbColumn.getName())) {
 				gradebookColumn = gbColumn;
 				gradebookColumnId = gbColumn.getId();
 				createNew = false;
+				updateName = !matchesAsnContentId;
 				break;
 			}
 		}
@@ -425,7 +429,9 @@ public class LineItemUtil {
 			gradebookColumn.setExternalId(stableExternalId);
 			gradebookColumn.setLineItemMetadata(lineitem_metadata);
 			gradebookColumn.setExternalAppName(GB_EXTERNAL_APP_NAME);
-			gradebookColumn.setName(lineItem.label);
+			if (updateName) {
+			    gradebookColumn.setName(lineItem.label);
+			}
 			Boolean releaseToStudent = lineItem.releaseToStudent == null ? Boolean.TRUE : lineItem.releaseToStudent; // Default to true
 			Boolean includeInComputation = lineItem.includeInComputation == null ? Boolean.TRUE : lineItem.includeInComputation; // Default true
 			gradebookColumn.setReleased(releaseToStudent); // default true


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52567

Follow-up commit for issues found when the GB item title does not match the title of the associated assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradebook column identification when syncing grades from external learning tools by supporting multiple matching methods.
  * Enhanced accuracy in aligning assignments with gradebook entries for more reliable grade synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->