### PR TITLE
SAK-52679 Fixed delete modal tool title in Site Info > Tool Order

### DIFF
--- a/site-manage/pageorder/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/pageorder/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -22,7 +22,7 @@
                  data-menu-show=#{menu_show_page},
                  data-menu-lock=#{menu_lock_page},
                  data-menu-unlock=#{menu_enable_page},
-                 data-remove-confirm-template=#{remove_tool_confirm('__TITLE__')}">
+                 data-remove-confirm-template=#{remove_tool_confirm('\_\_TITLE\_\_')}">
     <div class="tool-order-heading">
       <div>
         <h1 th:text="#{page_title}">Tool Order</h1>


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the display of tool titles in removal confirmation dialogs to ensure proper formatting when users confirm tool removal actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->