### PR TITLE
SAK-52652 Calendar UX improvements

### DIFF
--- a/calendar/calendar-bundles/resources/calendar.properties
+++ b/calendar/calendar-bundles/resources/calendar.properties
@@ -255,6 +255,7 @@ view.before = Earlier
 view.tomorrow = Next Day
 view.yesterday = Previous Day
 view.view = View
+view.toggleToolbar = Calendar options
 view.listnavselect = To operate the combo box, first press Alt+Down Arrow to open it, and then use the up and down arrow keys to scroll through the options.
 view.summary = Table represents a day - rows are half hours
 view.calday = Calendar by Day

--- a/calendar/calendar-bundles/resources/calendar_es.properties
+++ b/calendar/calendar-bundles/resources/calendar_es.properties
@@ -255,6 +255,7 @@ view.before=Antes
 view.tomorrow=Ma\u00f1ana
 view.yesterday=Ayer
 view.view=Vista
+view.toggleToolbar=Opciones del calendario
 view.listnavselect=Presiona Alt y las fechas del cursor (arriba y abajo) para desplazarse por el men\u00fa.
 view.summary=Esta tabla representa la planificaci\u00f3n del d\u00eda. Cada fila representa un margen temporal de media hora.
 view.calday=Calendario por d\u00eda

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.text.DateFormat;
 import java.text.NumberFormat;
@@ -4666,9 +4667,9 @@ extends VelocityPortletStateAction
 				state.setNewData(state.getPrimaryCalendarReference(), "", "", date.getMonthValue(), date.getDayOfMonth(),
 						String.valueOf(date.getYear()), hour, minute, -1, -1, "", am, "", new HashMap(), "");
 			}
-			catch (Exception e)
+			catch (DateTimeParseException e)
 			{
-				log.warn("doNew(): invalid date '{}' from calendar grid: {}", newEventDate, e.toString());
+				log.warn("doNew(): invalid date '{}' from calendar grid", newEventDate, e);
 			}
 		}
 	}	 // doNew

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -23,6 +23,7 @@ package org.sakaiproject.calendar.tool;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.text.DateFormat;
@@ -4651,7 +4652,25 @@ extends VelocityPortletStateAction
 		state.setIsNewCalendar(true);
 		sstate.setAttribute(FREQUENCY_SELECT, null);
 		sstate.setAttribute(CalendarAction.SSTATE__RECURRING_RULE, null);
-		
+
+		// Prefill the date and start time from the calendar grid (e.g. double-click on a time slot).
+		String newEventDate = data.getParameters().getString("newEventDate");
+		if (StringUtils.isNotBlank(newEventDate))
+		{
+			try
+			{
+				LocalDate date = LocalDate.parse(newEventDate);
+				int hour = data.getParameters().getInt("newEventHour", 0);
+				int minute = data.getParameters().getInt("newEventMinute", 0);
+				String am = hour < 12 ? "am" : "pm";
+				state.setNewData(state.getPrimaryCalendarReference(), "", "", date.getMonthValue(), date.getDayOfMonth(),
+						String.valueOf(date.getYear()), hour, minute, -1, -1, "", am, "", new HashMap(), "");
+			}
+			catch (Exception e)
+			{
+				log.warn("doNew(): invalid date '{}' from calendar grid: {}", newEventDate, e.toString());
+			}
+		}
 	}	 // doNew
 	
 	/**

--- a/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
+++ b/calendar/calendar-tool/tool/src/java/org/sakaiproject/calendar/tool/CalendarAction.java
@@ -4669,7 +4669,7 @@ extends VelocityPortletStateAction
 			}
 			catch (DateTimeParseException e)
 			{
-				log.warn("doNew(): invalid date '{}' from calendar grid", newEventDate, e);
+				log.warn("invalid date '{}' from calendar grid", newEventDate, e);
 			}
 		}
 	}	 // doNew

--- a/calendar/calendar-tool/tool/src/webapp/js/sakai-calendar.js
+++ b/calendar/calendar-tool/tool/src/webapp/js/sakai-calendar.js
@@ -37,6 +37,20 @@ const sakaiCalendar = {
       datesSet: (dateInfo) => {
         // This event fires when the calendar is fully rendered and ready
         this.setupViewButtonHandlers();
+        this.updateHeightForView(dateInfo.view.type);
+      },
+      dateClick: (info) => {
+        // Clicking on a day cell in month view navigates to the day view for that date.
+        if (info.view.type === 'dayGridMonth') {
+          this.calendar.changeView('timeGridDay', info.date);
+          // The second click of a double-click may land on the new day view once it
+          // re-renders; ignore it so it doesn't also open the new event form.
+          this.ignoreDateClickUntil = Date.now() + 400;
+        } else if (info.jsEvent.detail === 2 && info.view.type.startsWith('timeGrid')
+            && Date.now() >= (this.ignoreDateClickUntil || 0)) {
+          // Double-clicking on a time slot opens the new event form with that date/time prefilled.
+          this.openNewEventForm(info.dateStr);
+        }
       },
       buttonIcons: {
         /*Use of bootstrap5 as themeSystem will expect bootstrap icons and prepend bi bi-*/
