### PR TITLE
SAK-52535 Search load OpenSearch reindex plugin

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -253,6 +253,11 @@
         </dependency>
         <dependency>
             <groupId>org.opensearch.plugin</groupId>
+            <artifactId>reindex-client</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opensearch.plugin</groupId>
             <artifactId>parent-join-client</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/entitybroker/tool/src/test/java/org/sakaiproject/entitybroker/rest/EntityHandlerImplTest.java
+++ b/entitybroker/tool/src/test/java/org/sakaiproject/entitybroker/rest/EntityHandlerImplTest.java
@@ -57,17 +57,21 @@ public class EntityHandlerImplTest {
     @Autowired private ServerConfigurationService serverConfigurationService;
 
     private TestData td;
+    private EntityViewAccessProviderMock accessProvider;
 
     @Before
     public void setUp() {
         td = new TestData(entityProviderManager);
-        entityViewAccessProviderManager.registerProvider(TestData.PREFIX8, new EntityViewAccessProviderMock(TestData.PREFIX8));
+        accessProvider = new EntityViewAccessProviderMock(TestData.PREFIX8);
+        entityViewAccessProviderManager.registerProvider(TestData.PREFIX8, accessProvider);
         Mockito.when(serverConfigurationService.getServerUrl()).thenReturn("http://localhost:8080");
         Locale.setDefault(Locale.ENGLISH);
     }
 
     @After
     public void tearDown() {
+        entityViewAccessProviderManager.unregisterProvider(TestData.PREFIX8);
+        accessProvider = null;
         entityProviderManager.unRegistrarAllProvidersAndListeners();
         td = null;
     }

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1319,6 +1319,12 @@
       </dependency>
       <dependency>
         <groupId>org.opensearch.plugin</groupId>
+        <artifactId>reindex-client</artifactId>
+        <version>${sakai.opensearch.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.opensearch.plugin</groupId>
         <artifactId>parent-join-client</artifactId>
         <version>${sakai.opensearch.version}</version>
         <scope>provided</scope>

--- a/search/elasticsearch/impl/pom.xml
+++ b/search/elasticsearch/impl/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>org.opensearch.plugin</groupId>
+            <artifactId>reindex-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensearch.plugin</groupId>
             <artifactId>parent-join-client</artifactId>
         </dependency>
         <dependency>

--- a/search/elasticsearch/impl/src/java/org/sakaiproject/search/elasticsearch/ElasticSearchService.java
+++ b/search/elasticsearch/impl/src/java/org/sakaiproject/search/elasticsearch/ElasticSearchService.java
@@ -57,6 +57,7 @@ import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.network.InetAddresses;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.set.Sets;
+import org.opensearch.index.reindex.ReindexPlugin;
 import org.opensearch.node.InternalSettingsPreparer;
 import org.opensearch.node.Node;
 import org.opensearch.node.NodeValidationException;
@@ -253,7 +254,8 @@ import lombok.extern.slf4j.Slf4j;
     protected Node initializeSearchNode(Settings settings) {
         Collection<Class<? extends Plugin>> plugins = Arrays.asList(
                 Netty4Plugin.class,
-                CommonAnalysisPlugin.class);
+                CommonAnalysisPlugin.class,
+                ReindexPlugin.class);
 
         Map<String, String> systemProperties = System.getProperties().entrySet().stream()
                 .filter(e -> String.valueOf(e.getKey()).startsWith(ElasticSearchConstants.CONFIG_PROPERTY_PREFIX))


### PR DESCRIPTION
Samigo question indexing uses the OpenSearch delete-by-query API to remove stale assessment, site, and question pool documents before rebuilding them.

The embedded OpenSearch node was started with Netty and analysis plugins only, so the server never registered the /_delete_by_query REST handler. When Samigo called client.deleteByQuery(...), OpenSearch returned 'no handler found' even though the client request was valid.

Register ReindexPlugin with the embedded node and add the matching reindex-client artifact to search and deploy dependencies so the handler is present at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search infrastructure now supports reindexing, improving compatibility with OpenSearch-backed search operations.

* **Bug Fixes**
  * Updated test setup and cleanup to manage search access provider state more reliably.
  * Brought dependency management in line with the new search plugin support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->