### PR TITLE
SAK-52520 SiteInfo guard manual course range

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-editInfo.vm
@@ -72,25 +72,27 @@
 						</td>
 						</tr>
 				#end
-			#else
-				## for new site
-				#foreach ($k in [0..$manualAddNumber])
-					#set($courseFieldValues = $!fieldValues.get($k))
-					#set($bound = $!form_requiredFields.size())
-					#set($bound = $bound - 1)
-					<tr>
-					<td style="padding-left:1em">
-						#set($courseFieldString="")
-						#foreach ($fieldCount in [0..$!bound])
-							#set($courseFieldString=$courseFieldString.concat($!courseFieldValues.get($fieldCount).getValue()).concat(" "))
+				#else
+					## for new site
+					#if ($!manualAddNumber)
+						#foreach ($k in [0..$manualAddNumber])
+							#set($courseFieldValues = $!fieldValues.get($k))
+							#set($bound = $!form_requiredFields.size())
+							#set($bound = $bound - 1)
+							<tr>
+							<td style="padding-left:1em">
+								#set($courseFieldString="")
+								#foreach ($fieldCount in [0..$!bound])
+									#set($courseFieldString=$courseFieldString.concat($!courseFieldValues.get($fieldCount).getValue()).concat(" "))
+								#end
+								#set($courseFieldString=$courseFieldString.trim())
+								$courseFieldString $tlang.getString("man.requested")
+							</td>
+							</tr>
 						#end
-						#set($courseFieldString=$courseFieldString.trim())
-						$courseFieldString $tlang.getString("man.requested")
-					</td>
-					</tr>
+					#end
+				#end
 			#end
-			#end
-		#end
 		</table>
 	#end
 	#if (!$!existingSite && $!isProjectSite)


### PR DESCRIPTION
When creating a course site with an authorizer-requested section, the requested sections block is shown because cmAuthorizerSections is populated. That path does not populate manualAddNumber, but the new-site branch still evaluated the Velocity range `[0..$manualAddNumber]`.

Velocity cannot build a range with a null right-hand side, so the edit info page logged a server error before the user could continue. Only render the manual course rows when manualAddNumber is present, matching the existing confirmation templates while still displaying authorizer-requested sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated spacing and indentation on the “Edit Site Information” page for the new-site flow.
  * Improved readability of the section that displays required field information and the localized “requested” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->