### PR TITLE
SAK-52477 Search align bouncycastle version

### DIFF
--- a/kernel/kernel-impl/pom.xml
+++ b/kernel/kernel-impl/pom.xml
@@ -336,7 +336,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.83</version>
+            <version>1.84</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/search/search-impl/impl/pom.xml
+++ b/search/search-impl/impl/pom.xml
@@ -128,17 +128,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- PDF box uses BouncyCastle for crypotgraphic functions at runtime -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.83</version>
-    </dependency>
-     <dependency>
-       <groupId>org.bouncycastle</groupId>
-       <artifactId>bcmail-jdk18on</artifactId>
-       <version>1.83</version>
-    </dependency>
+
     <dependency>
        <groupId>org.apache.tika</groupId>
        <artifactId>tika-core</artifactId>

--- a/search/search-impl/impl/pom.xml
+++ b/search/search-impl/impl/pom.xml
@@ -131,13 +131,13 @@
     <!-- PDF box uses BouncyCastle for crypotgraphic functions at runtime -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.83</version>
     </dependency>
      <dependency>
        <groupId>org.bouncycastle</groupId>
-       <artifactId>bcmail-jdk15on</artifactId>
-       <version>1.70</version>
+       <artifactId>bcmail-jdk18on</artifactId>
+       <version>1.83</version>
     </dependency>
     <dependency>
        <groupId>org.apache.tika</groupId>


### PR DESCRIPTION
Search was explicitly declaring bcprov-jdk15on:1.70 and bcmail-jdk15on:1.70. Those are from the old Bouncy Castle jdk15on artifact line. Current Search already gets the modern jdk18on Bouncy Castle artifacts through Tika 3.3.1, specifically 1.84. Keeping
  the old explicit jars meant Search could carry both old jdk15on and modern jdk18on Bouncy Castle families on the classpath, which is exactly the kind of duplicate crypto-provider setup that can cause version/linkage ambiguity at runtime.

  The original PR from @axxter99  removed the obsolete Search declarations. After rebasing it onto current upstream/master, we found one remaining item: Kernel directly declared `bcprov-jdk18on:1.83`, while the current Tika brings BouncyCastle `jdk18on:1.84`. Our
  commit updates Kernel’s direct bcprov-jdk18on dependency from 1.83 to 1.84, so Kernel and Search now resolve the same Bouncy Castle line.