### PR TITLE
SAK-52687 Portal switch pinned-site position to a monotonic sort key

### DIFF
--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/repository/PinnedSiteRepository.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/repository/PinnedSiteRepository.java
@@ -21,14 +21,91 @@ import java.util.Optional;
 import org.sakaiproject.portal.api.model.PinnedSite;
 import org.sakaiproject.springframework.data.SpringCrudRepository;
 
+/**
+ * Persistence operations for {@link PinnedSite} records, which track the sites a user has pinned
+ * (and the sites a user has explicitly unpinned). A user has at most one record per site.
+ * {@code position} is a monotonic sort key used only for ordering pinned sites; it may contain gaps
+ * and is not a contiguous index.
+ */
 public interface PinnedSiteRepository extends SpringCrudRepository<PinnedSite, Long> {
 
+    /**
+     * Finds the user's currently pinned sites, ordered by ascending {@code position}.
+     *
+     * @param userId the user whose pinned sites to retrieve
+     * @return the pinned {@link PinnedSite} records in position order; empty if none
+     */
     List<PinnedSite> findByUserIdOrderByPosition(String userId);
+
+    /**
+     * Finds the user's records in the given pinned state, ordered by ascending {@code position}.
+     *
+     * @param userId the user whose records to retrieve
+     * @param hasBeenUnpinned {@code false} for currently pinned sites; {@code true} for sites the
+     *        user has explicitly unpinned
+     * @return the matching {@link PinnedSite} records in position order; empty if none
+     */
     List<PinnedSite> findByUserIdAndHasBeenUnpinnedOrderByPosition(String userId, boolean hasBeenUnpinned);
+
+    /**
+     * Returns the highest {@code position} among the user's currently pinned sites. Used to append a
+     * newly pinned site after the existing ones without loading them all.
+     *
+     * @param userId the user whose pinned sites to inspect
+     * @return the maximum position, or {@link Optional#empty()} if the user has no pinned sites
+     */
+    Optional<Integer> findMaxPositionByUserId(String userId);
+
+    /**
+     * Finds the single record for the given user and site, in either pinned state.
+     *
+     * @param userId the user
+     * @param siteId the site
+     * @return the {@link PinnedSite} record, or {@link Optional#empty()} if none exists
+     */
     Optional<PinnedSite> findByUserIdAndSiteId(String userId, String siteId);
+
+    /**
+     * Finds every record for the given site across all users, in either pinned state.
+     *
+     * @param siteId the site
+     * @return the matching {@link PinnedSite} records; empty if none
+     */
     List<PinnedSite> findBySiteId(String siteId);
+
+    /**
+     * Deletes the user's currently pinned records (those with {@code hasBeenUnpinned = false}).
+     * Records for sites the user has explicitly unpinned are left in place.
+     *
+     * @param userId the user whose pinned records to delete
+     * @return the number of rows deleted
+     */
     Integer deleteByUserId(String userId);
+
+    /**
+     * Deletes every record for the given site across all users, regardless of pinned state.
+     *
+     * @param siteId the site to purge from all users' pinned/unpinned records
+     * @return the number of rows deleted
+     */
     Integer deleteBySiteId(String siteId);
+
+    /**
+     * Deletes the record for the given user and site, regardless of pinned state.
+     *
+     * @param userId the user
+     * @param siteId the site
+     * @return the number of rows deleted (0 or 1)
+     */
     Integer deleteByUserIdAndSiteId(String userId, String siteId);
+
+    /**
+     * Deletes the user's records for the given sites, regardless of pinned state. Deletes are
+     * issued in batches.
+     *
+     * @param userId the user
+     * @param siteIds the sites to remove
+     * @return the number of rows deleted
+     */
     Integer deleteByUserIdAndSiteIds(String userId, List<String> siteIds);
 }

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/PortalServiceImpl.java
@@ -815,8 +815,8 @@ public class PortalServiceImpl implements PortalService, Observer
 
 		int position = PinnedSite.UNPINNED_POSITION;
 		if (isPinned) {
-			List<PinnedSite> pinned = pinnedSiteRepository.findByUserIdOrderByPosition(userId);
-			position = !pinned.isEmpty() ? pinned.get(pinned.size() - 1).getPosition() + 1 : 1;
+			// Append after the highest existing pinned position (POSITION is a monotonic sort key).
+			position = pinnedSiteRepository.findMaxPositionByUserId(userId).map(max -> max + 1).orElse(1);
 		}
 
 		pin.setPosition(position);
@@ -825,11 +825,6 @@ public class PortalServiceImpl implements PortalService, Observer
 
 		if (!isPinned) {
 			addRecentSite(userId, siteId);
-			List<PinnedSite> pinnedSites = pinnedSiteRepository.findByUserIdOrderByPosition(userId);
-			for (int i = 0; i < pinnedSites.size(); i++) {
-				PinnedSite pinnedSite = pinnedSites.get(i);
-				pinnedSite.setPosition(i);
-			}
 		}
 	}
 