@@ -127,6 +141,16 @@ const sakaiCalendar = {
         return {
           html: eventTitle.outerHTML
         };
+      },
+      // Show the full title, schedule, type and origin site as a native
+      // tooltip, since long titles get truncated in the month view cells.
+      eventDidMount: function (info) {
+        const { event } = info;
+        const { type, site_name } = event.extendedProps;
+        const startTime = sakaiCalendar.calendar.formatDate(event.start, { hour: 'numeric', minute: '2-digit' });
+        const endTime = sakaiCalendar.calendar.formatDate(event.end, { hour: 'numeric', minute: '2-digit' });
+        const schedule = `${startTime} - ${endTime}`;
+        info.el.title = [event.title, schedule, type, site_name].filter(Boolean).join('\n');
       }
     });
 
@@ -139,13 +163,67 @@ const sakaiCalendar = {
   gotoDate (currentDate) {
     this.calendar.gotoDate(currentDate);
   },
+
+  // Submit the hidden "new event" form, prefilling the date and time that was double-clicked.
+  openNewEventForm (dateStr) {
+    // dateStr is already expressed in the calendar's configured timezone, so parseZone
+    // keeps those literal values instead of converting to the browser's local timezone.
+    const m = moment.parseZone(dateStr);
+    document.getElementById('newEventDate').value = m.format('YYYY-MM-DD');
+    document.getElementById('newEventHour').value = m.format('H');
+    document.getElementById('newEventMinute').value = m.format('m');
+    document.getElementById('newEventForm').submit();
+  },
   
   setScrollTime (scrollTimeParam) {
+	// Update the option too (not just a one-off scroll), so that if a later option
+	// change (e.g. aspectRatio) causes the time grid to remount, it re-scrolls to
+	// this time instead of falling back to the default scrollTime.
+	this.calendar.setOption('scrollTime', scrollTimeParam);
 	this.calendar.scrollToTime(scrollTimeParam);
   },
   
   setAspectRatio (aspectRatio) {
 	this.calendar.setOption('aspectRatio', aspectRatio);
+  },
+
+  // Month view rows grow with the number of events per day, so a fixed
+  // aspectRatio leaves either too much empty space or makes busy weeks
+  // taller than the rest. Use 'auto' height for month view only, where
+  // each row sizes to its own content; other views keep using aspectRatio
+  // and its scroll-to-time behavior.
+  updateHeightForView (viewType) {
+    const desiredHeight = viewType === 'dayGridMonth' ? 'auto' : undefined;
+    if (this.currentHeight !== desiredHeight) {
+      this.currentHeight = desiredHeight;
+      this.calendar.setOption('height', desiredHeight);
+      if (viewType.startsWith('timeGrid')) {
+        // Changing height remounts the time grid's scroll container,
+        // resetting its scroll position; restore it once rendered.
+        requestAnimationFrame(() => {
+          this.calendar.scrollToTime(this.calendar.getOption('scrollTime'));
+        });
+      }
+    }
+  },
+
+  // Toggle the toolbar/view-selector/print-link section, remembering the user's
+  // preference (expanded by default) across visits via localStorage.
+  initToolbarToggle (toggleButton, collapseDiv) {
+    const storageKey = 'sakai-calendar-toolbar-expanded';
+
+    const setExpanded = (expanded) => {
+      collapseDiv.hidden = !expanded;
+      toggleButton.setAttribute('aria-expanded', expanded);
+    };
+
+    setExpanded(localStorage.getItem(storageKey) !== 'false');
+
+    toggleButton.addEventListener('click', () => {
+      const expanded = toggleButton.getAttribute('aria-expanded') !== 'true';
+      setExpanded(expanded);
+      localStorage.setItem(storageKey, expanded);
+    });
   },
 
   // When the user changes the view, reflect the change in a param to set the default view.

--- a/calendar/calendar-tool/tool/src/webapp/js/sakai-calendar.js
+++ b/calendar/calendar-tool/tool/src/webapp/js/sakai-calendar.js
@@ -217,12 +217,24 @@ const sakaiCalendar = {
       toggleButton.setAttribute('aria-expanded', expanded);
     };
 
-    setExpanded(localStorage.getItem(storageKey) !== 'false');
+    // localStorage can throw in restricted contexts (e.g. browser private mode);
+    // fall back to the expanded-by-default behaviour in that case.
+    let storedValue = null;
+    try {
+      storedValue = localStorage.getItem(storageKey);
+    } catch (e) {
+      console.warn('Could not read calendar toolbar preference from localStorage', e);
+    }
+    setExpanded(storedValue !== 'false');
 
     toggleButton.addEventListener('click', () => {
       const expanded = toggleButton.getAttribute('aria-expanded') !== 'true';
       setExpanded(expanded);
-      localStorage.setItem(storageKey, expanded);
+      try {
+        localStorage.setItem(storageKey, expanded);
+      } catch (e) {
+        console.warn('Could not save calendar toolbar preference to localStorage', e);
+      }
     });
   },
 

