### PR TITLE
SAK-52656 Site Info Unpublishing and republishing a site makes it visible in Site Browser

### DIFF
--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/SiteAction.java
@@ -9863,8 +9863,7 @@ private Map<String, List<MyTool>> getTools(SessionState state, String type, Site
 			List publicChangeableSiteTypes = (List) state.getAttribute(STATE_PUBLIC_CHANGEABLE_SITE_TYPES);
 			if (publicChangeableSiteTypes != null && sEdit.getType() != null && !publicChangeableSiteTypes.contains(sEdit.getType()))
 			{
-				// set pubview to true for those site types which pubview change is not allowed
-				sEdit.setPubView(true);
+				sEdit.setPubView(sEdit.isPubView());
 			}
 			else
 			{

--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editAccess.vm
@@ -350,14 +350,12 @@
 				## the site should be public
 				$tlang.getString("ediacc.dismysit")
 			</p>
-			<p />
 		</div>
 		<div id="publicChangeableNoUnpublishDiv" $publicChangeableNoUnpublishDivDisplay>
 			<p>
 				## not changeable due to this is a draft site
 				$tlang.getString("ediacc.disdraft")
 			</p>
-			<p />
 		</div>
 		</fieldset>
 		## END site visibility ##


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated site visibility handling so non-public-changeable site types now preserve the current public view setting instead of being forced to public, aligning behavior with user expectations.
* **Style**
  * Cleaned up the site access configuration page markup by removing redundant empty spacing elements in the “draft site” visibility section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->