### PR TITLE
SAK-52418 profile Add official image toggle

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/user/api/PreferencesService.java
+++ b/kernel/api/src/main/java/org/sakaiproject/user/api/PreferencesService.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.user.api;
 
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.sakaiproject.entity.api.EntityProducer;
@@ -83,6 +84,17 @@ public interface PreferencesService extends EntityProducer
 	 * @return The Preferences object.
 	 */
 	Preferences getPreferences(String id);
+
+	/**
+	 * Get an optional value for the supplied preferences id, key and property name
+	 *
+	 * @param id The preferences id.
+	 * @param key The key of the property set that we want to query.
+	 * @param name The property name that we want to lookup.
+	 *
+	 * @return An Optional optionally containing the value as a string.
+	 */
+	Optional<String> getValue(String id, String key, String name);
 
 	/**
 	 * Check to see if the current user can add or modify permissions with this id.

--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BasePreferencesService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/user/impl/BasePreferencesService.java
@@ -220,6 +220,11 @@ public abstract class BasePreferencesService implements PreferencesService, Sing
 	}
 
     @Override
+    public Optional<String> getValue(String id, String key, String name) {
+        return Optional.ofNullable(getPreferences(id).getProperties(key).getProperty(name));
+    }
+
+    @Override
     public boolean applyEditWithAutoCommit(String userId, Consumer<PreferencesEdit> editFunction) {
         PreferencesEdit edit = null;
         try {

--- a/profile2/api/src/main/java/org/sakaiproject/profile2/api/ProfileConstants.java
+++ b/profile2/api/src/main/java/org/sakaiproject/profile2/api/ProfileConstants.java
@@ -58,8 +58,6 @@ public class ProfileConstants {
 	//and the default if not specified or invalid one specified
 	public static final int PICTURE_SETTING_UPLOAD = 1;
 	public static final String PICTURE_SETTING_UPLOAD_PROP = "upload";
-	public static final int PICTURE_SETTING_URL = 2;
-	public static final String PICTURE_SETTING_URL_PROP = "url";
 	public static final int PICTURE_SETTING_OFFICIAL = 3;
 	public static final String PICTURE_SETTING_OFFICIAL_PROP = "official";
 

--- a/profile2/api/src/main/java/org/sakaiproject/profile2/api/ProfileService.java
+++ b/profile2/api/src/main/java/org/sakaiproject/profile2/api/ProfileService.java
@@ -169,7 +169,7 @@ public interface ProfileService {
      * @param url           url to image
      * @return
      */
-    boolean saveOfficialImageUrl(final String userUuid, final String url);
+    boolean saveOfficialImageUrl(String userUuid, String url);
 
     /**
      * Get the entity url to a profile image for a user.
@@ -196,14 +196,14 @@ public interface ProfileService {
      * @param userUuid uuid for the user
      * @return
      */
-    boolean profileImageIsDefault(final String userUuid);
+    boolean profileImageIsDefault(String userUuid);
 
     /**
      * Generate a profile image for a user with his name/last name initials
      * @param userUuid uuid for the user
      * @return The ProfileImage object, populated with either a url or binary data.
      */
-    ProfileImage getProfileAvatarInitials(final String userUuid);
+    ProfileImage getProfileAvatarInitials(String userUuid);
 
     String getProfileImageURL(String userId, boolean thumbnail);
 }