--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_view.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_view.vm
@@ -3,24 +3,57 @@
 <script src="/sakai-calendar-tool/js/sakai-calendar.js"></script>
 
 <div class="portletBody">
-  #if($menu)#toolbar($menu)#end
   <div class="page-header">
     <h1>$tlang.getString("tool_title")</h1>
     <div class="sakai-sideHeading">
+      <button type="button" id="calendarToolbarToggle" class="sakai-calendarToolbarToggle btn-link" aria-expanded="true" aria-controls="calendarToolbarCollapse">
+        $tlang.getString("view.toggleToolbar")
+        <span class="fa fa-chevron-down" aria-hidden="true"></span>
+      </button>
+    </div>
+  </div>
+  ## Toolbar actions, view selector and printable version link, shown by default
+  ## (see sakaiCalendar.initToolbarToggle) but collapsible to keep the calendar grid closer to the top.
+  <div id="calendarToolbarCollapse">
+    #if($menu)#toolbar($menu)#end
+    <div class="sakai-sideHeading">
+      #calendarView()
       <a onclick="sakaiCalendar.printCalendar('$printableVersionUrl')" title="$!tlang.getString('java.print')" href="#">$!tlang.getString('java.print')</a>
     </div>
   </div>
   #if ($alertMessage)<div class="sak-banner-warn">$tlang.getString('gen.alert') $formattedText.escapeHtml($alertMessage)</div>#end
-  <div class="sakai-table-toolBar">
-    <div class="sakai-table-filterContainer">
-      #calendarView()
-    </div>
-  </div>
   ## Calendar DIV where the full calendar will be rendered
   <div id="calendarDiv"></div>
   ## include the Legend:
   #calendarLegend()
