### PR TITLE
SAK-52678 LTI emit locale language tag

### DIFF
--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.Collection;
@@ -1034,9 +1035,11 @@ public class SakaiLTIUtil {
 
 	public static void addGlobalData(Site site, Properties props, Properties custom, ResourceLoader rb) {
 		if (rb != null) {
-			String locale = rb.getLocale().toString();
-			setProperty(props, LTIConstants.LAUNCH_PRESENTATION_LOCALE, locale);
-			setProperty(custom, LTICustomVars.MESSAGE_LOCALE, locale);
+			String locale = formatLocaleForLti(rb.getLocale());
+			if (locale != null) {
+				setProperty(props, LTIConstants.LAUNCH_PRESENTATION_LOCALE, locale);
+				setProperty(custom, LTICustomVars.MESSAGE_LOCALE, locale);
+			}
 		}
 
 		addPropertyExtensionData(props, custom);
@@ -1073,6 +1076,10 @@ public class SakaiLTIUtil {
 		String serverId = ServerConfigurationService.getServerId();
 		setProperty(props, "ext_sakai_serverid", serverId);
 		setProperty(props, "ext_sakai_server", getOurServerUrl());
+	}
+
+	static String formatLocaleForLti(Locale locale) {
+		return locale == null ? null : locale.toLanguageTag();
 	}
 
 		// This must return an HTML message as the [0] in the array

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -32,6 +32,7 @@ import java.util.TreeMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Set;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -80,6 +81,14 @@ public class SakaiLTIUtilTest {
 
 	@Before
 	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testFormatLocaleForLtiUsesLanguageTag() {
+		assertEquals("en-US", SakaiLTIUtil.formatLocaleForLti(Locale.US));
+		assertEquals("zh-Hant-TW", SakaiLTIUtil.formatLocaleForLti(Locale.forLanguageTag("zh-Hant-TW")));
+		assertNotEquals("en_US", SakaiLTIUtil.formatLocaleForLti(Locale.US));
+		assertNull(SakaiLTIUtil.formatLocaleForLti(null));
 	}
 
 	@Test
@@ -1346,5 +1355,4 @@ public class SakaiLTIUtilTest {
 		assertNull("findBestToolMatchBean should return null when all tools are null", result);
 	}
 }
-
 


### PR DESCRIPTION
https://www.rfc-editor.org/info/rfc5646/

## Summary
- format the LTI launch locale with `Locale.toLanguageTag()`
- keep the locale source as Sakai's `ResourceLoader`
- add regression coverage for BCP47 language tag output

## Root Cause
The LTI launch locale was derived with Java `Locale.toString()`, which emits values such as `en_US`. LTI 1.3 expects BCP47 language tags such as `en-US`.

## Testing
- `mvn -pl lti/lti-common -Dtest=SakaiLTIUtilTest test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how locale information is sent during LTI launches by using standard language tags instead of underscore-based formats.
  * Locale values are now only included when a valid formatted locale is available, avoiding empty or invalid entries.

* **Tests**
  * Added coverage for locale formatting behavior, including standard locales, language-tag-based locales, and null handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->