--- a/profile2/api/src/main/java/org/sakaiproject/profile2/api/ProfileTransferBean.java
+++ b/profile2/api/src/main/java/org/sakaiproject/profile2/api/ProfileTransferBean.java
@@ -22,6 +22,7 @@ public class ProfileTransferBean {
     public String displayName;
     public String imageUrl;
     public String imageThumbUrl;
+    public String imageUserPreference;
     public boolean locked;
     public String mobile;
     public String type;
@@ -45,6 +46,7 @@ public class ProfileTransferBean {
 
     public boolean disabled;
     public boolean canUpdatePicture;
+    public boolean canSelectPictureSource;
     public boolean canEdit;
     public boolean canEditNameAndEmail;
 }

--- a/profile2/api/src/main/java/org/sakaiproject/profile2/api/SakaiProxy.java
+++ b/profile2/api/src/main/java/org/sakaiproject/profile2/api/SakaiProxy.java
@@ -261,16 +261,15 @@ public interface SakaiProxy {
 	/**
 	 * Get the profile2.picture.type setting in sakai.properties
 	 * <p>
-	 * Possible values for the sakai property are 'upload', 'url' and 'official'. If not set, defaults to 'upload'.
+	 * Possible values for the sakai property are 'upload' and 'official'. If not set, defaults to 'upload'.
 	 * </p>
 	 * <p>
-	 * This returns an int which matches one of: ProfileConstants.PICTURE_SETTING_UPLOAD, ProfileConstants.PICTURE_SETTING_URL,
-	 * ProfileConstants.PICTURE_SETTING_OFFICIAL.
+	 * This returns an int which matches one of: ProfileConstants.PICTURE_SETTING_UPLOAD or ProfileConstants.PICTURE_SETTING_OFFICIAL.
 	 * </p>
 	 *
 	 * <p>
 	 * Depending on this setting, Profile2 will decide how it retrieves a user's profile image, and the method by which users can add their
-	 * own image. ie by uploading their own image, providing a URL, or not at all (for official)
+	 * own image. ie by uploading their own image or not at all (for official)
 	 * </p>
 	 *
 	 * @return

--- a/profile2/impl/src/main/java/org/sakaiproject/profile2/impl/ProfileServiceImpl.java
+++ b/profile2/impl/src/main/java/org/sakaiproject/profile2/impl/ProfileServiceImpl.java
@@ -40,6 +40,8 @@ import org.sakaiproject.api.common.edu.person.SakaiPerson;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityManager;
 import org.sakaiproject.entity.api.EntityProducer;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.memory.api.Cache;
 import org.sakaiproject.memory.api.MemoryService;
 import org.sakaiproject.memory.api.SimpleConfiguration;
@@ -57,6 +59,8 @@ import org.sakaiproject.profile2.api.ProfileDao;
 import org.sakaiproject.profile2.util.ProfileUtils;
 import org.sakaiproject.profile2.util.Messages;
 import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.user.api.User;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,6 +74,7 @@ public class ProfileServiceImpl implements ProfileService, EntityProducer {
     @Autowired private ProfileDao dao;
     @Autowired private EntityManager entityManager;
     @Autowired private MemoryService memoryService;
+    @Autowired private PreferencesService preferencesService;
     @Autowired private SakaiProxy sakaiProxy;
     @Autowired private SessionManager sessionManager;
 
@@ -207,21 +212,30 @@ public class ProfileServiceImpl implements ProfileService, EntityProducer {
         //get the image based on the global type/preference
         switch (imageType) {
             case ProfileConstants.PICTURE_SETTING_UPLOAD:
-                MimeTypeByteArray mtba = getUploadedProfileImage(userUuid, size);
 
-                //if no uploaded image, use the default image url
-                if (mtba == null || mtba.getBytes() == null) {
-                    boolean useAvatarInitials = Boolean.valueOf(sakaiProxy.getServerConfigurationParameter("profile2.avatar.initials.enabled", "true"));
-                    if (useAvatarInitials) {
-                        image = this.getProfileAvatarInitials(userUuid);
-                        image.setMimeType("image/png");
-                    } else {
-                        image.setExternalImageUrl(defaultImageUrl);
-                        image.setDefault(true);
-                    }
+                String userImagePreference
+                    = preferencesService.getValue(userUuid, "profile", "image-type")
+                        .orElse(ProfileConstants.PICTURE_SETTING_UPLOAD_PROP);
+
+                if (userImagePreference.equals(ProfileConstants.PICTURE_SETTING_OFFICIAL_PROP)) {
+                    image = getOfficialImage(userUuid, image, defaultImageUrl, isSameUser);
                 } else {
-                    image.setUploadedImage(mtba.getBytes());
-                    image.setMimeType(mtba.getMimeType());
+                    MimeTypeByteArray mtba = getUploadedProfileImage(userUuid, size);
+
+                    //if no uploaded image, use the default image url
+                    if (mtba == null || mtba.getBytes() == null) {
+                        boolean useAvatarInitials = Boolean.valueOf(sakaiProxy.getServerConfigurationParameter("profile2.avatar.initials.enabled", "true"));
+                        if (useAvatarInitials) {
+                            image = this.getProfileAvatarInitials(userUuid);
+                            image.setMimeType("image/png");
+                        } else {
+                            image.setExternalImageUrl(defaultImageUrl);
+                            image.setDefault(true);
+                        }
+                    } else {
+                        image.setUploadedImage(mtba.getBytes());
+                        image.setMimeType(mtba.getMimeType());
+                    }
                 }
                 image.setAltText(getAltText(userUuid, isSameUser, true));
             break;
@@ -824,17 +838,22 @@ public class ProfileServiceImpl implements ProfileService, EntityProducer {
         p.displayName = u.getDisplayName();
         p.imageUrl = getProfileImageEntityUrl(userId, ProfileConstants.PROFILE_IMAGE_MAIN);
         p.imageThumbUrl = getProfileImageEntityUrl(userId, ProfileConstants.PROFILE_IMAGE_THUMBNAIL);
+        p.imageUserPreference = preferencesService.getValue(userId, "profile", "image-type")
+            .orElse(ProfileConstants.PICTURE_SETTING_UPLOAD_PROP);
         p.creatorDisplayName = u.getCreatedBy().getDisplayName();
         p.hasPronunciationRecording = sakaiProxy.resourceExists(getUserNamePronunciationResourceId(userId));
         p.modifierDisplayName = u.getModifiedBy().getDisplayName();
         p.type = u.getType();
 
-        p.canUpdatePicture = (StringUtils.equals(currentUserId, userId) && sakaiProxy.isProfilePictureChangeEnabled()) || sakaiProxy.isSuperUser();
+        p.canUpdatePicture = !sakaiProxy.isUsingOfficialImage()
+                                && !p.imageUserPreference.equals(ProfileConstants.PICTURE_SETTING_OFFICIAL_PROP)
+                                && ((StringUtils.equals(currentUserId, userId) && sakaiProxy.isProfilePictureChangeEnabled()) || sakaiProxy.isSuperUser());
+        p.canSelectPictureSource = sakaiProxy.isOfficialImageEnabledGlobally() && !sakaiProxy.isUsingOfficialImage();
         p.canEdit = StringUtils.equals(currentUserId, userId) || sakaiProxy.isSuperUser();
         p.canEditNameAndEmail = sakaiProxy.isSuperUser();
 
-        Optional<SakaiPerson> sakaiPerson = sakaiProxy.getSakaiPerson(userId);
-        sakaiPerson.ifPresent(sp -> {
+        sakaiProxy.getSakaiPerson(userId).ifPresent(sp -> {
+
             p.nickname = sp.getNickname();
             p.phoneticPronunciation = sp.getPhoneticPronunciation();
             p.pronouns = sp.getPronouns();
@@ -842,6 +861,7 @@ public class ProfileServiceImpl implements ProfileService, EntityProducer {
         });
 
         dao.getSocialNetworkingInfo(userId).ifPresent(socialInfo -> {
+
             p.facebookUrl = socialInfo.getFacebookUrl();
             p.instagramUrl = socialInfo.getInstagramUrl();
             p.linkedinUrl = socialInfo.getLinkedinUrl();
@@ -874,6 +894,7 @@ public class ProfileServiceImpl implements ProfileService, EntityProducer {
 
         Optional<SakaiPerson> sakaiPerson = sakaiProxy.getSakaiPerson(profileBean.id);
         sakaiPerson.ifPresent(sp -> {
+
             sp.setNickname(profileBean.nickname);
             sp.setPronouns(profileBean.pronouns);
             sp.setPhoneticPronunciation(profileBean.phoneticPronunciation);
@@ -886,6 +907,24 @@ public class ProfileServiceImpl implements ProfileService, EntityProducer {
         socialInfo.setFacebookUrl(profileBean.facebookUrl);
         socialInfo.setInstagramUrl(profileBean.instagramUrl);
         socialInfo.setLinkedinUrl(profileBean.linkedinUrl);
+
+        if (profileBean.imageUserPreference != null) {
+            if (!ProfileConstants.PICTURE_SETTING_UPLOAD_PROP.equals(profileBean.imageUserPreference)
+                    && !ProfileConstants.PICTURE_SETTING_OFFICIAL_PROP.equals(profileBean.imageUserPreference)) {
+                log.warn("Unsupported image preference '{}' for user {}", profileBean.imageUserPreference, profileBean.id);
+                return false;
+            }
+
+            boolean preferenceSaved = preferencesService.applyEditWithAutoCommit(profileBean.id, edit -> {
+                ResourcePropertiesEdit profileProps = edit.getPropertiesEdit("profile");
+                profileProps.addProperty("image-type", profileBean.imageUserPreference);
+            });
+
+            if (!preferenceSaved) {
+                log.warn("Failed to persist image preference '{}' for user {}", profileBean.imageUserPreference, profileBean.id);
+                return false;
+            }
+        }
 
         dao.saveSocialNetworkingInfo(socialInfo);
 

--- a/profile2/impl/src/main/java/org/sakaiproject/profile2/impl/SakaiProxyImpl.java
+++ b/profile2/impl/src/main/java/org/sakaiproject/profile2/impl/SakaiProxyImpl.java
@@ -428,10 +428,6 @@ public class SakaiProxyImpl implements SakaiProxy {
         if (StringUtils.equals(pictureType, ProfileConstants.PICTURE_SETTING_UPLOAD_PROP)) {
             return ProfileConstants.PICTURE_SETTING_UPLOAD;
         }
-        // if 'url'
-        else if (StringUtils.equals(pictureType, ProfileConstants.PICTURE_SETTING_URL_PROP)) {
-            return ProfileConstants.PICTURE_SETTING_URL;
-        }
         // if 'official'
         else if (StringUtils.equals(pictureType, ProfileConstants.PICTURE_SETTING_OFFICIAL_PROP)) {
             return ProfileConstants.PICTURE_SETTING_OFFICIAL;

--- a/profile2/impl/src/test/org/sakaiproject/profile2/impl/test/ProfileServiceTestConfiguration.java
+++ b/profile2/impl/src/test/org/sakaiproject/profile2/impl/test/ProfileServiceTestConfiguration.java
@@ -34,6 +34,7 @@ import org.sakaiproject.profile2.impl.repository.SocialNetworkingInfoRepositoryI
 import org.sakaiproject.search.api.SearchIndexBuilder;
 import org.sakaiproject.springframework.orm.hibernate.AdditionalHibernateMappings;
 import org.sakaiproject.test.SakaiTestConfiguration;
+import org.sakaiproject.user.api.PreferencesService;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,16 +70,6 @@ public class ProfileServiceTestConfiguration extends SakaiTestConfiguration {
         return profileImageUploadedRepository;
     }
 
-    /*
-    @Bean(name="org.sakaiproject.profile2.api.repository.SocialNetworkingInfoRepository")
-    public SocialNetworkingInfoRepository socialNetworkingInfoRepository(SessionFactory sessionFactory) {
-
-        SocialNetworkingInfoRepositoryImpl socialNetworkingInfoRepository = new SocialNetworkingInfoRepositoryImpl();
-        socialNetworkingInfoRepository.setSessionFactory(sessionFactory);
-        return socialNetworkingInfoRepository;
-    }
-    */
-
     @Bean(name = "org.sakaiproject.api.common.edu.person.SakaiPersonManager")
     public SakaiPersonManager sakaiPersonManager() {
         return mock(SakaiPersonManager.class);
@@ -97,6 +88,11 @@ public class ProfileServiceTestConfiguration extends SakaiTestConfiguration {
     @Bean(name = "org.sakaiproject.event.api.ActivityService")
     public ActivityService activityService() {
         return mock(ActivityService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.user.api.PreferencesService")
+    public PreferencesService preferencesService() {
+        return mock(PreferencesService.class);
     }
 
     @Bean(name = "org.sakaiproject.search.elasticsearch.ElasticSearchIndexBuilder")

--- a/profile2/impl/src/test/org/sakaiproject/profile2/impl/test/ProfileServiceTests.java
+++ b/profile2/impl/src/test/org/sakaiproject/profile2/impl/test/ProfileServiceTests.java
@@ -33,6 +33,7 @@ import org.sakaiproject.profile2.api.model.ProfileImageUploaded;
 import org.sakaiproject.profile2.api.repository.ProfileImageUploadedRepository;
 import org.sakaiproject.profile2.api.repository.SocialNetworkingInfoRepository;
 import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.user.api.UserNotDefinedException;
@@ -59,6 +60,7 @@ public class ProfileServiceTests extends AbstractTransactionalJUnit4SpringContex
     @Autowired private ProfileImageUploadedRepository profileImageUploadedRepository;
     @Autowired private SocialNetworkingInfoRepository socialNetworkingInfoRepository;
     @Autowired private UserDirectoryService userDirectoryService;
+    @Autowired private PreferencesService preferencesService;
 
     private String user1Id = UUID.randomUUID().toString();
     private String user2Id = UUID.randomUUID().toString();
@@ -72,6 +74,7 @@ public class ProfileServiceTests extends AbstractTransactionalJUnit4SpringContex
       reset(securityService);
       reset(sessionManager);
       reset(contentHostingService);
+      reset(preferencesService);
 
       user1 = mock(User.class);
       when(user1.getCreatedBy()).thenReturn(user1);
@@ -345,6 +348,9 @@ public class ProfileServiceTests extends AbstractTransactionalJUnit4SpringContex
         userProfile.instagramUrl = instagramUrl;
         userProfile.linkedinUrl = linkedinUrl;
         userProfile.nickname = nickname;
+        userProfile.imageUserPreference = "upload";
+
+        when(preferencesService.applyEditWithAutoCommit(any(), any())).thenReturn(true);
 
         profileService.saveUserProfile(userProfile);
 

--- a/webapi/src/main/java/org/sakaiproject/webapi/controllers/ProfileController.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/controllers/ProfileController.java
@@ -164,7 +164,7 @@ public class ProfileController extends AbstractSakaiApiController {
         }
 
         if (!StringUtils.equals(currentUserId, userId)) {
-		    eventTrackingService.post(this.eventTrackingService.newEvent(ProfileConstants.EVENT_IMAGE_REQUEST, "/profile/" + currentUserId + "/imagerequest/", false));
+            eventTrackingService.post(this.eventTrackingService.newEvent(ProfileConstants.EVENT_IMAGE_REQUEST, "/profile/" + currentUserId + "/imagerequest/", false));
         }
 
         // check for binary

--- a/webapi/src/main/java/org/sakaiproject/webapi/exception/GlobalExceptionHandler.java
+++ b/webapi/src/main/java/org/sakaiproject/webapi/exception/GlobalExceptionHandler.java
@@ -15,11 +15,15 @@ package org.sakaiproject.webapi.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.HandlerMapping;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.InUseException;
@@ -36,47 +40,47 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingSessionException.class)
     public ResponseEntity<Object> handleMissingSessionException(MissingSessionException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.FORBIDDEN, "Missing or invalid Sakai session", ex);
+        return createErrorResponse(HttpStatus.FORBIDDEN, "Missing or invalid Sakai session", ex, request);
     }
 
     @ExceptionHandler(UnknownSiteException.class)
     public ResponseEntity<Object> handleUnknownSiteException(UnknownSiteException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.BAD_REQUEST, "Unknown Sakai site", ex);
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "Unknown Sakai site", ex, request);
     }
 
     @ExceptionHandler(ForbiddenAccessException.class)
     public ResponseEntity<Object> handleForbiddenAccessException(ForbiddenAccessException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.FORBIDDEN, "Access forbidden", ex);
+        return createErrorResponse(HttpStatus.FORBIDDEN, "Access forbidden", ex, request);
     }
 
     @ExceptionHandler(SecurityException.class)
     public ResponseEntity<Object> handleSecurityException(SecurityException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.FORBIDDEN, "Access forbidden", ex);
+        return createErrorResponse(HttpStatus.FORBIDDEN, "Access forbidden", ex, request);
     }
 
     @ExceptionHandler(PermissionException.class)
     public ResponseEntity<Object> handlePermissionException(PermissionException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.FORBIDDEN, "Permission denied", ex);
