### PR TITLE
SAK-52668 Assignments Choose whether the opening announcement is published immediately or on the assignment open date

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentConstants.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentConstants.java
@@ -146,6 +146,7 @@ public final class AssignmentConstants {
      */
     public static final String NEW_ASSIGNMENT_DUE_DATE_SCHEDULED = "new_assignment_due_date_scheduled";
     public static final String NEW_ASSIGNMENT_OPEN_DATE_ANNOUNCED = "new_assignment_open_date_announced";
+    public static final String NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE = "new_assignment_announce_on_open_date";
     /**
      * the String for all choice in dropdown menu
      */
@@ -394,4 +395,10 @@ public final class AssignmentConstants {
     public static final List<String> SAK_PROP_NON_SUBMITTER_PERMISSIONS_DEFAULT = List.of(AssignmentServiceConstants.SECURE_ADD_ASSIGNMENT);
 
     public static final String ASSIGNMENT_INPUT_ADD_SUBMISSION_TIME_SPENT = "value_ASSIGNMENT_INPUT_ADD_SUBMISSION_TIME_SPENT";
+
+    /*
+     * Sakai properties of the option to send a new assignment announcement immediately (false) or delay publishing the announcement until the assignment open date (true).
+     */
+    public static final String SAK_PROP_ANNOUNCE_ON_OPEN_DATE = "assignment.announce.on.open.date.default";
+    public static final String SAK_PROP_ANNOUNCE_ON_OPEN_DATE_DEFAULT = "false";
 }

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -393,7 +393,7 @@ public interface AssignmentService extends EntityProducer {
      * @param oldDueTime the previous assignment due date.
      * @param checkAddDueTime true to add the due date to calendar.
      * @param checkAutoAnnounce true to announce the open date.
-     * @param announceOnOpenDate true to announce the open date immediately, false to announce on the open date.
+     * @param announceOnOpenDate true to delay the announcement until the open date, false to publish the announcement immediately.
      * @param openDateNotification open date notification level.
      */
     public void integrateAssignmentWithCalendarAndAnnouncement(Assignment assignment, String title, Instant openTime, Instant dueTime,

--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -393,10 +393,11 @@ public interface AssignmentService extends EntityProducer {
      * @param oldDueTime the previous assignment due date.
      * @param checkAddDueTime true to add the due date to calendar.
      * @param checkAutoAnnounce true to announce the open date.
+     * @param announceOnOpenDate true to announce the open date immediately, false to announce on the open date.
      * @param openDateNotification open date notification level.
      */
     public void integrateAssignmentWithCalendarAndAnnouncement(Assignment assignment, String title, Instant openTime, Instant dueTime,
-            Instant oldOpenTime, Instant oldDueTime, boolean checkAddDueTime, boolean checkAutoAnnounce,
+            Instant oldOpenTime, Instant oldDueTime, boolean checkAddDueTime, boolean checkAutoAnnounce, boolean announceOnOpenDate,
             OpenDateNotification openDateNotification);
 
     /**

--- a/assignment/api/src/resources/assignment.properties
+++ b/assignment/api/src/resources/assignment.properties
@@ -105,6 +105,7 @@ gen.addinstatts   = Instructor's attachments to this submission
 gen.addres2       = Additional resources for assignment
 gen.alert         = Alert:
 gen.anntheope     = Add an announcement about the open date to Announcements
+gen.anntheope.delay = Do not publish the announcement until the opening date
 gen.assdet        = Assignment Details
 gen.assig         = Assignment
 gen.assinf        = Assignment Instructions

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -35,6 +35,7 @@ import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.FormatStyle;
 import java.time.format.DateTimeFormatter;
@@ -1736,12 +1737,14 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         Instant dueTime = assignment.getDueDate();
         String checkAddDueTime = properties.get(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_DUE_DATE);
         String checkAutoAnnounce = properties.get(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE);
+        String announceOnOpenDate = properties.get(AssignmentConstants.NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE);
         OpenDateNotification openDateNotification = OpenDateNotification.fromProperty(
                 properties.get(AssignmentConstants.ASSIGNMENT_OPENDATE_NOTIFICATION));
 
         integrateAssignmentWithCalendarAndAnnouncement(assignment, title, openTime, dueTime, openTime, dueTime,
                 BooleanUtils.toBoolean(checkAddDueTime),
                 BooleanUtils.toBoolean(checkAutoAnnounce),
+                BooleanUtils.toBoolean(announceOnOpenDate),
                 openDateNotification);
 
         postFirstPublishEvents(assignment, openTime);
@@ -1762,7 +1765,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void integrateAssignmentWithCalendarAndAnnouncement(Assignment assignment, String title, Instant openTime, Instant dueTime,
-            Instant oldOpenTime, Instant oldDueTime, boolean checkAddDueTime, boolean checkAutoAnnounce,
+            Instant oldOpenTime, Instant oldDueTime, boolean checkAddDueTime, boolean checkAutoAnnounce, boolean announceOnOpenDate,
             OpenDateNotification openDateNotification) {
 
         try {
@@ -1772,14 +1775,14 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         }
 
         try {
-            integrateWithAnnouncement(assignment, title, openTime, checkAutoAnnounce, openDateNotification, oldOpenTime);
+            integrateWithAnnouncement(assignment, title, openTime, checkAutoAnnounce, announceOnOpenDate, openDateNotification, oldOpenTime);
         } catch (PermissionException e) {
             log.warn("Cannot update assignment announcement integration, {}", e.getMessage());
         }
     }
 
     private void integrateWithAnnouncement(Assignment assignment, String title, Instant openTime, boolean checkAutoAnnounce,
-            OpenDateNotification openDateNotification, Instant oldOpenTime) throws PermissionException {
+            boolean announceOnOpenDate, OpenDateNotification openDateNotification, Instant oldOpenTime) throws PermissionException {
         if (!checkAutoAnnounce) {
             return;
         }
@@ -1866,6 +1869,12 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                         }
                     } else {
                         header.clearGroupAccess();
+                    }
+
+                    // If instructor selected to schedule the announcement at the open date, set the RELEASE_DATE property.
+                    if (announceOnOpenDate) {
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").withZone(ZoneId.of("UTC"));
+                        message.getPropertiesEdit().addProperty(AnnouncementService.RELEASE_DATE, formatter.format(openTime));
                     }
 
                     int notiLevel;

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -1875,6 +1875,12 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     if (announceOnOpenDate) {
                         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS").withZone(ZoneId.of("UTC"));
                         message.getPropertiesEdit().addProperty(AnnouncementService.RELEASE_DATE, formatter.format(openTime));
+                    } else {
+                        try {
+                            message.getPropertiesEdit().removeProperty(AnnouncementService.RELEASE_DATE);
+                        } catch (Exception e) {
+                            log.debug("Could not remove release date property: {}", e.getMessage());
+                        }
                     }
 
                     int notiLevel;

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -254,7 +254,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         when(userTimeService.dateTimeFormat(openTime, null, null)).thenReturn("Apr 14, 2026 12:00 PM EDT");
 
         service.integrateAssignmentWithCalendarAndAnnouncement(assignment, "Imported Assignment", openTime, null,
-                openTime, null, false, true, OpenDateNotification.NONE);
+                openTime, null, false, true, true, OpenDateNotification.NONE);
 
         verify(channel).editAnnouncementMessage("draft-announcement-id");
         verify(editHeader).setDraft(false);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -666,7 +666,7 @@ public class AssignmentAction extends PagedResourceActionII {
     private static final String NEW_ASSIGNMENT_OPEN_DATE_ANNOUNCED = "new_assignment_open_date_announced";
     private static final String NEW_ASSIGNMENT_CHECK_ADD_HONOR_PLEDGE = "new_assignment_check_add_honor_pledge";
     private static final String NEW_ASSIGNMENT_CHECK_ALLOW_UNRESTRICTED_EXTERNAL_TOOL_LAUNCH = "new_assignment_check_allow_unrestricted_external_tool_launch";
-    private static final String NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE = "new_assignment_announce_on_open_date";
+    private static final String NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE = AssignmentConstants.NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE;
     private static final String NEW_ASSIGNMENT_CHECK_ADD_GROUP_TAGS = "new_assignment_check_add_group_tags";
     private static final String NEW_ASSIGNMENT_CHECK_ADD_INSTRUCTOR_TAGS = "new_assignment_check_add_instructor_tags";
     private static final String NEW_ASSIGNMENT_CHECK_HIDE_DUE_DATE = "new_assignment_check_hide_due_date";
@@ -9426,8 +9426,8 @@ public class AssignmentAction extends PagedResourceActionII {
                 String resolvedAddtoGradebook = getResolvedGradebookIntegration(addtoGradebook, post,
                         gradebookCategoriesMap, gradebookItemMap);
 
-                editAssignmentProperties(a, checkAddDueTime, checkAutoAnnounce, announceOnOpenDate,
-                    resolvedAddtoGradebook, gradebookItemKeys, allowResubmitNumber,
+                editAssignmentProperties(a, checkAddDueTime, checkAutoAnnounce, resolvedAddtoGradebook, announceOnOpenDate,
+                    gradebookItemKeys, allowResubmitNumber,
                     aProperties, post, resubmitCloseTime, checkAnonymousGrading);
 
                 // Store category information in assignment properties for drafts

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -666,6 +666,7 @@ public class AssignmentAction extends PagedResourceActionII {
     private static final String NEW_ASSIGNMENT_OPEN_DATE_ANNOUNCED = "new_assignment_open_date_announced";
     private static final String NEW_ASSIGNMENT_CHECK_ADD_HONOR_PLEDGE = "new_assignment_check_add_honor_pledge";
     private static final String NEW_ASSIGNMENT_CHECK_ALLOW_UNRESTRICTED_EXTERNAL_TOOL_LAUNCH = "new_assignment_check_allow_unrestricted_external_tool_launch";
+    private static final String NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE = "new_assignment_announce_on_open_date";
     private static final String NEW_ASSIGNMENT_CHECK_ADD_GROUP_TAGS = "new_assignment_check_add_group_tags";
     private static final String NEW_ASSIGNMENT_CHECK_ADD_INSTRUCTOR_TAGS = "new_assignment_check_add_instructor_tags";
     private static final String NEW_ASSIGNMENT_CHECK_HIDE_DUE_DATE = "new_assignment_check_hide_due_date";
@@ -3414,6 +3415,13 @@ public class AssignmentAction extends PagedResourceActionII {
         if (state.getAttribute(ANNOUNCEMENT_CHANNEL) != null) {
             context.put("name_CheckAutoAnnounce", ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE);
             context.put("name_OpenDateNotification", AssignmentConstants.ASSIGNMENT_OPENDATE_NOTIFICATION);
+            context.put("name_AnnounceOnOpenDate", NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE);
+            Object val = state.getAttribute(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE);
+            if (val == null) {
+                context.put("value_AnnounceOnOpenDate", serverConfigurationService.getString(AssignmentConstants.SAK_PROP_ANNOUNCE_ON_OPEN_DATE, AssignmentConstants.SAK_PROP_ANNOUNCE_ON_OPEN_DATE_DEFAULT));
+            } else {
+                context.put("value_AnnounceOnOpenDate", val);
+            }
         }
         context.put("name_CheckAddHonorPledge", NEW_ASSIGNMENT_CHECK_ADD_HONOR_PLEDGE);
         context.put("name_CheckAllowUnrestrictedExternalToolLaunch", NEW_ASSIGNMENT_CHECK_ALLOW_UNRESTRICTED_EXTERNAL_TOOL_LAUNCH);
@@ -8517,6 +8525,13 @@ public class AssignmentAction extends PagedResourceActionII {
             }
         }
 
+        // announce immediately checkbox
+        if (params.getString(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE) != null && params.getString(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE).equalsIgnoreCase(Boolean.TRUE.toString())) {
+            state.setAttribute(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE, Boolean.TRUE.toString());
+        } else {
+            state.setAttribute(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE, Boolean.FALSE.toString());
+        }
+
         if (StringUtils.equalsIgnoreCase(params.getString(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_ESTIMATE), Boolean.TRUE.toString())) {
             state.setAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_ESTIMATE, Boolean.TRUE);
             String isEstimateRequiredStr = params.getString(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_ESTIMATE_REQUIRED);
@@ -9220,6 +9235,8 @@ public class AssignmentAction extends PagedResourceActionII {
 
             String checkAutoAnnounce = (String) state.getAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE);
 
+            String announceOnOpenDate = (String) state.getAttribute(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE);
+
             String valueOpenDateNotification = (String) state.getAttribute(AssignmentConstants.ASSIGNMENT_OPENDATE_NOTIFICATION);
 
             Boolean checkAddHonorPledge = (Boolean) state.getAttribute(NEW_ASSIGNMENT_CHECK_ADD_HONOR_PLEDGE);
@@ -9409,7 +9426,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 String resolvedAddtoGradebook = getResolvedGradebookIntegration(addtoGradebook, post,
                         gradebookCategoriesMap, gradebookItemMap);
 
-                editAssignmentProperties(a, checkAddDueTime, checkAutoAnnounce,
+                editAssignmentProperties(a, checkAddDueTime, checkAutoAnnounce, announceOnOpenDate,
                     resolvedAddtoGradebook, gradebookItemKeys, allowResubmitNumber,
                     aProperties, post, resubmitCloseTime, checkAnonymousGrading);
 
@@ -9548,7 +9565,7 @@ public class AssignmentAction extends PagedResourceActionII {
                     if (post) {
                         assignmentService.integrateAssignmentWithCalendarAndAnnouncement(a, title, openTime, dueTime,
                                 oldOpenTime, oldDueTime, BooleanUtils.toBoolean(checkAddDueTime),
-                                BooleanUtils.toBoolean(checkAutoAnnounce),
+                                BooleanUtils.toBoolean(checkAutoAnnounce), BooleanUtils.toBoolean(announceOnOpenDate),
                                 OpenDateNotification.fromProperty(valueOpenDateNotification));
 
                         // It should only be called once when updateAssignment has already been done
@@ -10121,7 +10138,7 @@ public class AssignmentAction extends PagedResourceActionII {
         }
     }
 
-    private void editAssignmentProperties(Assignment assignment, String checkAddDueTime, String checkAutoAnnounce, String addtoGradebook, String associateGradebookAssignment, String allowResubmitNumber, Map<String, String> properties, boolean post, Instant closeTime, boolean checkAnonymousGrading) {
+    private void editAssignmentProperties(Assignment assignment, String checkAddDueTime, String checkAutoAnnounce, String addtoGradebook, String announceOnOpenDate, String associateGradebookAssignment, String allowResubmitNumber, Map<String, String> properties, boolean post, Instant closeTime, boolean checkAnonymousGrading) {
         if (properties.get("newAssignment") != null) {
             if (properties.get("newAssignment").equalsIgnoreCase(Boolean.TRUE.toString())) {
                 // not a newly created assignment, been added.
@@ -10137,6 +10154,11 @@ public class AssignmentAction extends PagedResourceActionII {
             properties.remove(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_DUE_DATE);
         }
         properties.put(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE, checkAutoAnnounce);
+        if (announceOnOpenDate != null) {
+            properties.put(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE, announceOnOpenDate);
+        } else {
+            properties.remove(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE);
+        }
 
         properties.put(NEW_ASSIGNMENT_CHECK_ANONYMOUS_GRADING, Boolean.toString(checkAnonymousGrading));
 
@@ -10793,6 +10815,12 @@ public class AssignmentAction extends PagedResourceActionII {
                 state.setAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_DUE_DATE, properties.get(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_DUE_DATE));
 
                 state.setAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE, properties.get(ResourceProperties.NEW_ASSIGNMENT_CHECK_AUTO_ANNOUNCE));
+                String annImm = properties.get(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE);
+                if (annImm != null) {
+                    state.setAttribute(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE, annImm);
+                } else {
+                    state.setAttribute(NEW_ASSIGNMENT_ANNOUNCE_ON_OPEN_DATE, serverConfigurationService.getString(AssignmentConstants.SAK_PROP_ANNOUNCE_ON_OPEN_DATE, AssignmentConstants.SAK_PROP_ANNOUNCE_ON_OPEN_DATE_DEFAULT));
+                }
 
                 if (StringUtils.isNotBlank(a.getEstimate())) {
                     state.setAttribute(ResourceProperties.NEW_ASSIGNMENT_CHECK_ADD_ESTIMATE, Boolean.TRUE);

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -467,6 +467,16 @@
 			<div id="selectAutoAnnounceOptions" style="display:none" class="indnt3">
 			#end
 				<div class="col-sm-offset-1">
+					<div class="checkbox">
+						<label for="$name_AnnounceOnOpenDate">
+						#if ($value_AnnounceOnOpenDate && $value_AnnounceOnOpenDate.equals("true"))
+							<input id="$name_AnnounceOnOpenDate" name="$name_AnnounceOnOpenDate" type="checkbox" value="true" checked="checked" />
+						#else
+							<input id="$name_AnnounceOnOpenDate" name="$name_AnnounceOnOpenDate" type="checkbox" value="true" />
+						#end
+						$tlang.getString("gen.anntheope.delay")
+						</label>
+					</div>
 					<select name="$name_OpenDateNotification" id="$name_OpenDateNotification">
 						<option value="$value_opendate_notification_none" #if($value_OpenDateNotification.equals($value_opendate_notification_none)) selected="selected" #end>$tlang.getString('send.notification.opendate.email.none')</option>
 						<option value="$value_opendate_notification_low" #if($value_OpenDateNotification.equals($value_opendate_notification_low)) selected="selected" #end>$tlang.getString('send.notification.opendate.email.low')</option>

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -2026,6 +2026,10 @@
 # DEFAULT: empty
 # assignment.points.default=10
 
+# Default value to delay publishing the announcement until the assignment open date
+# DEFAULT: false (send immediately)
+# assignment.announce.on.open.date.default=true
+
 ## SAK-23812 Peer Review feature for Assignments
 # set to true to use peer assessment in the Assignments tool
 #assignment.usePeerAssessment=true


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Announce on open date” option for assignments, allowing announcement publication to be delayed until the assignment open date.
  * Added a new instructor setting so announcement timing can be controlled per assignment.
* **Configuration**
  * Added a server-level configuration option to define the default behavior for when assignment announcements are published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->