+  ## Hidden form submitted on double-click of a time slot, to open the new event form
+  ## with the clicked date/time prefilled (see sakaiCalendar.openNewEventForm).
+  <form id="newEventForm" name="newEventForm" method="post" action="#toolForm("CalendarAction")" style="display:none;">
+    <input type="hidden" name="sakai_csrf_token" value="$sakai_csrf_token" />
+    <input type="hidden" id="newEventDate" name="newEventDate" value="" />
+    <input type="hidden" id="newEventHour" name="newEventHour" value="" />
+    <input type="hidden" id="newEventMinute" name="newEventMinute" value="" />
+    <input type="hidden" name="eventSubmit_doNew" value="New" />
+  </form>
 </div>
+
+## Shade the second half-hour of each hour slot in Day/Week view, so that the
+## two halves of an hourly slot (used by sakaiCalendar.openNewEventForm) are
+## visually distinguishable.
+<style>
+.fc .fc-timegrid-slot-minor {
+  background-color: rgba(127, 127, 127, 0.12);
+}
+
+## Shade day cells (Month view) and time slots (Week/Day view) on hover, to
+## show the user that clicking them navigates to Day view or opens the new
+## event form, respectively.
+.fc .fc-daygrid-day:hover,
+.fc .fc-timegrid-slot-lane:hover {
+  background-color: rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+}
+</style>
 
 <script>
 
@@ -32,5 +65,7 @@
   sakaiCalendar.setAspectRatio(aspectRatio);
   const scrollTime = '$scrollTime';
   sakaiCalendar.setScrollTime(scrollTime);
+
+  sakaiCalendar.initToolbarToggle(document.getElementById('calendarToolbarToggle'), document.getElementById('calendarToolbarCollapse'));
 
 </script>

--- a/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_view.vm
+++ b/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_view.vm
@@ -18,7 +18,7 @@
     #if($menu)#toolbar($menu)#end
     <div class="sakai-sideHeading">
       #calendarView()
-      <a onclick="sakaiCalendar.printCalendar('$printableVersionUrl')" title="$!tlang.getString('java.print')" href="#">$!tlang.getString('java.print')</a>
+      <button type="button" class="btn-link" onclick="sakaiCalendar.printCalendar('$printableVersionUrl')" title="$!tlang.getString('java.print')">$!tlang.getString('java.print')</button>
     </div>
   </div>
   #if ($alertMessage)<div class="sak-banner-warn">$tlang.getString('gen.alert') $formattedText.escapeHtml($alertMessage)</div>#end

--- a/library/src/skins/default/src/sass/modules/tool/calendar/_calendar.scss
+++ b/library/src/skins/default/src/sass/modules/tool/calendar/_calendar.scss
@@ -7,9 +7,72 @@
 		@include display-flex;
 		@include justify-content(space-between);
 		@include align-items(flex-end);
-		
+		margin: 0 0 $standard-space-2x 0;		// remove the extra top gap now that #toolbar($menu) is no longer adjacent to it, keep a small bottom gap
+		padding-bottom: 0;
+	}
+
+	// Used both by the toggle button in .page-header and by the view selector
+	// and print link inside #calendarToolbarCollapse.
+	.sakai-sideHeading {
+		@include display-flex;
+		@include align-items(center);
+		@include flex-wrap(wrap);
+		gap: $standard-spacing;
+
+		.sakai-table-viewFilter {
+			@include display-flex;
+			@include align-items(center);
+			gap: $standard-space;
+			margin: 0;
+
+			form {
+				@include display-flex;
+				@include align-items(center);
+				margin: 0;
+			}
+
+			.form-group {
+				@include display-flex;
+				@include align-items(center);
+				margin: 0;
+
+				label {
+					margin: 0 $standard-space 0 0;
+					white-space: nowrap;
+				}
+
+				select {
+					width: auto;
+				}
+			}
+
+			input[type="submit"] {
+				margin: 0;
+				white-space: nowrap;
+			}
+		}
+	}
+
+	// Collapsible toolbar actions, view selector and print link (see
+	// sakaiCalendar.initToolbarToggle).
+	#calendarToolbarCollapse {
+		margin-top: $standard-spacing;
+		padding-bottom: $standard-spacing;
+		border-bottom: 1px solid $page-header-border-color;
+
 		.sakai-sideHeading {
-			text-align: right;
+			margin-top: $standard-spacing;
+		}
+	}
+
+	.sakai-calendarToolbarToggle {
+		.fa-chevron-down {
+			margin-left: $standard-space;
+			transition: transform 0.2s ease;
+		}
+
+		&[aria-expanded="true"] .fa-chevron-down {
+			transform: rotate(180deg);
 		}
 	}
 