+        return createErrorResponse(HttpStatus.FORBIDDEN, "Permission denied", ex, request);
     }
 
     @ExceptionHandler(IdUnusedException.class)
     public ResponseEntity<Object> handleIdUnusedException(IdUnusedException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.NOT_FOUND, "Resource not found", ex);
+        return createErrorResponse(HttpStatus.NOT_FOUND, "Resource not found", ex, request);
     }
 
     @ExceptionHandler(InUseException.class)
     public ResponseEntity<Object> handleInUseException(InUseException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.CONFLICT, "Resource is currently in use", ex);
+        return createErrorResponse(HttpStatus.CONFLICT, "Resource is currently in use", ex, request);
     }
 
     @ExceptionHandler(TypeException.class)
     public ResponseEntity<Object> handleTypeException(TypeException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid resource type", ex);
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid resource type", ex, request);
     }
 
     @ExceptionHandler(ServerOverloadException.class)
     public ResponseEntity<Object> handleServerOverloadException(ServerOverloadException ex, WebRequest request) {
-        return createErrorResponse(HttpStatus.SERVICE_UNAVAILABLE, "Server is currently overloaded", ex);
+        return createErrorResponse(HttpStatus.SERVICE_UNAVAILABLE, "Server is currently overloaded", ex, request);
     }
 
     @ExceptionHandler(ResponseStatusException.class)
