### PR TITLE
SAK-52655 Lessons LTI picker needs sakai-lti-iframe web component

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/BltiPickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/BltiPickerProducer.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.net.URLEncoder;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import uk.org.ponder.messageutil.MessageLocator;
@@ -36,9 +37,10 @@ import uk.org.ponder.rsf.components.UIBranchContainer;
 import uk.org.ponder.rsf.components.UICommand;
 import uk.org.ponder.rsf.components.UIContainer;
 import uk.org.ponder.rsf.components.UIForm;
+import uk.org.ponder.rsf.components.UIInput;
 import uk.org.ponder.rsf.components.UILink;
 import uk.org.ponder.rsf.components.UIOutput;
-import uk.org.ponder.rsf.components.UIInput;
+import uk.org.ponder.rsf.components.UIVerbatim;
 import uk.org.ponder.rsf.components.decorators.UIFreeAttributeDecorator;
 import uk.org.ponder.rsf.flow.jsfnav.NavigationCase;
 import uk.org.ponder.rsf.flow.jsfnav.NavigationCaseReporter;
@@ -198,6 +200,11 @@ public class BltiPickerProducer implements ViewComponentProducer, NavigationCase
 			UIInput.make(cancelform, "select", "simplePageBean.selectedBlti", ltiItemId);
 			UICommand.make(cancelform, "cancel", messageLocator.getMessage("simplepage.cancel"), "#{simplePageBean.cancel}");
 			UICommand.make(cancelform, "cancel2", messageLocator.getMessage("simplepage.cancel"), "#{simplePageBean.cancel}");
+
+			String allow = ServerConfigurationService.getBrowserFeatureAllowString();
+			String allowEscaped = StringEscapeUtils.escapeHtml4(allow);
+			String iframeHtml = "<sakai-lti-iframe id=\"sakai-lti-admin-iframe\" name=\"sakai-lti-admin-iframe\" launch-url=\"/library/image/sakai/spinner.gif\" allow=\"" + allowEscaped + "\" height=\"100%\" allow-resize=\"yes\"></sakai-lti-iframe>";
+			UIVerbatim.make(tofill, "iframe-container", iframeHtml);
 		}
 	}
 

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -13,6 +13,7 @@
     opacity:.75;
 }
 </style>
+<script type="module" src="/webcomponents/bundles/lti.js"></script>
 </head>
 <body rsf:id="scr=sakai-body">
 	<div class="portletBody" id="portletBody">
@@ -49,7 +50,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
-			      <iframe name="sakai-lti-admin-iframe" id="sakai-lti-admin-iframe" src="/library/image/sakai/spinner.gif" tabindex="0"></iframe>
+            <div rsf:id="iframe-container"></div>
           </div>
         </div>
       </div>
@@ -72,13 +73,11 @@
 
       el.addEventListener("shown.bs.modal", e => {
         console.log('Height', modalDialogHeight());
-        $('#modal-iframe-div').attr('height', modalDialogHeight());
-        $('#sakai-lti-admin-iframe').attr('width', $("#modal-iframe-div").width());
-        $('#sakai-lti-admin-iframe').attr('height', modalDialogHeight()-50);
+        document.getElementById('#modal-iframe-div').setAttribute('height', modalDialogHeight());
       });
 
       el.addEventListener("hidden.bs.modal", e => {
-          $('#sakai-lti-admin-iframe').attr('src','/library/image/sakai/spinner.gif');
+          document.getElementById('sakai-lti-admin-iframe').setAttribute('launch-url', '/library/image/sakai/spinner.gif');
           var form = document.getElementById("blti-cancel");
           if ( form != null ) {
               console.debug("Cancelling");
@@ -91,8 +90,6 @@
         modal.handleUpdate();
         // Note that width() gives the content width, taking into consideration the border, padding, etc.
         console.log('Height', modalDialogHeight());
-        $('#sakai-lti-admin-iframe').attr('width', $("#modal-iframe-div").width());
-        $('#sakai-lti-admin-iframe').attr('height', modalDialogHeight()-50);
       });
     }
 
@@ -109,7 +106,7 @@ $( document ).ready(function() {
                 if ( shortcut_tag ) {
                     var shortcut_href = shortcut_tag.getAttribute('href');
                     if ( shortcut_href ) {
-                        document.getElementById('sakai-lti-admin-iframe').src = shortcut_href;
+                        document.getElementById('sakai-lti-admin-iframe').setAttribute('launch-url', shortcut_href);
                         showIframe();
                     }
                 }


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encoding of iframe attributes to prevent HTML injection when embedding external tools.

* **Refactor**
  * Switched the tool picker to use the modern web-component bundle for LTI content.
  * Reworked iframe lifecycle: initialization, loading and teardown now use the web component launch mechanism and simpler height handling for more reliable behavior and fewer redundant calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->