### PR TITLE
SAK-52677 LTI validate client assertions

### DIFF
--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/ignite-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/ignite-components.xml
@@ -260,6 +260,9 @@
                 <bean parent="org.sakaiproject.ignite.cache.eternal">
                     <property name="name" value="org.sakaiproject.lti13.LTI13Servlet_cache"/>
                 </bean>
+                <bean parent="org.sakaiproject.ignite.cache.atomic">
+                    <property name="name" value="org.sakaiproject.lti13.ClientAssertionReplay_cache"/>
+                </bean>
                 <bean parent="org.sakaiproject.ignite.cache.eternal">
                     <property name="name" value="org.sakaiproject.basiclti.util.SakaiKeySetUtil_cache"/>
                 </bean>

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -55,7 +55,6 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -140,8 +139,6 @@ public class LTI13Servlet extends HttpServlet {
 	private static final String CACHE_NAME = LTI13Servlet.class.getName() + "_cache";
 	private static final String CACHE_PUBLIC = "key::public";
 	private static final String CACHE_PRIVATE = "key::private";
-	private static final String CACHE_CLIENT_ASSERTION_JTI = "client_assertion_jti::";
-	private static final long CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS = 60_000L;
 
 	private static final String PLUS_NRPS_PAGING = "plus:nrps_paging";
 
@@ -843,7 +840,7 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		String tokenRequestError = validateTokenRequest(grant_type, client_assertion_type);
+		String tokenRequestError = LTI13TokenRequestValidator.validateTokenRequest(grant_type, client_assertion_type);
 		if (tokenRequestError != null) {
 			LTI13Util.return400(response, "invalid_request", tokenRequestError);
 			log.error("Invalid token request for tool {}: {}", tool_id, tokenRequestError);
@@ -905,14 +902,14 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		String tokenAudience = getOurServerUrl() + LTI13_PATH + "token/" + toolKey;
-		String claimError = validateClientAssertionClaims(claims.getBody(), tool.lti13ClientId, tokenAudience);
+		String claimError = LTI13TokenRequestValidator.validateClientAssertionClaims(claims.getBody(), tool.lti13ClientId, tokenAudience);
 		if (claimError != null) {
 			LTI13Util.return400(response, "invalid_client", claimError);
 			log.error("Invalid client_assertion for tool {}: {}", tool_id, claimError);
 			return;
 		}
 
-		String replayError = validateClientAssertionReplay(cache, claims.getBody(), tool.lti13ClientId);
+		String replayError = LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims.getBody(), tool.lti13ClientId);
 		if (replayError != null) {
 			LTI13Util.return400(response, "invalid_client", replayError);
 			log.error("Invalid client_assertion replay state for tool {}: {}", tool_id, replayError);
@@ -1016,96 +1013,6 @@ public class LTI13Servlet extends HttpServlet {
 			LTI13Util.return400(response, "Token post request failed");
 			return;
 		}
-	}
-
-	static String validateTokenRequest(String grantType, String clientAssertionType) {
-		if (!ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS.equals(grantType)) {
-			return "Invalid grant_type";
-		}
-		if (!ClientAssertion.CLIENT_ASSERTION_TYPE_JWT.equals(clientAssertionType)) {
-			return "Invalid client_assertion_type";
-		}
-		return null;
-	}
-
-	static String validateClientAssertionClaims(Claims claims, String clientId, String tokenAudience) {
-		if (claims == null) {
-			return "Missing client_assertion claims";
-		}
-		if (StringUtils.isBlank(clientId)) {
-			return "Tool is missing client_id";
-		}
-		if (!clientId.equals(claims.getIssuer())) {
-			return "Invalid issuer";
-		}
-		if (!clientId.equals(claims.getSubject())) {
-			return "Invalid subject";
-		}
-		if (!hasAudience(claims, tokenAudience)) {
-			return "Invalid audience";
-		}
-		if (claims.getIssuedAt() == null) {
-			return "Missing iat";
-		}
-		if (claims.getExpiration() == null) {
-			return "Missing exp";
-		}
-		if (StringUtils.isBlank(claims.getId())) {
-			return "Missing jti";
-		}
-
-		long now = System.currentTimeMillis();
-		if (claims.getIssuedAt().getTime() > now + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
-			return "Invalid iat";
-		}
-		if (claims.getExpiration().getTime() <= now - CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
-			return "Invalid exp";
-		}
-		if (claims.getIssuedAt().after(claims.getExpiration())) {
-			return "Invalid iat";
-		}
-		return null;
-	}
-
-	static boolean hasAudience(Claims claims, String tokenAudience) {
-		if (claims == null || StringUtils.isBlank(tokenAudience)) {
-			return false;
-		}
-
-		Object audience = claims.get(Claims.AUDIENCE);
-		if (audience instanceof String) {
-			return tokenAudience.equals(audience);
-		}
-		if (audience instanceof Collection<?>) {
-			for (Object entry : (Collection<?>) audience) {
-				if (tokenAudience.equals(entry)) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	static String validateClientAssertionReplay(Cache cache, Claims claims, String clientId) {
-		if (cache == null) {
-			return "Replay cache unavailable";
-		}
-		if (claims == null || StringUtils.isBlank(claims.getId()) || StringUtils.isBlank(clientId) || claims.getExpiration() == null) {
-			return "Missing jti";
-		}
-
-		String cacheKey = CACHE_CLIENT_ASSERTION_JTI + clientId + "::" + claims.getId();
-		Long expires = Long.valueOf(claims.getExpiration().getTime());
-		long now = System.currentTimeMillis();
-		Cache.ValueWrapper existing = cache.putIfAbsent(cacheKey, expires);
-		if (existing != null) {
-			Object existingExpires = existing.get();
-			if (!(existingExpires instanceof Long) || ((Long) existingExpires).longValue() > now) {
-				return "Replayed client_assertion";
-			}
-			cache.put(cacheKey, expires);
-		}
-		return null;
 	}
 
 	// SAK-47261 - lineItemId can only be null for old-style signed placements

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import java.security.Key;
 import java.security.KeyPairGenerator;
 import java.util.logging.Level;
@@ -54,6 +55,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -138,6 +140,8 @@ public class LTI13Servlet extends HttpServlet {
 	private static final String CACHE_NAME = LTI13Servlet.class.getName() + "_cache";
 	private static final String CACHE_PUBLIC = "key::public";
 	private static final String CACHE_PRIVATE = "key::private";
+	private static final String CACHE_CLIENT_ASSERTION_JTI = "client_assertion_jti::";
+	private static final long CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS = 60_000L;
 
 	private static final String PLUS_NRPS_PAGING = "plus:nrps_paging";
 
@@ -817,11 +821,15 @@ public class LTI13Servlet extends HttpServlet {
 		}
 
 		String grant_type = request.getParameter(ClientAssertion.GRANT_TYPE);
+		String client_assertion_type = request.getParameter(ClientAssertion.CLIENT_ASSERTION_TYPE);
 		String client_assertion = request.getParameter(ClientAssertion.CLIENT_ASSERTION);
 		String scope = request.getParameter(ClientAssertion.SCOPE);
 		String missing = "";
 		if (grant_type == null) {
 			missing += " " + "grant_type";
+		}
+		if (client_assertion_type == null) {
+			missing += " " + "client_assertion_type";
 		}
 		if (client_assertion == null) {
 			missing += " " + "client_assertion";
@@ -832,6 +840,13 @@ public class LTI13Servlet extends HttpServlet {
 		if (missing.length() > 0) {
 			LTI13Util.return400(response, "Token request missing fields:" + missing);
 			log.error("Token Request missing fields: {}", missing);
+			return;
+		}
+
+		String tokenRequestError = validateTokenRequest(grant_type, client_assertion_type);
+		if (tokenRequestError != null) {
+			LTI13Util.return400(response, "invalid_request", tokenRequestError);
+			log.error("Invalid token request for tool {}: {}", tool_id, tokenRequestError);
 			return;
 		}
 
@@ -874,11 +889,33 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		Jws<Claims> claims = Jwts.parser().setAllowedClockSkewSeconds(60).setSigningKey(publicKey).parseClaimsJws(client_assertion);
+		Jws<Claims> claims = null;
+		try {
+			claims = Jwts.parser().setAllowedClockSkewSeconds(60).setSigningKey(publicKey).parseClaimsJws(client_assertion);
+		} catch (JwtException | IllegalArgumentException e) {
+			log.error("Could not verify client_assertion for tool {}", tool_id, e);
+			LTI13Util.return400(response, "invalid_client", "Could not verify client_assertion");
+			return;
+		}
 
 		if (claims == null) {
 			LTI13Util.return400(response, "Could not verify signature");
 			log.error("Could not verify signature {}", tool_id);
+			return;
+		}
+
+		String tokenAudience = getOurServerUrl() + LTI13_PATH + "token/" + toolKey;
+		String claimError = validateClientAssertionClaims(claims.getBody(), tool.lti13ClientId, tokenAudience);
+		if (claimError != null) {
+			LTI13Util.return400(response, "invalid_client", claimError);
+			log.error("Invalid client_assertion for tool {}: {}", tool_id, claimError);
+			return;
+		}
+
+		String replayError = validateClientAssertionReplay(cache, claims.getBody(), tool.lti13ClientId);
+		if (replayError != null) {
+			LTI13Util.return400(response, "invalid_client", replayError);
+			log.error("Invalid client_assertion replay state for tool {}: {}", tool_id, replayError);
 			return;
 		}
 
@@ -979,6 +1016,96 @@ public class LTI13Servlet extends HttpServlet {
 			LTI13Util.return400(response, "Token post request failed");
 			return;
 		}
+	}
+
+	static String validateTokenRequest(String grantType, String clientAssertionType) {
+		if (!ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS.equals(grantType)) {
+			return "Invalid grant_type";
+		}
+		if (!ClientAssertion.CLIENT_ASSERTION_TYPE_JWT.equals(clientAssertionType)) {
+			return "Invalid client_assertion_type";
+		}
+		return null;
+	}
+
+	static String validateClientAssertionClaims(Claims claims, String clientId, String tokenAudience) {
+		if (claims == null) {
+			return "Missing client_assertion claims";
+		}
+		if (StringUtils.isBlank(clientId)) {
+			return "Tool is missing client_id";
+		}
+		if (!clientId.equals(claims.getIssuer())) {
+			return "Invalid issuer";
+		}
+		if (!clientId.equals(claims.getSubject())) {
+			return "Invalid subject";
+		}
+		if (!hasAudience(claims, tokenAudience)) {
+			return "Invalid audience";
+		}
+		if (claims.getIssuedAt() == null) {
+			return "Missing iat";
+		}
+		if (claims.getExpiration() == null) {
+			return "Missing exp";
+		}
+		if (StringUtils.isBlank(claims.getId())) {
+			return "Missing jti";
+		}
+
+		long now = System.currentTimeMillis();
+		if (claims.getIssuedAt().getTime() > now + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
+			return "Invalid iat";
+		}
+		if (claims.getExpiration().getTime() <= now - CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
+			return "Invalid exp";
+		}
+		if (claims.getIssuedAt().after(claims.getExpiration())) {
+			return "Invalid iat";
+		}
+		return null;
+	}
+
+	static boolean hasAudience(Claims claims, String tokenAudience) {
+		if (claims == null || StringUtils.isBlank(tokenAudience)) {
+			return false;
+		}
+
+		Object audience = claims.get(Claims.AUDIENCE);
+		if (audience instanceof String) {
+			return tokenAudience.equals(audience);
+		}
+		if (audience instanceof Collection<?>) {
+			for (Object entry : (Collection<?>) audience) {
+				if (tokenAudience.equals(entry)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	static String validateClientAssertionReplay(Cache cache, Claims claims, String clientId) {
+		if (cache == null) {
+			return "Replay cache unavailable";
+		}
+		if (claims == null || StringUtils.isBlank(claims.getId()) || StringUtils.isBlank(clientId) || claims.getExpiration() == null) {
+			return "Missing jti";
+		}
+
+		String cacheKey = CACHE_CLIENT_ASSERTION_JTI + clientId + "::" + claims.getId();
+		Long expires = Long.valueOf(claims.getExpiration().getTime());
+		long now = System.currentTimeMillis();
+		Cache.ValueWrapper existing = cache.putIfAbsent(cacheKey, expires);
+		if (existing != null) {
+			Object existingExpires = existing.get();
+			if (!(existingExpires instanceof Long) || ((Long) existingExpires).longValue() > now) {
+				return "Replayed client_assertion";
+			}
+			cache.put(cacheKey, expires);
+		}
+		return null;
 	}
 
 	// SAK-47261 - lineItemId can only be null for old-style signed placements

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -135,8 +135,10 @@ public class LTI13Servlet extends HttpServlet {
 
     private CacheManager cacheManager;
     private Cache cache;
+    private Cache clientAssertionReplayCache;
 
 	private static final String CACHE_NAME = LTI13Servlet.class.getName() + "_cache";
+	private static final String CLIENT_ASSERTION_REPLAY_CACHE_NAME = "org.sakaiproject.lti13.ClientAssertionReplay_cache";
 	private static final String CACHE_PUBLIC = "key::public";
 	private static final String CACHE_PRIVATE = "key::private";
 
@@ -151,6 +153,7 @@ public class LTI13Servlet extends HttpServlet {
 
         cacheManager = (CacheManager) ComponentManager.get("org.sakaiproject.ignite.SakaiCacheManager");
         cache = cacheManager.getCache(CACHE_NAME);
+        clientAssertionReplayCache = cacheManager.getCache(CLIENT_ASSERTION_REPLAY_CACHE_NAME);
 
 		// Lets try to load from properties
 		if (tokenKeyPair == null) {
@@ -909,10 +912,17 @@ public class LTI13Servlet extends HttpServlet {
 			return;
 		}
 
-		String replayError = LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims.getBody(), tool.lti13ClientId);
-		if (replayError != null) {
-			LTI13Util.return400(response, "invalid_client", replayError);
-			log.error("Invalid client_assertion replay state for tool {}: {}", tool_id, replayError);
+		LTI13TokenRequestValidator.ClientAssertionReplayResult replayResult =
+				LTI13TokenRequestValidator.validateClientAssertionReplay(clientAssertionReplayCache, claims.getBody(), tool.lti13ClientId);
+		if (replayResult == LTI13TokenRequestValidator.ClientAssertionReplayResult.CACHE_UNAVAILABLE) {
+			LTI13Util.return4XX(response, "temporarily_unavailable", "Token request temporarily unavailable",
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+			log.warn("Client assertion replay cache unavailable for tool {} client {}", tool_id, tool.lti13ClientId);
+			return;
+		}
+		if (replayResult == LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED) {
+			LTI13Util.return400(response, "invalid_client", replayResult.getClientMessage());
+			log.error("Invalid client_assertion replay state for tool {}: {}", tool_id, replayResult.getClientMessage());
 			return;
 		}
 

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13Servlet.java
@@ -915,12 +915,8 @@ public class LTI13Servlet extends HttpServlet {
 		LTI13TokenRequestValidator.ClientAssertionReplayResult replayResult =
 				LTI13TokenRequestValidator.validateClientAssertionReplay(clientAssertionReplayCache, claims.getBody(), tool.lti13ClientId);
 		if (replayResult == LTI13TokenRequestValidator.ClientAssertionReplayResult.CACHE_UNAVAILABLE) {
-			LTI13Util.return4XX(response, "temporarily_unavailable", "Token request temporarily unavailable",
-					HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-			log.warn("Client assertion replay cache unavailable for tool {} client {}", tool_id, tool.lti13ClientId);
-			return;
-		}
-		if (replayResult == LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED) {
+			log.warn("Client assertion replay cache unavailable for tool {} client {}; continuing without replay cache", tool_id, tool.lti13ClientId);
+		} else if (replayResult == LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED) {
 			LTI13Util.return400(response, "invalid_client", replayResult.getClientMessage());
 			log.error("Invalid client_assertion replay state for tool {}: {}", tool_id, replayResult.getClientMessage());
 			return;

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
@@ -18,16 +18,14 @@ package org.sakaiproject.lti13;
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.cache.Cache;
 import org.tsugi.oauth2.objects.ClientAssertion;
 
 import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 final class LTI13TokenRequestValidator {
-
-	private static final Logger log = LoggerFactory.getLogger(LTI13TokenRequestValidator.class);
 
 	static final long CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS = 60_000L;
 	static final long CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS = 600_000L;

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lti13;
+
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.cache.Cache;
+import org.tsugi.oauth2.objects.ClientAssertion;
+
+import io.jsonwebtoken.Claims;
+
+final class LTI13TokenRequestValidator {
+
+	static final long CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS = 60_000L;
+
+	private static final String CACHE_CLIENT_ASSERTION_JTI = "client_assertion_jti::";
+
+	private LTI13TokenRequestValidator() {
+	}
+
+	static String validateTokenRequest(String grantType, String clientAssertionType) {
+		if (!ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS.equals(grantType)) {
+			return "Invalid grant_type";
+		}
+		if (!ClientAssertion.CLIENT_ASSERTION_TYPE_JWT.equals(clientAssertionType)) {
+			return "Invalid client_assertion_type";
+		}
+		return null;
+	}
+
+	static String validateClientAssertionClaims(Claims claims, String clientId, String tokenAudience) {
+		if (claims == null) {
+			return "Missing client_assertion claims";
+		}
+		if (StringUtils.isBlank(clientId)) {
+			return "Tool is missing client_id";
+		}
+		if (!clientId.equals(claims.getIssuer())) {
+			return "Invalid issuer";
+		}
+		if (!clientId.equals(claims.getSubject())) {
+			return "Invalid subject";
+		}
+		if (!hasAudience(claims, tokenAudience)) {
+			return "Invalid audience";
+		}
+		if (claims.getIssuedAt() == null) {
+			return "Missing iat";
+		}
+		if (claims.getExpiration() == null) {
+			return "Missing exp";
+		}
+		if (StringUtils.isBlank(claims.getId())) {
+			return "Missing jti";
+		}
+
+		long now = System.currentTimeMillis();
+		if (claims.getIssuedAt().getTime() > now + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
+			return "Invalid iat";
+		}
+		if (claims.getExpiration().getTime() <= now - CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
+			return "Invalid exp";
+		}
+		if (claims.getIssuedAt().after(claims.getExpiration())) {
+			return "Invalid iat";
+		}
+		return null;
+	}
+
+	static boolean hasAudience(Claims claims, String tokenAudience) {
+		if (claims == null || StringUtils.isBlank(tokenAudience)) {
+			return false;
+		}
+
+		Object audience = claims.get(Claims.AUDIENCE);
+		if (audience instanceof String) {
+			return tokenAudience.equals(audience);
+		}
+		if (audience instanceof Collection<?>) {
+			for (Object entry : (Collection<?>) audience) {
+				if (tokenAudience.equals(entry)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	static String validateClientAssertionReplay(Cache cache, Claims claims, String clientId) {
+		if (cache == null) {
+			return "Replay cache unavailable";
+		}
+		if (claims == null || StringUtils.isBlank(claims.getId()) || StringUtils.isBlank(clientId) || claims.getExpiration() == null) {
+			return "Missing jti";
+		}
+
+		String cacheKey = CACHE_CLIENT_ASSERTION_JTI + clientId + "::" + claims.getId();
+		Long expires = Long.valueOf(claims.getExpiration().getTime() + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS);
+		long now = System.currentTimeMillis();
+		Cache.ValueWrapper existing = cache.putIfAbsent(cacheKey, expires);
+		if (existing != null) {
+			Object existingExpires = existing.get();
+			if (!(existingExpires instanceof Long) || ((Long) existingExpires).longValue() > now) {
+				return "Replayed client_assertion";
+			}
+			cache.put(cacheKey, expires);
+		}
+		return null;
+	}
+}

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
@@ -18,6 +18,8 @@ package org.sakaiproject.lti13;
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cache.Cache;
 import org.tsugi.oauth2.objects.ClientAssertion;
 
@@ -25,9 +27,32 @@ import io.jsonwebtoken.Claims;
 
 final class LTI13TokenRequestValidator {
 
+	private static final Logger log = LoggerFactory.getLogger(LTI13TokenRequestValidator.class);
+
 	static final long CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS = 60_000L;
+	static final long CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS = 600_000L;
 
 	private static final String CACHE_CLIENT_ASSERTION_JTI = "client_assertion_jti::";
+
+	enum ClientAssertionReplayResult {
+		OK,
+		REPLAYED("Replayed client_assertion"),
+		CACHE_UNAVAILABLE;
+
+		private final String clientMessage;
+
+		ClientAssertionReplayResult() {
+			this.clientMessage = null;
+		}
+
+		ClientAssertionReplayResult(String clientMessage) {
+			this.clientMessage = clientMessage;
+		}
+
+		String getClientMessage() {
+			return clientMessage;
+		}
+	}
 
 	private LTI13TokenRequestValidator() {
 	}
@@ -78,6 +103,10 @@ final class LTI13TokenRequestValidator {
 		if (claims.getIssuedAt().after(claims.getExpiration())) {
 			return "Invalid iat";
 		}
+		if (claims.getExpiration().getTime() - claims.getIssuedAt().getTime()
+				> CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
+			return "Invalid exp";
+		}
 		return null;
 	}
 
@@ -100,25 +129,28 @@ final class LTI13TokenRequestValidator {
 		return false;
 	}
 
-	static String validateClientAssertionReplay(Cache cache, Claims claims, String clientId) {
+	static ClientAssertionReplayResult validateClientAssertionReplay(Cache cache, Claims claims, String clientId) {
 		if (cache == null) {
-			return "Replay cache unavailable";
-		}
-		if (claims == null || StringUtils.isBlank(claims.getId()) || StringUtils.isBlank(clientId) || claims.getExpiration() == null) {
-			return "Missing jti";
+			log.warn("Client assertion replay cache unavailable for client {}", clientId);
+			return ClientAssertionReplayResult.CACHE_UNAVAILABLE;
 		}
 
-		String cacheKey = CACHE_CLIENT_ASSERTION_JTI + clientId + "::" + claims.getId();
-		Long expires = Long.valueOf(claims.getExpiration().getTime() + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS);
-		long now = System.currentTimeMillis();
-		Cache.ValueWrapper existing = cache.putIfAbsent(cacheKey, expires);
-		if (existing != null) {
-			Object existingExpires = existing.get();
-			if (!(existingExpires instanceof Long) || ((Long) existingExpires).longValue() > now) {
-				return "Replayed client_assertion";
+		try {
+			String cacheKey = CACHE_CLIENT_ASSERTION_JTI + clientId + "::" + claims.getId();
+			Long expires = Long.valueOf(claims.getExpiration().getTime() + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS);
+			long now = System.currentTimeMillis();
+			Cache.ValueWrapper existing = cache.putIfAbsent(cacheKey, expires);
+			if (existing != null) {
+				Object existingExpires = existing.get();
+				if (!(existingExpires instanceof Long) || ((Long) existingExpires).longValue() > now) {
+					return ClientAssertionReplayResult.REPLAYED;
+				}
+				cache.put(cacheKey, expires);
 			}
-			cache.put(cacheKey, expires);
+		} catch (RuntimeException e) {
+			log.warn("Client assertion replay cache operation failed for client {} jti {}", clientId, claims.getId(), e);
+			return ClientAssertionReplayResult.CACHE_UNAVAILABLE;
 		}
-		return null;
+		return ClientAssertionReplayResult.OK;
 	}
 }

--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
@@ -137,14 +137,14 @@ final class LTI13TokenRequestValidator {
 			String cacheKey = CACHE_CLIENT_ASSERTION_JTI + clientId + "::" + claims.getId();
 			Long expires = Long.valueOf(claims.getExpiration().getTime() + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS);
 			long now = System.currentTimeMillis();
-			Cache.ValueWrapper existing = cache.putIfAbsent(cacheKey, expires);
+			Cache.ValueWrapper existing = cache.get(cacheKey);
 			if (existing != null) {
 				Object existingExpires = existing.get();
 				if (!(existingExpires instanceof Long) || ((Long) existingExpires).longValue() > now) {
 					return ClientAssertionReplayResult.REPLAYED;
 				}
-				cache.put(cacheKey, expires);
 			}
+			cache.putIfAbsent(cacheKey, expires);
 		} catch (RuntimeException e) {
 			log.warn("Client assertion replay cache operation failed for client {} jti {}", clientId, claims.getId(), e);
 			return ClientAssertionReplayResult.CACHE_UNAVAILABLE;

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13ServletTest.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lti13;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+import org.springframework.cache.Cache;
+import org.tsugi.oauth2.objects.ClientAssertion;
+
+import io.jsonwebtoken.Claims;
+
+public class LTI13ServletTest {
+
+	private static final String CLIENT_ID = "client-123";
+	private static final String TOKEN_AUDIENCE = "https://sakai.example/imsblis/lti13/token/42";
+
+	@Test
+	public void validateTokenRequestRequiresClientCredentialsGrant() {
+		assertNull(LTI13Servlet.validateTokenRequest(ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS,
+				ClientAssertion.CLIENT_ASSERTION_TYPE_JWT));
+		assertEquals("Invalid grant_type", LTI13Servlet.validateTokenRequest("authorization_code",
+				ClientAssertion.CLIENT_ASSERTION_TYPE_JWT));
+		assertEquals("Invalid client_assertion_type", LTI13Servlet.validateTokenRequest(
+				ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS, "jwt"));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsAcceptsRequiredClaims() {
+		assertNull(LTI13Servlet.validateClientAssertionClaims(validClaims("jti-1"), CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsRejectsWrongClientIdClaims() {
+		Claims claims = validClaims("jti-1");
+		claims.setSubject("other-client");
+
+		assertEquals("Invalid subject", LTI13Servlet.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsRejectsWrongAudience() {
+		Claims claims = validClaims("jti-1");
+		claims.setAudience("https://sakai.example/imsblis/lti13/token/99");
+
+		assertEquals("Invalid audience", LTI13Servlet.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsAcceptsAudienceLists() {
+		Claims claims = validClaims("jti-1");
+		claims.put(Claims.AUDIENCE, Arrays.asList("https://sakai.example/other", TOKEN_AUDIENCE));
+
+		assertNull(LTI13Servlet.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionReplayRejectsRepeatedJti() {
+		MapCache cache = new MapCache();
+		Claims claims = validClaims("jti-1");
+
+		assertNull(LTI13Servlet.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertEquals("Replayed client_assertion", LTI13Servlet.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+	}
+
+	private Claims validClaims(String jti) {
+		long now = System.currentTimeMillis();
+		return new TestClaims()
+				.setIssuer(CLIENT_ID)
+				.setSubject(CLIENT_ID)
+				.setAudience(TOKEN_AUDIENCE)
+				.setIssuedAt(new Date(now - 1_000L))
+				.setExpiration(new Date(now + 60_000L))
+				.setId(jti);
+	}
+
+	private static class TestClaims extends HashMap<String, Object> implements Claims {
+
+		@Override
+		public String getIssuer() {
+			return get(ISSUER, String.class);
+		}
+
+		@Override
+		public Claims setIssuer(String iss) {
+			put(ISSUER, iss);
+			return this;
+		}
+
+		@Override
+		public String getSubject() {
+			return get(SUBJECT, String.class);
+		}
+
+		@Override
+		public Claims setSubject(String sub) {
+			put(SUBJECT, sub);
+			return this;
+		}
+
+		@Override
+		public String getAudience() {
+			return get(AUDIENCE, String.class);
+		}
+
+		@Override
+		public Claims setAudience(String aud) {
+			put(AUDIENCE, aud);
+			return this;
+		}
+
+		@Override
+		public Date getExpiration() {
+			return get(EXPIRATION, Date.class);
+		}
+
+		@Override
+		public Claims setExpiration(Date exp) {
+			put(EXPIRATION, exp);
+			return this;
+		}
+
+		@Override
+		public Date getNotBefore() {
+			return get(NOT_BEFORE, Date.class);
+		}
+
+		@Override
+		public Claims setNotBefore(Date nbf) {
+			put(NOT_BEFORE, nbf);
+			return this;
+		}
+
+		@Override
+		public Date getIssuedAt() {
+			return get(ISSUED_AT, Date.class);
+		}
+
+		@Override
+		public Claims setIssuedAt(Date iat) {
+			put(ISSUED_AT, iat);
+			return this;
+		}
+
+		@Override
+		public String getId() {
+			return get(ID, String.class);
+		}
+
+		@Override
+		public Claims setId(String jti) {
+			put(ID, jti);
+			return this;
+		}
+
+		@Override
+		public <T> T get(String claimName, Class<T> requiredType) {
+			Object value = get(claimName);
+			return value == null ? null : requiredType.cast(value);
+		}
+	}
+
+	private static class MapCache implements Cache {
+
+		private final Map<Object, Object> values = new HashMap<>();
+
+		@Override
+		public String getName() {
+			return "test";
+		}
+
+		@Override
+		public Object getNativeCache() {
+			return values;
+		}
+
+		@Override
+		public ValueWrapper get(Object key) {
+			if (!values.containsKey(key)) {
+				return null;
+			}
+			Object value = values.get(key);
+			return () -> value;
+		}
+
+		@Override
+		public <T> T get(Object key, Class<T> type) {
+			Object value = values.get(key);
+			return value == null ? null : type.cast(value);
+		}
+
+		@Override
+		public <T> T get(Object key, Callable<T> valueLoader) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void put(Object key, Object value) {
+			values.put(key, value);
+		}
+
+		@Override
+		public ValueWrapper putIfAbsent(Object key, Object value) {
+			Object existing = values.putIfAbsent(key, value);
+			return existing == null ? null : () -> existing;
+		}
+
+		@Override
+		public void evict(Object key) {
+			values.remove(key);
+		}
+
+		@Override
+		public void clear() {
+			values.clear();
+		}
+	}
+}

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -30,24 +30,24 @@ import org.tsugi.oauth2.objects.ClientAssertion;
 
 import io.jsonwebtoken.Claims;
 
-public class LTI13ServletTest {
+public class LTI13TokenRequestValidatorTest {
 
 	private static final String CLIENT_ID = "client-123";
 	private static final String TOKEN_AUDIENCE = "https://sakai.example/imsblis/lti13/token/42";
 
 	@Test
 	public void validateTokenRequestRequiresClientCredentialsGrant() {
-		assertNull(LTI13Servlet.validateTokenRequest(ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS,
+		assertNull(LTI13TokenRequestValidator.validateTokenRequest(ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS,
 				ClientAssertion.CLIENT_ASSERTION_TYPE_JWT));
-		assertEquals("Invalid grant_type", LTI13Servlet.validateTokenRequest("authorization_code",
+		assertEquals("Invalid grant_type", LTI13TokenRequestValidator.validateTokenRequest("authorization_code",
 				ClientAssertion.CLIENT_ASSERTION_TYPE_JWT));
-		assertEquals("Invalid client_assertion_type", LTI13Servlet.validateTokenRequest(
+		assertEquals("Invalid client_assertion_type", LTI13TokenRequestValidator.validateTokenRequest(
 				ClientAssertion.GRANT_TYPE_CLIENT_CREDENTIALS, "jwt"));
 	}
 
 	@Test
 	public void validateClientAssertionClaimsAcceptsRequiredClaims() {
-		assertNull(LTI13Servlet.validateClientAssertionClaims(validClaims("jti-1"), CLIENT_ID, TOKEN_AUDIENCE));
+		assertNull(LTI13TokenRequestValidator.validateClientAssertionClaims(validClaims("jti-1"), CLIENT_ID, TOKEN_AUDIENCE));
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class LTI13ServletTest {
 		Claims claims = validClaims("jti-1");
 		claims.setSubject("other-client");
 
-		assertEquals("Invalid subject", LTI13Servlet.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+		assertEquals("Invalid subject", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
 	}
 
 	@Test
@@ -63,7 +63,7 @@ public class LTI13ServletTest {
 		Claims claims = validClaims("jti-1");
 		claims.setAudience("https://sakai.example/imsblis/lti13/token/99");
 
-		assertEquals("Invalid audience", LTI13Servlet.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+		assertEquals("Invalid audience", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class LTI13ServletTest {
 		Claims claims = validClaims("jti-1");
 		claims.put(Claims.AUDIENCE, Arrays.asList("https://sakai.example/other", TOKEN_AUDIENCE));
 
-		assertNull(LTI13Servlet.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+		assertNull(LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
 	}
 
 	@Test
@@ -79,8 +79,18 @@ public class LTI13ServletTest {
 		MapCache cache = new MapCache();
 		Claims claims = validClaims("jti-1");
 
-		assertNull(LTI13Servlet.validateClientAssertionReplay(cache, claims, CLIENT_ID));
-		assertEquals("Replayed client_assertion", LTI13Servlet.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertNull(LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertEquals("Replayed client_assertion", LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+	}
+
+	@Test
+	public void validateClientAssertionReplayRejectsRepeatedJtiDuringClockSkewWindow() {
+		MapCache cache = new MapCache();
+		Claims claims = validClaims("jti-1");
+		claims.setExpiration(new Date(System.currentTimeMillis() - 1_000L));
+
+		assertNull(LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertEquals("Replayed client_assertion", LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
 	}
 
 	private Claims validClaims(String jti) {

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -17,6 +17,7 @@ package org.sakaiproject.lti13;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -75,12 +76,53 @@ public class LTI13TokenRequestValidatorTest {
 	}
 
 	@Test
+	public void validateClientAssertionClaimsRejectsMissingRequiredClaims() {
+		Claims claims = validClaims("jti-1");
+
+		claims.setIssuedAt(null);
+		assertEquals("Missing iat", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+
+		claims = validClaims("jti-1");
+		claims.setExpiration(null);
+		assertEquals("Missing exp", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+
+		claims = validClaims("jti-1");
+		claims.setId(null);
+		assertEquals("Missing jti", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsRejectsExcessiveLifetime() {
+		Claims claims = validClaims("jti-1");
+		claims.setIssuedAt(new Date(System.currentTimeMillis()));
+		claims.setExpiration(new Date(System.currentTimeMillis()
+				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS
+				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
+				+ 1_000L));
+
+		assertEquals("Invalid exp", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
 	public void validateClientAssertionReplayRejectsRepeatedJti() {
 		MapCache cache = new MapCache();
 		Claims claims = validClaims("jti-1");
 
-		assertNull(LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
-		assertEquals("Replayed client_assertion", LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+	}
+
+	@Test
+	public void validateClientAssertionReplayScopesJtiByClientId() {
+		MapCache cache = new MapCache();
+		Claims claims = validClaims("jti-1");
+
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, "client-456"));
 	}
 
 	@Test
@@ -89,8 +131,38 @@ public class LTI13TokenRequestValidatorTest {
 		Claims claims = validClaims("jti-1");
 		claims.setExpiration(new Date(System.currentTimeMillis() - 1_000L));
 
-		assertNull(LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
-		assertEquals("Replayed client_assertion", LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+	}
+
+	@Test
+	public void validateClientAssertionReplayRejectsNullCache() {
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.CACHE_UNAVAILABLE,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(null, validClaims("jti-1"), CLIENT_ID));
+	}
+
+	@Test
+	public void validateClientAssertionReplayHandlesPutIfAbsentFailures() {
+		Claims claims = validClaims("jti-1");
+
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.CACHE_UNAVAILABLE,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(new ThrowingPutIfAbsentCache(), claims, CLIENT_ID));
+	}
+
+	@Test
+	public void validateClientAssertionReplayHandlesPutFailures() {
+		MapCache cache = new ThrowingPutCache();
+		Claims claims = validClaims("jti-1");
+		claims.setExpiration(new Date(System.currentTimeMillis()
+				- LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
+				- 5_000L));
+
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.CACHE_UNAVAILABLE,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
 	}
 
 	private Claims validClaims(String jti) {
@@ -243,6 +315,22 @@ public class LTI13TokenRequestValidatorTest {
 		@Override
 		public void clear() {
 			values.clear();
+		}
+	}
+
+	private static class ThrowingPutIfAbsentCache extends MapCache {
+
+		@Override
+		public ValueWrapper putIfAbsent(Object key, Object value) {
+			throw new IllegalStateException("cache unavailable");
+		}
+	}
+
+	private static class ThrowingPutCache extends MapCache {
+
+		@Override
+		public void put(Object key, Object value) {
+			throw new IllegalStateException("cache put failed");
 		}
 	}
 }

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -60,6 +60,14 @@ public class LTI13TokenRequestValidatorTest {
 	}
 
 	@Test
+	public void validateClientAssertionClaimsRejectsWrongIssuer() {
+		Claims claims = validClaims("jti-1");
+		claims.setIssuer("other-client");
+
+		assertEquals("Invalid issuer", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
 	public void validateClientAssertionClaimsRejectsWrongAudience() {
 		Claims claims = validClaims("jti-1");
 		claims.setAudience("https://sakai.example/imsblis/lti13/token/99");
@@ -99,6 +107,26 @@ public class LTI13TokenRequestValidatorTest {
 				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS
 				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
 				+ 1_000L));
+
+		assertEquals("Invalid exp", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsRejectsFutureIssuedAt() {
+		Claims claims = validClaims("jti-1");
+		claims.setIssuedAt(new Date(System.currentTimeMillis()
+				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
+				+ 1_000L));
+
+		assertEquals("Invalid iat", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+	}
+
+	@Test
+	public void validateClientAssertionClaimsRejectsExpiredExpiration() {
+		Claims claims = validClaims("jti-1");
+		claims.setExpiration(new Date(System.currentTimeMillis()
+				- LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
+				- 1_000L));
 
 		assertEquals("Invalid exp", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
 	}

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -22,11 +22,10 @@ import static org.junit.Assert.assertSame;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Callable;
 
 import org.junit.Test;
 import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.tsugi.oauth2.objects.ClientAssertion;
 
 import io.jsonwebtoken.Claims;
@@ -133,7 +132,7 @@ public class LTI13TokenRequestValidatorTest {
 
 	@Test
 	public void validateClientAssertionReplayRejectsRepeatedJti() {
-		MapCache cache = new MapCache();
+		Cache cache = new ConcurrentMapCache("test");
 		Claims claims = validClaims("jti-1");
 
 		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
@@ -144,7 +143,7 @@ public class LTI13TokenRequestValidatorTest {
 
 	@Test
 	public void validateClientAssertionReplayScopesJtiByClientId() {
-		MapCache cache = new MapCache();
+		Cache cache = new ConcurrentMapCache("test");
 		Claims claims = validClaims("jti-1");
 
 		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
@@ -155,7 +154,7 @@ public class LTI13TokenRequestValidatorTest {
 
 	@Test
 	public void validateClientAssertionReplayRejectsRepeatedJtiDuringClockSkewWindow() {
-		MapCache cache = new MapCache();
+		Cache cache = new ConcurrentMapCache("test");
 		Claims claims = validClaims("jti-1");
 		claims.setExpiration(new Date(System.currentTimeMillis() - 1_000L));
 
@@ -181,7 +180,7 @@ public class LTI13TokenRequestValidatorTest {
 
 	@Test
 	public void validateClientAssertionReplayAllowsRepeatedJtiAfterExpirationAndClockSkewWindow() {
-		MapCache cache = new MapCache();
+		Cache cache = new ConcurrentMapCache("test");
 		Claims claims = validClaims("jti-1");
 		claims.setExpiration(new Date(System.currentTimeMillis()
 				- LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
@@ -190,17 +189,6 @@ public class LTI13TokenRequestValidatorTest {
 		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
 				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
 		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
-				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
-	}
-
-	@Test
-	public void validateClientAssertionReplayRejectsRepeatedJtiWhenPutIfAbsentDoesNotReturnExistingValue() {
-		MapCache cache = new NullReturningPutIfAbsentCache();
-		Claims claims = validClaims("jti-1");
-
-		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
-				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
-		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED,
 				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
 	}
 
@@ -301,76 +289,15 @@ public class LTI13TokenRequestValidatorTest {
 		}
 	}
 
-	private static class MapCache implements Cache {
+	private static class ThrowingPutIfAbsentCache extends ConcurrentMapCache {
 
-		private final Map<Object, Object> values = new HashMap<>();
-
-		@Override
-		public String getName() {
-			return "test";
+		ThrowingPutIfAbsentCache() {
+			super("test");
 		}
-
-		@Override
-		public Object getNativeCache() {
-			return values;
-		}
-
-		@Override
-		public ValueWrapper get(Object key) {
-			if (!values.containsKey(key)) {
-				return null;
-			}
-			Object value = values.get(key);
-			return () -> value;
-		}
-
-		@Override
-		public <T> T get(Object key, Class<T> type) {
-			Object value = values.get(key);
-			return value == null ? null : type.cast(value);
-		}
-
-		@Override
-		public <T> T get(Object key, Callable<T> valueLoader) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void put(Object key, Object value) {
-			values.put(key, value);
-		}
-
-		@Override
-		public ValueWrapper putIfAbsent(Object key, Object value) {
-			Object existing = values.putIfAbsent(key, value);
-			return existing == null ? null : () -> existing;
-		}
-
-		@Override
-		public void evict(Object key) {
-			values.remove(key);
-		}
-
-		@Override
-		public void clear() {
-			values.clear();
-		}
-	}
-
-	private static class ThrowingPutIfAbsentCache extends MapCache {
 
 		@Override
 		public ValueWrapper putIfAbsent(Object key, Object value) {
 			throw new IllegalStateException("cache unavailable");
-		}
-	}
-
-	private static class NullReturningPutIfAbsentCache extends MapCache {
-
-		@Override
-		public ValueWrapper putIfAbsent(Object key, Object value) {
-			super.putIfAbsent(key, value);
-			return null;
 		}
 	}
 }

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -189,7 +189,18 @@ public class LTI13TokenRequestValidatorTest {
 
 		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
 				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
-		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.CACHE_UNAVAILABLE,
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+	}
+
+	@Test
+	public void validateClientAssertionReplayRejectsRepeatedJtiWhenPutIfAbsentDoesNotReturnExistingValue() {
+		MapCache cache = new NullReturningPutIfAbsentCache();
+		Claims claims = validClaims("jti-1");
+
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.OK,
+				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
+		assertSame(LTI13TokenRequestValidator.ClientAssertionReplayResult.REPLAYED,
 				LTI13TokenRequestValidator.validateClientAssertionReplay(cache, claims, CLIENT_ID));
 	}
 
@@ -359,6 +370,15 @@ public class LTI13TokenRequestValidatorTest {
 		@Override
 		public void put(Object key, Object value) {
 			throw new IllegalStateException("cache put failed");
+		}
+	}
+
+	private static class NullReturningPutIfAbsentCache extends MapCache {
+
+		@Override
+		public ValueWrapper putIfAbsent(Object key, Object value) {
+			super.putIfAbsent(key, value);
+			return null;
 		}
 	}
 }

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -180,8 +180,8 @@ public class LTI13TokenRequestValidatorTest {
 	}
 
 	@Test
-	public void validateClientAssertionReplayHandlesPutFailures() {
-		MapCache cache = new ThrowingPutCache();
+	public void validateClientAssertionReplayAllowsRepeatedJtiAfterExpirationAndClockSkewWindow() {
+		MapCache cache = new MapCache();
 		Claims claims = validClaims("jti-1");
 		claims.setExpiration(new Date(System.currentTimeMillis()
 				- LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
@@ -362,14 +362,6 @@ public class LTI13TokenRequestValidatorTest {
 		@Override
 		public ValueWrapper putIfAbsent(Object key, Object value) {
 			throw new IllegalStateException("cache unavailable");
-		}
-	}
-
-	private static class ThrowingPutCache extends MapCache {
-
-		@Override
-		public void put(Object key, Object value) {
-			throw new IllegalStateException("cache put failed");
 		}
 	}
 


### PR DESCRIPTION
## Summary
- require the LTI token request OAuth form values to match the client credentials assertion flow
- validate signed client assertion `iss`, `sub`, `aud`, `iat`, `exp`, and `jti` before issuing access tokens
- reject repeated client assertion `jti` values through a new Ignite cache
- add focused token assertion validation tests

## Root Cause
The token endpoint verified the client assertion signature, but did not enforce the required client assertion request parameters and claims before minting an access token. Invalid or replayed signed assertions could therefore reach scope processing.

## Testing
- `mvn -pl lti/lti-blis -Dtest=LTI13ServletTest test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened LTI 1.3 token request validation with stricter grant/type and client-assertion JWT claim checks.
  * Added one-time replay protection for client-assertion JWTs via a dedicated replay cache.
* **Bug Fixes**
  * Improved error handling for malformed/invalid client assertions, returning correct OAuth error responses for verification, claim, and replay failures.
* **Tests**
  * Added unit tests covering grant/type enforcement, claim/timing validation, and replay-cache behavior (including cache failure and replay edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->