### PR TITLE
SAK-52680 Update tabulator-tables dependency to version 6.5.1

### DIFF
--- a/gradebookng/tool/pom.xml
+++ b/gradebookng/tool/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>tabulator-tables</artifactId>
-			<version>6.4.0</version>
+			<version>6.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>

--- a/gradebookng/tool/pom.xml
+++ b/gradebookng/tool/pom.xml
@@ -152,7 +152,7 @@
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>tabulator-tables</artifactId>
-			<version>6.5.0</version>
+			<version>6.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.java
@@ -124,8 +124,8 @@ public class GbGradeTable extends Panel implements IHeaderContributor {
 		response.render(JavaScriptHeaderItem.forUrl("/library/js/sakai-reminder.js"));
 
 		response.render(
-				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.4.0/dist/js/tabulator.min.js%s", version)));
-		response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.4.0/dist/css/tabulator.min.css%s", version)));
+				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.5.0/dist/js/tabulator.min.js%s", version)));
+		response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.5.0/dist/css/tabulator.min.css%s", version)));
 
 		response.render(
 				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/scripts/gradebook-gbgrade-table.js%s", version)));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/component/GbGradeTable.java
@@ -124,8 +124,8 @@ public class GbGradeTable extends Panel implements IHeaderContributor {
 		response.render(JavaScriptHeaderItem.forUrl("/library/js/sakai-reminder.js"));
 
 		response.render(
-				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.5.0/dist/js/tabulator.min.js%s", version)));
-		response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.5.0/dist/css/tabulator.min.css%s", version)));
+				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.5.1/dist/js/tabulator.min.js%s", version)));
+		response.render(CssHeaderItem.forUrl(String.format("/gradebookng-tool/webjars/tabulator-tables/6.5.1/dist/css/tabulator.min.css%s", version)));
 
 		response.render(
 				JavaScriptHeaderItem.forUrl(String.format("/gradebookng-tool/scripts/gradebook-gbgrade-table.js%s", version)));


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the gradebook table library to a newer version, including refreshed JavaScript and CSS assets used for rendering the grade table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->