### PR TITLE
SAK-52385: Become user portal border highlighted with a different color

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/swapped-view/_base.scss
+++ b/library/src/skins/default/src/sass/modules/tool/swapped-view/_base.scss
@@ -17,8 +17,6 @@ body.Mrphs-become-user-enabled {
 		border-left: 7px solid var(--become-user-primary);
 		border-right: 7px solid var(--become-user-primary);
 		border-bottom: 7px solid var(--become-user-primary);
+		border-top: 7px solid var(--become-user-primary);
 	}		
-	.#{$namespace}topHeader, .#{$namespace}headerLogo {
-		background: var(--become-user-primary);
-	}
 }


### PR DESCRIPTION
The top border is also highlighted to provide a better advise that an user is impersonated by admin.
The portal header highlight is removed, it wasn't working anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the admin "Become User" interface to include an additional border element for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->