@@ -84,25 +88,40 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(ex.getStatus()).build();
     }
 
+    @ExceptionHandler(AsyncRequestNotUsableException.class)
+    public ResponseEntity<Object> handleClientDisconnect(AsyncRequestNotUsableException ex, WebRequest request) {
+        // The client closed the connection before the response was fully written (e.g. a browser cancelling
+        // an <img> request for a profile image). This is harmless: the connection is already gone, so there
+        // is nothing to send back and no need to log it as an error.
+        log.debug("Client disconnected before the response could be written: {}", ex.getMessage());
+        return null;
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleAllUncaughtException(Exception ex, WebRequest request) {
         log.error("Uncaught exception", ex);
-        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred", ex);
+        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred", ex, request);
     }
 
-    private ResponseEntity<Object> createErrorResponse(HttpStatus status, String message, Exception ex) {
+    private ResponseEntity<Object> createErrorResponse(HttpStatus status, String message, Exception ex, WebRequest request) {
+        // The handler method that threw may have declared a non-JSON `produces` (e.g. octet-stream for image
+        // endpoints). That media type is "preset" on the request and would otherwise cause Spring to fail to
+        // serialise this JSON error body ("No converter for ... with preset Content-Type 'application/octet-stream'").
+        // Clear it so the error body is always written as JSON.
+        request.removeAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("timestamp", LocalDateTime.now());
         body.put("status", status.value());
         body.put("error", status.getReasonPhrase());
         body.put("message", message);
-        
+
         if (ex.getMessage() != null) {
             body.put("detail", ex.getMessage());
         }
-        
+
         log.error("WEBAPI {}: {}", message, ex.toString());
         log.debug("WEBAPI full exception", ex);
-        return new ResponseEntity<>(body, status);
+        return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(body);
     }
 } 

--- a/webcomponents/bundle/src/main/bundle/account.properties
+++ b/webcomponents/bundle/src/main/bundle/account.properties
@@ -27,6 +27,7 @@ in your course sites.
 name_recording_label=Name Recording
 nickname_label=Nickname
 nothing_filled_out=You haven't filled out any information yet
+official=Official
 phonetic_example_1_pronun_name=(Christine Berret)
 phonetic_example_1_pronun=kris-TEEN BEAR-it
 phonetic_example_2_pronun_name = (Ajeet Chawla)
@@ -43,3 +44,4 @@ save=Save
 social_heading=Social Networking
 social_info_updated=Social info updated successfully
 stop=Stop
+upload=Upload

--- a/webcomponents/tool/src/main/frontend/packages/sakai-account/src/SakaiAccount.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-account/src/SakaiAccount.js
@@ -4,6 +4,7 @@ import "@sakai-ui/sakai-picture-changer/sakai-picture-changer.js";
 import "@sakai-ui/sakai-audio-recorder/sakai-audio-recorder.js";
 import "@sakai-ui/sakai-pronunciation-player/sakai-pronunciation-player.js";
 import isEmail from "validator/es/lib/isEmail.js";
+import { refreshProfileImageTags } from "@sakai-ui/sakai-user-photo";
 const SOCIAL_HOSTS = {
   facebook: [ "facebook.com" ],
   instagram: [ "instagram.com" ],
@@ -48,11 +49,6 @@ export class SakaiAccount extends SakaiElement {
     };
 
     this.loadTranslations("account");
-  }
-
-  connectedCallback() {
-
-    super.connectedCallback();
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
@@ -115,6 +111,32 @@ export class SakaiAccount extends SakaiElement {
         throw new Error(`Network error while patching to ${url}`);
       })
       .then(profile => this._profile = profile);
+  }
+
+  _uploadClicked() {
+
+    const patch = [ { op: "replace", path: "/imageUserPreference", value: SakaiAccount.UPLOAD } ];
+
+    this._patchProfile(patch)
+      .then(() => refreshProfileImageTags(this.userId, SakaiAccount.UPLOAD))
+      .catch (error => {
+
+        console.error(error);
+        this._loadUser();
+      });
+  }
+
+  _officialClicked() {
+
+    const patch = [ { op: "replace", path: "/imageUserPreference", value: SakaiAccount.OFFICIAL } ];
+
+    this._patchProfile(patch)
+      .then(() => refreshProfileImageTags(this.userId, SakaiAccount.OFFICIAL))
+      .catch (error => {
+
+        console.error(error);
+        this._loadUser();
+      });
   }
 
   _saveBasicInfo() {
@@ -791,7 +813,7 @@ export class SakaiAccount extends SakaiElement {
         <div class="d-flex mb-3">
           <div class="d-flex flex-column align-items-center">
             <div>
-              <sakai-user-photo user-id="${this.userId}" classes="medium"></sakai-user-photo>
+              <sakai-user-photo user-id="${this.userId}" classes="medium" ?official=${this._profile.imageUserPreference === SakaiAccount.OFFICIAL}></sakai-user-photo>
             </div>
             <div>
 
@@ -802,6 +824,28 @@ export class SakaiAccount extends SakaiElement {
               <i class="si si-edit"></i>
               <span>${this._i18n.change_profile_picture}</span>
             </button>
+            ` : nothing}
+
+            ${this._profile.canSelectPictureSource ? html`
+              <div class="ms-1 mt-3">
+                <label>
+                  <input type="radio"
+                      name="picture-source"
+                      value="${SakaiAccount.UPLOAD}"
+                      @click=${this._uploadClicked}
+                      .checked=${this._profile.imageUserPreference === SakaiAccount.UPLOAD} />
+                  <span class="ms-1">${this._i18n.upload}</span>
+                </label>
+                <label>
+                  <input type="radio"
+                      class="ms-1"
+                      name="picture-source"
+                      value="${SakaiAccount.OFFICIAL}"
+                      @click=${this._officialClicked}
+                      .checked=${this._profile.imageUserPreference === SakaiAccount.OFFICIAL} />
+                  <span class="ms-1">${this._i18n.official}</span>
+                </label>
+              </div>
             ` : nothing}
 
             </div>
@@ -815,3 +859,6 @@ export class SakaiAccount extends SakaiElement {
     `;
   }
 }
+
+SakaiAccount.OFFICIAL = "official";
+SakaiAccount.UPLOAD = "upload";

--- a/webcomponents/tool/src/main/frontend/packages/sakai-picture-changer/src/SakaiPictureChanger.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-picture-changer/src/SakaiPictureChanger.js
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { SakaiElement } from "@sakai-ui/sakai-element";
 import Cropper from "cropperjs";
-import { getUserId } from "@sakai-ui/sakai-portal-utils";
+import { refreshProfileImageTags } from "@sakai-ui/sakai-user-photo";
 
 export class SakaiPictureChanger extends SakaiElement {
 
@@ -26,7 +26,6 @@ export class SakaiPictureChanger extends SakaiElement {
     super.attributeChangedCallback(name, oldValue, newValue);
 
     if (name === "user-id") {
-      console.log(this.userId);
       this._loadExisting();
     }
   }
@@ -119,22 +118,6 @@ export class SakaiPictureChanger extends SakaiElement {
     this._needsSave = true;
   }
 
-  _refreshProfileImageTags() {
-
-    const d = new Date();
-
-    const uid = this.userId?.trim() || "blank";
-    const imageUrl = `/api/users/${uid}/profile/image?${d.getTime()}`;
-    console.log(imageUrl);
-
-    if (this.userId === getUserId()) {
-      document.querySelectorAll(".sakai-accountProfileImage")
-        .forEach(pic => pic.setAttribute("src", imageUrl));
-    }
-
-    document.querySelectorAll(`.sakai-user-photo[user-id='${this.userId}']`).forEach(up => up.refresh());
-  }
-
   _loadExisting() {
 
     const uid = this.userId?.trim() || "blank";
@@ -184,7 +167,7 @@ export class SakaiPictureChanger extends SakaiElement {
         this._uploadError = false;
         this._needsSave = false;
         this._loadExisting();
-        this._refreshProfileImageTags();
+        refreshProfileImageTags(this.userId);
         this.dispatchEvent(new CustomEvent("updated"));
       } else {
         this._uploadError = true;
@@ -211,7 +194,7 @@ export class SakaiPictureChanger extends SakaiElement {
         this._removeError = false;
         this._needsSave = false;
         this._loadExisting();
-        this._refreshProfileImageTags();
+        refreshProfileImageTags(this.userId);
         this.dispatchEvent(new CustomEvent("updated"));
       } else {
         this._removeError = true;

--- a/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/index.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/index.js
@@ -1,1 +1,2 @@
 export { SakaiUserPhoto } from './src/SakaiUserPhoto.js';
+export { refreshProfileImageTags } from './src/profile-image-utils.js';

--- a/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/SakaiUserPhoto.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/SakaiUserPhoto.js
@@ -43,10 +43,12 @@ export class SakaiUserPhoto extends SakaiElement {
     this.profilePopup = SakaiUserPhoto.OFF;
   }
 
-  refresh() {
+  refresh(imageType) {
+
     if (this.blank) {
       this.url = "/api/users/blank/profile/image";
     } else {
+      imageType && (this.official = imageType === "official");
       this.url = this.getImageUrl();
     }
   }
@@ -56,6 +58,7 @@ export class SakaiUserPhoto extends SakaiElement {
   }
 
   willUpdate(changedProperties) {
+
     if (changedProperties.has("userId") || changedProperties.has("official") || changedProperties.has("blank") || changedProperties.has("siteId")) {
       if (this.blank) {
         this.url = "/api/users/blank/profile/image";
@@ -66,6 +69,7 @@ export class SakaiUserPhoto extends SakaiElement {
   }
 
   getImageUrl() {
+
     const uid = this.userId?.trim() || "blank";
     const sid = this.siteId?.trim() || getSiteId();
     const imageType = this.official ? "official" : "thumb";

--- a/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/profile-image-utils.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-user-photo/src/profile-image-utils.js
@@ -1,0 +1,16 @@
+import { getUserId } from "@sakai-ui/sakai-portal-utils";
+
+export const refreshProfileImageTags = (userId, imageType) => {
+
+  const d = new Date();
+
+  const uid = userId?.trim() || "blank";
+  const imageUrl = `/api/users/${uid}/profile/image?${d.getTime()}`;
+
+  if (uid === getUserId()) {
+    document.querySelectorAll(".sakai-accountProfileImage")
+      .forEach(pic => pic.setAttribute("src", imageUrl));
+  }
+
+  document.querySelectorAll(`sakai-user-photo[user-id='${CSS.escape(uid)}']`).forEach(up => up.refresh(imageType));
+};


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a profile picture source setting (Official or Upload) that users can select in the profile photo UI and save.
* **Updates/Improvements**
  * Profile photo behavior now respects the saved choice, including serving official images and updating whether the user can change their photo.
  * Profile image refresh is more reliable after updates and deletions.
  * URL-based picture option support was removed; only Upload/Official remain.
* **Localization**
  * Added “Official” and “Upload” labels.
* **Bug Fixes**
  * Improved API error response handling, including more consistent JSON for async disconnect scenarios.
* **Tests**
  * Updated profile service tests to cover preference persistence and editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->