--- a/library/src/skins/default/src/sass/modules/tool/calendar/_calendar.scss
+++ b/library/src/skins/default/src/sass/modules/tool/calendar/_calendar.scss
@@ -7,8 +7,17 @@
 		@include display-flex;
 		@include justify-content(space-between);
 		@include align-items(flex-end);
-		margin: 0 0 $standard-space-2x 0;		// remove the extra top gap now that #toolbar($menu) is no longer adjacent to it, keep a small bottom gap
-		padding-bottom: 0;
+
+		// The main calendar view moved its action toolbar into the collapsible
+		// block below the title (#calendarToolbarCollapse), so unlike every
+		// other calendar page, there's no #toolbar($menu) button row directly
+		// above this page-header, and the collapse block already adds its own
+		// margin/border spacing below. Skip the default .portletBody
+		// .page-header top/bottom spacing only in that case.
+		&:has(#calendarToolbarToggle) {
+			margin: 0 0 $standard-space-2x 0;
+			padding-bottom: 0;
+		}
 	}
 
 	// Used both by the toggle button in .page-header and by the view selector


### PR DESCRIPTION
## Summary

Several usability improvements to the FullCalendar-based Calendar tool view:

- **Click a day in Month view → Day view**: clicking a day cell navigates to the Day view for that date.
- **Double-click a time slot → New event**: in Day/Week view, double-clicking a time slot opens the "New event" form with that date and time prefilled. `CalendarAction.doNew()` now reads `newEventDate`/`newEventHour`/`newEventMinute` parameters submitted by a hidden form.
- **Slot/hover shading**: the second half-hour of each hourly slot is shaded in Day/Week view (so it's clear a double-click can land on `:00` or `:30`), and the cell/slot under the cursor is shaded on hover in Month/Day/Week to indicate it's clickable.
- **Auto height in Month view**: each week row now sizes to its own content (`height: 'auto'`) instead of a fixed aspect ratio that left empty space on light weeks or felt cramped on busy ones. Day/Week/List keep the existing `aspectRatio` + `scrollTime` behaviour.
- **Fix `scrollTime` reset**: the height change above causes FullCalendar to remount the time grid's scroll container on next render, which was resetting the configured `scrollTime` back to its default. Now reapplied after the remount.
- **Event tooltips**: events show a native tooltip with their full title, schedule, type and originating site, since long titles get truncated in Month view.
- **Collapsible "Calendar options" toolbar**: the view selector, print link and toolbar actions are now under a "Calendar options" toggle, expanded by default and collapsible for users who want more vertical space; the choice is remembered per-browser via `localStorage`.

Test plan: SAK-52652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible calendar toolbar with its expanded/collapsed state remembered between visits.
  * Improved calendar interactions with month/day navigation on single click and double-click-to-create events with pre-filled date/time.
  * Enhanced event display with native tooltips (title, formatted time, type, and origin) and improved view height/scroll handling (including scroll-time syncing).
* **Localization**
  * Added the `view.toggleToolbar` label (“Calendar options” / “Opciones del calendario”).
* **Style**
  * Refreshed calendar toolbar and day/time-slot styling, including smoother chevron animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->