### PR TITLE
SAK-52644 Portal missing site path segment in more sites

### DIFF
--- a/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalConstants.java
+++ b/portal/portal-api/api/src/java/org/sakaiproject/portal/api/PortalConstants.java
@@ -23,6 +23,16 @@ package org.sakaiproject.portal.api;
 
 public class PortalConstants {
 
+    public static final String SITE_URL_PREFIX = "site";
+    public static final String TOOL_URL_PREFIX = "tool";
+    public static final String TOOLRESET_URL_PREFIX = "tool-reset";
+    public static final String PAGE_URL_PREFIX = "page";
+    public static final String PAGERESET_URL_PREFIX = "page-reset";
+    public static final String SITE_URL_SEGMENT = "/" + SITE_URL_PREFIX + "/";
+    public static final String TOOL_URL_SEGMENT = "/" + TOOL_URL_PREFIX + "/";
+    public static final String TOOLRESET_URL_SEGMENT = "/" + TOOLRESET_URL_PREFIX + "/";
+    public static final String PAGE_URL_SEGMENT = "/" + PAGE_URL_PREFIX + "/";
+
     public static final String PROP_CURRENT_EXPANDED = "currentExpanded";
     public static final String PROP_EXPANDED_SITE = "expandedSite";
     public static final String PROP_SIDEBAR_COLLAPSED = "sidebarCollapsed";

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/SkinnableCharonPortal.java
@@ -249,7 +249,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
         googleAnonIp = serverConfigurationService.getBoolean(PROP_GOOGLE_ANON_IP, false);
         googleGA4Id = serverConfigurationService.getString(PROP_GOOGLE_GA4_ID, null);
         googleTagManagerContainerId = serverConfigurationService.getString(PROP_GOOGLE_CONTAINER_ID, null);
-        handlerPrefix = serverConfigurationService.getString(PROP_PORTAL_DEFAULT_HANDLER, "site");
+        handlerPrefix = serverConfigurationService.getString(PROP_PORTAL_DEFAULT_HANDLER, SITE_URL_PREFIX);
         displayHelpIcon = serverConfigurationService.getBoolean(PROP_DISPLAY_HELP_ICON, true);
         includeExtraHead = serverConfigurationService.getString(PROP_INCLUDE_EXTRAHEAD, "");
         mathJaxEnabled = serverConfigurationService.getBoolean(PROP_MATHJAX_ENABLED, true);
@@ -616,7 +616,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
         boolean showResetButton = !"false".equals(placement.getConfig().getProperty(
                 Portal.TOOLCONFIG_SHOW_RESET_BUTTON));
 
-        String resetActionUrl = PortalStringUtil.replaceFirst(toolUrl, "/tool/", "/tool-reset/");
+        String resetActionUrl = PortalStringUtil.replaceFirst(toolUrl, TOOL_URL_SEGMENT, TOOLRESET_URL_SEGMENT);
         log.debug("includeTool resetActionUrl={}", resetActionUrl);
 
         // SAK-20462 - Pass through the sakai_action parameter
@@ -1294,9 +1294,9 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
     }
 
     private String fixPath(String s, StringBuilder ctx) {
-        s = fixPath1(s, "/site/", ctx);
-        s = fixPath1(s, "/tool/", ctx);
-        s = fixPath1(s, "/page/", ctx);
+        s = fixPath1(s, SITE_URL_SEGMENT, ctx);
+        s = fixPath1(s, TOOL_URL_SEGMENT, ctx);
+        s = fixPath1(s, PAGE_URL_SEGMENT, ctx);
         return s;
     }
 
@@ -1406,10 +1406,10 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
             page = p.getPageId();
         }
 
-        return "/site/" +
-                p.getSiteId() +
-                "/page/" +
-                page;
+        return SITE_URL_SEGMENT
+                + p.getSiteId()
+                + PAGE_URL_SEGMENT
+                + page;
     }
 
     @Override
