### PR TITLE
SAK-52631 SiteInfo import Announcements before Assignments to handle cleanup routines

### DIFF
--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTransferCopyEntitiesTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTransferCopyEntitiesTest.java
@@ -166,6 +166,50 @@ public class AssignmentTransferCopyEntitiesTest extends AbstractTransactionalJUn
     }
 
     @Test
+    public void transferCopyEntitiesWithCleanupRecreatesPublishedOpenDateAnnouncement() throws Exception {
+
+        String fromContext = UUID.randomUUID().toString();
+        String toContext = UUID.randomUUID().toString();
+        Assignment sourceAssignment = createPublishedAssignment(fromContext);
+        sourceAssignment.getProperties().put(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE, Boolean.TRUE.toString());
+        sourceAssignment.getProperties().put(AssignmentConstants.NEW_ASSIGNMENT_OPEN_DATE_ANNOUNCED, Boolean.TRUE.toString());
+        updateAssignment(sourceAssignment);
+
+        String toChannelId = "/announcement/" + toContext + "/main";
+        AnnouncementChannel announcementChannel = mock(AnnouncementChannel.class);
+        AnnouncementMessageEdit message = mock(AnnouncementMessageEdit.class);
+        AnnouncementMessageHeaderEdit header = mock(AnnouncementMessageHeaderEdit.class);
+        ResourcePropertiesEdit messageProperties = mock(ResourcePropertiesEdit.class);
+
+        when(announcementService.channelReference(toContext, SiteService.MAIN_CONTAINER)).thenReturn(toChannelId);
+        when(announcementService.getAnnouncementChannel(toChannelId)).thenReturn(announcementChannel);
+        when(announcementChannel.addAnnouncementMessage()).thenReturn(message);
+        when(message.getAnnouncementHeaderEdit()).thenReturn(header);
+        when(message.getPropertiesEdit()).thenReturn(messageProperties);
+        when(message.getId()).thenReturn("replace-import-announcement-id");
+
+        stubContextPermissions(toContext);
+
+        Map<String, String> copied = getAssignmentServiceImpl().transferCopyEntities(fromContext, toContext, null,
+            List.of(EntityTransferrer.PUBLISH_OPTION), true);
+
+        assertTrue(copied.containsKey("assignment/" + sourceAssignment.getId()));
+
+        Collection<Assignment> importedAssignments = assignmentService.getAssignmentsForContext(toContext);
+        assertEquals(1, importedAssignments.size());
+        Assignment importedAssignment = importedAssignments.iterator().next();
+        Assert.assertFalse(importedAssignment.getDraft());
+        assertEquals("replace-import-announcement-id",
+            importedAssignment.getProperties().get(ResourceProperties.PROP_ASSIGNMENT_OPENDATE_ANNOUNCEMENT_MESSAGE_ID));
+        assertEquals(Boolean.TRUE.toString(),
+            importedAssignment.getProperties().get(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE));
+        assertEquals(Boolean.TRUE.toString(),
+            importedAssignment.getProperties().get(AssignmentConstants.NEW_ASSIGNMENT_OPEN_DATE_ANNOUNCED));
+        verify(messageProperties, never()).addProperty(eq(AnnouncementService.RELEASE_DATE), anyString());
+        verify(announcementChannel).commitMessage(message, 0, "org.sakaiproject.announcement.impl.SiteEmailNotificationAnnc");
+    }
+
+    @Test
     public void transferCopyEntitiesRecreatesDraftOpenDateAnnouncementWhenImportDefaultsToDraft() throws Exception {
 
         String fromContext = UUID.randomUUID().toString();

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/support/SakaiHelper.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/support/SakaiHelper.java
@@ -60,7 +60,12 @@ public class SakaiHelper {
         if (siteUrl == null) {
             return "";
         }
-        return siteUrl.replaceFirst("^.*/portal/site/", "").replaceFirst("[/?#].*$", "");
+        String marker = "/portal/site/";
+        int start = siteUrl.indexOf(marker);
+        if (start < 0) {
+            return "";
+        }
+        return siteUrl.substring(start + marker.length()).replaceFirst("[/?#].*$", "");
     }
 
     public String resolveUsername(String username) {

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/support/SakaiHelper.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/support/SakaiHelper.java
@@ -56,6 +56,13 @@ public class SakaiHelper {
         return Long.toString(System.currentTimeMillis());
     }
 
+    public String siteIdFromUrl(String siteUrl) {
+        if (siteUrl == null) {
+            return "";
+        }
+        return siteUrl.replaceFirst("^.*/portal/site/", "").replaceFirst("[/?#].*$", "");
+    }
+
     public String resolveUsername(String username) {
         return resolveUser(username);
     }

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentImportAnnouncementTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentImportAnnouncementTest.java
@@ -95,7 +95,10 @@ class AssignmentImportAnnouncementTest extends SakaiUiTestBase {
         page.onDialog(dialog -> dialog.accept());
         clickContinueOrFinish();
         page.waitForLoadState();
+        page.waitForTimeout(10_000);
 
+        page.navigate(destinationSite);
+        page.waitForLoadState();
         sakai.toolClick("Assignments");
         assertThat(page.locator("body")).containsText(ASSIGNMENT_TITLE);
         Locator assignmentRow = page.locator("tr, li, .assignment").filter(new Locator.FilterOptions().setHasText(ASSIGNMENT_TITLE)).first();

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentImportAnnouncementTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AssignmentImportAnnouncementTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+class AssignmentImportAnnouncementTest extends SakaiUiTestBase {
+
+    private static final String ASSIGNMENT_TITLE = "SAK-51487 Assignment " + System.currentTimeMillis();
+
+    @Test
+    void replaceImportPublishingAssignmentsCreatesOpenDateAnnouncement() {
+        sakai.login("instructor1");
+        String sourceSite = sakai.createCourse("instructor1", List.of(
+            "sakai\\.announcements",
+            "sakai\\.assignment\\.grades",
+            "sakai\\.schedule",
+            "sakai\\.gradebookng"
+        ));
+        String destinationSite = sakai.createCourse("instructor1", List.of(
+            "sakai\\.announcements",
+            "sakai\\.assignment\\.grades",
+            "sakai\\.schedule",
+            "sakai\\.gradebookng",
+            "sakai\\.dashboard"
+        ));
+
+        page.navigate(sourceSite);
+        sakai.toolClick("Assignments");
+        openAddAssignmentForm();
+        page.locator("#new_assignment_title").fill(ASSIGNMENT_TITLE);
+
+        Locator gradeAssignment = page.locator("#gradeAssignment").first();
+        if (gradeAssignment.count() > 0 && gradeAssignment.isChecked()) {
+            gradeAssignment.uncheck(new Locator.UncheckOptions().setForce(true));
+        }
+
+        page.locator("#new_assignment_check_auto_announce").check(new Locator.CheckOptions().setForce(true));
+        Locator addDueDate = page.locator("#new_assignment_check_add_due_date").first();
+        if (addDueDate.count() > 0) {
+            addDueDate.check(new Locator.CheckOptions().setForce(true));
+        }
+
+        fillAssignmentInstructions("<p>Import announcement regression assignment.</p>");
+        submitAssignmentForm();
+        assertThat(page.locator("body")).containsText(ASSIGNMENT_TITLE);
+
+        sakai.toolClick("Announcements");
+        assertThat(page.locator("body")).containsText(ASSIGNMENT_TITLE);
+
+        page.navigate(destinationSite);
+        sakai.toolClick("Site Info");
+        page.locator(".navIntraTool a, .navIntraTool button")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Import from Site$", Pattern.CASE_INSENSITIVE)))
+            .first()
+            .click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions()
+                .setName(Pattern.compile("replace my data", Pattern.CASE_INSENSITIVE)))
+            .first()
+            .click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+
+        String sourceSiteId = sakai.siteIdFromUrl(sourceSite);
+        page.locator("input[name=\"importSites\"][value=\"" + sourceSiteId + "\"]").check(new Locator.CheckOptions().setForce(true));
+        clickContinueOrFinish();
+
+        page.locator("#toolSite-sakai\\.assignment\\.grades-" + sourceSiteId).check(new Locator.CheckOptions().setForce(true));
+        page.locator("#toolSite-sakai\\.announcements-" + sourceSiteId).check(new Locator.CheckOptions().setForce(true));
+        page.locator("#toolSite-sakai\\.schedule-" + sourceSiteId).check(new Locator.CheckOptions().setForce(true));
+        page.locator("#toolSite-sakai\\.gradebookng-" + sourceSiteId).check(new Locator.CheckOptions().setForce(true));
+        page.locator("input[name=\"sakai.assignment.grades$" + sourceSiteId + "-import-option-publish\"]")
+            .check(new Locator.CheckOptions().setForce(true));
+        page.onDialog(dialog -> dialog.accept());
+        clickContinueOrFinish();
+        page.waitForLoadState();
+
+        sakai.toolClick("Assignments");
+        assertThat(page.locator("body")).containsText(ASSIGNMENT_TITLE);
+        Locator assignmentRow = page.locator("tr, li, .assignment").filter(new Locator.FilterOptions().setHasText(ASSIGNMENT_TITLE)).first();
+        assertThat(assignmentRow).not().containsText(Pattern.compile("\\bDraft\\b", Pattern.CASE_INSENSITIVE));
+
+        sakai.toolClick("Announcements");
+        assertThat(page.locator("body")).containsText(ASSIGNMENT_TITLE);
+    }
+
+    private void openAddAssignmentForm() {
+        Locator addLink = page.locator(".navIntraTool a, .navIntraTool button, .navIntraTool [role=\"button\"]")
+            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^(Add|New)$", Pattern.CASE_INSENSITIVE)))
+            .first();
+        assertThat(addLink).isVisible();
+        addLink.click(new Locator.ClickOptions().setForce(true));
+        assertThat(page.locator("#new_assignment_title")).isVisible();
+    }
+
+    private void fillAssignmentInstructions(String html) {
+        if (!sakai.typeCkEditorIfPresent("new_assignment_instructions", html)) {
+            Locator fallback = page.locator("textarea#new_assignment_instructions, textarea:visible, [contenteditable=\"true\"]:visible").first();
+            if (fallback.count() > 0) {
+                fallback.fill(html.replaceAll("<[^>]+>", ""));
+            }
+        }
+    }
+
+    private void submitAssignmentForm() {
+        Locator submit = page.locator(
+            "div.act input[type=\"button\"][name=\"post\"]:visible, .act input[type=\"button\"][name=\"post\"]:visible, " +
+            "div.act input[type=\"submit\"][name=\"post\"]:visible, .act input[type=\"submit\"][name=\"post\"]:visible, " +
+            "div.act input[type=\"button\"][value*=\"Save and Release\"]:visible, .act input[type=\"button\"][value*=\"Save and Release\"]:visible, " +
+            "div.act input[type=\"submit\"][value*=\"Save and Release\"]:visible, .act input[type=\"submit\"][value*=\"Save and Release\"]:visible, " +
+            "div.act button:has-text(\"Save and Release\"):visible, .act button:has-text(\"Save and Release\"):visible, " +
+            "div.act input[type=\"button\"][value=\"Post\"]:visible, .act input[type=\"button\"][value=\"Post\"]:visible, " +
+            "div.act input[type=\"submit\"][value=\"Post\"]:visible, .act input[type=\"submit\"][value=\"Post\"]:visible, " +
+            "div.act button:has-text(\"Post\"):visible, .act button:has-text(\"Post\"):visible"
+        ).first();
+        assertThat(submit).isVisible();
+        submit.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+    }
+
+    private void clickContinueOrFinish() {
+        Locator button = page.locator(
+            "input[type=\"submit\"][value*=\"Continue\"], input[type=\"submit\"][value*=\"Finish\"], " +
+            "button:has-text(\"Continue\"), button:has-text(\"Finish\"), #siteimport-finish-button"
+        ).first();
+        assertThat(button).isVisible();
+        button.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+    }
+
+}

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
@@ -688,11 +688,16 @@ public class SiteManageServiceImpl implements SiteManageService {
 		// run before Assignments imports published assignments.
 		if (toolIds.contains(ANNOUNCEMENTS_TOOL_ID)) {
 			for (String toolId : toolIds) {
-				if (StringUtils.equalsIgnoreCase(toolId, ANNOUNCEMENTS_TOOL_ID) && importTools.containsKey(toolId)) {
+				if (StringUtils.equalsIgnoreCase(toolId, ANNOUNCEMENTS_TOOL_ID)) {
 					Map<String, List<String>> siteItems = toolItemMap.getOrDefault(toolId, Collections.EMPTY_MAP);
 					Map<String, List<String>> siteOptions = toolOptions.getOrDefault(toolId, Collections.EMPTY_MAP);
 
-					for (String fromSiteId : importTools.get(toolId)) {
+					Set<String> sourceSiteIds = new LinkedHashSet<>();
+					sourceSiteIds.addAll(importTools.getOrDefault(toolId, Collections.EMPTY_LIST));
+					sourceSiteIds.addAll(siteItems.keySet());
+					sourceSiteIds.addAll(siteOptions.keySet());
+
+					for (String fromSiteId : sourceSiteIds) {
 						doImport(transversalMap, toolId, siteIds, fromSiteId, toSiteId, siteItems, siteOptions, cleanup, false);
 					}
 				}

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImpl.java
@@ -90,6 +90,8 @@ import org.sakaiproject.authz.api.Role;
 @Slf4j
 public class SiteManageServiceImpl implements SiteManageService {
 
+    private static final String ANNOUNCEMENTS_TOOL_ID = "sakai.announcements";
+
     @Setter private ContentHostingService contentHostingService;
     @Setter private EntityManager entityManager;
     @Setter private EventTrackingService eventTrackingService;
@@ -681,12 +683,29 @@ public class SiteManageServiceImpl implements SiteManageService {
 			}
 		}
 
+		// Now announcements. Assignment-generated announcements are intentionally skipped by
+		// the Announcements import and recreated by Assignments, so Announcements cleanup must
+		// run before Assignments imports published assignments.
+		if (toolIds.contains(ANNOUNCEMENTS_TOOL_ID)) {
+			for (String toolId : toolIds) {
+				if (StringUtils.equalsIgnoreCase(toolId, ANNOUNCEMENTS_TOOL_ID) && importTools.containsKey(toolId)) {
+					Map<String, List<String>> siteItems = toolItemMap.getOrDefault(toolId, Collections.EMPTY_MAP);
+					Map<String, List<String>> siteOptions = toolOptions.getOrDefault(toolId, Collections.EMPTY_MAP);
+
+					for (String fromSiteId : importTools.get(toolId)) {
+						doImport(transversalMap, toolId, siteIds, fromSiteId, toSiteId, siteItems, siteOptions, cleanup, false);
+					}
+				}
+			}
+		}
+
 		// Now import the rest of the tools
 		if (!toolIds.isEmpty()) {
 			for (String toolId : toolIds) {
 				if (!StringUtils.equalsIgnoreCase(toolId, SiteManageConstants.RESOURCES_TOOL_ID)
 						&& !StringUtils.equalsIgnoreCase(toolId, SiteManageConstants.GRADEBOOK_TOOL_ID)
-						&& !StringUtils.equalsIgnoreCase(toolId, SiteManageConstants.CALENDAR_TOOL_ID)) {
+						&& !StringUtils.equalsIgnoreCase(toolId, SiteManageConstants.CALENDAR_TOOL_ID)
+						&& !StringUtils.equalsIgnoreCase(toolId, ANNOUNCEMENTS_TOOL_ID)) {
 
 					Map<String, List<String>> siteItems = toolItemMap.getOrDefault(toolId, Collections.EMPTY_MAP);
 					Map<String, List<String>> siteOptions = toolOptions.getOrDefault(toolId, Collections.EMPTY_MAP);

--- a/site-manage/site-manage-impl/impl/src/test/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImplImportToolContentTest.java
+++ b/site-manage/site-manage-impl/impl/src/test/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImplImportToolContentTest.java
@@ -306,6 +306,60 @@ public class SiteManageServiceImplImportToolContentTest {
         InOrder inOrder = inOrder(announcementTransferrer, assignmentTransferrer);
         inOrder.verify(announcementTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
         inOrder.verify(assignmentTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
+        verify(announcementTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
+        verify(assignmentTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
+    }
+
+    @Test
+    public void importToolsIntoSiteImportsAnnouncementItemsBeforeAssignments() throws Exception {
+
+        final String oldSiteId = "site-old";
+        final String newSiteId = "site-new";
+        final List<String> announcementItems = List.of("announcement-1");
+
+        Site sourceSite = mock(Site.class);
+        Site destinationSite = mock(Site.class);
+        ResourceProperties sourceSiteProperties = mock(ResourceProperties.class);
+        ResourcePropertiesEdit destinationSiteProperties = mock(ResourcePropertiesEdit.class);
+
+        when(sourceSite.getProperties()).thenReturn(sourceSiteProperties);
+        when(sourceSiteProperties.getProperty(LTICustomVars.CONTEXT_ID_HISTORY)).thenReturn(null);
+        when(destinationSite.getId()).thenReturn(newSiteId);
+        when(destinationSite.getPropertiesEdit()).thenReturn(destinationSiteProperties);
+        when(siteService.getSite(oldSiteId)).thenReturn(sourceSite);
+        when(siteService.getSite(newSiteId)).thenReturn(destinationSite);
+
+        EntityProducer assignmentProducer = mock(EntityProducer.class, withSettings().extraInterfaces(EntityTransferrer.class));
+        EntityProducer announcementProducer = mock(EntityProducer.class, withSettings().extraInterfaces(EntityTransferrer.class));
+        EntityTransferrer assignmentTransferrer = (EntityTransferrer) assignmentProducer;
+        EntityTransferrer announcementTransferrer = (EntityTransferrer) announcementProducer;
+
+        when(assignmentTransferrer.myToolIds()).thenReturn(new String[] { "sakai.assignment.grades" });
+        when(announcementTransferrer.myToolIds()).thenReturn(new String[] { ANNOUNCEMENTS_TOOL_ID });
+        when(assignmentTransferrer.transferCopyEntities(oldSiteId, newSiteId, null, null, true)).thenReturn(Collections.emptyMap());
+        when(announcementTransferrer.transferCopyEntities(oldSiteId, newSiteId, announcementItems, null, true)).thenReturn(Collections.emptyMap());
+        when(entityManager.getEntityProducers()).thenReturn(List.of(assignmentProducer, announcementProducer));
+
+        Map<String, List<String>> importTools = new HashMap<>();
+        importTools.put("sakai.assignment.grades", List.of(oldSiteId));
+
+        Map<String, Map<String, List<String>>> toolItemMap = new HashMap<>();
+        toolItemMap.put(ANNOUNCEMENTS_TOOL_ID, Map.of(oldSiteId, announcementItems));
+
+        siteManageService.importToolsIntoSite(
+            destinationSite,
+            new ArrayList<>(List.of("sakai.assignment.grades", ANNOUNCEMENTS_TOOL_ID)),
+            importTools,
+            toolItemMap,
+            Collections.emptyMap(),
+            true
+        );
+
+        InOrder inOrder = inOrder(announcementTransferrer, assignmentTransferrer);
+        inOrder.verify(announcementTransferrer).transferCopyEntities(oldSiteId, newSiteId, announcementItems, null, true);
+        inOrder.verify(assignmentTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
+        verify(announcementTransferrer).transferCopyEntities(oldSiteId, newSiteId, announcementItems, null, true);
+        verify(assignmentTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
     }
 
     private SitePage mockSiteInfoPage() {

--- a/site-manage/site-manage-impl/impl/src/test/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImplImportToolContentTest.java
+++ b/site-manage/site-manage-impl/impl/src/test/java/org/sakaiproject/sitemanage/impl/SiteManageServiceImplImportToolContentTest.java
@@ -29,6 +29,8 @@ import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.EntityProducer;
+import org.sakaiproject.entity.api.EntityTransferrer;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.site.api.Site;
@@ -37,8 +39,12 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.sitemanage.api.SiteManageConstants;
 import org.sakaiproject.tool.api.Tool;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.tsugi.lti13.LTICustomVars;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
@@ -47,11 +53,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Focused unit tests for SiteManageServiceImpl#importToolContent site info URL behavior.
  */
 public class SiteManageServiceImplImportToolContentTest {
+
+    private static final String ANNOUNCEMENTS_TOOL_ID = "sakai.announcements";
 
     private SiteManageServiceImpl siteManageService;
     private SiteService siteService;
@@ -68,16 +77,22 @@ public class SiteManageServiceImplImportToolContentTest {
         functionManager = mock(FunctionManager.class);
         serverConfigurationService = mock(ServerConfigurationService.class);
         entityManager = mock(EntityManager.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
 
         siteManageService.setSiteService(siteService);
         siteManageService.setAuthzGroupService(authzGroupService);
         siteManageService.setFunctionManager(functionManager);
         siteManageService.setServerConfigurationService(serverConfigurationService);
         siteManageService.setEntityManager(entityManager);
+        siteManageService.setTransactionTemplate(transactionTemplate);
 
         // Keep this test class focused on site-info URL behavior.
         doReturn(false).when(siteManageService).isAddMissingToolsOnImportEnabled();
         when(entityManager.getEntityProducers()).thenReturn(Collections.emptyList());
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
     }
 
     @Test
@@ -244,6 +259,53 @@ public class SiteManageServiceImplImportToolContentTest {
         verify(destinationSite).setInfoUrl(expectedSiteInfoUrl);
         verify(destinationSite, never()).setInfoUrl("");
         verify(siteService, atLeastOnce()).save(destinationSite);
+    }
+
+    @Test
+    public void importToolsIntoSiteImportsAnnouncementsBeforeAssignments() throws Exception {
+
+        final String oldSiteId = "site-old";
+        final String newSiteId = "site-new";
+
+        Site sourceSite = mock(Site.class);
+        Site destinationSite = mock(Site.class);
+        ResourceProperties sourceSiteProperties = mock(ResourceProperties.class);
+        ResourcePropertiesEdit destinationSiteProperties = mock(ResourcePropertiesEdit.class);
+
+        when(sourceSite.getProperties()).thenReturn(sourceSiteProperties);
+        when(sourceSiteProperties.getProperty(LTICustomVars.CONTEXT_ID_HISTORY)).thenReturn(null);
+        when(destinationSite.getId()).thenReturn(newSiteId);
+        when(destinationSite.getPropertiesEdit()).thenReturn(destinationSiteProperties);
+        when(siteService.getSite(oldSiteId)).thenReturn(sourceSite);
+        when(siteService.getSite(newSiteId)).thenReturn(destinationSite);
+
+        EntityProducer assignmentProducer = mock(EntityProducer.class, withSettings().extraInterfaces(EntityTransferrer.class));
+        EntityProducer announcementProducer = mock(EntityProducer.class, withSettings().extraInterfaces(EntityTransferrer.class));
+        EntityTransferrer assignmentTransferrer = (EntityTransferrer) assignmentProducer;
+        EntityTransferrer announcementTransferrer = (EntityTransferrer) announcementProducer;
+
+        when(assignmentTransferrer.myToolIds()).thenReturn(new String[] { "sakai.assignment.grades" });
+        when(announcementTransferrer.myToolIds()).thenReturn(new String[] { ANNOUNCEMENTS_TOOL_ID });
+        when(assignmentTransferrer.transferCopyEntities(oldSiteId, newSiteId, null, null, true)).thenReturn(Collections.emptyMap());
+        when(announcementTransferrer.transferCopyEntities(oldSiteId, newSiteId, null, null, true)).thenReturn(Collections.emptyMap());
+        when(entityManager.getEntityProducers()).thenReturn(List.of(assignmentProducer, announcementProducer));
+
+        Map<String, List<String>> importTools = new HashMap<>();
+        importTools.put("sakai.assignment.grades", List.of(oldSiteId));
+        importTools.put(ANNOUNCEMENTS_TOOL_ID, List.of(oldSiteId));
+
+        siteManageService.importToolsIntoSite(
+            destinationSite,
+            new ArrayList<>(List.of("sakai.assignment.grades", ANNOUNCEMENTS_TOOL_ID)),
+            importTools,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            true
+        );
+
+        InOrder inOrder = inOrder(announcementTransferrer, assignmentTransferrer);
+        inOrder.verify(announcementTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
+        inOrder.verify(assignmentTransferrer).transferCopyEntities(oldSiteId, newSiteId, null, null, true);
     }
 
     private SitePage mockSiteInfoPage() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for recreating published open-date assignment announcements during transfer with cleanup.
  * Added end-to-end test validating open-date assignment announcements import correctly and appear in both the Assignments and Announcements tools.
  * Added unit tests ensuring announcement imports (including announcement items) run before assignments during site tool import.
  * Enhanced test URL parsing helper for extracting site ids.
* **Bug Fixes**
  * Improved site tool import flow so announcements are imported in a dedicated step, preventing missing or duplicate announcement content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->