### PR TITLE
SAK-52502 Forums avoid gradebook auth log noise

### DIFF
--- a/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
+++ b/gradebookng/api/src/main/java/org/sakaiproject/grading/api/GradingService.java
@@ -87,6 +87,12 @@ public interface GradingService extends EntityProducer {
     public List<Assignment> getAssignments(String gradebookUid, String siteId, SortType sortBy);
 
     /**
+     * Like {@link #getAssignments(String, String, SortType)} but returns an empty list when the current user
+     * may not view assignments, instead of throwing {@link GradingSecurityException}.
+     */
+    public List<Assignment> getAssignmentsIfViewable(String gradebookUid, String siteId, SortType sortBy);
+
+    /**
      * Get an assignment based on its id
      *
      * @param gradebookUid

--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -233,6 +233,16 @@ public class GradingServiceImpl implements GradingService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<Assignment> getAssignmentsIfViewable(String gradebookUid, String siteId, SortType sortBy) {
+
+        if (!isUserAbleToViewAssignments(siteId)) {
+            return Collections.emptyList();
+        }
+        return getAssignments(gradebookUid, siteId, sortBy);
+    }
+
+    @Override
     public Assignment getAssignment(String gradebookUid, String siteId, Long assignmentId) throws AssessmentNotFoundException {
 
         if (assignmentId == null || gradebookUid == null) {

--- a/gradebookng/impl/src/test/java/org/sakaiproject/grading/impl/test/GradingServiceTests.java
+++ b/gradebookng/impl/src/test/java/org/sakaiproject/grading/impl/test/GradingServiceTests.java
@@ -255,6 +255,17 @@ public class GradingServiceTests extends AbstractTransactionalJUnit4SpringContex
     }
 
     @Test
+    public void getAssignmentsIfViewableReturnsEmptyWhenUnauthorized() {
+
+        Gradebook gradebook = createGradebook();
+        createAssignment1(gradebook);
+        switchToUser1();
+        assertTrue(gradingService.getAssignmentsIfViewable(gradebook.getUid(), siteId, SortType.SORT_BY_SORTING).isEmpty());
+        assertThrows(GradingSecurityException.class,
+            () -> gradingService.getAssignments(gradebook.getUid(), siteId, SortType.SORT_BY_SORTING));
+    }
+
+    @Test
     public void addAndUpdateExternalAssessment() {
 
         Gradebook gradebook = createGradebook();

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -687,16 +687,17 @@ public class DiscussionForumTool {
 
         //Code to get the gradebook service from ComponentManager
         GradingService gradingService = getGradingService();
-        
-		for (Assignment thisAssign : gradingService.getAssignments(toolManager.getCurrentPlacement().getContext(), toolManager.getCurrentPlacement().getContext(), SortType.SORT_BY_NONE)) {
-			if (!thisAssign.getExternallyMaintained()) {
-				try {
-					assignments.add(new SelectItem(Long.toString(thisAssign.getId()), thisAssign.getName()));
-				} catch (Exception e) {
-					log.error("DiscussionForumTool - processDfMsgGrd:" + e);
-				}
-			}
-		}
+
+        String siteId = toolManager.getCurrentPlacement().getContext();
+        for (Assignment thisAssign : gradingService.getAssignmentsIfViewable(siteId, siteId, SortType.SORT_BY_NONE)) {
+            if (!thisAssign.getExternallyMaintained()) {
+                try {
+                    assignments.add(new SelectItem(Long.toString(thisAssign.getId()), thisAssign.getName()));
+                } catch (Exception e) {
+                    log.error("DiscussionForumTool - processDfMsgGrd:" + e);
+                }
+            }
+        }
         
       } catch (SecurityException se) {
           log.debug("SecurityException caught while getting assignments.", se);

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/MessageForumStatisticsBean.java
@@ -2816,16 +2816,17 @@ public class MessageForumStatisticsBean {
 			//Code to get the gradebook service from ComponentManager
 
 			GradingService gradingService = getGradingService();
-			if (gradingService.isGradebookGroupEnabled(toolManager.getCurrentPlacement().getContext())) {
-				List<Gradebook> gradeAssignments = gradingService.getGradebookGroupInstances(toolManager.getCurrentPlacement().getContext());
+			String siteId = toolManager.getCurrentPlacement().getContext();
+			if (gradingService.isGradebookGroupEnabled(siteId)) {
+				List<Gradebook> gradeAssignments = gradingService.getGradebookGroupInstances(siteId);
 				for(int i=0; i<gradeAssignments.size(); i++) {
-					List<Assignment> groupAssignments = gradingService.getAssignments(gradeAssignments.get(i).getUid(), toolManager.getCurrentPlacement().getContext(), SortType.SORT_BY_NONE);
+					List<Assignment> groupAssignments = gradingService.getAssignmentsIfViewable(gradeAssignments.get(i).getUid(), siteId, SortType.SORT_BY_NONE);
 					for (Assignment assignment: groupAssignments) {
 						assignments.add(new SelectItem(Long.toString(assignment.getId()), assignment.getName(), assignment.getPoints().toString() + "," + gradeAssignments.get(i).getUid()));
 					}
 				}
 			} else {
-				List gradeAssignmentsBeforeFilter = gradingService.getAssignments(toolManager.getCurrentPlacement().getContext(), toolManager.getCurrentPlacement().getContext(), SortType.SORT_BY_NONE);
+				List gradeAssignmentsBeforeFilter = gradingService.getAssignmentsIfViewable(siteId, siteId, SortType.SORT_BY_NONE);
 				for(int i=0; i<gradeAssignmentsBeforeFilter.size(); i++) {
 					Assignment thisAssign = (Assignment) gradeAssignmentsBeforeFilter.get(i);
 					if(!thisAssign.getExternallyMaintained()) {

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/entity/TopicEntityProviderImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/entity/TopicEntityProviderImpl.java
@@ -66,7 +66,6 @@ import org.sakaiproject.entitybroker.entityprovider.search.Search;
 import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.grading.api.GradingService;
 import org.sakaiproject.grading.api.SortType;
-import org.sakaiproject.grading.api.model.Gradebook;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 
@@ -351,12 +350,8 @@ AutoRegisterEntityProvider, PropertyProvideable, RESTful, RequestStorable, Reque
 				if (siteId != null) {
 					try {
 					    GradingService gradingService = (GradingService) ComponentManager.get("org.sakaiproject.grading.api.GradingService");
-					    final Gradebook gradebook = (Gradebook) gradingService.getGradebook(siteId, siteId);
-					    List<Assignment> gbItems = gradingService.getAssignments(gradebook.getUid(), siteId, SortType.SORT_BY_NONE);
-					    if (gbItems != null) {
-					        for (Assignment gbItem : gbItems) {
-					            gbItemNameToId.put(gbItem.getName(), gbItem.getId());
-					        }
+					    for (Assignment gbItem : gradingService.getAssignmentsIfViewable(siteId, siteId, SortType.SORT_BY_NONE)) {
+					        gbItemNameToId.put(gbItem.getName(), gbItem.getId());
 					    }
 					} catch (Exception e) {
 					    log.debug("Exception attempting to retrieve gradebook information for site " + siteId + ". ", e);


### PR DESCRIPTION
Add a non-throwing gradebook assignment lookup for optional consumers so Forums can skip unauthorized assignment metadata without weakening getAssignments authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gradebook assignment lists now gracefully hide items when a user doesn’t have permission to view them, instead of showing an error.

* **Bug Fixes**
  * Improved assignment dropdowns in forum and statistics screens to use the visible assignment list consistently.
  * Default assignment name matching is now more reliable when selecting forum/topic gradebook links.

* **Tests**
  * Added coverage for the no-access case to confirm unauthorized users receive an empty assignment list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->