@@ -1853,7 +1853,7 @@ public class SkinnableCharonPortal extends HttpServlet implements Portal {
         if (renderInline) {
 
             //build tool context path directly to the tool
-            String toolContextPath = req.getContextPath() + req.getServletPath() + "/site/" + placement.getSiteId() + "/tool/" + placement.getId();
+            String toolContextPath = req.getContextPath() + req.getServletPath() + SITE_URL_SEGMENT + placement.getSiteId() + TOOL_URL_SEGMENT + placement.getId();
 
             // setup the rest of the params
             String[] parts = getParts(req);

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/DirectToolHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/DirectToolHandler.java
@@ -44,6 +44,9 @@ import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.util.Web;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.api.ServerConfigurationService;
+
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -159,7 +162,7 @@ public class DirectToolHandler extends BasePortalHandler
 		// storedstate will replace directool with tool, so we just insert site
 		String portalPath = serverConfigurationService.getString("portalPath", "/portal");
 		if (toolContextPath.startsWith(portalPath + "/directtool/")) {
-		    toolContextPath = portalPath + "/site/" + siteTool.getSiteId() + toolContextPath.substring(portalPath.length());
+		    toolContextPath = portalPath + SITE_URL_SEGMENT + siteTool.getSiteId() + toolContextPath.substring(portalPath.length());
 		}
 
 		// permission check - visit the site (unless the tool is configured to

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/MoreSitesHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/MoreSitesHandler.java
@@ -36,6 +36,8 @@ import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.util.ResourceLoader;
 
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_PREFIX;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -75,6 +77,7 @@ public class MoreSitesHandler extends BasePortalHandler {
 
         try {
             SiteView siteView = portal.getSiteHelper().getSitesView(SiteView.View.DHTML_MORE_VIEW, req, session, siteId);
+            siteView.setPrefix(SITE_URL_PREFIX);
             siteView.setToolContextPath(null);
             Map<String, Object> drawerContext = ((MoreSiteViewImpl) siteView).getMoreSitesDrawerContext();
 

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageResetHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/PageResetHandler.java
@@ -29,6 +29,9 @@ import org.sakaiproject.portal.util.URLUtils;
 import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.util.Web;
 
+import static org.sakaiproject.portal.api.PortalConstants.PAGERESET_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.PAGE_URL_PREFIX;
+
 /**
  * 
  * @author ieb
@@ -38,22 +41,22 @@ import org.sakaiproject.util.Web;
  */
 public class PageResetHandler extends BasePortalHandler
 {
-	private static final String URL_FRAGMENT = "page-reset";
-
 	public PageResetHandler()
 	{
-		setUrlFragment(PageResetHandler.URL_FRAGMENT);
+		setUrlFragment(PAGERESET_URL_PREFIX);
 	}
 
 	@Override
 	public int doGet(String[] parts, HttpServletRequest req, HttpServletResponse res,
 			Session session) throws PortalHandlerException
 	{
-		if ((parts.length > 2) && (parts[1].equals(PageResetHandler.URL_FRAGMENT)))
+		if ((parts.length > 2) && (parts[1].equals(PAGERESET_URL_PREFIX)))
 		{
 			try
 			{
-				String pagelUrl = req.getContextPath() + "/page"
+				String pagelUrl = req.getContextPath()
+						+ "/"
+						+ PAGE_URL_PREFIX
 						+ Web.makePath(parts, 2, parts.length);
 				portalService.setResetState("true");
 				res.addHeader("Cache-Control", "no-cache");

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchHandler.java
@@ -40,6 +40,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -124,7 +127,7 @@ public class RoleSwitchHandler extends BasePortalHandler
 
 			try
 			{
-				String url = portalUrl + "/site/" + parts[2] + "/tool/" + parts[4] + "/";
+				String url = portalUrl + SITE_URL_SEGMENT + parts[2] + TOOL_URL_SEGMENT + parts[4] + "/";
 
 				AtomicBoolean isToolHidden = new AtomicBoolean(false);
 				activeSite.getPages().stream() // get all pages in site
@@ -136,7 +139,7 @@ public class RoleSwitchHandler extends BasePortalHandler
 						if (tool.getId().equals(parts[4]) && toolManager.isHidden(tool)) { isToolHidden.set(true); } //check if the active tool is hidden
 					});
 
-				if (isToolHidden.get()) { url = (!homePageIsHidden(activeSite)) ? portalUrl + "/site/" + parts[2] + "/" : portalUrl; }
+				if (isToolHidden.get()) { url = (!homePageIsHidden(activeSite)) ? portalUrl + SITE_URL_SEGMENT + parts[2] + "/" : portalUrl; }
 
 				portalService.setResetState("true"); // flag the portal to reset
 				

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/RoleSwitchOutHandler.java
@@ -30,6 +30,10 @@ import org.sakaiproject.portal.api.PortalHandlerException;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.Session;
+
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -78,7 +82,7 @@ public class RoleSwitchOutHandler extends BasePortalHandler
 
 			try
 			{
-				String roleExitUrl = ServerConfigurationService.getPortalUrl() + "/site/" + parts[2] + "/tool/" + parts[4] + "/";
+				String roleExitUrl = ServerConfigurationService.getPortalUrl() + SITE_URL_SEGMENT + parts[2] + TOOL_URL_SEGMENT + parts[4] + "/";
 
 				activeSite.getPages().stream() // get all pages in site
 						.map(page -> page.getTools()) // tools for each page

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -88,6 +88,13 @@ import org.sakaiproject.util.Validator;
 import org.sakaiproject.util.Web;
 import org.sakaiproject.util.RequestFilter;
 
+import static org.sakaiproject.portal.api.PortalConstants.PAGERESET_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.PAGE_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -107,7 +114,7 @@ public class SiteHandler extends WorksiteHandler
 	private static final String INCLUDE_TABS = "include-tabs";
 
 	// Cannot be static to allow for this class to be extended at a different fragment
-	protected String URL_FRAGMENT = "site";
+	protected String URL_FRAGMENT = SITE_URL_PREFIX;
 
 	private static ResourceLoader rb = new ResourceLoader("sitenav");
 	
@@ -240,7 +247,10 @@ public class SiteHandler extends WorksiteHandler
 		if ((siteId != null) && (parts.length == 5) && (parts[3].equals("tool-reset")))
 		{
 			toolId = parts[4];
-			String toolUrl = req.getContextPath() + "/site/" + siteId + "/tool"
+			String toolUrl = req.getContextPath()
+					+ SITE_URL_SEGMENT
+					+ siteId + "/"
+					+ TOOL_URL_PREFIX
 					+ Web.makePath(parts, 4, parts.length);
 			portalService.setResetState("true");
 			res.addHeader("Cache-Control", "no-cache");
@@ -252,7 +262,7 @@ public class SiteHandler extends WorksiteHandler
 		// URL
 		// /portal/site/site-id/page-reset/pageId
 		// 0 1 2 3 4
-		if ((siteId != null) && (parts.length == 5) && (parts[3].equals("page-reset")))
+		if ((siteId != null) && (parts.length == 5) && (parts[3].equals(PAGERESET_URL_PREFIX)))
 		{
 			pageId = parts[4];
 			Site site = null;
@@ -282,7 +292,11 @@ public class SiteHandler extends WorksiteHandler
 				}
 			}
 
-			String pageUrl = URLUtils.sanitisePath(req.getContextPath() + "/site/" + siteId + "/page"
+			String pageUrl = URLUtils.sanitisePath(req.getContextPath()
+					+ SITE_URL_SEGMENT
+					+ siteId
+					+ "/"
+					+ PAGE_URL_PREFIX
 					+ Web.makePath(parts, 4, parts.length));
 
 			if ( hasJSR168 ) pageUrl = pageUrl + "?sakai.state.reset=true";
@@ -704,14 +718,13 @@ public class SiteHandler extends WorksiteHandler
 		// If still can't find page id see if can determine it from a well known
 		// tool id (assumes that such a tool is in the site and the first instance of 
 		// the tool found would be the right one).
-		String toolSegment = "/tool/";
 		String toolId = null;
 
 			try
 			{
 			// does the URL contain a tool id?
-			if (toolContextPath.contains(toolSegment)) {
-				toolId = toolContextPath.substring(toolContextPath.lastIndexOf(toolSegment)+toolSegment.length());
+			if (toolContextPath.contains(TOOL_URL_SEGMENT)) {
+				toolId = toolContextPath.substring(toolContextPath.lastIndexOf(TOOL_URL_SEGMENT) + TOOL_URL_SEGMENT.length());
 				ToolConfiguration toolConfig = site.getToolForCommonId(toolId);
 				log.debug("trying to resolve page id from toolId: [{}]", toolId);
 				if (toolConfig != null) {
@@ -737,7 +750,7 @@ public class SiteHandler extends WorksiteHandler
 	 * @throws IOException
 	 */
 	protected void doSendResponse(PortalRenderContext rcontext, HttpServletResponse res, String contentType) throws IOException {
-		portal.sendResponse(rcontext, res, "site", null);
+		portal.sendResponse(rcontext, res, SITE_URL_PREFIX, null);
 	}
 
 	protected void includeSiteNav(PortalRenderContext rcontext, HttpServletRequest req, Session session, String siteId, String toolId)
@@ -845,7 +858,7 @@ public class SiteHandler extends WorksiteHandler
 				String switchRoleUrl = serverConfigurationService.getPortalUrl()
 						+ "/role-switch-out/"
 						+ siteId
-						+ "/tool/"
+						+ TOOL_URL_SEGMENT
 						+ toolId;
 				rcontext.put("roleUrlValue", roleswitchvalue);
 				rcontext.put("switchRoleUrl", switchRoleUrl);
@@ -902,7 +915,7 @@ public class SiteHandler extends WorksiteHandler
 						switchRoleUrl = serverConfigurationService.getPortalUrl()
 								+ "/role-switch/"
 								+ siteId
-								+ "/tool/"
+								+ TOOL_URL_SEGMENT
 								+ toolId
 								+ "/";
 
@@ -912,7 +925,7 @@ public class SiteHandler extends WorksiteHandler
 						switchRoleUrl = serverConfigurationService.getPortalUrl()
 								+ "/role-switch/"
 								+ siteId
-								+ "/tool/"
+								+ TOOL_URL_SEGMENT
 								+ toolId
 								+ "/"
 								+ svRolesFinal.get(0)

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/TimeoutDialogHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/TimeoutDialogHandler.java
@@ -32,6 +32,8 @@ import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.cover.ComponentManager;
 
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_PREFIX;
+
 /**
  * This is a portal handler to get the necessary information for the timeout
  * dialog functionality. This is new functionality in Sakai 2.6, detailed in
@@ -103,7 +105,7 @@ public class TimeoutDialogHandler extends BasePortalHandler
 				PortalRenderContext rcontext = portal.includePortal(req, res, session,
 						null,
 						/* toolId */null, req.getContextPath() + req.getServletPath(),
-						/* prefix */"site", /* doPages */false, /* resetTools */false,
+						/* prefix */SITE_URL_PREFIX, /* doPages */false, /* resetTools */false,
 						/* includeSummary */false, /* expandSite */false);
 				portal.sendResponse(rcontext, res, parts[1], "text/html; charset=UTF-8");
 			} catch (Exception e) {

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/DefaultSiteViewImpl.java
@@ -36,6 +36,11 @@ import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.tool.api.Session;
 
 import org.sakaiproject.util.Web;
+
+import static org.sakaiproject.portal.api.PortalConstants.PAGE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOLRESET_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -94,7 +99,7 @@ public class DefaultSiteViewImpl extends AbstractSiteViewImpl
             for (Iterator iSi = mySites.iterator(); iSi.hasNext();) {
                 Site s = (Site) iSi.next();
                 if (myWorkspaceSiteId.equals(s.getId()) ) {
-                    mrphs_worksiteUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)));
+                    mrphs_worksiteUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)));
                     List pages = siteHelper.getPermittedPagesInOrder(s);
                     for (Iterator iPg = pages.iterator(); iPg.hasNext();) {
                         SitePage p = (SitePage) iPg.next();
@@ -103,11 +108,11 @@ public class DefaultSiteViewImpl extends AbstractSiteViewImpl
                         while (iPt.hasNext()) {
                             ToolConfiguration placement = (ToolConfiguration) iPt.next();
                             if ( preferencesToolId.equals(placement.getToolId()) ) {
-                                prefsToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/page/" + Web.escapeUrl(p.getId()));
-                                mrphs_prefsToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/tool-reset/" + Web.escapeUrl(placement.getId()));
+                                prefsToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + PAGE_URL_SEGMENT + Web.escapeUrl(p.getId()));
+                                mrphs_prefsToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + TOOLRESET_URL_SEGMENT + Web.escapeUrl(placement.getId()));
                             } else if ( worksiteToolId.equals(placement.getToolId()) ) {
-                                worksiteToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/page/" + Web.escapeUrl(p.getId()));
-                                mrphs_worksiteToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/tool-reset/" + Web.escapeUrl(placement.getId()));
+                                worksiteToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + PAGE_URL_SEGMENT + Web.escapeUrl(p.getId()));
+                                mrphs_worksiteToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + TOOLRESET_URL_SEGMENT + Web.escapeUrl(placement.getId()));
                             }
                         }
                     }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/MoreSiteViewImpl.java
@@ -47,6 +47,10 @@ import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.Web;
 
+import static org.sakaiproject.portal.api.PortalConstants.PAGE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -99,16 +103,16 @@ public class MoreSiteViewImpl extends AbstractSiteViewImpl
         if ( myWorkspaceSiteId != null ) {
             for (Site s : favoritesSites) {
                 if (myWorkspaceSiteId.equals(s.getId()) ) {
-                    mrphs_worksiteUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)));
+                    mrphs_worksiteUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)));
                     List<SitePage> pages = siteHelper.getPermittedPagesInOrder(s);
                     for (SitePage p : pages) {
                         List<ToolConfiguration> pTools = p.getTools();
                         for (ToolConfiguration placement : pTools) {
                             if ( calendarToolId.equals(placement.getToolId()) ) {
-                                calendarToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/page/" + Web.escapeUrl(p.getId()));
+                                calendarToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + PAGE_URL_SEGMENT + Web.escapeUrl(p.getId()));
                             } else if ( worksiteToolId.equals(placement.getToolId()) ) {
-                                worksiteToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/page/" + Web.escapeUrl(p.getId()));
-                                mrphs_worksiteToolUrl = Web.returnUrl(request, "/site/" + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + "/tool/" + Web.escapeUrl(placement.getId()));
+                                worksiteToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + PAGE_URL_SEGMENT + Web.escapeUrl(p.getId()));
+                                mrphs_worksiteToolUrl = Web.returnUrl(request, SITE_URL_SEGMENT + Web.escapeUrl(siteHelper.getSiteEffectiveId(s)) + TOOL_URL_SEGMENT + Web.escapeUrl(placement.getId()));
                             }
                         }
                     }

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -104,6 +104,12 @@ import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.comparator.AliasCreatedTimeComparator;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import static org.sakaiproject.portal.api.PortalConstants.PAGERESET_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.PAGE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOLRESET_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.TOOLRESET_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -388,7 +394,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
                 for (String segment : pathSegments) {
 					// only replace first occurrence of page in path
                     if (!firstSegmentMatch && "page".equals(segment)) {
-						pageUriBuilder.pathSegment("page-reset");
+						pageUriBuilder.pathSegment(PAGERESET_URL_PREFIX);
 						firstSegmentMatch = true;
 					} else {
 						pageUriBuilder.pathSegment(segment);
@@ -930,7 +936,7 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				boolean legacyAddMoreToolsPropertyValue = serverConfigurationService.getBoolean("portal.experimental.addmoretools", false);
 				if ( ! serverConfigurationService.getBoolean("portal.addmoretools.enable", legacyAddMoreToolsPropertyValue) ) addMoreToolsUrl = null;
 
-				String pagePopupUrl = Web.returnUrl(req, "/page/");
+				String pagePopupUrl = Web.returnUrl(req, PAGE_URL_SEGMENT);
 
 				UriComponentsBuilder pageResetUrlBuilder = UriComponentsBuilder.fromUriString(pageRefUrl);
 				List<String> pathSegments = pageResetUrlBuilder.build().getPathSegments();
@@ -939,10 +945,10 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				boolean firstSegmentMatch = false;
                 for (String segment : pathSegments) {
                     if (!firstSegmentMatch && "tool".equals(segment)) {
-                        pageResetUrlBuilder.pathSegment("tool-reset");
+                        pageResetUrlBuilder.pathSegment(TOOLRESET_URL_PREFIX);
                         firstSegmentMatch = true;
                     } else if (!firstSegmentMatch && "page".equals(segment)) {
-                        pageResetUrlBuilder.pathSegment("page-reset");
+                        pageResetUrlBuilder.pathSegment(PAGERESET_URL_PREFIX);
                         firstSegmentMatch = true;
                     } else {
 						pageResetUrlBuilder.pathSegment(segment);
@@ -998,9 +1004,9 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 			String toolUrl = Web.returnUrl(req, "/" + portalPrefix + "/"
 			+ formattedText.escapeUrl(getSiteEffectiveId(site)));
 			if (resetTools) {
-				toolUrl = toolUrl + "/tool-reset/";
+				toolUrl = toolUrl + TOOLRESET_URL_SEGMENT;
 			} else {
-				toolUrl = toolUrl + "/tool/";
+				toolUrl = toolUrl + TOOL_URL_SEGMENT;
 			}
 
 			// Loop through the tools again and Unroll the tools

--- a/portal/portal-render-impl/impl/src/java/org/sakaiproject/portal/render/fragment/FragmentToolRenderService.java
+++ b/portal/portal-render-impl/impl/src/java/org/sakaiproject/portal/render/fragment/FragmentToolRenderService.java
@@ -51,6 +51,9 @@ import org.sakaiproject.tool.api.ToolURL;
 import org.sakaiproject.tool.cover.ActiveToolManager;
 import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.util.Web;
+
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_SEGMENT;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -123,12 +126,12 @@ public class FragmentToolRenderService implements ToolRenderService
 					{
 						if (session.getUserId() == null)
 						{
-							option = "/site/"
+							option = SITE_URL_SEGMENT
 									+ ServerConfigurationService.getGatewaySiteId();
 						}
 						else
 						{
-							option = "/site/"
+							option = SITE_URL_SEGMENT
 									+ SiteService.getUserSiteId(session.getUserId());
 						}
 					}

--- a/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ToolUtils.java
+++ b/portal/portal-util/util/src/java/org/sakaiproject/portal/util/ToolUtils.java
@@ -50,6 +50,11 @@ import org.sakaiproject.tool.cover.ToolManager;
 import org.sakaiproject.thread_local.cover.ThreadLocalManager;
 import org.sakaiproject.util.RequestFilter;
 
+import static org.sakaiproject.portal.api.PortalConstants.PAGE_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.SITE_URL_PREFIX;
+import static org.sakaiproject.portal.api.PortalConstants.TOOLRESET_URL_SEGMENT;
+import static org.sakaiproject.portal.api.PortalConstants.TOOL_URL_SEGMENT;
+
 /**
  * A set of utilities provided by the portal for use by tools.
  *
@@ -123,7 +128,7 @@ public class ToolUtils
 	{
 		// .../portal/site/1234
 		if ( req == null ) req = getRequestFromThreadLocal();
-		String portalPrefix = "site";
+		String portalPrefix = SITE_URL_PREFIX;
 		Session s = SessionManager.getCurrentSession();
 		if ( s != null ) {
 			String control = (String) s.getAttribute(PortalService.SAKAI_CONTROLLING_PORTAL);
@@ -190,7 +195,7 @@ public class ToolUtils
 
 		// The normal URL
 		String pageUrl = Web.returnUrl(req, "/" + portalPrefix + "/"
-				+ Web.escapeUrl(effectiveSiteId) + "/page/");
+				+ Web.escapeUrl(effectiveSiteId) + PAGE_URL_SEGMENT);
 		pageUrl = pageUrl + Web.escapeUrl(pageAlias);
 
 		List<ToolConfiguration> pTools = page.getTools();
@@ -209,9 +214,9 @@ public class ToolUtils
 
 		pageUrl = Web.returnUrl(req, "/" + portalPrefix + "/" + Web.escapeUrl(effectiveSiteId));
 		if (reset || resetSiteProperty) {
-			pageUrl = pageUrl + "/tool-reset/";
+			pageUrl = pageUrl + TOOLRESET_URL_SEGMENT;
 		} else {
-			pageUrl = pageUrl + "/tool/";
+			pageUrl = pageUrl + TOOL_URL_SEGMENT;
 		}
 		return pageUrl + pageTool.getId();
 	}


### PR DESCRIPTION
This also creates constants for the common portal url segments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized portal URL handling across site, tool, page, and reset links.
  * Improved redirects and navigation paths for role switching, page resets, direct tool access, and portal rendering.
  * Updated “More Sites” and timeout flows to use consistent portal paths.
  * Reduced broken-link risk by replacing hardcoded URL fragments with shared values throughout the portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->