### PR TITLE
SAK-52509 Assignment avoid null all groups unlock

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -3891,6 +3891,10 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                 userId = sessionManager.getCurrentSessionUserId();
             }
 
+            if (StringUtils.isBlank(userId)) {
+                return rv;
+            }
+
             Collection<Group> groups = site.getGroups();
             // if the user has SECURE_ALL_GROUPS in the context (site), select all site groups
             if (securityService.unlock(userId, SECURE_ALL_GROUPS, siteService.siteReference(context))

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -2127,6 +2127,25 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
     }
 
     @Test
+    public void getGroupsAllowAddAssignmentWithoutCurrentUserReturnsNoGroups() throws Exception {
+        String context = UUID.randomUUID().toString();
+        String siteReference = "/site/" + context;
+        Site site = mock(Site.class);
+        Group group = mock(Group.class);
+
+        when(siteService.getSite(context)).thenReturn(site);
+        when(siteService.siteReference(context)).thenReturn(siteReference);
+        when(site.getGroups()).thenReturn(Collections.singleton(group));
+        when(sessionManager.getCurrentSessionUserId()).thenReturn(null);
+
+        Collection<Group> groups = assignmentService.getGroupsAllowAddAssignment(context, null);
+
+        Assert.assertTrue(groups.isEmpty());
+        Mockito.verify(securityService, Mockito.never()).unlock(Mockito.isNull(String.class),
+                eq(AssignmentServiceConstants.SECURE_ALL_GROUPS), eq(siteReference));
+    }
+
+    @Test
     public void countSubmissions() {
         String context = UUID.randomUUID().toString();
         List<String> submitterIds = Collections.nCopies(10,1).stream().map(i -> UUID.randomUUID().toString()).collect(Collectors.toList());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group permissions are no longer evaluated when no user ID is available, preventing access checks from running with an unspecified identity.
  * When the current user is unavailable, assignment group lookups now return no groups instead of using a fallback user.
  
* **Tests**
  * Added coverage to confirm assignment group access returns an empty result when there is no current user and permission checks are not triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->