### PR TITLE
SAK-52438 Quiz with accented title not displayed correctly in several GB screens

### DIFF
--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/QuickEntryPage.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/pages/QuickEntryPage.java
@@ -67,7 +67,7 @@ public class QuickEntryPage extends BasePage {
             private static final long serialVersionUID = 1L;
             @Override
             public Object getDisplayValue(final Assignment a) {
-                return a.getName();
+                return FormatHelper.htmlUnescape(a.getName());
             }
             @Override
             public String getIdValue(final Assignment a,final int index) {
@@ -209,7 +209,7 @@ public class QuickEntryPage extends BasePage {
                     break;
                 }
             }
-            form.add(new Label("itemtitle", assignmentNow.getName()));
+            form.add(new Label("itemtitle", assignmentNow.getName()).setEscapeModelStrings(false));
             String localePoints = FormatHelper.formatGradeForDisplay(assignmentNow.getPoints());
             String itemdetails = " - " + (Objects.equals(GradingConstants.GRADE_TYPE_PERCENTAGE, gradeType) ? getString("quickentry.percentages") : getString("quickentry.points")) + ": " + localePoints;
             if(assignmentNow.getExternallyMaintained()){

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/BulkEditItemsPanel.java
@@ -98,7 +98,7 @@ public class BulkEditItemsPanel extends BasePanel {
 
 			final Assignment assignment = item.getModelObject();
 
-			item.add(new Label("itemTitle", assignment.getName()));
+			item.add(new Label("itemTitle", assignment.getName()).setEscapeModelStrings(false));
 
 			final ReleaseCheckbox release = new ReleaseCheckbox("release", new PropertyModel<Boolean>(assignment, "released"));
 			final IncludeCheckbox include = new IncludeCheckbox("include", new PropertyModel<Boolean>(assignment, "counted"));

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/GradeSummaryTablePanel.java
@@ -261,7 +261,7 @@ public class GradeSummaryTablePanel extends BasePanel implements IAjaxIndicatorA
 						}
 
 						final Label title = new Label("title", assignment.getName());
-						assignmentItem.add(title);
+						assignmentItem.add(title.setEscapeModelStrings(false));
 
 						final BasePage page = (BasePage) getPage();
 

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/ToggleGradeItemsToolbarPanel.java
@@ -115,7 +115,7 @@ public class ToggleGradeItemsToolbarPanel extends BasePanel {
 
 						final GradebookUiSettings settings = gradebookPage.getUiSettings();
 
-						assignmentItem.add(new Label("assignmentTitle", FormatHelper.abbreviateMiddle(assignment.getName())));
+						assignmentItem.add(new Label("assignmentTitle", FormatHelper.abbreviateMiddle(assignment.getName())).setEscapeModelStrings(false));
 
 						final WebMarkupContainer assignmentSignal = new WebMarkupContainer("assignmentSignal");
 						if (settings.isCategoriesEnabled()) {

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/importExport/ExportPanel.java
@@ -405,10 +405,10 @@ public class ExportPanel extends BasePanel {
 							externalPrefix = IGNORE_COLUMN_PREFIX;
 						}
 						if (!isCustomExport || this.includeGradeItemScores) {
-							header.add(externalPrefix + a1.getName() + " [" + StringUtils.removeEnd(assignmentPoints, localeService.getDecimalSeparator() + "0") + "]");
+							header.add(externalPrefix + FormatHelper.htmlUnescape(a1.getName()) + " [" + StringUtils.removeEnd(assignmentPoints, localeService.getDecimalSeparator() + "0") + "]");
 						}
 						if (!isCustomExport || this.includeGradeItemComments) {
-							header.add(String.join(" ", externalPrefix, COMMENTS_COLUMN_PREFIX, a1.getName()));
+							header.add(String.join(" ", externalPrefix, COMMENTS_COLUMN_PREFIX, FormatHelper.htmlUnescape(a1.getName())));
 						}
 						
 						if (isCustomExport && this.includeCategoryAverages


### PR DESCRIPTION
SAK-52438 Quiz with accented title not displayed correctly in several GB screens

https://sakaiproject.atlassian.net/browse/SAK-52438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assignment and grade item names now display properly with special characters instead of showing encoded HTML entities.
  * Improved consistency in gradebook views, bulk edit, summary tables, and assignment toggles when rendering item titles.
  * Exported CSV headers for scores and comments now use the correctly displayed assignment names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->