### PR TITLE
SAK-52653 Assignments Reorder view does not display all assignments

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5690,13 +5690,7 @@ public class AssignmentAction extends PagedResourceActionII {
         String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
         context.put("context", contextString);
 
-        List<Assignment> assignments = new ArrayList<>();
-
-        for (Assignment assignment : assignmentService.getAssignmentsForContext(contextString)) {
-            if (assignment != null && !assignment.getDeleted()) {
-                assignments.add(assignment);
-            }
-        }
+        List<Assignment> assignments = prepReorderAssignments(state);
 
         context.put("assignments", assignments.iterator());
         context.put("assignmentsize", assignments.size());
@@ -10423,13 +10417,10 @@ public class AssignmentAction extends PagedResourceActionII {
         SessionState state = ((JetspeedRunData) data).getPortletSessionState(((JetspeedRunData) data).getJs_peid());
         ParameterParser params = data.getParameters();
 
-        List assignments = prepPage(state);
+        List<Assignment> assignments = prepReorderAssignments(state);
 
-        Iterator it = assignments.iterator();
-
-        while (it.hasNext()) // reads and writes the parameter for default ordering
+        for (Assignment a : assignments) // reads and writes the parameter for default ordering
         {
-            Assignment a = (Assignment) it.next();
             String assignmentid = a.getId();
             String assignmentposition = params.getString("position_" + assignmentid);
             SecurityAdvisor sa = new SecurityAdvisor() {
@@ -13837,6 +13828,12 @@ public class AssignmentAction extends PagedResourceActionII {
         }
         return v;
     } // iterator_to_list
+
+    @SuppressWarnings("unchecked")
+    private List<Assignment> prepReorderAssignments(SessionState state) {
+        sizeResources(state);
+        return (List<Assignment>) state.getAttribute(STATE_PAGEING_TOTAL_ITEMS);
+    }
 
     /**
      * Implement this to return alist of all the resources that there are to page. Sort them as appropriate.

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -5687,9 +5687,16 @@ public class AssignmentAction extends PagedResourceActionII {
      * build the instructor view of reordering assignments
      */
     private String build_instructor_reorder_assignment_context(VelocityPortlet portlet, Context context, RunData data, SessionState state) {
-        context.put("context", state.getAttribute(STATE_CONTEXT_STRING));
+        String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
+        context.put("context", contextString);
 
-        List assignments = prepPage(state);
+        List<Assignment> assignments = new ArrayList<>();
+
+        for (Assignment assignment : assignmentService.getAssignmentsForContext(contextString)) {
+            if (assignment != null && !assignment.getDeleted()) {
+                assignments.add(assignment);
+            }
+        }
 
         context.put("assignments", assignments.iterator());
         context.put("assignmentsize", assignments.size());

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentTest.java
@@ -263,7 +263,10 @@ class AssignmentTest extends SakaiUiTestBase {
         assertThat(page.locator("#reorder-list")).containsText(lastTitle);
 
         Locator lastAssignment = reorderItems.filter(new Locator.FilterOptions().setHasText(lastTitle)).first();
-        lastAssignment.locator("select[name^=\"position_\"]").selectOption("1");
+        Locator lastAssignmentPosition = lastAssignment.locator("input[id^=\"index\"]");
+        lastAssignmentPosition.fill("1");
+        lastAssignmentPosition.dispatchEvent("change");
+        assertThat(lastAssignment.locator("select[name^=\"position_\"]")).hasValue("1");
 
         page.locator("input[name=\"save\"][value=\"Save\"], input[name=\"save\"]").first().click(new Locator.ClickOptions().setForce(true));
         page.waitForLoadState(com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED);

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentTest.java
@@ -237,6 +237,46 @@ class AssignmentTest extends SakaiUiTestBase {
         assertThat(page.locator("body")).containsText(nonElectronicTitle);
     }
 
+    @Test
+    @Order(9)
+    void reorderShowsAndSavesAssignmentsBeyondFirstPage() {
+        String courseUrl = ensureCourseUrl();
+        String titlePrefix = "Reorder Assignment " + System.currentTimeMillis() + " ";
+        String firstTitle = titlePrefix + "01";
+        String lastTitle = titlePrefix + "21";
+
+        sakai.login("instructor1");
+        page.navigate(courseUrl);
+        sakai.toolClick("Assignments");
+
+        for (int i = 1; i <= 21; i++) {
+            createSimpleAssignment(titlePrefix + String.format("%02d", i));
+        }
+
+        openReorderAssignments();
+
+        Locator reorderItems = page.locator("#reorder-list li.sortable");
+        if (reorderItems.count() < 21) {
+            fail("Expected the reorder list to include assignments beyond the first page.");
+        }
+        assertThat(page.locator("#reorder-list")).containsText(firstTitle);
+        assertThat(page.locator("#reorder-list")).containsText(lastTitle);
+
+        Locator lastAssignment = reorderItems.filter(new Locator.FilterOptions().setHasText(lastTitle)).first();
+        lastAssignment.locator("select[name^=\"position_\"]").selectOption("1");
+
+        page.locator("input[name=\"save\"][value=\"Save\"], input[name=\"save\"]").first().click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState(com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED);
+
+        goToAssignmentsList();
+        String assignmentListText = page.locator("body").innerText();
+        int lastIndex = assignmentListText.indexOf(lastTitle);
+        int firstIndex = assignmentListText.indexOf(firstTitle);
+        if (lastIndex < 0 || firstIndex < 0 || lastIndex > firstIndex) {
+            fail("Expected reordered assignment beyond the first page to be saved before the first generated assignment.");
+        }
+    }
+
     private void openAddAssignmentForm() {
         goToAssignmentsList();
 
@@ -262,6 +302,32 @@ class AssignmentTest extends SakaiUiTestBase {
         }
 
         assertThat(titleInput).isVisible();
+    }
+
+    private void openReorderAssignments() {
+        goToAssignmentsList();
+
+        Locator reorderLink = page.locator(".navIntraTool a, .navIntraTool button, .navIntraTool [role=\"button\"]")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Reorder$", Pattern.CASE_INSENSITIVE)))
+            .first();
+        assertThat(reorderLink).isVisible();
+        reorderLink.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState(com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED);
+        assertThat(page.locator("#reorder-list")).isVisible();
+    }
+
+    private void createSimpleAssignment(String title) {
+        openAddAssignmentForm();
+        page.locator("#new_assignment_title").fill(title);
+
+        Locator gradeAssignment = page.locator("#gradeAssignment").first();
+        if (gradeAssignment.count() > 0 && gradeAssignment.isChecked()) {
+            gradeAssignment.uncheck(new Locator.UncheckOptions().setForce(true));
+        }
+
+        fillAssignmentInstructions("<p>Reorder regression assignment.</p>");
+        submitAssignmentForm();
+        goToAssignmentsList();
     }
 
     private void goToAssignmentsList() {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the instructor “Reorder” assignment view to reliably show and reorder assignments beyond the first page, with the saved order persisting as expected.
* **Refactor**
  * Updated how reorder context and assignment lists are prepared for the instructor reorder interface.
* **Tests**
  * Added an end-to-end test that creates multiple assignments, reorders an item from the last page, and verifies the new ordering is saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->