### PR TITLE
SAK-52683 Microsoft - Team creation failures not surfaced to user and cache updated with correct name

### DIFF
--- a/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
+++ b/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
@@ -901,7 +901,7 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 				} catch (ODataError e) {
 					attempts++;
 					log.info("Group not yet provisioned for groupId={}, attempt {}/{} - Exception: {}",
-							groupId, attempts, MAX_RETRY, e.toString())
+							groupId, attempts, MAX_RETRY, e.toString());
 					if (attempts < MAX_RETRY) {
 						try {
 							Thread.sleep(5000L * attempts);

--- a/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
+++ b/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
@@ -173,7 +173,7 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 	public static int COLUMN_SIZE = 7;
 	private static final int TEAM_CHARACTER_LIMIT = 256;// 256 is the maximum length for a Team name in the UI, no limits specified on the API docs
 	private static final int CHANNEL_CHARACTER_LIMIT = 50;// this is an official restriction
-	private final int MAX_RETRY = 2;
+	private final int MAX_RETRY = 6;
 	private final int MAX_PER_REQUEST = 20;
 	private final int MAX_LENGTH = 20;
 
@@ -900,8 +900,8 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 					teamCreated = true;
 				} catch (ODataError e) {
 					attempts++;
-					log.debug("Group not yet provisioned for groupId={}, attempt {}/{} - code: {}",
-							groupId, attempts, MAX_RETRY, e.getError().getCode());
+					log.info("Group not yet provisioned for groupId={}, attempt {}/{} - Exception: {}",
+							groupId, attempts, MAX_RETRY, e.toString())
 					if (attempts < MAX_RETRY) {
 						try {
 							Thread.sleep(5000L * attempts);
@@ -910,6 +910,11 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 							break;
 						}
 					}
+				} catch (Exception e) {
+					attempts++;
+					log.error("Unexpected error converting group to Team, groupId={}, attempt {}/{}",
+							groupId, attempts, MAX_RETRY, e.toString());
+					break;
 				}
 			}
 			
@@ -923,8 +928,8 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 				Map<String, MicrosoftTeam> teamsMap = (Map<String, MicrosoftTeam>) cachedValue.get();
 				teamsMap.put(groupId, MicrosoftTeam.builder()
 						.id(groupId)
-						.name(name)
-						.description(name)
+						.name(truncatedName)
+						.description(truncatedName)
 						.build());
 				getCache().put(CACHE_TEAMS, teamsMap);
 			}

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric.properties
@@ -1159,3 +1159,4 @@ sinfo.synchronization.microsoft.allowForSite=Enable <strong>forced synchronizati
 sinfo.synchronization.microsoft.confirmEnabled=You have enabled forced synchronization with Microsoft Teams for this site.
 sinfo.synchronization.microsoft.enabled=Enabled for the site
 sinfo.error.enabling.synchronization.term_eid.empty=The term_eid cannot be empty. Please contact with your administrator to enable synchronization with Microsoft Teams.
+sinfo.error.creating.microsoft.team=Unable to create or restore a Microsoft Teams for this site. Please try again, and if the problem persists, contact your administrator.

--- a/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_es.properties
+++ b/site-manage/site-manage-tool/tool/src/bundle/sitesetupgeneric_es.properties
@@ -1131,3 +1131,4 @@ sinfo.synchronization.microsoft.allowForSite=Habilitar <strong>la sincronizaci\u
 sinfo.synchronization.microsoft.confirmEnabled=Has habilitado la sincronizaci\u00f3n forzada con Microsoft Teams para este sitio.
 sinfo.synchronization.microsoft.enabled=Activado para este sitio
 sinfo.error.enabling.synchronization.term_eid.empty=No se puede habilitar la sincronizaci\u00f3n forzada con Microsoft Teams porque el term_eid no est\u00e1 definido. Por favor, contacte con su personal de soporte.
+sinfo.error.creating.microsoft.team=No se pudo crear o restaurar un MS Teams para este sitio. Por favor, int\u00e9ntelo de nuevo y si el problema persiste contacte con su personal de soporte.

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MicrosoftSynchronizationEnabler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MicrosoftSynchronizationEnabler.java
@@ -176,7 +176,14 @@ public class MicrosoftSynchronizationEnabler {
                     }
                 }
 
-                createOrRestoreMicrosoftTeamForSite(site, microsoftCommonService, microsoftConfigurationService, microsoftSynchronizationService);
+                boolean teamReady = createOrRestoreMicrosoftTeamForSite(site, microsoftCommonService, microsoftConfigurationService, microsoftSynchronizationService);
+
+                if (!teamReady) {
+                    props.removeProperty(SITE_PROPERTY);
+                    state.setAttribute("alertMessage", rb.getString("sinfo.error.creating.microsoft.team"));
+                    state.setAttribute(STATE_KEY, false);
+                    return false;
+                }
 
                 
             } else {
@@ -235,7 +242,7 @@ public class MicrosoftSynchronizationEnabler {
      * @param microsoftConfigurationService   the Microsoft configuration service
      * @param microsoftSynchronizationService the Microsoft synchronization service
      */
-    private static void createOrRestoreMicrosoftTeamForSite(
+    private static boolean createOrRestoreMicrosoftTeamForSite(
             Site site,
             MicrosoftCommonService microsoftCommonService,
             MicrosoftConfigurationService microsoftConfigurationService,
@@ -243,7 +250,7 @@ public class MicrosoftSynchronizationEnabler {
 
         if (microsoftCommonService == null || microsoftConfigurationService == null || microsoftSynchronizationService == null) {
             log.warn("One or more Microsoft services are null, cannot create team for site: {}", site.getId());
-            return;
+            return false;
         }
 
         try {
@@ -251,7 +258,7 @@ public class MicrosoftSynchronizationEnabler {
 
             if (credentials == null || credentials.getEmail() == null) {
                 log.warn("Could not resolve Microsoft credentials email for site: {}, team will not be created", site.getId());
-                return;
+                return false;
             }
 
             final long syncDuration = microsoftConfigurationService.getSyncDuration();
@@ -287,12 +294,12 @@ public class MicrosoftSynchronizationEnabler {
                     teamId = microsoftCommonService.createTeam(site.getTitle(), credentials.getEmail());
                 } catch (Exception e) {
                     log.error("Microsoft Team creation failed for site: {}, {}", site.getId(), e.toString());
-                    return;
+                    return false;
                 }
 
                 if (teamId == null || teamId.isEmpty()) {
                     log.warn("Microsoft Team creation returned null or empty teamId for site: {}", site.getId());
-                    return;
+                    return false;
                 }
 
                 final SiteSynchronization ss = SiteSynchronization.builder()
@@ -308,7 +315,10 @@ public class MicrosoftSynchronizationEnabler {
             }
         } catch (Exception e) {
             log.error("Unexpected error while creating Microsoft Team for site: {}, {}", site.getId(), e.toString());
+            return false;
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Microsoft Teams setup reliability by increasing the provisioning retry limit when converting groups to Teams.
  * Added clearer failure handling during site save: on setup failure, the sync setting is cleaned up, enablement is disabled, and a user-facing alert is shown.
  * Ensured cached/saved Teams details use the final truncated display name and description.
  * Added localized error messages for Microsoft Teams setup failures (English and Spanish).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->