### PR TITLE
SAK-52676 LTI require exact scope matching

### DIFF
--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -989,16 +989,20 @@ public class LTI13Servlet extends HttpServlet {
 
 	static String validateRequestedScopes(Set<String> requestedScopes, String originalScope) {
 		if (requestedScopes == null || requestedScopes.isEmpty()) {
-			return originalScope;
+			return sanitizeErrorDetail(originalScope);
 		}
 
 		Set<String> supportedScopes = new HashSet<String>(LTI13ConstantsUtil.SCOPES_SUPPORTED);
 		for (String scope : requestedScopes) {
 			if (!supportedScopes.contains(scope)) {
-				return scope;
+				return sanitizeErrorDetail(scope);
 			}
 		}
 		return null;
+	}
+
+	static String sanitizeErrorDetail(String detail) {
+		return detail != null ? detail.replaceAll("\\p{Cntrl}", "") : null;
 	}
 
 	// SAK-47261 - lineItemId can only be null for old-style signed placements

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -57,7 +57,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -992,7 +991,7 @@ public class LTI13Servlet extends HttpServlet {
 		if (scope == null) {
 			return new HashSet<String>();
 		}
-		return SakaiAccessToken.parseScopes(scope.toLowerCase(Locale.ROOT));
+		return SakaiAccessToken.parseScopes(scope);
 	}
 
 	static String validateRequestedScopes(Set<String> requestedScopes, String originalScope) {

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -57,6 +57,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -882,7 +883,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		scope = scope.toLowerCase();
+		Set<String> requestedScopes = parseRequestedScopes(scope);
 
 
 		SakaiAccessToken sat = new SakaiAccessToken();
@@ -894,7 +895,7 @@ public class LTI13Servlet extends HttpServlet {
 		HashSet<String> returnScopeSet = new HashSet<String> ();
 
 		// Work through requested scopes
-		if (scope.contains(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY)) {
+		if (requestedScopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY)) {
 			if (!Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
 				log.error("Scope lineitem readonly not allowed {}", tool_id);
@@ -904,7 +905,7 @@ public class LTI13Servlet extends HttpServlet {
 			sat.addScope(SakaiAccessToken.SCOPE_LINEITEMS_READONLY);
 		}
 
-		if (scope.contains(LTI13ConstantsUtil.SCOPE_LINEITEM)) {
+		if (requestedScopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM)) {
 			if (!Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_LINEITEM);
 				log.error("Scope lineitem not allowed {}", tool_id);
@@ -916,7 +917,7 @@ public class LTI13Servlet extends HttpServlet {
 			sat.addScope(SakaiAccessToken.SCOPE_LINEITEMS_READONLY);
 		}
 
-		if (scope.contains(LTI13ConstantsUtil.SCOPE_SCORE)) {
+		if (requestedScopes.contains(LTI13ConstantsUtil.SCOPE_SCORE)) {
 			if (!Boolean.TRUE.equals(tool.allowoutcomes) || !Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_SCORE);
 				log.error("Scope score not allowed {}", tool_id);
@@ -927,7 +928,7 @@ public class LTI13Servlet extends HttpServlet {
 			sat.addScope(SakaiAccessToken.SCOPE_SCORE);
 		}
 
-		if (scope.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY)) {
+		if (requestedScopes.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY)) {
 			if (!Boolean.TRUE.equals(tool.allowoutcomes) || !Boolean.TRUE.equals(tool.allowlineitems)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_RESULT_READONLY);
 				log.error("Scope result readonly not allowed {}", tool_id);
@@ -938,7 +939,7 @@ public class LTI13Servlet extends HttpServlet {
 			sat.addScope(SakaiAccessToken.SCOPE_RESULT_READONLY);
 		}
 
-		if (scope.contains(LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES)) {
+		if (requestedScopes.contains(LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES)) {
 			if (!Boolean.TRUE.equals(tool.allowroster)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES);
 				log.error("Scope names and roles not allowed {}", tool_id);
@@ -949,7 +950,7 @@ public class LTI13Servlet extends HttpServlet {
 			sat.addScope(SakaiAccessToken.SCOPE_ROSTER);
 		}
 
-		if (scope.contains(LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY)) {
+		if (requestedScopes.contains(LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY)) {
 			if (!Boolean.TRUE.equals(tool.allowroster)) {
 				LTI13Util.return400(response, "invalid_scope", LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY);
 				log.error("Scope context group not allowed {}", tool_id);
@@ -979,6 +980,13 @@ public class LTI13Servlet extends HttpServlet {
 			LTI13Util.return400(response, "Token post request failed");
 			return;
 		}
+	}
+
+	static Set<String> parseRequestedScopes(String scope) {
+		if (scope == null) {
+			return new HashSet<String>();
+		}
+		return SakaiAccessToken.parseScopes(scope.toLowerCase(Locale.ROOT));
 	}
 
 	// SAK-47261 - lineItemId can only be null for old-style signed placements

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -882,7 +882,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		Set<String> requestedScopes = parseRequestedScopes(scope);
+		Set<String> requestedScopes = SakaiAccessToken.parseScopes(scope);
 		String invalidScope = validateRequestedScopes(requestedScopes, scope);
 		if (invalidScope != null) {
 			LTI13Util.return400(response, "invalid_scope", invalidScope);
@@ -987,35 +987,18 @@ public class LTI13Servlet extends HttpServlet {
 		}
 	}
 
-	static Set<String> parseRequestedScopes(String scope) {
-		if (scope == null) {
-			return new HashSet<String>();
-		}
-		return SakaiAccessToken.parseScopes(scope);
-	}
-
 	static String validateRequestedScopes(Set<String> requestedScopes, String originalScope) {
 		if (requestedScopes == null || requestedScopes.isEmpty()) {
 			return originalScope;
 		}
 
-		HashSet<String> unsupportedScopes = new HashSet<String>(requestedScopes);
-		unsupportedScopes.removeAll(supportedTokenRequestScopes());
-		if (unsupportedScopes.isEmpty()) {
-			return null;
+		Set<String> supportedScopes = new HashSet<String>(LTI13ConstantsUtil.SCOPES_SUPPORTED);
+		for (String scope : requestedScopes) {
+			if (!supportedScopes.contains(scope)) {
+				return scope;
+			}
 		}
-		return unsupportedScopes.iterator().next();
-	}
-
-	private static Set<String> supportedTokenRequestScopes() {
-		HashSet<String> scopes = new HashSet<String>();
-		scopes.add(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
-		scopes.add(LTI13ConstantsUtil.SCOPE_LINEITEM);
-		scopes.add(LTI13ConstantsUtil.SCOPE_SCORE);
-		scopes.add(LTI13ConstantsUtil.SCOPE_RESULT_READONLY);
-		scopes.add(LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES);
-		scopes.add(LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY);
-		return scopes;
+		return null;
 	}
 
 	// SAK-47261 - lineItemId can only be null for old-style signed placements

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -884,6 +884,12 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		Set<String> requestedScopes = parseRequestedScopes(scope);
+		String invalidScope = validateRequestedScopes(requestedScopes, scope);
+		if (invalidScope != null) {
+			LTI13Util.return400(response, "invalid_scope", invalidScope);
+			log.error("Unsupported scope {} requested for tool {}", invalidScope, tool_id);
+			return;
+		}
 
 
 		SakaiAccessToken sat = new SakaiAccessToken();
@@ -987,6 +993,30 @@ public class LTI13Servlet extends HttpServlet {
 			return new HashSet<String>();
 		}
 		return SakaiAccessToken.parseScopes(scope.toLowerCase(Locale.ROOT));
+	}
+
+	static String validateRequestedScopes(Set<String> requestedScopes, String originalScope) {
+		if (requestedScopes == null || requestedScopes.isEmpty()) {
+			return originalScope;
+		}
+
+		HashSet<String> unsupportedScopes = new HashSet<String>(requestedScopes);
+		unsupportedScopes.removeAll(supportedTokenRequestScopes());
+		if (unsupportedScopes.isEmpty()) {
+			return null;
+		}
+		return unsupportedScopes.iterator().next();
+	}
+
+	private static Set<String> supportedTokenRequestScopes() {
+		HashSet<String> scopes = new HashSet<String>();
+		scopes.add(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
+		scopes.add(LTI13ConstantsUtil.SCOPE_LINEITEM);
+		scopes.add(LTI13ConstantsUtil.SCOPE_SCORE);
+		scopes.add(LTI13ConstantsUtil.SCOPE_RESULT_READONLY);
+		scopes.add(LTI13ConstantsUtil.SCOPE_NAMES_AND_ROLES);
+		scopes.add(LTI13ConstantsUtil.SCOPE_CONTEXTGROUP_READONLY);
+		return scopes;
 	}
 
 	// SAK-47261 - lineItemId can only be null for old-style signed placements

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.Test;
@@ -64,6 +65,14 @@ public class LTI13ServletTest {
 	public void validateRequestedScopesRejectsUnsupportedScopeTokens() {
 		String unsupportedScope = LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY + "x";
 		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM + " " + unsupportedScope);
+
+		assertEquals(unsupportedScope, LTI13Servlet.validateRequestedScopes(scopes, unsupportedScope));
+	}
+
+	@Test
+	public void validateRequestedScopesRejectsNonCanonicalScopeCase() {
+		String unsupportedScope = LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY.toUpperCase(Locale.ROOT);
+		Set<String> scopes = LTI13Servlet.parseRequestedScopes(unsupportedScope);
 
 		assertEquals(unsupportedScope, LTI13Servlet.validateRequestedScopes(scopes, unsupportedScope));
 	}

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
@@ -16,47 +16,30 @@
 package org.sakaiproject.lti13;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
 import java.util.Set;
 
 import org.junit.Test;
+import org.sakaiproject.lti13.util.SakaiAccessToken;
 import org.tsugi.lti13.LTI13ConstantsUtil;
 
 public class LTI13ServletTest {
 
 	@Test
-	public void parseRequestedScopesRequiresExactScopeTokenMatch() {
-		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
-
-		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY));
-		assertFalse(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
-	}
-
-	@Test
-	public void parseRequestedScopesHandlesWhitespaceDelimitedScopeTokens() {
-		Set<String> scopes = LTI13Servlet.parseRequestedScopes("  " + LTI13ConstantsUtil.SCOPE_LINEITEM + "\n"
-				+ LTI13ConstantsUtil.SCOPE_RESULT_READONLY + "  ");
-
-		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
-		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY));
-	}
-
-	@Test
 	public void validateRequestedScopesAcceptsSupportedScopes() {
-		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM + " "
-				+ LTI13ConstantsUtil.SCOPE_RESULT_READONLY);
+		String originalScope = LTI13ConstantsUtil.SCOPE_LINEITEM + " "
+				+ LTI13ConstantsUtil.SCOPE_RESULT_READONLY;
+		Set<String> scopes = SakaiAccessToken.parseScopes(originalScope);
 
-		assertNull(LTI13Servlet.validateRequestedScopes(scopes, LTI13ConstantsUtil.SCOPE_LINEITEM));
+		assertNull(LTI13Servlet.validateRequestedScopes(scopes, originalScope));
 	}
 
 	@Test
 	public void validateRequestedScopesRejectsWhitespaceOnlyScopeRequest() {
 		String originalScope = "   ";
-		Set<String> scopes = LTI13Servlet.parseRequestedScopes(originalScope);
+		Set<String> scopes = SakaiAccessToken.parseScopes(originalScope);
 
 		assertEquals(originalScope, LTI13Servlet.validateRequestedScopes(scopes, originalScope));
 	}
@@ -64,16 +47,17 @@ public class LTI13ServletTest {
 	@Test
 	public void validateRequestedScopesRejectsUnsupportedScopeTokens() {
 		String unsupportedScope = LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY + "x";
-		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM + " " + unsupportedScope);
+		String originalScope = LTI13ConstantsUtil.SCOPE_LINEITEM + " " + unsupportedScope;
+		Set<String> scopes = SakaiAccessToken.parseScopes(originalScope);
 
-		assertEquals(unsupportedScope, LTI13Servlet.validateRequestedScopes(scopes, unsupportedScope));
+		assertEquals(unsupportedScope, LTI13Servlet.validateRequestedScopes(scopes, originalScope));
 	}
 
 	@Test
 	public void validateRequestedScopesRejectsNonCanonicalScopeCase() {
-		String unsupportedScope = LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY.toUpperCase(Locale.ROOT);
-		Set<String> scopes = LTI13Servlet.parseRequestedScopes(unsupportedScope);
+		String originalScope = LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY.toUpperCase(Locale.ROOT);
+		Set<String> scopes = SakaiAccessToken.parseScopes(originalScope);
 
-		assertEquals(unsupportedScope, LTI13Servlet.validateRequestedScopes(scopes, unsupportedScope));
+		assertEquals(originalScope, LTI13Servlet.validateRequestedScopes(scopes, originalScope));
 	}
 }

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lti13;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.tsugi.lti13.LTI13ConstantsUtil;
+
+public class LTI13ServletTest {
+
+	@Test
+	public void parseRequestedScopesRequiresExactScopeTokenMatch() {
+		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
+
+		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY));
+		assertFalse(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
+	}
+
+	@Test
+	public void parseRequestedScopesHandlesWhitespaceDelimitedScopeTokens() {
+		Set<String> scopes = LTI13Servlet.parseRequestedScopes("  " + LTI13ConstantsUtil.SCOPE_LINEITEM + "\n"
+				+ LTI13ConstantsUtil.SCOPE_RESULT_READONLY + "  ");
+
+		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
+		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY));
+	}
+}

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
@@ -15,7 +15,9 @@
  */
 package org.sakaiproject.lti13;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
@@ -40,5 +42,29 @@ public class LTI13ServletTest {
 
 		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
 		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY));
+	}
+
+	@Test
+	public void validateRequestedScopesAcceptsSupportedScopes() {
+		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM + " "
+				+ LTI13ConstantsUtil.SCOPE_RESULT_READONLY);
+
+		assertNull(LTI13Servlet.validateRequestedScopes(scopes, LTI13ConstantsUtil.SCOPE_LINEITEM));
+	}
+
+	@Test
+	public void validateRequestedScopesRejectsWhitespaceOnlyScopeRequest() {
+		String originalScope = "   ";
+		Set<String> scopes = LTI13Servlet.parseRequestedScopes(originalScope);
+
+		assertEquals(originalScope, LTI13Servlet.validateRequestedScopes(scopes, originalScope));
+	}
+
+	@Test
+	public void validateRequestedScopesRejectsUnsupportedScopeTokens() {
+		String unsupportedScope = LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY + "x";
+		Set<String> scopes = LTI13Servlet.parseRequestedScopes(LTI13ConstantsUtil.SCOPE_LINEITEM + " " + unsupportedScope);
+
+		assertEquals(unsupportedScope, LTI13Servlet.validateRequestedScopes(scopes, unsupportedScope));
 	}
 }

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/util/SakaiAccessToken.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/util/SakaiAccessToken.java
@@ -20,6 +20,9 @@
 package org.sakaiproject.lti13.util;
 
 
+import java.util.HashSet;
+import java.util.Set;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -63,17 +66,35 @@ public class SakaiAccessToken extends  org.tsugi.lti13.objects.BaseJWT {
 	@JsonProperty("tool_id")
 	public Long tool_id;
 
-	public void addScope(String newScope) {
-		if ( this.scope == null ) {
-			this.scope = newScope;
+	public static Set<String> parseScopes(String scopes) {
+		HashSet<String> scopeSet = new HashSet<String>();
+		if (scopes == null) {
+			return scopeSet;
 		}
-		if ( this.scope.contains(newScope)) return;
+
+		String trimmedScopes = scopes.trim();
+		if (trimmedScopes.length() < 1) {
+			return scopeSet;
+		}
+
+		for (String scope : trimmedScopes.split("\\s+")) {
+			scopeSet.add(scope);
+		}
+		return scopeSet;
+	}
+
+	public void addScope(String newScope) {
+		if ( this.scope == null || this.scope.trim().length() < 1 ) {
+			this.scope = newScope;
+			return;
+		}
+		if ( parseScopes(this.scope).contains(newScope)) return;
 		this.scope += " " + newScope;
 	}
 
 	public boolean hasScope(String scope) {
-		if ( this.scope == null ) return false;
-		return this.scope.contains(scope);
+		if ( this.scope == null || scope == null ) return false;
+		return parseScopes(this.scope).contains(scope);
 	}
 
 }

--- a/lti/lti-common/src/java/org/sakaiproject/lti13/util/SakaiAccessToken.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti13/util/SakaiAccessToken.java
@@ -20,7 +20,7 @@
 package org.sakaiproject.lti13.util;
 
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
@@ -67,7 +67,7 @@ public class SakaiAccessToken extends  org.tsugi.lti13.objects.BaseJWT {
 	public Long tool_id;
 
 	public static Set<String> parseScopes(String scopes) {
-		HashSet<String> scopeSet = new HashSet<String>();
+		LinkedHashSet<String> scopeSet = new LinkedHashSet<String>();
 		if (scopes == null) {
 			return scopeSet;
 		}

--- a/lti/lti-common/src/test/org/sakaiproject/lti13/util/SakaiAccessTokenTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti13/util/SakaiAccessTokenTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lti13.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SakaiAccessTokenTest {
+
+	@Test
+	public void hasScopeRequiresExactScopeTokenMatch() {
+		SakaiAccessToken token = new SakaiAccessToken();
+		token.addScope(SakaiAccessToken.SCOPE_LINEITEMS_READONLY);
+
+		assertTrue(token.hasScope(SakaiAccessToken.SCOPE_LINEITEMS_READONLY));
+		assertFalse(token.hasScope(SakaiAccessToken.SCOPE_LINEITEMS));
+	}
+
+	@Test
+	public void addScopeKeepsPrefixRelatedScopesDistinct() {
+		SakaiAccessToken token = new SakaiAccessToken();
+		token.addScope(SakaiAccessToken.SCOPE_LINEITEMS_READONLY);
+		token.addScope(SakaiAccessToken.SCOPE_LINEITEMS);
+		token.addScope(SakaiAccessToken.SCOPE_LINEITEMS);
+
+		assertEquals(SakaiAccessToken.SCOPE_LINEITEMS_READONLY + " " + SakaiAccessToken.SCOPE_LINEITEMS, token.scope);
+		assertTrue(token.hasScope(SakaiAccessToken.SCOPE_LINEITEMS_READONLY));
+		assertTrue(token.hasScope(SakaiAccessToken.SCOPE_LINEITEMS));
+	}
+}

--- a/lti/lti-common/src/test/org/sakaiproject/lti13/util/SakaiAccessTokenTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti13/util/SakaiAccessTokenTest.java
@@ -19,9 +19,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Set;
+
 import org.junit.Test;
+import org.tsugi.lti13.LTI13ConstantsUtil;
 
 public class SakaiAccessTokenTest {
+
+	@Test
+	public void parseScopesRequiresExactScopeTokenMatch() {
+		Set<String> scopes = SakaiAccessToken.parseScopes(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY);
+
+		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM_READONLY));
+		assertFalse(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
+	}
+
+	@Test
+	public void parseScopesHandlesWhitespaceDelimitedScopeTokens() {
+		Set<String> scopes = SakaiAccessToken.parseScopes("  " + LTI13ConstantsUtil.SCOPE_LINEITEM + "\n"
+				+ LTI13ConstantsUtil.SCOPE_RESULT_READONLY + "  ");
+
+		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_LINEITEM));
+		assertTrue(scopes.contains(LTI13ConstantsUtil.SCOPE_RESULT_READONLY));
+	}
 
 	@Test
 	public void hasScopeRequiresExactScopeTokenMatch() {


### PR DESCRIPTION
## Summary
- require exact whitespace-delimited scope matching for LTI 1.3 token requests
- require exact internal access-token scope checks
- add regression coverage for `lineitem.readonly` not granting line item write access

## Root Cause
The token endpoint and internal access token helper used substring matching for scopes. The AGS readonly line item scope contains the write line item scope as a prefix, so readonly requests and tokens could be treated as write-capable.

## Testing
- `mvn -pl lti/lti-common -Dtest=SakaiAccessTokenTest test`
- `mvn -pl lti/lti-common -DskipTests install`
- `mvn -pl lti/lti-blis -Dtest=LTI13ServletTest test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth `scope` values are now tokenized and validated against supported LTI scopes before issuing tokens (returns `400 invalid_scope` for unsupported requests).
  * Scope checks and authorization gating use exact token membership rather than partial-string matching, improving correctness for similarly named scopes.
  * Blank/missing or non-canonical scope inputs are handled safely and treated as invalid where appropriate.
* **Tests**
  * Added/extended unit tests for scope parsing, exact-match behavior, and requested-scope validation edge cases (including whitespace/newline-delimited inputs and mixed supported/unsupported tokens).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->