### PR TITLE
SAK-47877 Admin Add property to flag worksite setup creation in AdminSitesAction

### DIFF
--- a/admin-tools/src/java/org/sakaiproject/site/tool/AdminSitesAction.java
+++ b/admin-tools/src/java/org/sakaiproject/site/tool/AdminSitesAction.java
@@ -1882,6 +1882,8 @@ public class AdminSitesAction extends PagedResourceActionII
 		// make the page so we have the id
 		Site site = (Site) state.getAttribute("site");
 		Group group = site.addGroup();
+		// flag as worksite setup created so it shows in Site Info > Manage Groups
+		group.getProperties().addProperty(Group.GROUP_PROP_WSETUP_CREATED, Boolean.TRUE.toString());
 		state.setAttribute("group", group);
 
 		// mark the site as new, so on cancel it can be deleted


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created groups are now tagged correctly when they’re added through the site setup flow, improving consistency for downstream site and group handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->