@@ -850,12 +845,6 @@ public class PortalServiceImpl implements PortalService, Observer
 		}
 
 		pinnedSiteRepository.deleteByUserIdAndSiteId(userId, siteId);
-
-		List<PinnedSite> pinnedSites = pinnedSiteRepository.findByUserIdOrderByPosition(userId);
-		for (int i = 0; i < pinnedSites.size(); i++) {
-			PinnedSite pinnedSite = pinnedSites.get(i);
-			pinnedSite.setPosition(i);
-		}
 	}
 
 	@Transactional
@@ -881,12 +870,14 @@ public class PortalServiceImpl implements PortalService, Observer
 		// unpin sites
 		sitesToUnpin.forEach(siteId -> addPinnedSite(userId, siteId, false));
 
-		// pin remaining sites
-		int start = currentPinned.size() - sitesToUnpin.size();
+		// pin remaining sites, appending after the highest existing pinned position. POSITION is a
+		// monotonic sort key that may contain gaps (from earlier removals), so we base off the
+		// current maximum rather than the count.
+		int base = pinnedSiteRepository.findMaxPositionByUserId(userId).map(max -> max + 1).orElse(0);
 		IntStream.range(0, sitesToPin.size()).forEach(i -> {
 			String siteId = sitesToPin.get(i);
 			PinnedSite pin = pinnedSiteRepository.findByUserIdAndSiteId(userId, siteId).orElseGet(() -> new PinnedSite(userId, siteId));
-			pin.setPosition(i + start);
+			pin.setPosition(base + i);
 			pin.setHasBeenUnpinned(false);
 			pinnedSiteRepository.save(pin);
 		});

--- a/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/repository/PinnedSiteRepositoryImpl.java
+++ b/portal/portal-service-impl/impl/src/java/org/sakaiproject/portal/service/repository/PinnedSiteRepositoryImpl.java
@@ -59,6 +59,25 @@ public class PinnedSiteRepositoryImpl extends SpringCrudRepositoryImpl<PinnedSit
 
     @Override
     @Transactional(readOnly = true)
+    public Optional<Integer> findMaxPositionByUserId(String userId) {
+
+        Session session = sessionFactory.getCurrentSession();
+
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Integer> query = cb.createQuery(Integer.class);
+        Root<PinnedSite> pinnedSite = query.from(PinnedSite.class);
+        query.select(cb.max(pinnedSite.get("position")));
+        Predicate[] predicates = new Predicate[2];
+        predicates[0] = cb.equal(pinnedSite.get("userId"), userId);
+        predicates[1] = cb.equal(pinnedSite.get("hasBeenUnpinned"), false);
+        query.where(predicates);
+
+        // max() over no rows yields a null result.
+        return Optional.ofNullable(session.createQuery(query).uniqueResult());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Optional<PinnedSite> findByUserIdAndSiteId(String userId, String siteId) {
 
         Session session = sessionFactory.getCurrentSession();

--- a/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
+++ b/portal/portal-service-impl/impl/src/test/org/sakaiproject/portal/service/PortalServiceTests.java
@@ -241,18 +241,21 @@ public class PortalServiceTests extends SakaiTests {
         pinnedSites = portalService.getPinnedSites(user1);
         Assert.assertEquals(2, pinnedSites.size());
 
+        // POSITION is a monotonic sort key, not a contiguous index: removing site2 leaves site3 at
+        // its original position (a gap at 1), and order is what matters.
         List<PinnedSite> pinned = pinnedSiteRepository.findByUserIdOrderByPosition(user1);
         Assert.assertEquals(2, pinned.size());
         Assert.assertEquals(0, pinned.get(0).getPosition());
         Assert.assertEquals(site1Id, pinned.get(0).getSiteId());
-        Assert.assertEquals(1, pinned.get(1).getPosition());
+        Assert.assertEquals(2, pinned.get(1).getPosition());
         Assert.assertEquals(site3Id, pinned.get(1).getSiteId());
 
         portalService.addPinnedSite(user1, site4Id, true);
 
+        // A newly pinned site appends after the current maximum position (2), i.e. 3.
         pinned = pinnedSiteRepository.findByUserIdOrderByPosition(user1);
         Assert.assertEquals(3, pinned.size());
-        Assert.assertEquals(2, pinned.get(2).getPosition());
+        Assert.assertEquals(3, pinned.get(2).getPosition());
         Assert.assertEquals(site4Id, pinned.get(2).getSiteId());
 
         siteIds.add(site4Id);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pinned-site handling so newly pinned sites are added to the end of the list consistently, even after earlier removals.
  * Bulk removal of pinned-site records now works across multiple sites at once.

* **Bug Fixes**
  * Fixed pinned-site ordering so existing items keep their position when another item is unpinned or removed, preventing unexpected reshuffling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->