### PR TITLE
SAK-52598 DateManager add term-rollover date tools (per-column fill, Smart Shift, Bulk Anchor)

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
@@ -104,6 +104,27 @@ class DateManagerTest extends SakaiUiTestBase {
         assertThat(page.locator(".term-target")).hasCount(0);
     }
 
+    @Test
+    void visualPreviewOpensCalendar() {
+        sakai.login("instructor1");
+
+        // Any site with a dated tool renders the footer actions; the Visual Preview button and its
+        // read-only calendar modal are wired regardless of whether the site has any dated items yet.
+        String site = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng", "sakai\\.resources"));
+        page.navigate(site);
+        openDateManager();
+
+        Locator previewButton = page.locator("#datemanager-preview");
+        assertThat(previewButton).isVisible();
+
+        previewButton.click();
+
+        // The modal opens (its title resolves via i18n) and mounts either the FullCalendar month grid
+        // or the empty-state message, depending on whether the site has any dated items.
+        assertThat(page.locator("#modal-calendar-preview")).isVisible();
+        assertThat(page.locator("#datemanager-preview-title")).isVisible();
+    }
+
     private void openDateManager() {
         sakai.toolClick("Site Info");
         Locator dateManager = page.locator(".navIntraTool a, .navIntraTool button")

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
@@ -30,7 +30,7 @@ class DateManagerTest extends SakaiUiTestBase {
     void dateColumnsMatchSiteTools() {
         sakai.login("instructor1");
 
-        // The "Bulk Anchor" term-date matrix renders one checkbox per (tool, date column) present in the
+        // The "Bulk Term Date Matrix" term-date matrix renders one checkbox per (tool, date column) present in the
         // site - driven by tool presence (not by whether the tool has items), so it is the surface that
         // reflects "which date fields exist for this site's tools". Each checkbox carries
         // data-root='collapse-<tool>' and data-field='<column>'; we scope to one term row for a count of 1.

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
@@ -30,76 +30,77 @@ class DateManagerTest extends SakaiUiTestBase {
     void bulkSetterOnlyShowsFieldsForSiteTools() {
         sakai.login("instructor1");
 
+        // The per-column date setters live in each tool section's column headers, so a setter is rendered
+        // only when the site has that tool (and that tool has that date column). Each setter's id is
+        // bulkcol-<toolId>-<field>. Sections are collapsed by default (progressive disclosure), so we
+        // assert presence in the DOM rather than visibility.
         String gradebookResourcesSite = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng", "sakai\\.resources"));
         page.navigate(gradebookResourcesSite);
         openDateManager();
 
-        assertBulkDateFieldVisible("bulk-open-date");
-        assertBulkDateFieldVisible("bulk-due-date");
-        assertBulkDateFieldHidden("bulk-accept-until");
-        assertBulkDateFieldHidden("bulk-feedback-start");
-        assertBulkDateFieldHidden("bulk-feedback-end");
-        assertBulkDateFieldHidden("bulk-signup-begins");
-        assertBulkDateFieldHidden("bulk-signup-deadline");
+        assertColumnSetterPresent("gradebookItems", "due_date");
+        assertColumnSetterPresent("resources", "open_date");
+        assertColumnSetterPresent("resources", "due_date");
+        assertColumnSetterAbsent("assignments", "open_date");
+        assertColumnSetterAbsent("assignments", "accept_until");
+        assertColumnSetterAbsent("assessments", "feedback_start");
+        assertColumnSetterAbsent("signupMeetings", "signup_begins");
 
         String assignmentsSite = sakai.createCourse("instructor1",
             List.of("sakai\\.gradebookng", "sakai\\.resources", "sakai\\.assignment\\.grades"));
         page.navigate(assignmentsSite);
         openDateManager();
 
-        assertBulkDateFieldVisible("bulk-open-date");
-        assertBulkDateFieldVisible("bulk-due-date");
-        assertBulkDateFieldVisible("bulk-accept-until");
-        assertBulkDateFieldHidden("bulk-feedback-start");
-        assertBulkDateFieldHidden("bulk-feedback-end");
-        assertBulkDateFieldHidden("bulk-signup-begins");
-        assertBulkDateFieldHidden("bulk-signup-deadline");
+        assertColumnSetterPresent("assignments", "open_date");
+        assertColumnSetterPresent("assignments", "due_date");
+        assertColumnSetterPresent("assignments", "accept_until");
+        assertColumnSetterAbsent("assessments", "feedback_start");
+        assertColumnSetterAbsent("signupMeetings", "signup_begins");
 
         String gradebookOnlySite = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng"));
         page.navigate(gradebookOnlySite);
         openDateManager();
 
-        assertBulkDateFieldVisible("bulk-due-date");
-        assertBulkDateFieldHidden("bulk-open-date");
-        assertBulkDateFieldHidden("bulk-accept-until");
+        assertColumnSetterPresent("gradebookItems", "due_date");
+        assertColumnSetterAbsent("gradebookItems", "open_date");
+        assertColumnSetterAbsent("assignments", "open_date");
 
         String assessmentsSite = sakai.createCourse("instructor1", List.of("sakai\\.samigo"));
         page.navigate(assessmentsSite);
         openDateManager();
 
-        assertBulkDateFieldVisible("bulk-open-date");
-        assertBulkDateFieldVisible("bulk-due-date");
-        assertBulkDateFieldVisible("bulk-accept-until");
-        assertBulkDateFieldVisible("bulk-feedback-start");
-        assertBulkDateFieldVisible("bulk-feedback-end");
-        assertBulkDateFieldHidden("bulk-signup-begins");
-        assertBulkDateFieldHidden("bulk-signup-deadline");
+        assertColumnSetterPresent("assessments", "open_date");
+        assertColumnSetterPresent("assessments", "due_date");
+        assertColumnSetterPresent("assessments", "accept_until");
+        assertColumnSetterPresent("assessments", "feedback_start");
+        assertColumnSetterPresent("assessments", "feedback_end");
+        assertColumnSetterAbsent("signupMeetings", "signup_begins");
 
         String signupSite = sakai.createCourse("instructor1", List.of("sakai\\.signup"));
         page.navigate(signupSite);
         openDateManager();
 
-        assertBulkDateFieldVisible("bulk-open-date");
-        assertBulkDateFieldVisible("bulk-due-date");
-        assertBulkDateFieldVisible("bulk-signup-begins");
-        assertBulkDateFieldVisible("bulk-signup-deadline");
-        assertBulkDateFieldHidden("bulk-accept-until");
-        assertBulkDateFieldHidden("bulk-feedback-start");
-        assertBulkDateFieldHidden("bulk-feedback-end");
+        assertColumnSetterPresent("signupMeetings", "open_date");
+        assertColumnSetterPresent("signupMeetings", "due_date");
+        assertColumnSetterPresent("signupMeetings", "signup_begins");
+        assertColumnSetterPresent("signupMeetings", "signup_deadline");
+        assertColumnSetterAbsent("assignments", "accept_until");
+        assertColumnSetterAbsent("assessments", "feedback_start");
 
         String lessonsSite = sakai.createCourse("instructor1", List.of("sakai\\.lessonbuildertool"));
         page.navigate(lessonsSite);
         openDateManager();
 
-        assertBulkDateFieldVisible("bulk-open-date");
-        assertBulkDateFieldHidden("bulk-due-date");
-        assertBulkDateFieldHidden("bulk-accept-until");
+        assertColumnSetterPresent("lessons", "open_date");
+        assertColumnSetterAbsent("lessons", "due_date");
+        assertColumnSetterAbsent("assignments", "open_date");
 
         String dashboardOnlySite = sakai.createCourse("instructor1", List.of("sakai\\.dashboard"));
         page.navigate(dashboardOnlySite);
         openDateManager();
 
-        assertThat(page.locator(".date-manager-setter")).hasCount(0);
+        // No dated tools -> no per-column setters at all.
+        assertThat(page.locator(".bulk-col-setter")).hasCount(0);
     }
 
     private void openDateManager() {
@@ -113,12 +114,12 @@ class DateManagerTest extends SakaiUiTestBase {
         assertNoTemplateRenderingError();
     }
 
-    private void assertBulkDateFieldVisible(String id) {
-        assertThat(page.locator("#" + id)).isVisible();
+    private void assertColumnSetterPresent(String toolId, String field) {
+        assertThat(page.locator("#bulkcol-" + toolId + "-" + field)).hasCount(1);
     }
 
-    private void assertBulkDateFieldHidden(String id) {
-        assertThat(page.locator("#" + id)).hasCount(0);
+    private void assertColumnSetterAbsent(String toolId, String field) {
+        assertThat(page.locator("#bulkcol-" + toolId + "-" + field)).hasCount(0);
     }
 
     private void assertNoTemplateRenderingError() {

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/DateManagerTest.java
@@ -27,80 +27,81 @@ import org.sakaiproject.e2e.support.SakaiUiTestBase;
 class DateManagerTest extends SakaiUiTestBase {
 
     @Test
-    void bulkSetterOnlyShowsFieldsForSiteTools() {
+    void dateColumnsMatchSiteTools() {
         sakai.login("instructor1");
 
-        // The per-column date setters live in each tool section's column headers, so a setter is rendered
-        // only when the site has that tool (and that tool has that date column). Each setter's id is
-        // bulkcol-<toolId>-<field>. Sections are collapsed by default (progressive disclosure), so we
-        // assert presence in the DOM rather than visibility.
+        // The "Bulk Anchor" term-date matrix renders one checkbox per (tool, date column) present in the
+        // site - driven by tool presence (not by whether the tool has items), so it is the surface that
+        // reflects "which date fields exist for this site's tools". Each checkbox carries
+        // data-root='collapse-<tool>' and data-field='<column>'; we scope to one term row for a count of 1.
+        // The panel is collapsed by default, so we assert presence in the DOM rather than visibility.
         String gradebookResourcesSite = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng", "sakai\\.resources"));
         page.navigate(gradebookResourcesSite);
         openDateManager();
 
-        assertColumnSetterPresent("gradebookItems", "due_date");
-        assertColumnSetterPresent("resources", "open_date");
-        assertColumnSetterPresent("resources", "due_date");
-        assertColumnSetterAbsent("assignments", "open_date");
-        assertColumnSetterAbsent("assignments", "accept_until");
-        assertColumnSetterAbsent("assessments", "feedback_start");
-        assertColumnSetterAbsent("signupMeetings", "signup_begins");
+        assertTermColumnPresent("gradebook", "due_date");
+        assertTermColumnPresent("resources", "open_date");
+        assertTermColumnPresent("resources", "due_date");
+        assertTermColumnAbsent("assignments", "open_date");
+        assertTermColumnAbsent("assignments", "accept_until");
+        assertTermColumnAbsent("assessments", "feedback_start");
+        assertTermColumnAbsent("signup", "signup_begins");
 
         String assignmentsSite = sakai.createCourse("instructor1",
             List.of("sakai\\.gradebookng", "sakai\\.resources", "sakai\\.assignment\\.grades"));
         page.navigate(assignmentsSite);
         openDateManager();
 
-        assertColumnSetterPresent("assignments", "open_date");
-        assertColumnSetterPresent("assignments", "due_date");
-        assertColumnSetterPresent("assignments", "accept_until");
-        assertColumnSetterAbsent("assessments", "feedback_start");
-        assertColumnSetterAbsent("signupMeetings", "signup_begins");
+        assertTermColumnPresent("assignments", "open_date");
+        assertTermColumnPresent("assignments", "due_date");
+        assertTermColumnPresent("assignments", "accept_until");
+        assertTermColumnAbsent("assessments", "feedback_start");
+        assertTermColumnAbsent("signup", "signup_begins");
 
         String gradebookOnlySite = sakai.createCourse("instructor1", List.of("sakai\\.gradebookng"));
         page.navigate(gradebookOnlySite);
         openDateManager();
 
-        assertColumnSetterPresent("gradebookItems", "due_date");
-        assertColumnSetterAbsent("gradebookItems", "open_date");
-        assertColumnSetterAbsent("assignments", "open_date");
+        assertTermColumnPresent("gradebook", "due_date");
+        assertTermColumnAbsent("gradebook", "open_date");
+        assertTermColumnAbsent("assignments", "open_date");
 
         String assessmentsSite = sakai.createCourse("instructor1", List.of("sakai\\.samigo"));
         page.navigate(assessmentsSite);
         openDateManager();
 
-        assertColumnSetterPresent("assessments", "open_date");
-        assertColumnSetterPresent("assessments", "due_date");
-        assertColumnSetterPresent("assessments", "accept_until");
-        assertColumnSetterPresent("assessments", "feedback_start");
-        assertColumnSetterPresent("assessments", "feedback_end");
-        assertColumnSetterAbsent("signupMeetings", "signup_begins");
+        assertTermColumnPresent("assessments", "open_date");
+        assertTermColumnPresent("assessments", "due_date");
+        assertTermColumnPresent("assessments", "accept_until");
+        assertTermColumnPresent("assessments", "feedback_start");
+        assertTermColumnPresent("assessments", "feedback_end");
+        assertTermColumnAbsent("signup", "signup_begins");
 
         String signupSite = sakai.createCourse("instructor1", List.of("sakai\\.signup"));
         page.navigate(signupSite);
         openDateManager();
 
-        assertColumnSetterPresent("signupMeetings", "open_date");
-        assertColumnSetterPresent("signupMeetings", "due_date");
-        assertColumnSetterPresent("signupMeetings", "signup_begins");
-        assertColumnSetterPresent("signupMeetings", "signup_deadline");
-        assertColumnSetterAbsent("assignments", "accept_until");
-        assertColumnSetterAbsent("assessments", "feedback_start");
+        assertTermColumnPresent("signup", "open_date");
+        assertTermColumnPresent("signup", "due_date");
+        assertTermColumnPresent("signup", "signup_begins");
+        assertTermColumnPresent("signup", "signup_deadline");
+        assertTermColumnAbsent("assignments", "accept_until");
+        assertTermColumnAbsent("assessments", "feedback_start");
 
         String lessonsSite = sakai.createCourse("instructor1", List.of("sakai\\.lessonbuildertool"));
         page.navigate(lessonsSite);
         openDateManager();
 
-        assertColumnSetterPresent("lessons", "open_date");
-        assertColumnSetterAbsent("lessons", "due_date");
-        assertColumnSetterAbsent("assignments", "open_date");
+        assertTermColumnPresent("lessons", "open_date");
+        assertTermColumnAbsent("lessons", "due_date");
+        assertTermColumnAbsent("assignments", "open_date");
 
         String dashboardOnlySite = sakai.createCourse("instructor1", List.of("sakai\\.dashboard"));
         page.navigate(dashboardOnlySite);
         openDateManager();
 
-        // No dated tools -> no per-column setters at all.
-        assertThat(page.locator(".bulk-col-setter")).hasCount(0);
+        // No dated tools -> the term matrix has no columns at all.
+        assertThat(page.locator(".term-target")).hasCount(0);
     }
 
     private void openDateManager() {
@@ -114,12 +115,18 @@ class DateManagerTest extends SakaiUiTestBase {
         assertNoTemplateRenderingError();
     }
 
-    private void assertColumnSetterPresent(String toolId, String field) {
-        assertThat(page.locator("#bulkcol-" + toolId + "-" + field)).hasCount(1);
+    private Locator termColumn(String toolRoot, String field) {
+        // Scope to a single term row (classes_start) so a present column matches exactly one checkbox.
+        return page.locator(".term-target[data-root='collapse-" + toolRoot + "']"
+            + "[data-field='" + field + "'][data-term='classes_start']");
     }
 
-    private void assertColumnSetterAbsent(String toolId, String field) {
-        assertThat(page.locator("#bulkcol-" + toolId + "-" + field)).hasCount(0);
+    private void assertTermColumnPresent(String toolRoot, String field) {
+        assertThat(termColumn(toolRoot, field)).hasCount(1);
+    }
+
+    private void assertTermColumnAbsent(String toolRoot, String field) {
+        assertThat(termColumn(toolRoot, field)).hasCount(0);
     }
 
     private void assertNoTemplateRenderingError() {

--- a/library/src/skins/default/src/sass/base/_extendables.scss
+++ b/library/src/skins/default/src/sass/base/_extendables.scss
@@ -324,6 +324,44 @@ input::placeholder {
 			cursor: pointer;
 			text-decoration: none;
 		}
+
+		// Bootstrap 5 tabs render as <button class="nav-link"> with .active on the button
+		// itself rather than on the <li>; give button-backed tabs the same treatment as the
+		// anchor form above so tools do not have to restate it.
+		> button.nav-link {
+			background: var(--tool-tab-background-color);
+			border: 1px solid var(--sakai-border-color);
+			color: var(--sakai-text-color-1);
+			cursor: pointer;
+
+			&:hover {
+				background: var(--tool-tab-hover-background-color);
+				color: var(--tool-tab-hover-text-color);
+			}
+
+			&.active {
+				position: relative;
+				background: var(--tool-tab-active-background-color);
+				border-color: var(--sakai-border-color) var(--sakai-border-color) var(--tool-tab-active-background-color);
+				color: var(--tool-tab-active-text-color);
+
+				&:hover {
+					background: var(--tool-tab-active-background-color);
+					color: var(--tool-tab-active-text-color);
+				}
+
+				&::before {
+					border-top: 4px solid var(--tool-tab-active-highlight-color);
+					border-radius: 4px 4px 0 0;
+					content: "";
+					display: block;
+					position: absolute;
+					top: -1px;
+					left: -1px;
+					right: -1px;
+				}
+			}
+		}
 	}
 }
 

--- a/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -39,39 +39,11 @@
 	}
 
 	#date-manager-form {
-		// The tabs use Bootstrap 5 button markup, which the shared Sakai tab rules
-		// (.nav.nav-tabs > li > a) never match, so restate that treatment on the
-		// .nav-link buttons: passive button-like tabs, solid active tab with the
-		// highlight bar, consistent with tabs elsewhere in Sakai.
-		.nav-tabs {
-			.nav-link {
-				margin-right: 0.4em;
-				background: var(--tool-tab-background-color);
-				border: 1px solid var(--sakai-border-color);
-				color: var(--sakai-text-color-1);
-
-				&:hover {
-					background: var(--tool-tab-hover-background-color);
-					color: var(--tool-tab-hover-text-color);
-				}
-
-				&.active {
-					position: relative;
-					background: var(--tool-tab-active-background-color);
-					border-color: var(--sakai-border-color) var(--sakai-border-color) var(--tool-tab-active-background-color);
-					color: var(--tool-tab-active-text-color);
-
-					&::before {
-						content: "";
-						position: absolute;
-						top: -1px;
-						left: -1px;
-						right: -1px;
-						border-top: 4px solid var(--tool-tab-active-highlight-color);
-						border-radius: 4px 4px 0 0;
-					}
-				}
-			}
+		// Tab colors, borders, and the active highlight come from the shared tab rule in
+		// base/_extendables.scss, which covers these Bootstrap button-backed .nav-link tabs;
+		// only DateManager's tab spacing is local.
+		.nav-tabs > li {
+			margin: 0 0.4em 0 0;
 		}
 
 		.card-header {

--- a/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -30,7 +30,50 @@
 		min-width: 100%;
 		padding-right: 0.5em;
 	}
+	// Export/Import use the standard .navIntraTool menu chips; keep the list itself flush
+	// so it sits cleanly on the right edge of the flex page header.
+	.date-manager-actions {
+		li:last-child {
+			margin-right: 0;
+		}
+	}
+
 	#date-manager-form {
+		// The tabs use Bootstrap 5 button markup, which the shared Sakai tab rules
+		// (.nav.nav-tabs > li > a) never match, so restate that treatment on the
+		// .nav-link buttons: passive button-like tabs, solid active tab with the
+		// highlight bar, consistent with tabs elsewhere in Sakai.
+		.nav-tabs {
+			.nav-link {
+				margin-right: 0.4em;
+				background: var(--tool-tab-background-color);
+				border: 1px solid var(--sakai-border-color);
+				color: var(--sakai-text-color-1);
+
+				&:hover {
+					background: var(--tool-tab-hover-background-color);
+					color: var(--tool-tab-hover-text-color);
+				}
+
+				&.active {
+					position: relative;
+					background: var(--tool-tab-active-background-color);
+					border-color: var(--sakai-border-color) var(--sakai-border-color) var(--tool-tab-active-background-color);
+					color: var(--tool-tab-active-text-color);
+
+					&::before {
+						content: "";
+						position: absolute;
+						top: -1px;
+						left: -1px;
+						right: -1px;
+						border-top: 4px solid var(--tool-tab-active-highlight-color);
+						border-radius: 4px 4px 0 0;
+					}
+				}
+			}
+		}
+
 		.card-header {
 			padding: 0;
 
@@ -102,6 +145,38 @@
 			--fc-page-bg-color: var(--sakai-background-color-1);
 			--fc-neutral-bg-color: var(--sakai-background-color-2);
 			--fc-border-color: var(--sakai-border-color);
+		}
+
+		// Term-milestone matrix: tint each tool's column block with its own subtle colour and
+		// open each tool boundary with a heavier rule, so the tools' checkbox columns don't
+		// merge into one continuous grid. The tints come from the theme palettes; the dark
+		// theme swaps them for their dark-end shades below.
+		.table-datemanager-term {
+			--dm-mx-assignments-bg: var(--sakai-color-blue--lighter-7);
+			--dm-mx-assessments-bg: var(--sakai-color-teal--lighter-7);
+			--dm-mx-signup-bg: var(--sakai-color-purple--lighter-7);
+			--dm-mx-gradebook-bg: var(--sakai-color-green--lighter-7);
+			--dm-mx-resources-bg: var(--sakai-color-gold--lighter-7);
+			--dm-mx-calendar-bg: var(--sakai-color-orange--lighter-7);
+			--dm-mx-forums-bg: var(--sakai-color-red--lighter-7);
+			--dm-mx-announcements-bg: var(--sakai-color-gray--lighter-7);
+			--dm-mx-lessons-bg: var(--sakai-lessons-navy--lighter-7);
+
+			th, td {
+				&.dm-mx-assignments { background-color: var(--dm-mx-assignments-bg); }
+				&.dm-mx-assessments { background-color: var(--dm-mx-assessments-bg); }
+				&.dm-mx-signup { background-color: var(--dm-mx-signup-bg); }
+				&.dm-mx-gradebook { background-color: var(--dm-mx-gradebook-bg); }
+				&.dm-mx-resources { background-color: var(--dm-mx-resources-bg); }
+				&.dm-mx-calendar { background-color: var(--dm-mx-calendar-bg); }
+				&.dm-mx-forums { background-color: var(--dm-mx-forums-bg); }
+				&.dm-mx-announcements { background-color: var(--dm-mx-announcements-bg); }
+				&.dm-mx-lessons { background-color: var(--dm-mx-lessons-bg); }
+
+				&.dm-mx-first {
+					border-left: 3px solid var(--sakai-border-color);
+				}
+			}
 		}
 
 		.table-datemanager {
@@ -251,6 +326,21 @@
    }
   /*End of Site Group Manager*/
 
+}
+
+// Dark ends of the same tool palettes for the milestone matrix tints.
+:root.sakaiUserTheme-dark {
+	.#{$namespace}sakai-siteinfo #date-manager-form .table-datemanager-term {
+		--dm-mx-assignments-bg: var(--sakai-color-blue--darker-6);
+		--dm-mx-assessments-bg: var(--sakai-color-teal--darker-6);
+		--dm-mx-signup-bg: var(--sakai-color-purple--darker-6);
+		--dm-mx-gradebook-bg: var(--sakai-color-green--darker-6);
+		--dm-mx-resources-bg: var(--sakai-color-gold--darker-6);
+		--dm-mx-calendar-bg: var(--sakai-color-orange--darker-6);
+		--dm-mx-forums-bg: var(--sakai-color-red--darker-6);
+		--dm-mx-announcements-bg: var(--sakai-color-gray--darker-6);
+		--dm-mx-lessons-bg: var(--sakai-lessons-navy--lighter-1);
+	}
 }
 
 #toolSelectionList{

--- a/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -72,6 +72,14 @@
 			}
 		}
 
+		// The calendar preview: point FullCalendar's own theming variables at the theme
+		// tokens so its sticky day-name header and neutral surfaces follow light/dark.
+		#datemanager-calendar {
+			--fc-page-bg-color: var(--sakai-background-color-1);
+			--fc-neutral-bg-color: var(--sakai-background-color-2);
+			--fc-border-color: var(--sakai-border-color);
+		}
+
 		.table-datemanager {
 			margin-bottom: 0;
 			table-layout: fixed;

--- a/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -72,6 +72,30 @@
 			}
 		}
 
+		// Three action weights: Save Changes keeps the primary style, the bulk-method apply
+		// buttons and Visual Preview take the standard secondary treatment (they act on the
+		// page but never save), and Cancel drops to a text button as the lowest-commitment
+		// action, so all three bottom buttons read differently.
+		.dm-bulk-apply,
+		#datemanager-preview,
+		#datemanager-cancel {
+			@include sakai_secondary_button();
+		}
+
+		#datemanager-cancel {
+			background: transparent;
+			border-color: transparent;
+			color: var(--sakai-text-color-1);
+			text-decoration: underline;
+
+			&:hover,
+			&:focus {
+				background: var(--sakai-background-color-2);
+				border-color: transparent;
+				color: var(--sakai-text-color-1);
+			}
+		}
+
 		// The calendar preview: point FullCalendar's own theming variables at the theme
 		// tokens so its sticky day-name header and neutral surfaces follow light/dark.
 		#datemanager-calendar {

--- a/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/siteinfo/_siteinfo.scss
@@ -193,6 +193,15 @@
 				}
 			}
 
+			th {
+				// The datepicker stamps an inline min-width on its input, which is wider
+				// than a header cell in tools with many date columns and would cover the
+				// neighboring header; let the column setter's input shrink to its cell.
+				.bulk-col-input {
+					min-width: 0 !important;
+				}
+			}
+
 			td {
 				&.ajax-error {
 					background-color: var(--errorBanner-bgcolor);

--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerConstants.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerConstants.java
@@ -15,8 +15,6 @@
  */
 package org.sakaiproject.datemanager.api;
 
-import java.util.Map;
-
 public class DateManagerConstants {
 	public static final String COMMON_ID_ASSIGNMENTS = "sakai.assignment.grades";
 	public static final String COMMON_ID_ASSESSMENTS = "sakai.samigo";
@@ -53,13 +51,4 @@ public class DateManagerConstants {
 
 	public static final String DATEPICKER_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 	public static final int LIST_VIEW_YEAR_RANGE = 18;
-
-	public static final Map<String, String> BULK_DATE_FIELD_LABEL_KEYS = Map.of(
-			JSON_OPENDATE_PARAM_NAME, "column.open.date",
-			JSON_DUEDATE_PARAM_NAME, "column.due.date",
-			JSON_ACCEPTUNTIL_PARAM_NAME, "column.accept.until",
-			JSON_FEEDBACKSTART_PARAM_NAME, "column.feedback.start.date",
-			JSON_FEEDBACKEND_PARAM_NAME, "column.feedback.end.date",
-			JSON_SIGNUPBEGINS_PARAM_NAME, "column.signup.begins.date",
-			JSON_SIGNUPDEADLINE_PARAM_NAME, "column.signup.deadline.date");
 }

--- a/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
+++ b/site-manage/datemanager/api/src/java/org/sakaiproject/datemanager/api/DateManagerService.java
@@ -49,7 +49,6 @@ public interface DateManagerService {
 	public String getMessage(String messageId);
 	public boolean currentSiteContainsTool(String commonId);
 	public String getToolTitle(String commonId);
-	public List<String> getBulkDateFieldsForCurrentSite();
 
 	// Assignments methods
 	public JSONArray getAssignmentsForContext(String siteId);

--- a/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -36,13 +36,11 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.opencsv.CSVReader;
@@ -266,39 +264,6 @@ public class DateManagerServiceImpl implements DateManagerService {
 			toolTitle = tool.getTitle();
 		}
 		return toolTitle;
-	}
-
-	@Override
-	public List<String> getBulkDateFieldsForCurrentSite() {
-		Set<String> fields = new LinkedHashSet<>();
-
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_ASSIGNMENTS, columnsNames[0]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_ASSESSMENTS, columnsNames[1]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_GRADEBOOK, columnsNames[2]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_SIGNUP, columnsNames[3]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_RESOURCES, columnsNames[5]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_CALENDAR, columnsNames[4]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_FORUMS, columnsNames[5]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_ANNOUNCEMENTS, columnsNames[4]);
-		addBulkDateFieldsForTool(fields, DateManagerConstants.COMMON_ID_LESSONS, columnsNames[6]);
-
-		return new ArrayList<>(fields);
-	}
-
-	private void addBulkDateFieldsForTool(Set<String> fields, String commonId, String[] toolColumnsNames) {
-		if (!currentSiteContainsTool(commonId)) {
-			return;
-		}
-
-		Arrays.stream(toolColumnsNames)
-			.filter(this::isBulkDateField)
-			.forEach(fields::add);
-	}
-
-	private boolean isBulkDateField(String fieldName) {
-		return !DateManagerConstants.JSON_ID_PARAM_NAME.equals(fieldName)
-				&& !DateManagerConstants.JSON_TITLE_PARAM_NAME.equals(fieldName)
-				&& !DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME.equals(fieldName);
 	}
 
 	private String getUrlForTool(String tool) {

--- a/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
+++ b/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
@@ -123,7 +123,6 @@ public class MainController {
     public String showIndex(@RequestParam(required=false) String code, Model model, HttpServletRequest request, HttpServletResponse response) {
 		String siteId = dateManagerService.getCurrentSiteId();
 		model = getModelWithLocale(model, request, response);
-		model.addAttribute("bulkDateFields", dateManagerService.getBulkDateFieldsForCurrentSite());
 
 		if (dateManagerService.currentSiteContainsTool(DateManagerConstants.COMMON_ID_ASSIGNMENTS)) {
 			JSONArray assignmentsJson = dateManagerService.getAssignmentsForContext(siteId);

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -42,7 +42,7 @@ section.batch.help = Set or shift many dates at once. Your changes appear in the
 section.shift.heading = Shift every date by a fixed amount
 section.fit.heading = Smart Shift
 section.set.heading = Bulk Term Date Matrix
-section.items.heading = Edit individual items
+section.items.heading = Edit dates by item or column
 section.items.help = Expand a tool to review or adjust each item's dates. Edits from the bulk tools above appear here before you save.
 
 success.message = The dates were updated successfully.

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -31,9 +31,13 @@ modal.confirm.instruction = You are about to modify the following course dates:
 page.instructions = Edit dates in batch
 
 # Headings for the batch-tool groups at the top of the page
+section.batch.heading = Bulk editing tools
+section.batch.help = Set or shift many dates at once. Your changes appear in the item sections below — review them, then click Save Changes.
 section.shift.heading = Shift every date by a fixed amount
 section.fit.heading = Fit dates to a new term
 section.set.heading = Set dates directly
+section.items.heading = Edit individual items
+section.items.help = Expand a tool to review or adjust each item's dates. Edits from the bulk tools above appear here before you save.
 
 success.message = The dates were updated successfully.
 success.export = The dates were exported successfully. Please note the following considerations:

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -28,6 +28,7 @@ modal.confirm = Confirm
 modal.confirm.description = A modal window which gives you the chance to confirm your date changes
 modal.confirm.instruction = You are about to modify the following course dates:
 
+page.title = Date Manager
 page.instructions = Edit dates in batch
 
 # Headings for the batch-tool groups at the top of the page

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -87,7 +87,7 @@ datesetter.column.fillempty.title=When ticked, every cell in the column gets the
 
 # Fill mode (applies to the term dates panel)
 bulk.help=This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.
-bulk.fill.mode.label=When the term dates and per-column boxes below fill a column:
+bulk.fill.mode.label=When the term dates below fill a column:
 bulk.fill.mode.all=Fill every cell (empty and existing)
 bulk.fill.mode.existing=Only cells that already have a date
 

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -1,6 +1,11 @@
 button.cancel = Cancel
+button.calendar.preview = Visual Preview
 button.save = Save Changes
 button.start.again = Start Again
+
+calendar.preview.title = Calendar preview of all dates
+calendar.preview.help = A read-only preview of every date currently entered below. Close this and choose Save Changes to apply them.
+calendar.preview.empty = There are no dates to preview.
 
 column.title = Title
 column.open.date = Open Date

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -45,6 +45,14 @@ dateshifter.visible.button=Apply to expanded sections only
 dateshifter.error.nonnumeric=Please enter a non-zero whole number between -9999 and 9999.
 dateshifter.export.dates.csv=Export Dates
 dateshifter.import.dates.csv=Import Dates
+# Re-anchor / fit dates between a new first and last date
+datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Only cells that already have a date are changed. Remember to click Save Changes at the bottom of the page to save your adjustments.
+datefit.first.label=New first date
+datefit.last.label=New last date
+datefit.snap.label=Snap to weeks (keep each item's weekday & time)
+datefit.all.button=Fit dates to all items
+datefit.visible.button=Fit dates to expanded sections only
+datefit.error.range=The new last date must be after the new first date.
 datesetter.instructions=Enter one or more dates below, then apply them to all items or expanded sections only. Remember to click Save Changes at the bottom of the page to save your adjustments.
 datesetter.all.button=Apply entered dates to all items
 datesetter.visible.button=Apply entered dates to expanded sections only

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -70,11 +70,6 @@ datefit.snap.label=Snap to weeks (keep each item's weekday & time)
 datefit.all.button=Fit dates to all items
 datefit.visible.button=Fit dates to expanded sections only
 datefit.error.range=The new last date must be after the new first date.
-datesetter.instructions=Enter one or more dates below, then apply them to all items or expanded sections only. Remember to click Save Changes at the bottom of the page to save your adjustments.
-datesetter.all.button=Apply entered dates to all items
-datesetter.visible.button=Apply entered dates to expanded sections only
-datesetter.error.empty=Enter at least one date before applying changes.
-datesetter.error.dateonly=The selected due date includes a time, but Gradebook due dates are date-only. Use 00:00 or apply dates to sections without Gradebook items.
 
 # Per-column bulk setter (in each editable date column header)
 datesetter.column.aria=Date to fill this column

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -51,6 +51,26 @@ datesetter.visible.button=Apply entered dates to expanded sections only
 datesetter.error.empty=Enter at least one date before applying changes.
 datesetter.error.dateonly=The selected due date includes a time, but Gradebook due dates are date-only. Use 00:00 or apply dates to sections without Gradebook items.
 
+# Per-column bulk setter (in each editable date column header)
+datesetter.column.aria=Date to fill this column
+datesetter.column.placeholder=Set whole column
+datesetter.column.button.title=Fill every row in this column with the date entered
+
+# Fill mode (applies to the per-column setters and the term dates panel)
+bulk.fill.mode.label=When applying a date to a column:
+bulk.fill.mode.all=Fill every cell (empty and existing)
+bulk.fill.mode.existing=Only cells that already have a date
+
+# Term dates panel
+termdates.instructions=Enter your term dates, tick which date columns each one should fill, then apply. Overlapping ticks apply from top to bottom, so a lower row wins. Remember to click Save Changes at the bottom of the page to save your adjustments.
+termdates.column.header=Term date
+termdates.classes.start=Classes Start
+termdates.classes.end=Classes End
+termdates.exam.begins=Exam Begins
+termdates.exam.ends=Exam Ends
+termdates.all.button=Apply term dates to all items
+termdates.visible.button=Apply term dates to expanded sections only
+
 page.import=Import dates
 page.confirm.import=Confirmation: Import dates
 page.confirm.import.instruction_0=Are you sure you want to make these changes?

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -82,8 +82,10 @@ datefit.error.range=The new last date must be after the new first date.
 # Per-column bulk setter (in each editable date column header)
 datesetter.column.aria=Date to fill this column
 datesetter.column.button.title=Fill every row in this column with the date entered
+datesetter.column.fillempty=Fill Empty
+datesetter.column.fillempty.title=Also put the date in cells that are currently empty; when unticked, only cells that already have a date are changed
 
-# Fill mode (applies to the per-column setters and the term dates panel)
+# Fill mode (applies to the term dates panel)
 bulk.help=This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.
 bulk.fill.mode.label=When the term dates and per-column boxes below fill a column:
 bulk.fill.mode.all=Fill every cell (empty and existing)

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -34,8 +34,8 @@ page.instructions = Edit dates in batch
 section.batch.heading = Bulk editing tools
 section.batch.help = Set or shift many dates at once. Your changes appear in the item sections below — review them, then click Save Changes.
 section.shift.heading = Shift every date by a fixed amount
-section.fit.heading = Fit dates to a new term
-section.set.heading = Set dates directly
+section.fit.heading = Smart Shift
+section.set.heading = Bulk Anchor
 section.items.heading = Edit individual items
 section.items.help = Expand a tool to review or adjust each item's dates. Edits from the bulk tools above appear here before you save.
 

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -81,7 +81,6 @@ datefit.error.range=The new last date must be after the new first date.
 
 # Per-column bulk setter (in each editable date column header)
 datesetter.column.aria=Date to fill this column
-datesetter.column.placeholder=Set whole column
 datesetter.column.button.title=Fill every row in this column with the date entered
 
 # Fill mode (applies to the per-column setters and the term dates panel)

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -54,6 +54,13 @@ dateshifter.visible.button=Apply to expanded sections only
 dateshifter.error.nonnumeric=Please enter a non-zero whole number between -9999 and 9999.
 dateshifter.export.dates.csv=Export Dates
 dateshifter.import.dates.csv=Import Dates
+
+# Date difference helper in the shift section: number of days between two dates
+datediff.label=Days between two dates
+datediff.from.label=From
+datediff.to.label=To
+datediff.button=Use as shift
+datediff.result={0} day(s)
 # Re-anchor / fit dates between a new first and last date
 datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Only cells that already have a date are changed. Remember to click Save Changes at the bottom of the page to save your adjustments.
 datefit.first.label=New first date

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -53,7 +53,7 @@ success.export.3 = The fields not marked as required or optional can only be mod
 success.export.4 = Only modify the date fields. Do not modify the rest of the fields.
 success.export.5 = Do not change the date format.
 
-dateshifter.help=This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board. To re-space items to fit a new term, use Smart Shift below instead.
+dateshifter.help=This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.
 dateshifter.label.before=Shift dates by
 dateshifter.label.after=day(s). Remember to click Save Changes at the bottom of the page to save your adjustments.
 dateshifter.all.button=Apply to all dates
@@ -63,7 +63,7 @@ dateshifter.export.dates.csv=Export Dates
 dateshifter.import.dates.csv=Import Dates
 
 # Date difference helper in the shift section: number of days between two dates
-datediff.label=Days between two dates
+datediff.label=Calculate the number of days between two dates with the utility below to apply a fixed integer shift to all dates
 datediff.from.label=From
 datediff.to.label=To
 datediff.button=Use as shift

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -53,6 +53,7 @@ success.export.3 = The fields not marked as required or optional can only be mod
 success.export.4 = Only modify the date fields. Do not modify the rest of the fields.
 success.export.5 = Do not change the date format.
 
+dateshifter.help=This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board. To re-space items to fit a new term, use Smart Shift below instead.
 dateshifter.label.before=Shift dates by
 dateshifter.label.after=day(s). Remember to click Save Changes at the bottom of the page to save your adjustments.
 dateshifter.all.button=Apply to all dates
@@ -67,7 +68,9 @@ datediff.from.label=From
 datediff.to.label=To
 datediff.button=Use as shift
 datediff.result={0} day(s)
+datediff.note=Note: this only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.
 # Re-anchor / fit dates between a new first and last date
+datefit.help=This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.
 datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Only cells that already have a date are changed. Remember to click Save Changes at the bottom of the page to save your adjustments.
 datefit.first.label=New first date
 datefit.last.label=New last date
@@ -82,6 +85,7 @@ datesetter.column.placeholder=Set whole column
 datesetter.column.button.title=Fill every row in this column with the date entered
 
 # Fill mode (applies to the per-column setters and the term dates panel)
+bulk.help=This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.
 bulk.fill.mode.label=When the term dates and per-column boxes below fill a column:
 bulk.fill.mode.all=Fill every cell (empty and existing)
 bulk.fill.mode.existing=Only cells that already have a date

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -82,8 +82,8 @@ datefit.error.range=The new last date must be after the new first date.
 # Per-column bulk setter (in each editable date column header)
 datesetter.column.aria=Date to fill this column
 datesetter.column.button.title=Fill every row in this column with the date entered
-datesetter.column.fillempty=Fill Empty
-datesetter.column.fillempty.title=Also put the date in cells that are currently empty; when unticked, only cells that already have a date are changed
+datesetter.column.fillempty=Fill ALL (including empty cells)
+datesetter.column.fillempty.title=When ticked, every cell in the column gets the date, including empty ones; when unticked, only cells that already have a date are changed
 
 # Fill mode (applies to the term dates panel)
 bulk.help=This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -41,7 +41,7 @@ section.batch.heading = Bulk editing tools
 section.batch.help = Set or shift many dates at once. Your changes appear in the item sections below — review them, then click Save Changes.
 section.shift.heading = Shift every date by a fixed amount
 section.fit.heading = Smart Shift
-section.set.heading = Bulk Anchor
+section.set.heading = Bulk Term Date Matrix
 section.items.heading = Edit individual items
 section.items.help = Expand a tool to review or adjust each item's dates. Edits from the bulk tools above appear here before you save.
 
@@ -68,7 +68,7 @@ datediff.from.label=From
 datediff.to.label=To
 datediff.button=Use as shift
 datediff.result={0} day(s)
-datediff.note=Note: this only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.
+datediff.note=Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.
 # Re-anchor / fit dates between a new first and last date
 datefit.help=This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.
 datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Only cells that already have a date are changed. Remember to click Save Changes at the bottom of the page to save your adjustments.

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -30,6 +30,11 @@ modal.confirm.instruction = You are about to modify the following course dates:
 
 page.instructions = Edit dates in batch
 
+# Headings for the batch-tool groups at the top of the page
+section.shift.heading = Shift every date by a fixed amount
+section.fit.heading = Fit dates to a new term
+section.set.heading = Set dates directly
+
 success.message = The dates were updated successfully.
 success.export = The dates were exported successfully. Please note the following considerations:
 success.export.1 = The fields marked as required cannot be left blank.
@@ -65,7 +70,7 @@ datesetter.column.placeholder=Set whole column
 datesetter.column.button.title=Fill every row in this column with the date entered
 
 # Fill mode (applies to the per-column setters and the term dates panel)
-bulk.fill.mode.label=When applying a date to a column:
+bulk.fill.mode.label=When the term dates and per-column boxes below fill a column:
 bulk.fill.mode.all=Fill every cell (empty and existing)
 bulk.fill.mode.existing=Only cells that already have a date
 

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -41,9 +41,9 @@ section.batch.heading = Bulk editing tools
 section.batch.help = Set or shift many dates at once. Your changes appear in the item sections below — review them, then click Save Changes.
 section.shift.heading = Shift every date by a fixed amount
 section.fit.heading = Smart Shift
-section.set.heading = Bulk Term Date Matrix
+section.set.heading = Term Dates
 section.items.heading = Edit dates by item or column
-section.items.help = Expand a tool to review or adjust each item's dates. Edits from the bulk tools above appear here before you save.
+section.items.help = Expand a tool to review or adjust each item's dates — this is the familiar Date Manager grid, unchanged, if you prefer working item by item. Edits from the bulk tools above appear here before you save.
 
 success.message = The dates were updated successfully.
 success.export = The dates were exported successfully. Please note the following considerations:
@@ -53,53 +53,53 @@ success.export.3 = The fields not marked as required or optional can only be mod
 success.export.4 = Only modify the date fields. Do not modify the rest of the fields.
 success.export.5 = Do not change the date format.
 
-dateshifter.help=This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.
+dateshifter.help=The classic Date Manager shift, kept for familiar workflows: ideal when your items are already spaced correctly relative to each other and everything can move together by the same fixed number of days.
 dateshifter.label.before=Shift dates by
 dateshifter.label.after=day(s). Remember to click Save Changes at the bottom of the page to save your adjustments.
 dateshifter.all.button=Apply to all dates
-dateshifter.visible.button=Apply to expanded sections only
+dateshifter.visible.button=Apply only to tools expanded below
 dateshifter.error.nonnumeric=Please enter a non-zero whole number between -9999 and 9999.
 dateshifter.export.dates.csv=Export Dates
 dateshifter.import.dates.csv=Import Dates
 
 # Date difference helper in the shift section: number of days between two dates
-datediff.label=Calculate the number of days between two dates with the utility below to apply a fixed integer shift to all dates
+datediff.label=Not sure how many days to shift? Pick your old term's start date and your new term's start date, and the day count is calculated for you.
 datediff.from.label=From
 datediff.to.label=To
-datediff.button=Use as shift
+datediff.button=Copy into shift amount
 datediff.result={0} day(s)
-datediff.note=Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.
+datediff.note=These two dates are only used for counting — nothing changes until the day count is copied into the shift amount below and you click Apply.
 # Re-anchor / fit dates between a new first and last date
 datefit.help=This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.
-datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Only cells that already have a date are changed. Remember to click Save Changes at the bottom of the page to save your adjustments.
+datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Items with no date stay blank. Remember to click Save Changes at the bottom of the page to save your adjustments.
 datefit.first.label=New first date
 datefit.last.label=New last date
 datefit.snap.label=Snap to weeks (keep each item's weekday & time)
 datefit.all.button=Fit dates to all items
-datefit.visible.button=Fit dates to expanded sections only
+datefit.visible.button=Fit dates only in tools expanded below
 datefit.error.range=The new last date must be after the new first date.
 
 # Per-column bulk setter (in each editable date column header)
 datesetter.column.aria=Date to fill this column
 datesetter.column.button.title=Fill every row in this column with the date entered
-datesetter.column.fillempty=Fill ALL (including empty cells)
-datesetter.column.fillempty.title=When ticked, every cell in the column gets the date, including empty ones; when unticked, only cells that already have a date are changed
+datesetter.column.fillempty=Also fill empty cells
+datesetter.column.fillempty.title=Unticked, only items that already have a date get the new one — items with no date stay blank. Ticked, every row in the column is filled.
 
 # Fill mode (applies to the term dates panel)
-bulk.help=This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.
-bulk.fill.mode.label=When the term dates below fill a column:
-bulk.fill.mode.all=Fill every cell (empty and existing)
-bulk.fill.mode.existing=Only cells that already have a date
+bulk.help=Ideal when many items share the same key dates: enter your term's dates once (first and last day of classes, exam window) and fill whole date columns with them — for example, put Classes Start into every Open Date column.
+bulk.fill.mode.label=When a term date fills a column:
+bulk.fill.mode.all=Fill every item, even ones with no date yet
+bulk.fill.mode.existing=Only update items that already have a date (blanks stay blank)
 
 # Term dates panel
-termdates.instructions=Enter your term dates, tick which date columns each one should fill, then apply. Overlapping ticks apply from top to bottom, so a lower row wins. Remember to click Save Changes at the bottom of the page to save your adjustments.
+termdates.instructions=Enter your new term's dates, then tick which date columns each one should fill. If two ticked rows target the same column, the lower row wins. Remember to click Save Changes at the bottom of the page to save your adjustments.
 termdates.column.header=Term date
 termdates.classes.start=Classes Start
 termdates.classes.end=Classes End
 termdates.exam.begins=Exam Begins
 termdates.exam.ends=Exam Ends
 termdates.all.button=Apply term dates to all items
-termdates.visible.button=Apply term dates to expanded sections only
+termdates.visible.button=Apply term dates only to tools expanded below
 
 page.import=Import dates
 page.confirm.import=Confirmation: Import dates

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -66,11 +66,14 @@ datediff.label=Pick your old and new term start dates and the number of days to 
 datediff.from.label=Old term start
 datediff.to.label=New term start
 datediff.result={0} day(s)
-# Re-anchor / fit dates between a new first and last date
-datefit.help=Pins your earliest dated item to the new first date, your latest to the new last date, and spreads everything in between to fit — ideal for items spaced evenly through the term. Items with no date stay blank.
-datefit.first.label=New first date
-datefit.last.label=New last date
-datefit.snap.label=Snap to weeks (keep each item's weekday & time)
+# Re-anchor / fit dates between two destination dates
+datefit.help=The earliest and latest dated items take these two dates exactly (including the time entered); everything in between is spread to fit — ideal for items spaced evenly through the term. Items with no date stay blank.
+datefit.first.label=Move earliest dated item to
+datefit.last.label=Move latest dated item to
+datefit.snap.label=Snap to weeks (keep each in-between item's weekday & time)
+# Live hint showing the current earliest/latest date the destination field will move
+datefit.anchor.current=currently: {0}
+datefit.anchor.none=currently: no dated items in the tools selected below
 datefit.error.range=The new last date must be after the new first date.
 
 # Per-column bulk setter (in each editable date column header)

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -6,6 +6,7 @@ button.start.again = Start Again
 calendar.preview.title = Calendar preview of all dates
 calendar.preview.help = A read-only preview of every date currently entered below. Close this and choose Save Changes to apply them.
 calendar.preview.empty = There are no dates to preview.
+calendar.preview.span.button = Overview
 
 column.title = Title
 column.open.date = Open Date
@@ -36,14 +37,14 @@ modal.confirm.instruction = You are about to modify the following course dates:
 page.title = Date Manager
 page.instructions = Edit dates in batch
 
-# Headings for the batch-tool groups at the top of the page
-section.batch.heading = Bulk editing tools
-section.batch.help = Set or shift many dates at once. Your changes appear in the item sections below — review them, then click Save Changes.
-section.shift.heading = Shift every date by a fixed amount
-section.fit.heading = Smart Shift
-section.set.heading = Term Dates
-section.items.heading = Edit dates by item or column
-section.items.help = Expand a tool to review or adjust each item's dates — this is the familiar Date Manager grid, unchanged, if you prefer working item by item. Edits from the bulk tools above appear here before you save.
+# Tab labels and method names for the two editing tabs
+section.batch.heading = Bulk Edit
+section.batch.help = Pick how you want to move dates, choose which tools to apply to, and apply. Review the results on the Edit Individual Items tab, then click Save Changes.
+section.shift.heading = Shift dates by a number of days
+section.fit.heading = Fit dates to a new term
+section.set.heading = Set dates from term milestones
+section.items.heading = Edit Individual Items
+section.items.help = Expand a tool to review or adjust each item's dates. Edits made on the Bulk Edit tab appear here before you save.
 
 success.message = The dates were updated successfully.
 success.export = The dates were exported successfully. Please note the following considerations:
@@ -53,30 +54,23 @@ success.export.3 = The fields not marked as required or optional can only be mod
 success.export.4 = Only modify the date fields. Do not modify the rest of the fields.
 success.export.5 = Do not change the date format.
 
-dateshifter.help=The classic Date Manager shift, kept for familiar workflows: ideal when your items are already spaced correctly relative to each other and everything can move together by the same fixed number of days.
+dateshifter.help=Moves every date by the same number of days — ideal when your items are already spaced correctly relative to each other.
 dateshifter.label.before=Shift dates by
-dateshifter.label.after=day(s). Remember to click Save Changes at the bottom of the page to save your adjustments.
-dateshifter.all.button=Apply to all dates
-dateshifter.visible.button=Apply only to tools expanded below
+dateshifter.label.after=day(s)
 dateshifter.error.nonnumeric=Please enter a non-zero whole number between -9999 and 9999.
 dateshifter.export.dates.csv=Export Dates
 dateshifter.import.dates.csv=Import Dates
 
-# Date difference helper in the shift section: number of days between two dates
-datediff.label=Not sure how many days to shift? Pick your old term's start date and your new term's start date, and the day count is calculated for you.
-datediff.from.label=From
-datediff.to.label=To
-datediff.button=Copy into shift amount
+# Term start pickers in the shift panel: they calculate the day count into the shift field
+datediff.label=Pick your old and new term start dates and the number of days to shift is calculated for you — or type the day count directly below.
+datediff.from.label=Old term start
+datediff.to.label=New term start
 datediff.result={0} day(s)
-datediff.note=These two dates are only used for counting — nothing changes until the day count is copied into the shift amount below and you click Apply.
 # Re-anchor / fit dates between a new first and last date
-datefit.help=This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.
-datefit.instructions=Re-anchor every dated item to a new term: enter the new first and last dates and the items in between are spread to fit. With "Snap to weeks" on, each item keeps its weekday and time of day and only moves by whole weeks. Items with no date stay blank. Remember to click Save Changes at the bottom of the page to save your adjustments.
+datefit.help=Pins your earliest dated item to the new first date, your latest to the new last date, and spreads everything in between to fit — ideal for items spaced evenly through the term. Items with no date stay blank.
 datefit.first.label=New first date
 datefit.last.label=New last date
 datefit.snap.label=Snap to weeks (keep each item's weekday & time)
-datefit.all.button=Fit dates to all items
-datefit.visible.button=Fit dates only in tools expanded below
 datefit.error.range=The new last date must be after the new first date.
 
 # Per-column bulk setter (in each editable date column header)
@@ -85,8 +79,8 @@ datesetter.column.button.title=Fill every row in this column with the date enter
 datesetter.column.fillempty=Also fill empty cells
 datesetter.column.fillempty.title=Unticked, only items that already have a date get the new one — items with no date stay blank. Ticked, every row in the column is filled.
 
-# Fill mode (applies to the term dates panel)
-bulk.help=Ideal when many items share the same key dates: enter your term's dates once (first and last day of classes, exam window) and fill whole date columns with them — for example, put Classes Start into every Open Date column.
+# Fill mode (applies to the term milestones panel)
+bulk.help=Enter your term's key dates once — first and last day of classes, exam window — and fill whole date columns with them. Ideal when many items share the same dates.
 bulk.fill.mode.label=When a term date fills a column:
 bulk.fill.mode.all=Fill every item, even ones with no date yet
 bulk.fill.mode.existing=Only update items that already have a date (blanks stay blank)
@@ -98,8 +92,13 @@ termdates.classes.start=Classes Start
 termdates.classes.end=Classes End
 termdates.exam.begins=Exam Begins
 termdates.exam.ends=Exam Ends
-termdates.all.button=Apply term dates to all items
-termdates.visible.button=Apply term dates only to tools expanded below
+
+# Tool-scope row shared by the bulk methods, and their apply buttons
+bulk.scope.label=Apply to:
+bulk.scope.all=All tools
+bulk.apply.shift=Apply shift
+bulk.apply.fit=Apply fit
+bulk.apply.term=Apply term dates
 
 page.import=Import dates
 page.confirm.import=Confirmation: Import dates

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -99,6 +99,17 @@ bulk.scope.all=All tools
 bulk.apply.shift=Apply shift
 bulk.apply.fit=Apply fit
 bulk.apply.term=Apply term dates
+# Appended to the apply button when only some tools are ticked in the scope row
+bulk.apply.scope.suffix=({0} of {1} tools)
+
+# Feedback banner shown on the bulk tab after each apply, summarising what it just did
+bulk.applied.shift=Shifted {0} date(s) in {1} tool(s). Items with no date were left unchanged.
+bulk.applied.fit=Re-fitted {0} date(s) in {1} tool(s). Items with no date were left blank.
+bulk.applied.term=Set {0} date(s) in {1} tool(s).
+bulk.applied.term.blanks={0} date cell(s) with no existing value were left blank — choose "Fill every item" above and apply again to fill them too.
+bulk.applied.scope=Applied only to: {0}.
+bulk.applied.none=No dates were changed — the selected tools have no matching dates to update.
+bulk.applied.review=Review the changes on the Edit Individual Items tab or with the Visual Preview below, then click Save Changes.
 
 page.import=Import dates
 page.confirm.import=Confirmation: Import dates

--- a/site-manage/datemanager/tool/src/main/resources/Messages.properties
+++ b/site-manage/datemanager/tool/src/main/resources/Messages.properties
@@ -111,6 +111,9 @@ bulk.applied.scope=Applied only to: {0}.
 bulk.applied.none=No dates were changed — the selected tools have no matching dates to update.
 bulk.applied.review=Review the changes on the Edit Individual Items tab or with the Visual Preview below, then click Save Changes.
 
+# Shown briefly after Cancel discards staged edits
+cancel.reverted=All unsaved changes were discarded — dates are back to their last saved values.
+
 page.import=Import dates
 page.confirm.import=Confirmation: Import dates
 page.confirm.import.instruction_0=Are you sure you want to make these changes?

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -138,8 +138,8 @@ DTMN.getFitAnchors = function() {
   if (DTMN.fitFirstHidden.value === "" || DTMN.fitLastHidden.value === "") {
     return null;
   }
-  const first = DTMN.parseDatePickerInputValue(DTMN.fitFirstHidden.value, true);
-  const last = DTMN.parseDatePickerInputValue(DTMN.fitLastHidden.value, true);
+  const first = DTMN.parseInputDateValue(DTMN.fitFirstHidden.value, true);
+  const last = DTMN.parseInputDateValue(DTMN.fitLastHidden.value, true);
   if (!first.isValid() || !last.isValid()) {
     return null;
   }
@@ -387,7 +387,7 @@ DTMN.applyColumnBulkDates = function(button, updates, notModified) {
   }
 
   const useTime = button.dataset.tool !== 'gradebookItems';
-  const date = DTMN.parseDatePickerInputValue(hidden.value, useTime);
+  const date = DTMN.parseInputDateValue(hidden.value, useTime);
   if (!date.isValid()) {
     return;
   }
@@ -505,7 +505,7 @@ DTMN.applyTermDates = function(restrictToExpanded, updates, notModified) {
       return;
     }
 
-    const date = DTMN.parseDatePickerInputValue(hidden.value, true);
+    const date = DTMN.parseInputDateValue(hidden.value, true);
     if (!date.isValid()) {
       return;
     }
@@ -582,6 +582,23 @@ DTMN.parseDatePickerInputValue = function(value, useTime)
 
   DTMN.warnDatePickerTimeZoneFallback("parseDatePickerInputValue", value, useTime);
   return moment(value, formats, true);
+};
+
+// Parse a value read from a localDatePicker "ashidden" iso8601 field. Those fields hold a full
+// ISO8601 string with a timezone offset (e.g. 2026-09-01T09:00:00+02:00), but our strict parser's
+// formats don't include the offset token, so a direct parse is always invalid. Strip the trailing
+// offset (keeping the wall-clock time the user picked), and drop the time entirely for date-only
+// fields, then parse in the user's zone like the rest of the tool.
+DTMN.parseInputDateValue = function(value, useTime)
+{
+  if (!value) {
+    return moment.invalid();
+  }
+  let stripped = value.replace(/([+-]\d{2}:?\d{2}|Z)$/, "");
+  if (!useTime) {
+    stripped = stripped.split("T")[0];
+  }
+  return DTMN.parseDatePickerInputValue(stripped, useTime);
 };
 
 DTMN.hasTime = function(date)

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -502,6 +502,23 @@ DTMN.getTermHiddenId = function(term) {
   return "term-hidden-" + term.replaceAll("_", "-");
 };
 
+// Default term-date -> column mapping applied on load so a fresh Bulk Anchor arrives pre-checked with
+// sane targets: the term's earliest date (Classes Start) fills every open/start column, and the latest
+// (Exam Ends) fills every due/close column. The instructor can tick or untick freely from there.
+DTMN.defaultTermTargets = {
+  classes_start: "open_date",
+  exam_ends: "due_date"
+};
+
+DTMN.applyDefaultTermTargets = function() {
+  Object.keys(DTMN.defaultTermTargets).forEach(function(term) {
+    const field = DTMN.defaultTermTargets[term];
+    document.querySelectorAll('.term-target[data-term="' + term + '"][data-field="' + field + '"]').forEach(function(check) {
+      check.checked = true;
+    });
+  });
+};
+
 DTMN.initTermDates = function(updates, notModified) {
 
   DTMN.termAllBtn = document.getElementById("apply-term-dates-all");
@@ -544,6 +561,7 @@ DTMN.initTermDates = function(updates, notModified) {
     DTMN.handleTermButtonClick(this, true, updates, notModified);
   }, false);
 
+  DTMN.applyDefaultTermTargets();
   DTMN.validateTermInputs();
 };
 

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -1020,7 +1020,7 @@ DTMN.collectPreviewEvents = function() {
     const titleEl = row ? row.querySelector('td a span') : null;
     const itemTitle = titleEl ? titleEl.textContent.trim() : '';
     const fieldLabel = (DTMN.fieldLabels && DTMN.fieldLabels[field]) || field;
-    const timeSuffix = (useTime && DTMN.hasTime(parsed)) ? ' ' + parsed.format('LT') : '';
+    const timeSuffix = (useTime && DTMN.hasTime(parsed)) ? ' ' + parsed.locale(sakai.locale.userLocale).format('LT') : '';
 
     events.push({
       title: (itemTitle ? itemTitle + ' — ' : '') + fieldLabel + timeSuffix,

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -2,7 +2,7 @@ var DTMN = DTMN || {};
 
 DTMN.toolList = [ "assignments", "assessments", "signup", "gradebook", "resources", "calendar", "forums", "announcements", "lessons" ];
 DTMN.collapseElements = [ ];
-DTMN.bulkFields = DTMN.bulkFields || [];
+DTMN.termFields = [ "classes_start", "classes_end", "exam_begins", "exam_ends" ];
 DTMN.nextIndex = -1;
 
 DTMN.initDatePicker = function(updates, notModified) {
@@ -34,14 +34,14 @@ DTMN.initDatePicker = function(updates, notModified) {
 
     collapseElement.addEventListener("shown.bs.collapse", () => {
       DTMN.validateShiftInput();
-      if (DTMN.validateBulkInputs) {
-        DTMN.validateBulkInputs();
+      if (DTMN.validateTermInputs) {
+        DTMN.validateTermInputs();
       }
     });
     collapseElement.addEventListener("hidden.bs.collapse", () => {
       DTMN.validateShiftInput();
-      if (DTMN.validateBulkInputs) {
-        DTMN.validateBulkInputs();
+      if (DTMN.validateTermInputs) {
+        DTMN.validateTermInputs();
       }
     });
   });
@@ -72,45 +72,136 @@ DTMN.initShifter = function(updates, notModified) {
   }, false);
 };
 
-DTMN.initBulkSetter = function(updates, notModified) {
+// Returns true when blank cells should also be filled. When false, only cells that already have a
+// date are overwritten and empty cells are left untouched. Driven by the "bulk-fill-mode" radios.
+DTMN.shouldFillEmptyCells = function() {
+  const selected = document.querySelector('input[name="bulk-fill-mode"]:checked');
+  return !selected || selected.value !== "existing";
+};
 
-  DTMN.bulkErrorBanner = document.getElementById("dateBulkSetterError");
-  DTMN.bulkAllBtn = document.getElementById("applyAllDates");
-  DTMN.bulkVisibleBtn = document.getElementById("applyVisibleDates");
-  DTMN.bulkInputs = Array.from(document.querySelectorAll(".bulk-date-input"));
+// Fill every row of a single column (identified by data-field) within one section with the given date.
+// Always overwrites existing values; honors the global fill mode for blank cells.
+DTMN.fillColumn = function(rootElementId, field, date, updates, notModified) {
 
-  if (!DTMN.bulkAllBtn || !DTMN.bulkVisibleBtn) {
+  const rootElement = "#" + rootElementId;
+
+  DTMN.attachDatePicker(rootElement + " .datepicker:not(.hasDatepicker)", updates, notModified);
+
+  const fillEmpty = DTMN.shouldFillEmptyCells();
+  const hiddenFields = document.querySelectorAll(rootElement + ' tbody input[type=hidden][data-field="' + field + '"]');
+
+  hiddenFields.forEach(function(hiddenField) {
+    const td = hiddenField.closest('td');
+    const datepicker = td ? td.querySelector('input.datepicker') : null;
+
+    if (!datepicker || datepicker.disabled) {
+      return;
+    }
+
+    // "Only cells that already have a date" mode: leave blanks alone.
+    if (!fillEmpty && hiddenField.value === "") {
+      return;
+    }
+
+    const useTime = hiddenField.dataset.tool !== 'gradebookItems';
+    DTMN.setDatePickerValue(datepicker, date, useTime);
+  });
+};
+
+// ----- Per-column bulk setters (one small date input inside each editable column header) -----
+
+DTMN.initColumnBulkSetters = function(updates, notModified) {
+
+  const setters = Array.from(document.querySelectorAll(".bulk-col-setter"));
+  if (setters.length === 0) {
     return;
   }
 
-  if (DTMN.bulkFields.length === 0) {
-    DTMN.bulkFields = Array.from(document.querySelectorAll(".date-manager-setter [data-field]"))
-      .map(function(el) { return el.getAttribute("data-field"); });
-  }
+  setters.forEach(function(setter) {
+    const input = setter.querySelector(".bulk-col-input");
+    const hidden = setter.querySelector(".bulk-col-hidden");
+    const button = setter.querySelector(".bulk-col-apply");
 
-  DTMN.initBulkDatePickers();
+    if (!input || !hidden || !button) {
+      return;
+    }
 
-  DTMN.bulkAllBtn.addEventListener("click", function() {
-    DTMN.handleBulkButtonClick(this, DTMN.collapseElements, updates, notModified);
-  }, false);
+    const useTime = input.dataset.tool !== 'gradebookItems';
+    localDatePicker({
+      input,
+      useTime: useTime ? 1 : 0,
+      parseFormat: useTime ? 'YYYY-MM-DDTHH:mm:ss' : 'YYYY-MM-DD',
+      allowEmptyDate: true,
+      ashidden: {
+        iso8601: hidden.id,
+      }
+    });
 
-  DTMN.bulkVisibleBtn.addEventListener("click", function() {
-    DTMN.handleBulkButtonClick(this, DTMN.findExpandedSections(), updates, notModified);
-  }, false);
+    button.disabled = true;
+    hidden.addEventListener("change", function() {
+      button.disabled = hidden.value === "";
+    }, false);
 
-  DTMN.validateBulkInputs();
+    button.addEventListener("click", function() {
+      DTMN.applyColumnBulkDates(button, updates, notModified);
+    }, false);
+  });
 };
 
-DTMN.initBulkDatePickers = function() {
-  DTMN.bulkFields.forEach(function(field) {
-    const input = document.getElementById(DTMN.getBulkInputId(field));
-    const hidden = document.getElementById(DTMN.getBulkHiddenId(field));
+DTMN.applyColumnBulkDates = function(button, updates, notModified) {
+
+  const setter = button.closest(".bulk-col-setter");
+  const hidden = setter ? setter.querySelector(".bulk-col-hidden") : null;
+  const section = button.closest(".collapse");
+
+  if (!hidden || hidden.value === "" || !section) {
+    return;
+  }
+
+  const useTime = button.dataset.tool !== 'gradebookItems';
+  const date = DTMN.parseDatePickerInputValue(hidden.value, useTime);
+  if (!date.isValid()) {
+    return;
+  }
+
+  button.classList.add("spinButton");
+  button.disabled = true;
+
+  window.setTimeout(function() {
+    DTMN.fillColumn(section.id, button.dataset.field, date, updates, notModified);
+    button.classList.remove("spinButton");
+    button.disabled = hidden.value === "";
+  }, 25);
+};
+
+// ----- Term dates panel (named term dates mapped onto columns via a checkbox matrix) -----
+
+DTMN.getTermInputId = function(term) {
+  return "term-input-" + term.replaceAll("_", "-");
+};
+
+DTMN.getTermHiddenId = function(term) {
+  return "term-hidden-" + term.replaceAll("_", "-");
+};
+
+DTMN.initTermDates = function(updates, notModified) {
+
+  DTMN.termAllBtn = document.getElementById("applyTermDatesAll");
+  DTMN.termVisibleBtn = document.getElementById("applyTermDatesVisible");
+
+  if (!DTMN.termAllBtn || !DTMN.termVisibleBtn) {
+    return;
+  }
+
+  DTMN.termFields.forEach(function(term) {
+    const input = document.getElementById(DTMN.getTermInputId(term));
+    const hidden = document.getElementById(DTMN.getTermHiddenId(term));
 
     if (!input || !hidden) {
       return;
     }
 
-    hidden.addEventListener("change", () => DTMN.validateBulkInputs(), false);
+    hidden.addEventListener("change", () => DTMN.validateTermInputs(), false);
 
     localDatePicker({
       input,
@@ -122,16 +213,91 @@ DTMN.initBulkDatePickers = function() {
       }
     });
   });
+
+  document.querySelectorAll(".term-target").forEach(function(check) {
+    check.addEventListener("change", () => DTMN.validateTermInputs(), false);
+  });
+
+  DTMN.termAllBtn.addEventListener("click", function() {
+    DTMN.handleTermButtonClick(this, false, updates, notModified);
+  }, false);
+
+  DTMN.termVisibleBtn.addEventListener("click", function() {
+    DTMN.handleTermButtonClick(this, true, updates, notModified);
+  }, false);
+
+  DTMN.validateTermInputs();
 };
 
-DTMN.getBulkInputId = function(field)
-{
-  return "bulk-" + field.replaceAll("_", "-");
+// A term date is actionable only when it has both a date AND at least one target column ticked.
+DTMN.termHasActionableInput = function() {
+  return DTMN.termFields.some(function(term) {
+    const hidden = document.getElementById(DTMN.getTermHiddenId(term));
+    if (!hidden || hidden.value === "") {
+      return false;
+    }
+    return document.querySelector('.term-target[data-term="' + term + '"]:checked') !== null;
+  });
 };
 
-DTMN.getBulkHiddenId = function(field)
-{
-  return "bulk-hidden-" + field.replaceAll("_", "-");
+DTMN.validateTermInputs = function() {
+  if (!DTMN.termAllBtn || !DTMN.termVisibleBtn) {
+    return;
+  }
+
+  const actionable = DTMN.termHasActionableInput();
+  DTMN.termAllBtn.disabled = !actionable;
+  DTMN.termVisibleBtn.disabled = !actionable || DTMN.findExpandedSections().length === 0;
+};
+
+DTMN.handleTermButtonClick = function(button, restrictToExpanded, updates, notModified) {
+
+  if (!DTMN.termHasActionableInput()) {
+    return;
+  }
+
+  button.classList.add("spinButton");
+  DTMN.termAllBtn.disabled = true;
+  DTMN.termVisibleBtn.disabled = true;
+
+  window.setTimeout(function() {
+    DTMN.applyTermDates(restrictToExpanded, updates, notModified);
+    button.classList.remove("spinButton");
+    DTMN.validateTermInputs();
+  }, 25);
+};
+
+DTMN.applyTermDates = function(restrictToExpanded, updates, notModified) {
+
+  // Process term dates top-to-bottom so that when two term dates target the same column,
+  // the lower one in the panel wins (applied last).
+  DTMN.termFields.forEach(function(term) {
+    const hidden = document.getElementById(DTMN.getTermHiddenId(term));
+    if (!hidden || hidden.value === "") {
+      return;
+    }
+
+    const date = DTMN.parseDatePickerInputValue(hidden.value, true);
+    if (!date.isValid()) {
+      return;
+    }
+
+    const checks = document.querySelectorAll('.term-target[data-term="' + term + '"]:checked');
+    checks.forEach(function(check) {
+      const root = check.dataset.root;
+      const field = check.dataset.field;
+      const sectionEl = document.getElementById(root);
+
+      if (!sectionEl) {
+        return;
+      }
+      if (restrictToExpanded && !sectionEl.classList.contains("show")) {
+        return;
+      }
+
+      DTMN.fillColumn(root, field, date, updates, notModified);
+    });
+  });
 };
 
 DTMN.getUserTimeZone = function()
@@ -224,7 +390,7 @@ DTMN.attachDatePicker = function (selector, updates, notModified) {
     var dataIdx = $hidden.data('idx');
     var $clearBtn = $(elt).siblings('a');
 
-    if (dataTool === 'assessments' || dataTool === 'gradebookItems' || dataTool === 'resources' || dataTool === 'forums' || dataTool === 'lessons' 
+    if (dataTool === 'assessments' || dataTool === 'gradebookItems' || dataTool === 'resources' || dataTool === 'forums' || dataTool === 'lessons'
        || dataTool === 'announcements' || dataTool === 'assignments' || dataTool === 'signupMeetings' || dataTool === 'calendarEvents') {
        $clearBtn.addClass('ui-datepicker-clear-date');
        $clearBtn.show();
@@ -240,9 +406,9 @@ DTMN.attachDatePicker = function (selector, updates, notModified) {
       $(this).parent().children('.form-control.datepicker.hasDatepicker').val('');
       // clear date on hidden element
       $(this).nextAll('input').val('');
-      // force event for hidden element so that clear btn will follow same update logic as backspace/delete in datapicker 
+      // force event for hidden element so that clear btn will follow same update logic as backspace/delete in datapicker
       $(this).nextAll('input').trigger('change');
-    } 
+    }
   });
 
     $hidden.on('change', function () {
@@ -301,7 +467,7 @@ DTMN.attachDatePicker = function (selector, updates, notModified) {
       }
     };
     // Allow null dates during editing then enforce rules for required fields serverside
-    if (dataTool === 'assessments' || dataTool === 'gradebookItems' || dataTool === 'resources' || dataTool === 'forums' || dataTool === 'lessons' 
+    if (dataTool === 'assessments' || dataTool === 'gradebookItems' || dataTool === 'resources' || dataTool === 'forums' || dataTool === 'lessons'
        || dataTool === 'announcements' || dataTool === 'assignments' || dataTool === 'signupMeetings' || dataTool === 'calendarEvents') {
       datepickerOpts.allowEmptyDate = true;
     }
@@ -354,36 +520,6 @@ DTMN.handleShiftButtonClick = function(button, collapseElements, updates, notMod
   }, 25);
 };
 
-DTMN.handleBulkButtonClick = function(button, collapseElements, updates, notModified)
-{
-  const hasValue = DTMN.bulkFields.some(function(field) {
-    const hidden = document.getElementById(DTMN.getBulkHiddenId(field));
-    return hidden && hidden.value !== "";
-  });
-
-  if (!hasValue) {
-    DTMN.showBulkError();
-    DTMN.validateBulkInputs();
-    return;
-  }
-
-  DTMN.hideBulkError();
-  DTMN.disableBulkControls(button);
-  window.setTimeout(function()
-  {
-    if (collapseElements.length === 0)
-    {
-      DTMN.enableBulkControls(button);
-      return;
-    }
-
-    for (let i = 0; i < collapseElements.length; i++)
-    {
-      window.setTimeout(function() { DTMN.applyBulkDates(updates, notModified, collapseElements[i].id, button, i === collapseElements.length - 1); }, 10);
-    }
-  }, 25);
-};
-
 DTMN.validateShiftInput = function()
 {
   const val = DTMN.shiftInput.value;
@@ -413,25 +549,6 @@ DTMN.findExpandedSections = function()
   return DTMN.collapseElements.filter(function (e) { return e.classList.contains("show") === true; });
 };
 
-DTMN.validateBulkInputs = function()
-{
-  if (!DTMN.bulkAllBtn || !DTMN.bulkVisibleBtn) {
-    return;
-  }
-
-  const hasValue = DTMN.bulkFields.some(function(field) {
-    const hidden = document.getElementById(DTMN.getBulkHiddenId(field));
-    return hidden && hidden.value !== "";
-  });
-
-  if (hasValue) {
-    DTMN.hideBulkError();
-  }
-
-  DTMN.bulkAllBtn.disabled = !hasValue;
-  DTMN.bulkVisibleBtn.disabled = !hasValue || DTMN.findExpandedSections().length === 0;
-};
-
 DTMN.hideShiftError = function()
 {
   DTMN.shiftErrorBanner.classList.add("d-none");
@@ -442,24 +559,6 @@ DTMN.showShiftError = function()
 {
   DTMN.shiftErrorBanner.classList.remove("d-none");
   DTMN.shiftErrorBanner.setAttribute("role", "alert");
-};
-
-DTMN.hideBulkError = function()
-{
-  DTMN.activeBulkError = null;
-  DTMN.bulkErrorBanner.classList.add("d-none");
-  DTMN.bulkErrorBanner.removeAttribute("role");
-};
-
-DTMN.showBulkError = function(errorType)
-{
-  errorType = errorType || "empty";
-  DTMN.activeBulkError = errorType;
-  DTMN.bulkErrorBanner.querySelectorAll("[data-error]").forEach(function(error) {
-    error.classList.toggle("d-none", error.dataset.error !== errorType);
-  });
-  DTMN.bulkErrorBanner.classList.remove("d-none");
-  DTMN.bulkErrorBanner.setAttribute("role", "alert");
 };
 
 DTMN.disableShiftControls = function(button)
@@ -475,41 +574,11 @@ DTMN.disableShiftButtons = function()
   DTMN.shiftVisibleBtn.disabled = true;
 };
 
-DTMN.disableBulkControls = function(button)
-{
-  DTMN.bulkInputs.forEach(function(input) {
-    input.disabled = true;
-  });
-  DTMN.disableBulkButtons();
-  button.classList.add("spinButton");
-};
-
-DTMN.disableBulkButtons = function()
-{
-  DTMN.bulkAllBtn.disabled = true;
-  DTMN.bulkVisibleBtn.disabled = true;
-};
-
-DTMN.enableBulkButtons = function()
-{
-  DTMN.bulkAllBtn.disabled = false;
-  DTMN.bulkVisibleBtn.disabled = DTMN.findExpandedSections().length === 0;
-};
-
 DTMN.enableShiftControls = function(button)
 {
   button.classList.remove("spinButton");
   DTMN.validateShiftInput();
   DTMN.shiftInput.disabled = false;
-};
-
-DTMN.enableBulkControls = function(button)
-{
-  button.classList.remove("spinButton");
-  DTMN.bulkInputs.forEach(function(input) {
-    input.disabled = false;
-  });
-  DTMN.validateBulkInputs();
 };
 
 DTMN.clearChangedDateIndication = function() {
@@ -574,47 +643,5 @@ DTMN.shiftDates = function (updates, notModified, rootElementId, button, enableB
   if (enableButton)
   {
     DTMN.enableShiftControls(button);
-  }
-};
-
-DTMN.applyBulkDates = function (updates, notModified, rootElementId, button, enableButton) {
-
-  const rootElement = "#" + rootElementId;
-
-  DTMN.attachDatePicker(rootElement + " .datepicker:not(.hasDatepicker)", updates, notModified);
-
-  DTMN.bulkFields.forEach(function(field) {
-    const bulkInput = document.getElementById(DTMN.getBulkInputId(field));
-    const bulkHidden = document.getElementById(DTMN.getBulkHiddenId(field));
-
-    if (!bulkInput || !bulkHidden || bulkHidden.value === "") {
-      return;
-    }
-
-    const bulkDate = DTMN.parseDatePickerInputValue(bulkInput.value, true);
-
-    if (!bulkDate.isValid()) {
-      return;
-    }
-
-    const hiddenFields = document.querySelectorAll(rootElement + ' input[type=hidden][data-field="' + field + '"]');
-    hiddenFields.forEach(function(hiddenField) {
-      const td = hiddenField.closest('td');
-      const datepicker = td ? td.querySelector('input.datepicker') : null;
-
-      if (!datepicker || datepicker.disabled) {
-        return;
-      }
-
-      const dataTool = hiddenField.dataset.tool;
-      const useTime = dataTool !== 'gradebookItems';
-
-      DTMN.setDatePickerValue(datepicker, bulkDate, useTime);
-    });
-  });
-
-  if (enableButton)
-  {
-    DTMN.enableBulkControls(button);
   }
 };

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -978,3 +978,125 @@ DTMN.shiftDates = function (updates, notModified, rootElementId, button, enableB
     DTMN.enableShiftControls(button);
   }
 };
+
+// ---------------------------------------------------------------------------
+// Calendar preview: a read-only month grid that plots every date currently
+// entered in the tables (one marker per date field) so the user can visually
+// check the outcome of a shift/fit/anchor before choosing Save Changes.
+// ---------------------------------------------------------------------------
+
+// Accent colour per tool, so markers are visually grouped by tool type.
+DTMN.previewToolColors = {
+  assignments:    "#0d6efd",
+  assessments:    "#6f42c1",
+  gradebookItems: "#198754",
+  signupMeetings: "#fd7e14",
+  resources:      "#20c997",
+  calendarEvents: "#0dcaf0",
+  forums:         "#d63384",
+  announcements:  "#dc3545",
+  lessons:        "#6c757d"
+};
+
+// Read the live hidden-input values and build one FullCalendar event per non-empty
+// date. Events are all-day and keyed on the calendar day so they land squarely in the
+// day cell regardless of time zone; the time (when present) is shown in the marker text.
+DTMN.collectPreviewEvents = function() {
+  const events = [];
+  document.querySelectorAll('input[type=hidden][data-tool][data-field]').forEach(function(hidden) {
+    const value = hidden.value;
+    if (!value) {
+      return;
+    }
+    const tool = hidden.getAttribute('data-tool');
+    const field = hidden.getAttribute('data-field');
+    const useTime = tool !== 'gradebookItems';
+    const parsed = DTMN.parseInputDateValue(value, useTime);
+    if (!parsed || !parsed.isValid()) {
+      return;
+    }
+
+    const row = hidden.closest('tr');
+    const titleEl = row ? row.querySelector('td a span') : null;
+    const itemTitle = titleEl ? titleEl.textContent.trim() : '';
+    const fieldLabel = (DTMN.fieldLabels && DTMN.fieldLabels[field]) || field;
+    const timeSuffix = (useTime && DTMN.hasTime(parsed)) ? ' ' + parsed.format('LT') : '';
+
+    events.push({
+      title: (itemTitle ? itemTitle + ' — ' : '') + fieldLabel + timeSuffix,
+      start: parsed.format('YYYY-MM-DD'),
+      allDay: true,
+      color: DTMN.previewToolColors[tool] || '#6c757d'
+    });
+  });
+  return events;
+};
+
+DTMN.renderCalendarPreview = function() {
+  const events = DTMN.collectPreviewEvents();
+  const emptyMsg = document.getElementById('datemanager-calendar-empty');
+  const calendarEl = document.getElementById('datemanager-calendar');
+  if (!calendarEl) {
+    return;
+  }
+
+  if (!events.length) {
+    emptyMsg && emptyMsg.classList.remove('d-none');
+    calendarEl.classList.add('d-none');
+    return;
+  }
+  emptyMsg && emptyMsg.classList.add('d-none');
+  calendarEl.classList.remove('d-none');
+
+  const locale = (sakai && sakai.locale && sakai.locale.userLanguage) || 'en';
+
+  if (!DTMN.previewCalendar) {
+    DTMN.previewCalendar = new FullCalendar.Calendar(calendarEl, {
+      initialView: 'dayGridMonth',
+      themeSystem: 'bootstrap5',
+      locale: locale,
+      displayEventTime: false,
+      height: 'auto',
+      headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: ''
+      },
+      buttonIcons: {
+        prev: 'chevron-left',
+        next: 'chevron-right'
+      },
+      events: events
+    });
+    DTMN.previewCalendar.render();
+  } else {
+    DTMN.previewCalendar.removeAllEvents();
+    DTMN.previewCalendar.addEventSource(events);
+    DTMN.previewCalendar.updateSize();
+  }
+
+  // Open on the earliest date so the first populated month is visible immediately.
+  const earliest = events.reduce(function(min, ev) {
+    return (min === null || ev.start < min) ? ev.start : min;
+  }, null);
+  if (earliest) {
+    DTMN.previewCalendar.gotoDate(earliest);
+  }
+};
+
+DTMN.initCalendarPreview = function() {
+  const button = document.getElementById('datemanager-preview');
+  const modalEl = document.getElementById('modal-calendar-preview');
+  if (!button || !modalEl) {
+    return;
+  }
+
+  button.addEventListener('click', function() {
+    bootstrap.Modal.getOrCreateInstance(modalEl).show();
+  });
+
+  // Render only once the modal is visible so FullCalendar can measure the container.
+  modalEl.addEventListener('shown.bs.modal', function() {
+    DTMN.renderCalendarPreview();
+  });
+};

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -78,6 +78,98 @@ DTMN.initShifter = function(updates, notModified) {
   }, false);
 };
 
+// ----- Date difference helper: whole days between two dates, loaded into the shift field -----
+
+// Pure: signed whole days from `from` to `to` (to - from), counting calendar days, ignoring time of day.
+DTMN.computeDayDiff = function(from, to) {
+  return to.clone().startOf("day").diff(from.clone().startOf("day"), "days");
+};
+
+DTMN.initDateDiff = function() {
+
+  DTMN.diffFromInput = document.getElementById("date-diff-from");
+  DTMN.diffFromHidden = document.getElementById("date-diff-from-hidden");
+  DTMN.diffToInput = document.getElementById("date-diff-to");
+  DTMN.diffToHidden = document.getElementById("date-diff-to-hidden");
+  DTMN.diffApplyBtn = document.getElementById("date-diff-apply");
+  DTMN.diffResult = document.getElementById("date-diff-result");
+
+  if (!DTMN.diffApplyBtn || !DTMN.diffFromHidden || !DTMN.diffToHidden) {
+    return;
+  }
+
+  [[DTMN.diffFromInput, DTMN.diffFromHidden], [DTMN.diffToInput, DTMN.diffToHidden]].forEach(function(pair) {
+    const input = pair[0];
+    const hidden = pair[1];
+    if (!input || !hidden) {
+      return;
+    }
+    localDatePicker({
+      input,
+      useTime: 0,
+      parseFormat: 'YYYY-MM-DD',
+      allowEmptyDate: true,
+      ashidden: {
+        iso8601: hidden.id,
+      }
+    });
+    hidden.addEventListener("change", () => DTMN.validateDateDiff(), false);
+  });
+
+  DTMN.diffApplyBtn.addEventListener("click", () => DTMN.applyDateDiff(), false);
+
+  DTMN.validateDateDiff();
+};
+
+// Returns the whole-day difference when both dates are present and valid, else null.
+DTMN.getDateDiffDays = function() {
+  if (!DTMN.diffFromHidden || !DTMN.diffToHidden) {
+    return null;
+  }
+  if (DTMN.diffFromHidden.value === "" || DTMN.diffToHidden.value === "") {
+    return null;
+  }
+  const from = DTMN.parseInputDateValue(DTMN.diffFromHidden.value, false);
+  const to = DTMN.parseInputDateValue(DTMN.diffToHidden.value, false);
+  if (!from.isValid() || !to.isValid()) {
+    return null;
+  }
+  return DTMN.computeDayDiff(from, to);
+};
+
+// Show the count live as soon as both dates are valid, and enable the "use as shift" button.
+DTMN.validateDateDiff = function() {
+  if (!DTMN.diffApplyBtn) {
+    return;
+  }
+
+  const days = DTMN.getDateDiffDays();
+  DTMN.diffApplyBtn.disabled = days === null;
+
+  if (DTMN.diffResult) {
+    if (days === null) {
+      DTMN.diffResult.textContent = "";
+    } else {
+      const template = DTMN.diffResult.dataset.template || "{0}";
+      DTMN.diffResult.textContent = template.replace("{0}", days);
+    }
+  }
+};
+
+DTMN.applyDateDiff = function() {
+  const days = DTMN.getDateDiffDays();
+  if (days === null) {
+    return;
+  }
+
+  // Load the day count into the shift field and let the shifter's own validation enable its buttons.
+  const shiftInput = document.getElementById("dateShifterDays");
+  if (shiftInput) {
+    shiftInput.value = days;
+    DTMN.validateShiftInput();
+  }
+};
+
 // ----- Re-anchor / fit dates between a new first and last date -----
 //
 // Unlike the offset shifter (which adds a constant number of days and lets the end float), the fitter

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -199,14 +199,6 @@ DTMN.handleFitButtonClick = function(button, restrictToExpanded, updates, notMod
   }, 25);
 };
 
-DTMN.momentInUserZone = function(ms) {
-  const userTimeZone = DTMN.getUserTimeZone();
-  if (moment.tz && userTimeZone) {
-    return moment.tz(ms, userTimeZone);
-  }
-  return moment(ms);
-};
-
 // Move `target` to the nearest day (within +/- 3 days) that shares `source`'s weekday, carrying
 // `source`'s clock time. Two items that share a weekday therefore stay a whole number of weeks apart.
 DTMN.snapToSourceWeekday = function(target, source) {
@@ -248,7 +240,7 @@ DTMN.computeFittedDate = function(currentMs, oldStartMs, oldSpan, anchors, snap,
 
   const newStartMs = anchors.first.valueOf();
   const newSpan = anchors.last.valueOf() - newStartMs;
-  const target = DTMN.momentInUserZone(newStartMs + frac * newSpan);
+  const target = moment(newStartMs + frac * newSpan);
   return snap ? DTMN.snapToSourceWeekday(target, sourceMoment) : target;
 };
 
@@ -534,67 +526,31 @@ DTMN.applyTermDates = function(restrictToExpanded, updates, notModified) {
   });
 };
 
-DTMN.getUserTimeZone = function()
-{
-  const userTimeZone = globalThis.sakai?.locale?.userTimeZone;
-  if (!userTimeZone && DTMN.warnDatePickerTimeZoneFallback) {
-    DTMN.warnDatePickerTimeZoneFallback("getUserTimeZone");
-  }
-  return userTimeZone || null;
-};
-
-DTMN.warnDatePickerTimeZoneFallback = function(functionName, value, useTime)
-{
-  const warningFlag = "_" + functionName + "TimeZoneFallbackWarned";
-  if (DTMN[warningFlag]) {
-    return;
-  }
-
-  DTMN[warningFlag] = true;
-  console.warn(functionName + " falling back to browser timezone because moment-timezone or sakai.locale.userTimeZone is unavailable.", {value, useTime});
-};
-
+// These helpers deliberately do NO timezone conversion. Sakai treats picker values as wall-clock and
+// resolves the timezone server-side: UserTimeService.parseISODateInUserTimezone() truncates the value
+// to its first 19 chars (StringUtils.left(value, 19)), discards any browser offset, and interprets the
+// wall-clock in the user's Sakai timezone. So the client just parses, formats, and does calendar math
+// on the wall-clock fields and hands a bare wall-clock string back for the backend to interpret.
 DTMN.getDatePickerInputValue = function(date, useTime)
 {
-  const userTimeZone = DTMN.getUserTimeZone();
-  let userDate = date;
-  if (moment.tz && userTimeZone) {
-    userDate = date.clone().tz(userTimeZone);
-  } else {
-    DTMN.warnDatePickerTimeZoneFallback("getDatePickerInputValue", date && date.format ? date.format() : date, useTime);
-  }
-  return useTime ? userDate.format("YYYY-MM-DDTHH:mm") : userDate.format("YYYY-MM-DD");
+  return useTime ? date.format("YYYY-MM-DDTHH:mm") : date.format("YYYY-MM-DD");
 };
 
 DTMN.getHiddenDateValue = function(date, useTime)
 {
-  const userTimeZone = DTMN.getUserTimeZone();
-  let userDate = date;
-  if (moment.tz && userTimeZone) {
-    userDate = date.clone().tz(userTimeZone);
-  } else {
-    DTMN.warnDatePickerTimeZoneFallback("getHiddenDateValue", date && date.format ? date.format() : date, useTime);
-  }
-  return useTime ? userDate.format("YYYY-MM-DDTHH:mm:ss") : userDate.format("YYYY-MM-DD");
+  return useTime ? date.format("YYYY-MM-DDTHH:mm:ss") : date.format("YYYY-MM-DD");
 };
 
 DTMN.parseDatePickerInputValue = function(value, useTime)
 {
   const formats = useTime ? ["YYYY-MM-DDTHH:mm:ss", "YYYY-MM-DDTHH:mm", "YYYY-MM-DD"] : "YYYY-MM-DD";
-  const userTimeZone = DTMN.getUserTimeZone();
-  if (moment.tz && userTimeZone) {
-    return moment.tz(value, formats, true, userTimeZone);
-  }
-
-  DTMN.warnDatePickerTimeZoneFallback("parseDatePickerInputValue", value, useTime);
   return moment(value, formats, true);
 };
 
-// Parse a value read from a localDatePicker "ashidden" iso8601 field. Those fields hold a full
-// ISO8601 string with a timezone offset (e.g. 2026-09-01T09:00:00+02:00), but our strict parser's
-// formats don't include the offset token, so a direct parse is always invalid. Strip the trailing
-// offset (keeping the wall-clock time the user picked), and drop the time entirely for date-only
-// fields, then parse in the user's zone like the rest of the tool.
+// Parse a value read from a localDatePicker "ashidden" iso8601 field. Those fields hold a full ISO8601
+// string with the browser's offset (e.g. 2026-09-01T09:00:00+02:00). We strip the trailing offset to
+// recover the wall-clock the user picked - the same thing the backend does with StringUtils.left(.,19) -
+// and drop the time entirely for date-only fields, then parse the wall-clock with no timezone applied.
 DTMN.parseInputDateValue = function(value, useTime)
 {
   if (!value) {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -37,11 +37,17 @@ DTMN.initDatePicker = function(updates, notModified) {
       if (DTMN.validateTermInputs) {
         DTMN.validateTermInputs();
       }
+      if (DTMN.validateFitInputs) {
+        DTMN.validateFitInputs();
+      }
     });
     collapseElement.addEventListener("hidden.bs.collapse", () => {
       DTMN.validateShiftInput();
       if (DTMN.validateTermInputs) {
         DTMN.validateTermInputs();
+      }
+      if (DTMN.validateFitInputs) {
+        DTMN.validateFitInputs();
       }
     });
   });
@@ -70,6 +76,228 @@ DTMN.initShifter = function(updates, notModified) {
   DTMN.shiftVisibleBtn.addEventListener("click", function() {
     DTMN.handleShiftButtonClick(this, DTMN.findExpandedSections(), updates, notModified);
   }, false);
+};
+
+// ----- Re-anchor / fit dates between a new first and last date -----
+//
+// Unlike the offset shifter (which adds a constant number of days and lets the end float), the fitter
+// pins the earliest dated item to the entered "new first" date and the latest to the entered "new last"
+// date, then spreads everything in between proportionally. With "Snap to weeks" on, each in-between item
+// keeps its own weekday and clock time and only moves by whole weeks, so the weekly cadence of a copied
+// course survives the move into a shorter or longer term. The fitter only ever rewrites cells that
+// already hold a date - it never fills blanks.
+
+DTMN.initFitter = function(updates, notModified) {
+
+  DTMN.fitErrorBanner = document.getElementById("dateFitError");
+  DTMN.fitFirstInput = document.getElementById("dateFitFirst");
+  DTMN.fitFirstHidden = document.getElementById("dateFitFirstHidden");
+  DTMN.fitLastInput = document.getElementById("dateFitLast");
+  DTMN.fitLastHidden = document.getElementById("dateFitLastHidden");
+  DTMN.fitSnapCheckbox = document.getElementById("dateFitSnap");
+  DTMN.fitAllBtn = document.getElementById("fitAllDates");
+  DTMN.fitVisibleBtn = document.getElementById("fitVisibleDates");
+
+  if (!DTMN.fitAllBtn || !DTMN.fitVisibleBtn || !DTMN.fitFirstHidden || !DTMN.fitLastHidden) {
+    return;
+  }
+
+  [[DTMN.fitFirstInput, DTMN.fitFirstHidden], [DTMN.fitLastInput, DTMN.fitLastHidden]].forEach(function(pair) {
+    const input = pair[0];
+    const hidden = pair[1];
+    if (!input || !hidden) {
+      return;
+    }
+    localDatePicker({
+      input,
+      useTime: 1,
+      parseFormat: 'YYYY-MM-DDTHH:mm:ss',
+      allowEmptyDate: true,
+      ashidden: {
+        iso8601: hidden.id,
+      }
+    });
+    hidden.addEventListener("change", () => DTMN.validateFitInputs(), false);
+  });
+
+  DTMN.fitAllBtn.addEventListener("click", function() {
+    DTMN.handleFitButtonClick(this, false, updates, notModified);
+  }, false);
+
+  DTMN.fitVisibleBtn.addEventListener("click", function() {
+    DTMN.handleFitButtonClick(this, true, updates, notModified);
+  }, false);
+
+  DTMN.validateFitInputs();
+};
+
+DTMN.getFitAnchors = function() {
+  if (!DTMN.fitFirstHidden || !DTMN.fitLastHidden) {
+    return null;
+  }
+  if (DTMN.fitFirstHidden.value === "" || DTMN.fitLastHidden.value === "") {
+    return null;
+  }
+  const first = DTMN.parseDatePickerInputValue(DTMN.fitFirstHidden.value, true);
+  const last = DTMN.parseDatePickerInputValue(DTMN.fitLastHidden.value, true);
+  if (!first.isValid() || !last.isValid()) {
+    return null;
+  }
+  return { first, last };
+};
+
+DTMN.validateFitInputs = function() {
+  if (!DTMN.fitAllBtn || !DTMN.fitVisibleBtn) {
+    return;
+  }
+
+  const anchors = DTMN.getFitAnchors();
+  const rangeOk = anchors !== null && anchors.last.valueOf() > anchors.first.valueOf();
+
+  // Surface the ordering error only once both dates are present but out of order.
+  if (anchors !== null && !rangeOk) {
+    DTMN.showFitError();
+  } else {
+    DTMN.hideFitError();
+  }
+
+  DTMN.fitAllBtn.disabled = !rangeOk;
+  DTMN.fitVisibleBtn.disabled = !rangeOk || DTMN.findExpandedSections().length === 0;
+};
+
+DTMN.showFitError = function() {
+  if (!DTMN.fitErrorBanner) {
+    return;
+  }
+  DTMN.fitErrorBanner.classList.remove("d-none");
+  DTMN.fitErrorBanner.setAttribute("role", "alert");
+};
+
+DTMN.hideFitError = function() {
+  if (!DTMN.fitErrorBanner) {
+    return;
+  }
+  DTMN.fitErrorBanner.classList.add("d-none");
+  DTMN.fitErrorBanner.removeAttribute("role");
+};
+
+DTMN.handleFitButtonClick = function(button, restrictToExpanded, updates, notModified) {
+
+  const anchors = DTMN.getFitAnchors();
+  if (!anchors || anchors.last.valueOf() <= anchors.first.valueOf()) {
+    return;
+  }
+
+  button.classList.add("spinButton");
+  DTMN.fitAllBtn.disabled = true;
+  DTMN.fitVisibleBtn.disabled = true;
+
+  window.setTimeout(function() {
+    DTMN.fitDates(anchors, restrictToExpanded, updates, notModified);
+    button.classList.remove("spinButton");
+    DTMN.validateFitInputs();
+  }, 25);
+};
+
+DTMN.momentInUserZone = function(ms) {
+  const userTimeZone = DTMN.getUserTimeZone();
+  if (moment.tz && userTimeZone) {
+    return moment.tz(ms, userTimeZone);
+  }
+  return moment(ms);
+};
+
+// Move `target` to the nearest day (within +/- 3 days) that shares `source`'s weekday, carrying
+// `source`'s clock time. Two items that share a weekday therefore stay a whole number of weeks apart.
+DTMN.snapToSourceWeekday = function(target, source) {
+  const result = target.clone();
+  result.hours(source.hours());
+  result.minutes(source.minutes());
+  result.seconds(source.seconds());
+  result.milliseconds(0);
+
+  let deltaDays = source.day() - result.day();
+  if (deltaDays > 3) {
+    deltaDays -= 7;
+  } else if (deltaDays < -3) {
+    deltaDays += 7;
+  }
+  if (deltaDays !== 0) {
+    result.add(deltaDays, "days");
+  }
+  return result;
+};
+
+DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
+
+  const sections = restrictToExpanded ? DTMN.findExpandedSections() : DTMN.collapseElements;
+  if (sections.length === 0) {
+    return;
+  }
+
+  // Pass 1: initialise every in-scope datepicker, then collect the editable, populated cells together
+  // with their current moment value. All sections share one timeline so the span is computed globally.
+  const cells = [];
+  sections.forEach(function(section) {
+    const rootElement = "#" + section.id;
+    DTMN.attachDatePicker(rootElement + " .datepicker:not(.hasDatepicker)", updates, notModified);
+
+    document.querySelectorAll(rootElement + " .datepicker.hasDatepicker").forEach(function(datepicker) {
+      if (datepicker.disabled || !datepicker.value) {
+        return;
+      }
+      const td = datepicker.closest("td");
+      const hiddenField = td ? td.querySelector("input[type=hidden]") : null;
+      if (!hiddenField) {
+        return;
+      }
+      const useTime = hiddenField.dataset.tool !== "gradebookItems";
+      const current = DTMN.parseDatePickerInputValue(datepicker.value, useTime);
+      if (!current.isValid()) {
+        return;
+      }
+      cells.push({ datepicker, useTime, current, currentMs: current.valueOf() });
+    });
+  });
+
+  if (cells.length === 0) {
+    return;
+  }
+
+  let oldStartMs = cells[0].currentMs;
+  let oldEndMs = cells[0].currentMs;
+  cells.forEach(function(cell) {
+    if (cell.currentMs < oldStartMs) { oldStartMs = cell.currentMs; }
+    if (cell.currentMs > oldEndMs) { oldEndMs = cell.currentMs; }
+  });
+
+  const newStartMs = anchors.first.valueOf();
+  const newSpan = anchors.last.valueOf() - newStartMs;
+  const oldSpan = oldEndMs - oldStartMs;
+  const snap = DTMN.fitSnapCheckbox ? DTMN.fitSnapCheckbox.checked : false;
+
+  // Pass 2: map each cell onto the new range. The earliest cell lands exactly on the new first date and
+  // the latest exactly on the new last date; everything between is placed proportionally, then snapped.
+  cells.forEach(function(cell) {
+    let newDate;
+
+    if (oldSpan <= 0) {
+      // Degenerate: every date is identical, so there is no span to preserve - collapse onto the start.
+      newDate = anchors.first.clone();
+    } else {
+      const frac = (cell.currentMs - oldStartMs) / oldSpan;
+      if (frac <= 0) {
+        newDate = anchors.first.clone();
+      } else if (frac >= 1) {
+        newDate = anchors.last.clone();
+      } else {
+        const target = DTMN.momentInUserZone(newStartMs + frac * newSpan);
+        newDate = snap ? DTMN.snapToSourceWeekday(target, cell.current) : target;
+      }
+    }
+
+    DTMN.setDatePickerValue(cell.datepicker, newDate, cell.useTime);
+  });
 };
 
 // Returns true when blank cells should also be filled. When false, only cells that already have a

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -138,13 +138,15 @@ DTMN.getDateDiffDays = function() {
 };
 
 // Show the count live as soon as both dates are valid, and enable the "use as shift" button.
+// The button stays disabled for a zero-day difference (nothing to shift) and for spans beyond
+// what the shifter accepts (+/-9999 days), so it can never load a value the shifter dead-ends on.
 DTMN.validateDateDiff = function() {
   if (!DTMN.diffApplyBtn) {
     return;
   }
 
   const days = DTMN.getDateDiffDays();
-  DTMN.diffApplyBtn.disabled = days === null;
+  DTMN.diffApplyBtn.disabled = days === null || days === 0 || days < -9999 || days > 9999;
 
   if (DTMN.diffResult) {
     if (days === null) {
@@ -336,6 +338,37 @@ DTMN.computeFittedDate = function(currentMs, oldStartMs, oldSpan, anchors, snap,
   return snap ? DTMN.snapToSourceWeekday(target, sourceMoment) : target;
 };
 
+// Map every cell of one item (table row) onto the new range. Snapping is decided per row, not per
+// cell: each cell is snapped independently first, but if that would reorder the row's own dates
+// (an open/due pair can invert under heavy term compression, which the server rejects on save) or
+// push a date outside the new [first, last] window, the whole row falls back to the plain
+// proportional placement, which preserves both by construction. Pure (no DOM). `rowCells` entries
+// need `current` (moment) and `currentMs`; returns one new moment per cell, in the same order.
+DTMN.computeRowFittedDates = function(rowCells, oldStartMs, oldSpan, anchors, snap) {
+  const proportional = rowCells.map(cell =>
+      DTMN.computeFittedDate(cell.currentMs, oldStartMs, oldSpan, anchors, false, cell.current));
+  if (!snap) {
+    return proportional;
+  }
+
+  const snapped = rowCells.map(cell =>
+      DTMN.computeFittedDate(cell.currentMs, oldStartMs, oldSpan, anchors, true, cell.current));
+  const firstMs = anchors.first.valueOf();
+  const lastMs = anchors.last.valueOf();
+  for (let i = 0; i < rowCells.length; i++) {
+    const snappedMs = snapped[i].valueOf();
+    if (snappedMs < firstMs || snappedMs > lastMs) {
+      return proportional;
+    }
+    for (let j = 0; j < rowCells.length; j++) {
+      if (rowCells[i].currentMs < rowCells[j].currentMs && snappedMs > snapped[j].valueOf()) {
+        return proportional;
+      }
+    }
+  }
+  return snapped;
+};
+
 DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
 
   const sections = restrictToExpanded ? DTMN.findExpandedSections() : DTMN.collapseElements;
@@ -364,7 +397,7 @@ DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
       if (!current.isValid()) {
         return;
       }
-      cells.push({ datepicker, useTime, current, currentMs: current.valueOf() });
+      cells.push({ datepicker, useTime, current, currentMs: current.valueOf(), row: datepicker.closest("tr") });
     });
   });
 
@@ -382,11 +415,23 @@ DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
   const oldSpan = oldEndMs - oldStartMs;
   const snap = DTMN.fitSnapCheckbox ? DTMN.fitSnapCheckbox.checked : false;
 
-  // Pass 2: map each cell onto the new range. The earliest cell lands exactly on the new first date and
-  // the latest exactly on the new last date; everything between is placed proportionally, then snapped.
+  // Pass 2: map each item's cells onto the new range, one row at a time. The earliest cell lands
+  // exactly on the new first date and the latest exactly on the new last date; everything between
+  // is placed proportionally, then snapped - unless snapping would corrupt the row (see
+  // computeRowFittedDates), in which case that row keeps the proportional placement.
+  const rows = new Map();
   cells.forEach(function(cell) {
-    const newDate = DTMN.computeFittedDate(cell.currentMs, oldStartMs, oldSpan, anchors, snap, cell.current);
-    DTMN.setDatePickerValue(cell.datepicker, newDate, cell.useTime);
+    const key = cell.row || cell.datepicker;
+    if (!rows.has(key)) {
+      rows.set(key, []);
+    }
+    rows.get(key).push(cell);
+  });
+  rows.forEach(function(rowCells) {
+    const newDates = DTMN.computeRowFittedDates(rowCells, oldStartMs, oldSpan, anchors, snap);
+    rowCells.forEach(function(cell, i) {
+      DTMN.setDatePickerValue(cell.datepicker, newDates[i], cell.useTime);
+    });
   });
 };
 
@@ -1003,7 +1048,9 @@ DTMN.previewToolColors = {
 // day cell regardless of time zone; the time (when present) is shown in the marker text.
 DTMN.collectPreviewEvents = function() {
   const events = [];
-  document.querySelectorAll('input[type=hidden][data-tool][data-field]').forEach(function(hidden) {
+  // tbody-scoped: the column-header "set whole column" boxes carry the same data attributes
+  // (.bulk-col-hidden in thead) but hold candidate values that are not saved dates
+  document.querySelectorAll('tbody input[type=hidden][data-tool][data-field]').forEach(function(hidden) {
     const value = hidden.value;
     if (!value) {
       return;

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -445,14 +445,18 @@ DTMN.shouldFillEmptyCells = function() {
 };
 
 // Fill every row of a single column (identified by data-field) within one section with the given date.
-// Always overwrites existing values; honors the global fill mode for blank cells.
-DTMN.fillColumn = function(rootElementId, field, date, updates, notModified) {
+// Always overwrites existing values. Blank cells are filled only when `fillEmpty` is true; when the
+// caller omits it, the term-date matrix's "bulk-fill-mode" radios decide (the per-column header
+// setters pass their own "Fill Empty" checkbox state instead).
+DTMN.fillColumn = function(rootElementId, field, date, updates, notModified, fillEmpty) {
 
   const rootElement = "#" + rootElementId;
 
   DTMN.attachDatePicker(rootElement + " .datepicker:not(.hasDatepicker)", updates, notModified);
 
-  const fillEmpty = DTMN.shouldFillEmptyCells();
+  if (fillEmpty === undefined) {
+    fillEmpty = DTMN.shouldFillEmptyCells();
+  }
   const hiddenFields = document.querySelectorAll(rootElement + ' tbody input[type=hidden][data-field="' + field + '"]');
 
   hiddenFields.forEach(function(hiddenField) {
@@ -529,11 +533,15 @@ DTMN.applyColumnBulkDates = function(button, updates, notModified) {
     return;
   }
 
+  // this column's own "Fill Empty" checkbox decides whether blank cells get the date too
+  const fillEmptyCheckbox = setter.querySelector(".bulk-col-fill-empty");
+  const fillEmpty = fillEmptyCheckbox != null && fillEmptyCheckbox.checked;
+
   button.classList.add("spinButton");
   button.disabled = true;
 
   window.setTimeout(function() {
-    DTMN.fillColumn(section.id, button.dataset.field, date, updates, notModified);
+    DTMN.fillColumn(section.id, button.dataset.field, date, updates, notModified, fillEmpty);
     button.classList.remove("spinButton");
     button.disabled = hidden.value === "";
   }, 25);

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -89,14 +89,14 @@ DTMN.initShifter = function(updates, notModified) {
 
 DTMN.initFitter = function(updates, notModified) {
 
-  DTMN.fitErrorBanner = document.getElementById("dateFitError");
-  DTMN.fitFirstInput = document.getElementById("dateFitFirst");
-  DTMN.fitFirstHidden = document.getElementById("dateFitFirstHidden");
-  DTMN.fitLastInput = document.getElementById("dateFitLast");
-  DTMN.fitLastHidden = document.getElementById("dateFitLastHidden");
-  DTMN.fitSnapCheckbox = document.getElementById("dateFitSnap");
-  DTMN.fitAllBtn = document.getElementById("fitAllDates");
-  DTMN.fitVisibleBtn = document.getElementById("fitVisibleDates");
+  DTMN.fitErrorBanner = document.getElementById("date-fit-error");
+  DTMN.fitFirstInput = document.getElementById("date-fit-first");
+  DTMN.fitFirstHidden = document.getElementById("date-fit-first-hidden");
+  DTMN.fitLastInput = document.getElementById("date-fit-last");
+  DTMN.fitLastHidden = document.getElementById("date-fit-last-hidden");
+  DTMN.fitSnapCheckbox = document.getElementById("date-fit-snap");
+  DTMN.fitAllBtn = document.getElementById("fit-all-dates");
+  DTMN.fitVisibleBtn = document.getElementById("fit-visible-dates");
 
   if (!DTMN.fitAllBtn || !DTMN.fitVisibleBtn || !DTMN.fitFirstHidden || !DTMN.fitLastHidden) {
     return;
@@ -420,8 +420,8 @@ DTMN.getTermHiddenId = function(term) {
 
 DTMN.initTermDates = function(updates, notModified) {
 
-  DTMN.termAllBtn = document.getElementById("applyTermDatesAll");
-  DTMN.termVisibleBtn = document.getElementById("applyTermDatesVisible");
+  DTMN.termAllBtn = document.getElementById("apply-term-dates-all");
+  DTMN.termVisibleBtn = document.getElementById("apply-term-dates-visible");
 
   if (!DTMN.termAllBtn || !DTMN.termVisibleBtn) {
     return;

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -436,10 +436,12 @@ DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
 };
 
 // Returns true when blank cells should also be filled. When false, only cells that already have a
-// date are overwritten and empty cells are left untouched. Driven by the "bulk-fill-mode" radios.
+// date are overwritten and empty cells are left untouched. Driven by the "bulk-fill-mode" radios;
+// defaults to the conservative existing-only mode when no radio is selected, matching the
+// template's checked option.
 DTMN.shouldFillEmptyCells = function() {
   const selected = document.querySelector('input[name="bulk-fill-mode"]:checked');
-  return !selected || selected.value !== "existing";
+  return selected != null && selected.value !== "existing";
 };
 
 // Fill every row of a single column (identified by data-field) within one section with the given date.

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -502,7 +502,7 @@ DTMN.getTermHiddenId = function(term) {
   return "term-hidden-" + term.replaceAll("_", "-");
 };
 
-// Default term-date -> column mapping applied on load so a fresh Bulk Anchor arrives pre-checked with
+// Default term-date -> column mapping applied on load so a fresh Bulk Term Date Matrix arrives pre-checked with
 // sane targets: the term's earliest date (Classes Start) fills every open/start column, and the latest
 // (Exam Ends) fills every due/close column. The instructor can tick or untick freely from there.
 DTMN.defaultTermTargets = {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -228,6 +228,30 @@ DTMN.snapToSourceWeekday = function(target, source) {
   return result;
 };
 
+// Map one source instant onto the new [first, last] range. Pure (no DOM): the earliest source
+// (frac <= 0) lands exactly on anchors.first, the latest (frac >= 1) exactly on anchors.last, and a
+// middle source is placed proportionally then, when snap is on, snapped to its own weekday/time.
+// `sourceMoment` is only used by the snap branch. A zero old span (all dates identical) collapses
+// every date onto anchors.first.
+DTMN.computeFittedDate = function(currentMs, oldStartMs, oldSpan, anchors, snap, sourceMoment) {
+  if (oldSpan <= 0) {
+    return anchors.first.clone();
+  }
+
+  const frac = (currentMs - oldStartMs) / oldSpan;
+  if (frac <= 0) {
+    return anchors.first.clone();
+  }
+  if (frac >= 1) {
+    return anchors.last.clone();
+  }
+
+  const newStartMs = anchors.first.valueOf();
+  const newSpan = anchors.last.valueOf() - newStartMs;
+  const target = DTMN.momentInUserZone(newStartMs + frac * newSpan);
+  return snap ? DTMN.snapToSourceWeekday(target, sourceMoment) : target;
+};
+
 DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
 
   const sections = restrictToExpanded ? DTMN.findExpandedSections() : DTMN.collapseElements;
@@ -271,31 +295,13 @@ DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
     if (cell.currentMs > oldEndMs) { oldEndMs = cell.currentMs; }
   });
 
-  const newStartMs = anchors.first.valueOf();
-  const newSpan = anchors.last.valueOf() - newStartMs;
   const oldSpan = oldEndMs - oldStartMs;
   const snap = DTMN.fitSnapCheckbox ? DTMN.fitSnapCheckbox.checked : false;
 
   // Pass 2: map each cell onto the new range. The earliest cell lands exactly on the new first date and
   // the latest exactly on the new last date; everything between is placed proportionally, then snapped.
   cells.forEach(function(cell) {
-    let newDate;
-
-    if (oldSpan <= 0) {
-      // Degenerate: every date is identical, so there is no span to preserve - collapse onto the start.
-      newDate = anchors.first.clone();
-    } else {
-      const frac = (cell.currentMs - oldStartMs) / oldSpan;
-      if (frac <= 0) {
-        newDate = anchors.first.clone();
-      } else if (frac >= 1) {
-        newDate = anchors.last.clone();
-      } else {
-        const target = DTMN.momentInUserZone(newStartMs + frac * newSpan);
-        newDate = snap ? DTMN.snapToSourceWeekday(target, cell.current) : target;
-      }
-    }
-
+    const newDate = DTMN.computeFittedDate(cell.currentMs, oldStartMs, oldSpan, anchors, snap, cell.current);
     DTMN.setDatePickerValue(cell.datepicker, newDate, cell.useTime);
   });
 };

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -558,14 +558,30 @@ DTMN.termHasActionableInput = function() {
   });
 };
 
+// Like termHasActionableInput, but only counts a checked target whose section is currently expanded.
+// The "apply to expanded sections only" path skips collapsed sections, so without this the button could
+// be enabled while every checked column lives in a collapsed section, making the click a no-op.
+DTMN.termHasActionableInputInExpandedSections = function() {
+  return DTMN.termFields.some(function(term) {
+    const hidden = document.getElementById(DTMN.getTermHiddenId(term));
+    if (!hidden || hidden.value === "") {
+      return false;
+    }
+    const checks = document.querySelectorAll('.term-target[data-term="' + term + '"]:checked');
+    return Array.prototype.some.call(checks, function(check) {
+      const section = document.getElementById(check.dataset.root);
+      return section !== null && section.classList.contains("show");
+    });
+  });
+};
+
 DTMN.validateTermInputs = function() {
   if (!DTMN.termAllBtn || !DTMN.termVisibleBtn) {
     return;
   }
 
-  const actionable = DTMN.termHasActionableInput();
-  DTMN.termAllBtn.disabled = !actionable;
-  DTMN.termVisibleBtn.disabled = !actionable || DTMN.findExpandedSections().length === 0;
+  DTMN.termAllBtn.disabled = !DTMN.termHasActionableInput();
+  DTMN.termVisibleBtn.disabled = !DTMN.termHasActionableInputInExpandedSections();
 };
 
 DTMN.handleTermButtonClick = function(button, restrictToExpanded, updates, notModified) {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -430,8 +430,8 @@ DTMN.updateFitAnchorHints = function() {
       if (!parsed.isValid()) {
         return;
       }
-      if (earliest === null || parsed.valueOf() < earliest.valueOf()) { earliest = parsed; }
-      if (latest === null || parsed.valueOf() > latest.valueOf()) { latest = parsed; }
+      if (earliest === null || DTMN.wallClockMs(parsed) < DTMN.wallClockMs(earliest)) { earliest = parsed; }
+      if (latest === null || DTMN.wallClockMs(parsed) > DTMN.wallClockMs(latest)) { latest = parsed; }
     });
   });
 
@@ -468,7 +468,7 @@ DTMN.validateFitInputs = function() {
   }
 
   const anchors = DTMN.getFitAnchors();
-  const rangeOk = anchors !== null && anchors.last.valueOf() > anchors.first.valueOf();
+  const rangeOk = anchors !== null && DTMN.wallClockMs(anchors.last) > DTMN.wallClockMs(anchors.first);
 
   // Surface the ordering error only once both dates are present but out of order.
   if (anchors !== null && !rangeOk) {
@@ -499,7 +499,7 @@ DTMN.hideFitError = function() {
 DTMN.handleFitButtonClick = function(button, sections, updates, notModified) {
 
   const anchors = DTMN.getFitAnchors();
-  if (!anchors || anchors.last.valueOf() <= anchors.first.valueOf() || sections.length === 0) {
+  if (!anchors || DTMN.wallClockMs(anchors.last) <= DTMN.wallClockMs(anchors.first) || sections.length === 0) {
     return;
   }
 
@@ -535,11 +535,21 @@ DTMN.snapToSourceWeekday = function(target, source) {
   return result;
 };
 
-// Map one source instant onto the new [first, last] range. Pure (no DOM): the earliest source
-// (frac <= 0) lands exactly on anchors.first, the latest (frac >= 1) exactly on anchors.last, and a
-// middle source is placed proportionally then, when snap is on, snapped to its own weekday/time.
-// `sourceMoment` is only used by the snap branch. A zero old span (all dates identical) collapses
-// every date onto anchors.first.
+// Timezone-neutral wall-clock milliseconds: the moment's own calendar fields laid onto the UTC
+// scale. All fitting arithmetic runs on these, never on valueOf(): valueOf() is a browser-local
+// instant, and across a DST transition elapsed instant-milliseconds differ from elapsed wall-clock
+// time, so the same spread would fit to different clock times depending on the browser's timezone.
+DTMN.wallClockMs = function(date) {
+  return Date.UTC(date.year(), date.month(), date.date(), date.hours(), date.minutes(), date.seconds());
+};
+
+// Map one source wall-clock value onto the new [first, last] range. Pure (no DOM): the earliest
+// source (frac <= 0) lands exactly on anchors.first, the latest (frac >= 1) exactly on anchors.last,
+// and a middle source is placed proportionally then, when snap is on, snapped to its own
+// weekday/time. `currentMs` and `oldStartMs` are wallClockMs values; the result is built in UTC
+// mode so an interpolated time that does not exist in the browser's zone (spring-forward gap)
+// cannot be shifted by moment. `sourceMoment` is only used by the snap branch. A zero old span
+// (all dates identical) collapses every date onto anchors.first.
 DTMN.computeFittedDate = function(currentMs, oldStartMs, oldSpan, anchors, snap, sourceMoment) {
   if (oldSpan <= 0) {
     return anchors.first.clone();
@@ -553,9 +563,9 @@ DTMN.computeFittedDate = function(currentMs, oldStartMs, oldSpan, anchors, snap,
     return anchors.last.clone();
   }
 
-  const newStartMs = anchors.first.valueOf();
-  const newSpan = anchors.last.valueOf() - newStartMs;
-  const target = moment(newStartMs + frac * newSpan);
+  const newStartMs = DTMN.wallClockMs(anchors.first);
+  const newSpan = DTMN.wallClockMs(anchors.last) - newStartMs;
+  const target = moment.utc(newStartMs + frac * newSpan);
   return snap ? DTMN.snapToSourceWeekday(target, sourceMoment) : target;
 };
 
@@ -574,15 +584,15 @@ DTMN.computeRowFittedDates = function(rowCells, oldStartMs, oldSpan, anchors, sn
 
   const snapped = rowCells.map(cell =>
       DTMN.computeFittedDate(cell.currentMs, oldStartMs, oldSpan, anchors, true, cell.current));
-  const firstMs = anchors.first.valueOf();
-  const lastMs = anchors.last.valueOf();
+  const firstMs = DTMN.wallClockMs(anchors.first);
+  const lastMs = DTMN.wallClockMs(anchors.last);
   for (let i = 0; i < rowCells.length; i++) {
-    const snappedMs = snapped[i].valueOf();
+    const snappedMs = DTMN.wallClockMs(snapped[i]);
     if (snappedMs < firstMs || snappedMs > lastMs) {
       return proportional;
     }
     for (let j = 0; j < rowCells.length; j++) {
-      if (rowCells[i].currentMs < rowCells[j].currentMs && snappedMs > snapped[j].valueOf()) {
+      if (rowCells[i].currentMs < rowCells[j].currentMs && snappedMs > DTMN.wallClockMs(snapped[j])) {
         return proportional;
       }
     }
@@ -617,7 +627,7 @@ DTMN.fitDates = function(anchors, sections, updates, notModified) {
       if (!current.isValid()) {
         return;
       }
-      cells.push({ datepicker, useTime, current, currentMs: current.valueOf(), row: datepicker.closest("tr"), sectionId: section.id });
+      cells.push({ datepicker, useTime, current, currentMs: DTMN.wallClockMs(current), row: datepicker.closest("tr"), sectionId: section.id });
     });
   });
 

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -56,6 +56,7 @@ DTMN.initDatePicker = function(updates, notModified) {
 // ----- Bulk method radios: show one bulk-edit panel (and its Apply button) at a time -----
 
 DTMN.initBulkModeRadios = function() {
+  const scopeRow = document.querySelector(".dm-scope");
   document.querySelectorAll("input[name='dm-bulk-mode']").forEach(function(radio) {
     radio.addEventListener("change", function() {
       document.querySelectorAll(".dm-bulk-panel").forEach(function(panel) {
@@ -64,6 +65,11 @@ DTMN.initBulkModeRadios = function() {
       document.querySelectorAll(".dm-bulk-apply").forEach(function(button) {
         button.classList.toggle("d-none", button.dataset.dmPanel !== radio.value);
       });
+      // The milestone matrix already targets tools column by column, so the scope row
+      // would be redundant there — it only accompanies the shift and fit methods.
+      if (scopeRow) {
+        scopeRow.classList.toggle("d-none", radio.value === "dm-bulk-panel-set");
+      }
     }, false);
   });
 };
@@ -78,14 +84,14 @@ DTMN.initScopePicker = function() {
     return;
   }
 
-  // A scope change can enable or disable any method's Apply button, so re-run all three
+  // A scope change can enable or disable the shift/fit Apply buttons, so re-run their
   // validators, and re-label the buttons so a narrowed scope stays visible before the click.
+  // The milestone matrix ignores the scope row, so its validator is not involved.
   const revalidate = function() {
     DTMN.updateScopeAllState();
     DTMN.updateApplyButtonLabels();
     DTMN.validateShiftInput();
     DTMN.validateFitInputs();
-    DTMN.validateTermInputs();
     DTMN.updateFitAnchorHints();
   };
 
@@ -121,14 +127,15 @@ DTMN.formatTemplate = function(template, args) {
 };
 
 // Reflect a narrowed scope right on the apply buttons ("Apply shift (2 of 7 tools)") so a
-// selection left over from an earlier apply is visible before the next click.
+// selection left over from an earlier apply is visible before the next click. The term
+// apply is exempt: the milestone matrix ignores the scope row.
 DTMN.updateApplyButtonLabels = function() {
   if (!DTMN.scopeChecks || !DTMN.scopeChecks.length || !DTMN.bulkFeedbackText) {
     return;
   }
   const checked = DTMN.scopeChecks.filter(function(check) { return check.checked; }).length;
   const total = DTMN.scopeChecks.length;
-  document.querySelectorAll(".dm-bulk-apply").forEach(function(button) {
+  document.querySelectorAll(".dm-bulk-apply:not(#dm-apply-term)").forEach(function(button) {
     if (!button.dataset.baseLabel) {
       button.dataset.baseLabel = button.textContent.trim();
     }
@@ -156,7 +163,10 @@ DTMN.showApplyFeedback = function(kind, stats) {
   msgSpan.textContent = msg + " ";
 
   if (scopeSpan) {
-    const narrowed = DTMN.scopeChecks && DTMN.scopeChecks.some(function(check) { return !check.checked; });
+    // The term apply ignores the scope row (the matrix picks its own tools), so a narrowed
+    // scope is only worth calling out for the shift and fit applies.
+    const narrowed = kind !== "term"
+        && DTMN.scopeChecks && DTMN.scopeChecks.some(function(check) { return !check.checked; });
     if (narrowed) {
       const names = DTMN.scopeChecks.filter(function(check) { return check.checked; })
           .map(function(check) { return check.closest("label").textContent.trim(); });
@@ -845,42 +855,27 @@ DTMN.termHasActionableInput = function() {
   });
 };
 
-// Like termHasActionableInput, but only counts a checked target whose section is ticked in the
-// scope row. Without this the button could be enabled while every checked column lives in an
-// unscoped section, making the click a no-op.
-DTMN.termHasActionableInputInScopedSections = function() {
-  const scopedIds = new Set(DTMN.getScopedSections().map(function(section) { return section.id; }));
-  return DTMN.termFields.some(function(term) {
-    const hidden = document.getElementById(DTMN.getTermHiddenId(term));
-    if (!hidden || hidden.value === "") {
-      return false;
-    }
-    const checks = document.querySelectorAll('.term-target[data-term="' + term + '"]:checked');
-    return Array.prototype.some.call(checks, function(check) {
-      return scopedIds.has(check.dataset.root);
-    });
-  });
-};
-
 DTMN.validateTermInputs = function() {
   if (!DTMN.termApplyBtn) {
     return;
   }
 
-  DTMN.termApplyBtn.disabled = !DTMN.termHasActionableInputInScopedSections();
+  DTMN.termApplyBtn.disabled = !DTMN.termHasActionableInput();
 };
 
 DTMN.handleTermButtonClick = function(button, updates, notModified) {
 
-  if (!DTMN.termHasActionableInputInScopedSections()) {
+  if (!DTMN.termHasActionableInput()) {
     return;
   }
 
   button.classList.add("spinButton");
   DTMN.termApplyBtn.disabled = true;
 
+  // The matrix checkboxes already say exactly which tools each term date fills, so the term
+  // apply deliberately ignores the shift/fit scope row and acts on every section.
   window.setTimeout(function() {
-    const stats = DTMN.applyTermDates(DTMN.getScopedSections(), updates, notModified);
+    const stats = DTMN.applyTermDates(DTMN.collapseElements, updates, notModified);
     button.classList.remove("spinButton");
     DTMN.validateTermInputs();
     DTMN.showApplyFeedback("term", stats);
@@ -889,7 +884,7 @@ DTMN.handleTermButtonClick = function(button, updates, notModified) {
 
 DTMN.applyTermDates = function(sections, updates, notModified) {
 
-  const scopedIds = new Set(sections.map(function(section) { return section.id; }));
+  const sectionIds = new Set(sections.map(function(section) { return section.id; }));
   const toolsTouched = new Set();
   let changed = 0;
   let blanksSkipped = 0;
@@ -912,7 +907,7 @@ DTMN.applyTermDates = function(sections, updates, notModified) {
       const root = check.dataset.root;
       const field = check.dataset.field;
 
-      if (!scopedIds.has(root) || !document.getElementById(root)) {
+      if (!sectionIds.has(root) || !document.getElementById(root)) {
         return;
       }
 

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -53,14 +53,80 @@ DTMN.initDatePicker = function(updates, notModified) {
   });
 };
 
+// ----- Bulk method radios: show one bulk-edit panel (and its Apply button) at a time -----
+
+DTMN.initBulkModeRadios = function() {
+  document.querySelectorAll("input[name='dm-bulk-mode']").forEach(function(radio) {
+    radio.addEventListener("change", function() {
+      document.querySelectorAll(".dm-bulk-panel").forEach(function(panel) {
+        panel.classList.toggle("d-none", panel.id !== radio.value);
+      });
+      document.querySelectorAll(".dm-bulk-apply").forEach(function(button) {
+        button.classList.toggle("d-none", button.dataset.dmPanel !== radio.value);
+      });
+    }, false);
+  });
+};
+
+// ----- Tool scope row: which tool sections the bulk applies act on -----
+
+DTMN.initScopePicker = function() {
+  DTMN.scopeChecks = Array.from(document.querySelectorAll(".dm-scope-tool"));
+  DTMN.scopeAllCheck = document.getElementById("dm-scope-all");
+
+  if (!DTMN.scopeChecks.length) {
+    return;
+  }
+
+  // A scope change can enable or disable any method's Apply button, so re-run all three validators.
+  const revalidate = function() {
+    DTMN.updateScopeAllState();
+    DTMN.validateShiftInput();
+    DTMN.validateFitInputs();
+    DTMN.validateTermInputs();
+  };
+
+  DTMN.scopeChecks.forEach(function(check) {
+    check.addEventListener("change", revalidate, false);
+  });
+
+  if (DTMN.scopeAllCheck) {
+    DTMN.scopeAllCheck.addEventListener("change", function() {
+      DTMN.scopeChecks.forEach(function(check) { check.checked = DTMN.scopeAllCheck.checked; });
+      revalidate();
+    }, false);
+  }
+
+  DTMN.updateScopeAllState();
+};
+
+DTMN.updateScopeAllState = function() {
+  if (!DTMN.scopeAllCheck) {
+    return;
+  }
+  const checkedCount = DTMN.scopeChecks.filter(function(check) { return check.checked; }).length;
+  DTMN.scopeAllCheck.checked = checkedCount === DTMN.scopeChecks.length;
+  DTMN.scopeAllCheck.indeterminate = checkedCount > 0 && checkedCount < DTMN.scopeChecks.length;
+};
+
+// Section elements for the tools ticked in the scope row. Falls back to every section when the
+// scope row is absent so the apply paths keep working without it.
+DTMN.getScopedSections = function() {
+  if (!DTMN.scopeChecks || !DTMN.scopeChecks.length) {
+    return DTMN.collapseElements;
+  }
+  const roots = new Set(DTMN.scopeChecks.filter(function(check) { return check.checked; })
+      .map(function(check) { return check.dataset.root; }));
+  return DTMN.collapseElements.filter(function(section) { return roots.has(section.id); });
+};
+
 DTMN.initShifter = function(updates, notModified) {
 
   DTMN.validShiftRegex = /^-{0,1}\d{1,4}$/;
 
   DTMN.shiftErrorBanner = document.getElementById("dateShifterError");
   DTMN.shiftInput = document.getElementById("dateShifterDays");
-  DTMN.shiftAllBtn = document.getElementById("shiftAllDates");
-  DTMN.shiftVisibleBtn = document.getElementById("shiftVisibleDates");
+  DTMN.shiftApplyBtn = document.getElementById("dm-apply-shift");
 
   // Add event listener to the submit button to clear visual indication
   $('#modal-btn-confirm').on('click', function() {
@@ -69,16 +135,21 @@ DTMN.initShifter = function(updates, notModified) {
 
   DTMN.shiftInput.addEventListener("input", () => DTMN.validateShiftInput(), false);
 
-  DTMN.shiftAllBtn.addEventListener("click", function() {
-    DTMN.handleShiftButtonClick(this, DTMN.collapseElements, updates, notModified);
+  // The whole page is one form; Enter in the day-count field must not trigger a save.
+  DTMN.shiftInput.addEventListener("keydown", function(e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+    }
   }, false);
 
-  DTMN.shiftVisibleBtn.addEventListener("click", function() {
-    DTMN.handleShiftButtonClick(this, DTMN.findExpandedSections(), updates, notModified);
+  DTMN.shiftApplyBtn.addEventListener("click", function() {
+    DTMN.handleShiftButtonClick(this, DTMN.getScopedSections(), updates, notModified);
   }, false);
+
+  DTMN.initDateDiff();
 };
 
-// ----- Date difference helper: whole days between two dates, loaded into the shift field -----
+// ----- Term start pickers: whole days between the old and new term start, driving the shift field -----
 
 // Pure: signed whole days from `from` to `to` (to - from), counting calendar days, ignoring time of day.
 DTMN.computeDayDiff = function(from, to) {
@@ -91,10 +162,9 @@ DTMN.initDateDiff = function() {
   DTMN.diffFromHidden = document.getElementById("date-diff-from-hidden");
   DTMN.diffToInput = document.getElementById("date-diff-to");
   DTMN.diffToHidden = document.getElementById("date-diff-to-hidden");
-  DTMN.diffApplyBtn = document.getElementById("date-diff-apply");
   DTMN.diffResult = document.getElementById("date-diff-result");
 
-  if (!DTMN.diffApplyBtn || !DTMN.diffFromHidden || !DTMN.diffToHidden) {
+  if (!DTMN.diffFromHidden || !DTMN.diffToHidden) {
     return;
   }
 
@@ -113,12 +183,8 @@ DTMN.initDateDiff = function() {
         iso8601: hidden.id,
       }
     });
-    hidden.addEventListener("change", () => DTMN.validateDateDiff(), false);
+    hidden.addEventListener("change", () => DTMN.applyDateDiff(), false);
   });
-
-  DTMN.diffApplyBtn.addEventListener("click", () => DTMN.applyDateDiff(), false);
-
-  DTMN.validateDateDiff();
 };
 
 // Returns the whole-day difference when both dates are present and valid, else null.
@@ -137,16 +203,12 @@ DTMN.getDateDiffDays = function() {
   return DTMN.computeDayDiff(from, to);
 };
 
-// Show the count live as soon as both dates are valid, and enable the "use as shift" button.
-// The button stays disabled for a zero-day difference (nothing to shift) and for spans beyond
-// what the shifter accepts (+/-9999 days), so it can never load a value the shifter dead-ends on.
-DTMN.validateDateDiff = function() {
-  if (!DTMN.diffApplyBtn) {
-    return;
-  }
-
+// Show the count as soon as both term start dates are valid and load it straight into the shift
+// field, where it stays editable for fine-tuning. The shifter's own validation then enables its
+// buttons (a zero-day count leaves them disabled). Spans beyond what the shifter accepts
+// (+/-9999 days) are shown but not loaded, so the field can never dead-end.
+DTMN.applyDateDiff = function() {
   const days = DTMN.getDateDiffDays();
-  DTMN.diffApplyBtn.disabled = days === null || days === 0 || days < -9999 || days > 9999;
 
   if (DTMN.diffResult) {
     if (days === null) {
@@ -156,20 +218,13 @@ DTMN.validateDateDiff = function() {
       DTMN.diffResult.textContent = template.replace("{0}", days);
     }
   }
-};
 
-DTMN.applyDateDiff = function() {
-  const days = DTMN.getDateDiffDays();
-  if (days === null) {
+  if (days === null || days < -9999 || days > 9999) {
     return;
   }
 
-  // Load the day count into the shift field and let the shifter's own validation enable its buttons.
-  const shiftInput = document.getElementById("dateShifterDays");
-  if (shiftInput) {
-    shiftInput.value = days;
-    DTMN.validateShiftInput();
-  }
+  DTMN.shiftInput.value = days;
+  DTMN.validateShiftInput();
 };
 
 // ----- Re-anchor / fit dates between a new first and last date -----
@@ -189,10 +244,9 @@ DTMN.initFitter = function(updates, notModified) {
   DTMN.fitLastInput = document.getElementById("date-fit-last");
   DTMN.fitLastHidden = document.getElementById("date-fit-last-hidden");
   DTMN.fitSnapCheckbox = document.getElementById("date-fit-snap");
-  DTMN.fitAllBtn = document.getElementById("fit-all-dates");
-  DTMN.fitVisibleBtn = document.getElementById("fit-visible-dates");
+  DTMN.fitApplyBtn = document.getElementById("dm-apply-fit");
 
-  if (!DTMN.fitAllBtn || !DTMN.fitVisibleBtn || !DTMN.fitFirstHidden || !DTMN.fitLastHidden) {
+  if (!DTMN.fitApplyBtn || !DTMN.fitFirstHidden || !DTMN.fitLastHidden) {
     return;
   }
 
@@ -214,12 +268,8 @@ DTMN.initFitter = function(updates, notModified) {
     hidden.addEventListener("change", () => DTMN.validateFitInputs(), false);
   });
 
-  DTMN.fitAllBtn.addEventListener("click", function() {
-    DTMN.handleFitButtonClick(this, false, updates, notModified);
-  }, false);
-
-  DTMN.fitVisibleBtn.addEventListener("click", function() {
-    DTMN.handleFitButtonClick(this, true, updates, notModified);
+  DTMN.fitApplyBtn.addEventListener("click", function() {
+    DTMN.handleFitButtonClick(this, DTMN.getScopedSections(), updates, notModified);
   }, false);
 
   DTMN.validateFitInputs();
@@ -241,7 +291,7 @@ DTMN.getFitAnchors = function() {
 };
 
 DTMN.validateFitInputs = function() {
-  if (!DTMN.fitAllBtn || !DTMN.fitVisibleBtn) {
+  if (!DTMN.fitApplyBtn) {
     return;
   }
 
@@ -255,8 +305,7 @@ DTMN.validateFitInputs = function() {
     DTMN.hideFitError();
   }
 
-  DTMN.fitAllBtn.disabled = !rangeOk;
-  DTMN.fitVisibleBtn.disabled = !rangeOk || DTMN.findExpandedSections().length === 0;
+  DTMN.fitApplyBtn.disabled = !rangeOk || DTMN.getScopedSections().length === 0;
 };
 
 DTMN.showFitError = function() {
@@ -275,19 +324,18 @@ DTMN.hideFitError = function() {
   DTMN.fitErrorBanner.removeAttribute("role");
 };
 
-DTMN.handleFitButtonClick = function(button, restrictToExpanded, updates, notModified) {
+DTMN.handleFitButtonClick = function(button, sections, updates, notModified) {
 
   const anchors = DTMN.getFitAnchors();
-  if (!anchors || anchors.last.valueOf() <= anchors.first.valueOf()) {
+  if (!anchors || anchors.last.valueOf() <= anchors.first.valueOf() || sections.length === 0) {
     return;
   }
 
   button.classList.add("spinButton");
-  DTMN.fitAllBtn.disabled = true;
-  DTMN.fitVisibleBtn.disabled = true;
+  DTMN.fitApplyBtn.disabled = true;
 
   window.setTimeout(function() {
-    DTMN.fitDates(anchors, restrictToExpanded, updates, notModified);
+    DTMN.fitDates(anchors, sections, updates, notModified);
     button.classList.remove("spinButton");
     DTMN.validateFitInputs();
   }, 25);
@@ -369,9 +417,8 @@ DTMN.computeRowFittedDates = function(rowCells, oldStartMs, oldSpan, anchors, sn
   return snapped;
 };
 
-DTMN.fitDates = function(anchors, restrictToExpanded, updates, notModified) {
+DTMN.fitDates = function(anchors, sections, updates, notModified) {
 
-  const sections = restrictToExpanded ? DTMN.findExpandedSections() : DTMN.collapseElements;
   if (sections.length === 0) {
     return;
   }
@@ -576,10 +623,9 @@ DTMN.applyDefaultTermTargets = function() {
 
 DTMN.initTermDates = function(updates, notModified) {
 
-  DTMN.termAllBtn = document.getElementById("apply-term-dates-all");
-  DTMN.termVisibleBtn = document.getElementById("apply-term-dates-visible");
+  DTMN.termApplyBtn = document.getElementById("dm-apply-term");
 
-  if (!DTMN.termAllBtn || !DTMN.termVisibleBtn) {
+  if (!DTMN.termApplyBtn) {
     return;
   }
 
@@ -608,12 +654,8 @@ DTMN.initTermDates = function(updates, notModified) {
     check.addEventListener("change", () => DTMN.validateTermInputs(), false);
   });
 
-  DTMN.termAllBtn.addEventListener("click", function() {
-    DTMN.handleTermButtonClick(this, false, updates, notModified);
-  }, false);
-
-  DTMN.termVisibleBtn.addEventListener("click", function() {
-    DTMN.handleTermButtonClick(this, true, updates, notModified);
+  DTMN.termApplyBtn.addEventListener("click", function() {
+    DTMN.handleTermButtonClick(this, updates, notModified);
   }, false);
 
   DTMN.applyDefaultTermTargets();
@@ -631,10 +673,11 @@ DTMN.termHasActionableInput = function() {
   });
 };
 
-// Like termHasActionableInput, but only counts a checked target whose section is currently expanded.
-// The "apply only to tools expanded below" path skips collapsed sections, so without this the button could
-// be enabled while every checked column lives in a collapsed section, making the click a no-op.
-DTMN.termHasActionableInputInExpandedSections = function() {
+// Like termHasActionableInput, but only counts a checked target whose section is ticked in the
+// scope row. Without this the button could be enabled while every checked column lives in an
+// unscoped section, making the click a no-op.
+DTMN.termHasActionableInputInScopedSections = function() {
+  const scopedIds = new Set(DTMN.getScopedSections().map(function(section) { return section.id; }));
   return DTMN.termFields.some(function(term) {
     const hidden = document.getElementById(DTMN.getTermHiddenId(term));
     if (!hidden || hidden.value === "") {
@@ -642,39 +685,38 @@ DTMN.termHasActionableInputInExpandedSections = function() {
     }
     const checks = document.querySelectorAll('.term-target[data-term="' + term + '"]:checked');
     return Array.prototype.some.call(checks, function(check) {
-      const section = document.getElementById(check.dataset.root);
-      return section !== null && section.classList.contains("show");
+      return scopedIds.has(check.dataset.root);
     });
   });
 };
 
 DTMN.validateTermInputs = function() {
-  if (!DTMN.termAllBtn || !DTMN.termVisibleBtn) {
+  if (!DTMN.termApplyBtn) {
     return;
   }
 
-  DTMN.termAllBtn.disabled = !DTMN.termHasActionableInput();
-  DTMN.termVisibleBtn.disabled = !DTMN.termHasActionableInputInExpandedSections();
+  DTMN.termApplyBtn.disabled = !DTMN.termHasActionableInputInScopedSections();
 };
 
-DTMN.handleTermButtonClick = function(button, restrictToExpanded, updates, notModified) {
+DTMN.handleTermButtonClick = function(button, updates, notModified) {
 
-  if (!DTMN.termHasActionableInput()) {
+  if (!DTMN.termHasActionableInputInScopedSections()) {
     return;
   }
 
   button.classList.add("spinButton");
-  DTMN.termAllBtn.disabled = true;
-  DTMN.termVisibleBtn.disabled = true;
+  DTMN.termApplyBtn.disabled = true;
 
   window.setTimeout(function() {
-    DTMN.applyTermDates(restrictToExpanded, updates, notModified);
+    DTMN.applyTermDates(DTMN.getScopedSections(), updates, notModified);
     button.classList.remove("spinButton");
     DTMN.validateTermInputs();
   }, 25);
 };
 
-DTMN.applyTermDates = function(restrictToExpanded, updates, notModified) {
+DTMN.applyTermDates = function(sections, updates, notModified) {
+
+  const scopedIds = new Set(sections.map(function(section) { return section.id; }));
 
   // Process term dates top-to-bottom so that when two term dates target the same column,
   // the lower one in the panel wins (applied last).
@@ -693,12 +735,8 @@ DTMN.applyTermDates = function(restrictToExpanded, updates, notModified) {
     checks.forEach(function(check) {
       const root = check.dataset.root;
       const field = check.dataset.field;
-      const sectionEl = document.getElementById(root);
 
-      if (!sectionEl) {
-        return;
-      }
-      if (restrictToExpanded && !sectionEl.classList.contains("show")) {
+      if (!scopedIds.has(root) || !document.getElementById(root)) {
         return;
       }
 
@@ -896,6 +934,11 @@ DTMN.attachDatePicker = function (selector, updates, notModified) {
 
 DTMN.handleShiftButtonClick = function(button, collapseElements, updates, notModified)
 {
+  if (collapseElements.length === 0)
+  {
+    return;
+  }
+
   DTMN.disableShiftControls(button);
   window.setTimeout(function()
   {
@@ -910,6 +953,11 @@ DTMN.handleShiftButtonClick = function(button, collapseElements, updates, notMod
 
 DTMN.validateShiftInput = function()
 {
+  if (!DTMN.shiftInput || !DTMN.shiftApplyBtn)
+  {
+    return;
+  }
+
   const val = DTMN.shiftInput.value;
   if (val === "" || val === "-")
   {
@@ -928,13 +976,7 @@ DTMN.validateShiftInput = function()
 
   DTMN.hideShiftError();
 
-  DTMN.shiftAllBtn.disabled = days === 0;
-  DTMN.shiftVisibleBtn.disabled = days === 0 || DTMN.findExpandedSections().length === 0;
-};
-
-DTMN.findExpandedSections = function()
-{
-  return DTMN.collapseElements.filter(function (e) { return e.classList.contains("show") === true; });
+  DTMN.shiftApplyBtn.disabled = days === 0 || DTMN.getScopedSections().length === 0;
 };
 
 DTMN.hideShiftError = function()
@@ -958,8 +1000,7 @@ DTMN.disableShiftControls = function(button)
 
 DTMN.disableShiftButtons = function()
 {
-  DTMN.shiftAllBtn.disabled = true;
-  DTMN.shiftVisibleBtn.disabled = true;
+  DTMN.shiftApplyBtn.disabled = true;
 };
 
 DTMN.enableShiftControls = function(button)
@@ -1089,6 +1130,32 @@ DTMN.collectPreviewEvents = function() {
   return events;
 };
 
+// Whole-month grid range covering every event, so the default "Overview" view shows the full
+// span from the first date to the last in one continuous scrollable grid. Very long spans are
+// clamped to a year past the first date to keep the grid a sane size.
+DTMN.computePreviewRange = function(events) {
+  let earliest = null;
+  let latest = null;
+  events.forEach(function(ev) {
+    if (earliest === null || ev.start < earliest) earliest = ev.start;
+    if (latest === null || ev.start > latest) latest = ev.start;
+  });
+  if (earliest === null) {
+    return null;
+  }
+  const start = moment(earliest, 'YYYY-MM-DD').startOf('month');
+  let end = moment(latest, 'YYYY-MM-DD').endOf('month').add(1, 'day').startOf('day');
+  const cap = start.clone().add(12, 'months');
+  if (end.isAfter(cap)) {
+    end = cap;
+  }
+  return {
+    earliest,
+    start: start.format('YYYY-MM-DD'),
+    end: end.format('YYYY-MM-DD'),
+  };
+};
+
 DTMN.renderCalendarPreview = function() {
   const events = DTMN.collectPreviewEvents();
   const emptyMsg = document.getElementById('datemanager-calendar-empty');
@@ -1106,10 +1173,25 @@ DTMN.renderCalendarPreview = function() {
   calendarEl.classList.remove('d-none');
 
   const locale = (sakai && sakai.locale && sakai.locale.userLanguage) || 'en';
+  const range = DTMN.computePreviewRange(events);
+  // Held on DTMN so the custom view's visibleRange callback always sees the current span,
+  // including after events are replaced on a later open of the modal.
+  DTMN.previewRange = { start: range.start, end: range.end };
 
   if (!DTMN.previewCalendar) {
     DTMN.previewCalendar = new FullCalendar.Calendar(calendarEl, {
-      initialView: 'dayGridMonth',
+      // The "Overview" view: a duration-less dayGrid driven by visibleRange, one continuous
+      // grid from the month of the first date through the month of the last.
+      initialView: 'dmSpan',
+      views: {
+        dmSpan: {
+          type: 'dayGrid',
+          buttonText: DTMN.previewSpanButtonText || 'Overview',
+        }
+      },
+      visibleRange: function() {
+        return DTMN.previewRange;
+      },
       themeSystem: 'bootstrap5',
       locale: locale,
       displayEventTime: false,
@@ -1117,7 +1199,7 @@ DTMN.renderCalendarPreview = function() {
       headerToolbar: {
         left: 'prev,next today',
         center: 'title',
-        right: ''
+        right: 'dmSpan,dayGridMonth,dayGridWeek'
       },
       buttonIcons: {
         prev: 'chevron-left',
@@ -1132,13 +1214,9 @@ DTMN.renderCalendarPreview = function() {
     DTMN.previewCalendar.updateSize();
   }
 
-  // Open on the earliest date so the first populated month is visible immediately.
-  const earliest = events.reduce(function(min, ev) {
-    return (min === null || ev.start < min) ? ev.start : min;
-  }, null);
-  if (earliest) {
-    DTMN.previewCalendar.gotoDate(earliest);
-  }
+  // Anchor on the earliest date: the overview starts there, and switching to the Month or
+  // Week views lands on the first populated month/week rather than today.
+  DTMN.previewCalendar.gotoDate(range.earliest);
 };
 
 DTMN.initCalendarPreview = function() {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -78,9 +78,11 @@ DTMN.initScopePicker = function() {
     return;
   }
 
-  // A scope change can enable or disable any method's Apply button, so re-run all three validators.
+  // A scope change can enable or disable any method's Apply button, so re-run all three
+  // validators, and re-label the buttons so a narrowed scope stays visible before the click.
   const revalidate = function() {
     DTMN.updateScopeAllState();
+    DTMN.updateApplyButtonLabels();
     DTMN.validateShiftInput();
     DTMN.validateFitInputs();
     DTMN.validateTermInputs();
@@ -98,6 +100,7 @@ DTMN.initScopePicker = function() {
   }
 
   DTMN.updateScopeAllState();
+  DTMN.updateApplyButtonLabels();
 };
 
 DTMN.updateScopeAllState = function() {
@@ -107,6 +110,63 @@ DTMN.updateScopeAllState = function() {
   const checkedCount = DTMN.scopeChecks.filter(function(check) { return check.checked; }).length;
   DTMN.scopeAllCheck.checked = checkedCount === DTMN.scopeChecks.length;
   DTMN.scopeAllCheck.indeterminate = checkedCount > 0 && checkedCount < DTMN.scopeChecks.length;
+};
+
+// {0}/{1}-style placeholder substitution for the localized banner/button templates.
+DTMN.formatTemplate = function(template, args) {
+  return args.reduce(function(acc, val, i) {
+    return acc.split("{" + i + "}").join(String(val));
+  }, template);
+};
+
+// Reflect a narrowed scope right on the apply buttons ("Apply shift (2 of 7 tools)") so a
+// selection left over from an earlier apply is visible before the next click.
+DTMN.updateApplyButtonLabels = function() {
+  if (!DTMN.scopeChecks || !DTMN.scopeChecks.length || !DTMN.bulkFeedbackText) {
+    return;
+  }
+  const checked = DTMN.scopeChecks.filter(function(check) { return check.checked; }).length;
+  const total = DTMN.scopeChecks.length;
+  document.querySelectorAll(".dm-bulk-apply").forEach(function(button) {
+    if (!button.dataset.baseLabel) {
+      button.dataset.baseLabel = button.textContent.trim();
+    }
+    button.textContent = button.dataset.baseLabel + (checked < total
+        ? " " + DTMN.formatTemplate(DTMN.bulkFeedbackText.applySuffix, [checked, total]) : "");
+  });
+};
+
+// Post-apply summary banner: says what the apply just changed (and what it skipped), since the
+// affected grid lives on the other tab. Names the ticked tools whenever the scope was narrowed.
+DTMN.showApplyFeedback = function(kind, stats) {
+  const banner = document.getElementById("dm-apply-feedback");
+  const msgSpan = document.getElementById("dm-apply-feedback-msg");
+  const scopeSpan = document.getElementById("dm-apply-feedback-scope");
+  if (!banner || !msgSpan || !DTMN.bulkFeedbackText) {
+    return;
+  }
+
+  let msg = stats.changed === 0
+      ? DTMN.bulkFeedbackText.none
+      : DTMN.formatTemplate(DTMN.bulkFeedbackText[kind], [stats.changed, stats.tools]);
+  if (kind === "term" && stats.blanksSkipped > 0) {
+    msg += " " + DTMN.formatTemplate(DTMN.bulkFeedbackText.termBlanks, [stats.blanksSkipped]);
+  }
+  msgSpan.textContent = msg + " ";
+
+  if (scopeSpan) {
+    const narrowed = DTMN.scopeChecks && DTMN.scopeChecks.some(function(check) { return !check.checked; });
+    if (narrowed) {
+      const names = DTMN.scopeChecks.filter(function(check) { return check.checked; })
+          .map(function(check) { return check.closest("label").textContent.trim(); });
+      scopeSpan.textContent = DTMN.formatTemplate(DTMN.bulkFeedbackText.scope, [names.join(", ")]) + " ";
+      scopeSpan.classList.remove("d-none");
+    } else {
+      scopeSpan.classList.add("d-none");
+    }
+  }
+
+  banner.classList.remove("d-none");
 };
 
 // Section elements for the tools ticked in the scope row. Falls back to every section when the
@@ -335,9 +395,10 @@ DTMN.handleFitButtonClick = function(button, sections, updates, notModified) {
   DTMN.fitApplyBtn.disabled = true;
 
   window.setTimeout(function() {
-    DTMN.fitDates(anchors, sections, updates, notModified);
+    const stats = DTMN.fitDates(anchors, sections, updates, notModified) || { changed: 0, tools: 0 };
     button.classList.remove("spinButton");
     DTMN.validateFitInputs();
+    DTMN.showApplyFeedback("fit", stats);
   }, 25);
 };
 
@@ -420,7 +481,7 @@ DTMN.computeRowFittedDates = function(rowCells, oldStartMs, oldSpan, anchors, sn
 DTMN.fitDates = function(anchors, sections, updates, notModified) {
 
   if (sections.length === 0) {
-    return;
+    return { changed: 0, tools: 0 };
   }
 
   // Pass 1: initialise every in-scope datepicker, then collect the editable, populated cells together
@@ -444,12 +505,12 @@ DTMN.fitDates = function(anchors, sections, updates, notModified) {
       if (!current.isValid()) {
         return;
       }
-      cells.push({ datepicker, useTime, current, currentMs: current.valueOf(), row: datepicker.closest("tr") });
+      cells.push({ datepicker, useTime, current, currentMs: current.valueOf(), row: datepicker.closest("tr"), sectionId: section.id });
     });
   });
 
   if (cells.length === 0) {
-    return;
+    return { changed: 0, tools: 0 };
   }
 
   let oldStartMs = cells[0].currentMs;
@@ -480,6 +541,9 @@ DTMN.fitDates = function(anchors, sections, updates, notModified) {
       DTMN.setDatePickerValue(cell.datepicker, newDates[i], cell.useTime);
     });
   });
+
+  const toolsTouched = new Set(cells.map(function(cell) { return cell.sectionId; }));
+  return { changed: cells.length, tools: toolsTouched.size };
 };
 
 // Returns true when blank cells should also be filled. When false, only cells that already have a
@@ -505,6 +569,8 @@ DTMN.fillColumn = function(rootElementId, field, date, updates, notModified, fil
     fillEmpty = DTMN.shouldFillEmptyCells();
   }
   const hiddenFields = document.querySelectorAll(rootElement + ' tbody input[type=hidden][data-field="' + field + '"]');
+  let changed = 0;
+  let blanksSkipped = 0;
 
   hiddenFields.forEach(function(hiddenField) {
     const td = hiddenField.closest('td');
@@ -516,12 +582,16 @@ DTMN.fillColumn = function(rootElementId, field, date, updates, notModified, fil
 
     // "Only update items that already have a date" mode: leave blanks alone.
     if (!fillEmpty && hiddenField.value === "") {
+      blanksSkipped++;
       return;
     }
 
     const useTime = hiddenField.dataset.tool !== 'gradebookItems';
     DTMN.setDatePickerValue(datepicker, date, useTime);
+    changed++;
   });
+
+  return { changed: changed, blanksSkipped: blanksSkipped };
 };
 
 // ----- Per-column bulk setters (one small date input inside each editable column header) -----
@@ -708,15 +778,19 @@ DTMN.handleTermButtonClick = function(button, updates, notModified) {
   DTMN.termApplyBtn.disabled = true;
 
   window.setTimeout(function() {
-    DTMN.applyTermDates(DTMN.getScopedSections(), updates, notModified);
+    const stats = DTMN.applyTermDates(DTMN.getScopedSections(), updates, notModified);
     button.classList.remove("spinButton");
     DTMN.validateTermInputs();
+    DTMN.showApplyFeedback("term", stats);
   }, 25);
 };
 
 DTMN.applyTermDates = function(sections, updates, notModified) {
 
   const scopedIds = new Set(sections.map(function(section) { return section.id; }));
+  const toolsTouched = new Set();
+  let changed = 0;
+  let blanksSkipped = 0;
 
   // Process term dates top-to-bottom so that when two term dates target the same column,
   // the lower one in the panel wins (applied last).
@@ -740,9 +814,16 @@ DTMN.applyTermDates = function(sections, updates, notModified) {
         return;
       }
 
-      DTMN.fillColumn(root, field, date, updates, notModified);
+      const result = DTMN.fillColumn(root, field, date, updates, notModified);
+      changed += result.changed;
+      blanksSkipped += result.blanksSkipped;
+      if (result.changed > 0) {
+        toolsTouched.add(root);
+      }
     });
   });
+
+  return { changed: changed, tools: toolsTouched.size, blanksSkipped: blanksSkipped };
 };
 
 // These helpers deliberately do NO timezone conversion. Sakai treats picker values as wall-clock and
@@ -942,11 +1023,20 @@ DTMN.handleShiftButtonClick = function(button, collapseElements, updates, notMod
   DTMN.disableShiftControls(button);
   window.setTimeout(function()
   {
+    let changed = 0;
+    let tools = 0;
     for (let i = 0; i < collapseElements.length; i++)
     {
       // use setTimeout() to space out the function calls so the browser doesn't report the page as unresponsive
-      // the last function will remove the spinner and re-enable the button
-      window.setTimeout(function() { DTMN.shiftDates(updates, notModified, collapseElements[i].id, button, i === collapseElements.length - 1); }, 10);
+      // the last function will remove the spinner, re-enable the button, and report the totals
+      window.setTimeout(function() {
+        const sectionChanged = DTMN.shiftDates(updates, notModified, collapseElements[i].id, button, i === collapseElements.length - 1) || 0;
+        changed += sectionChanged;
+        if (sectionChanged > 0) { tools++; }
+        if (i === collapseElements.length - 1) {
+          DTMN.showApplyFeedback("shift", { changed: changed, tools: tools });
+        }
+      }, 10);
     }
   }, 25);
 };
@@ -1020,7 +1110,7 @@ DTMN.shiftDates = function (updates, notModified, rootElementId, button, enableB
   if (!DTMN.shiftInput.value.match(DTMN.validShiftRegex)) {
     DTMN.showShiftError();
     DTMN.disableShiftButtons();
-    return;
+    return 0;
   }
 
   const days = parseInt(DTMN.shiftInput.value, 10);
@@ -1029,6 +1119,7 @@ DTMN.shiftDates = function (updates, notModified, rootElementId, button, enableB
   DTMN.attachDatePicker(rootElement + " .datepicker:not(.hasDatepicker)", updates, notModified);
 
   const datepickers = document.querySelectorAll(rootElement + " .datepicker.hasDatepicker");
+  let changed = 0;
 
   datepickers.forEach(function (datepicker) {
     const dateValue = datepicker.value;
@@ -1063,6 +1154,7 @@ DTMN.shiftDates = function (updates, notModified, rootElementId, button, enableB
       const newDate = currentDate.clone().add(days, 'days');
 
       DTMN.setDatePickerValue(datepicker, newDate, useTime);
+      changed++;
 
     } catch (error) {
       console.error('Error processing date:', dateValue, error);
@@ -1073,6 +1165,8 @@ DTMN.shiftDates = function (updates, notModified, rootElementId, button, enableB
   {
     DTMN.enableShiftControls(button);
   }
+
+  return changed;
 };
 
 // ---------------------------------------------------------------------------

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -169,6 +169,56 @@ DTMN.showApplyFeedback = function(kind, stats) {
   banner.classList.remove("d-none");
 };
 
+// ----- Unsaved-changes guard: staged edits live only in the page until Save Changes -----
+
+// The save button is enabled exactly while edits are staged and disabled again once they
+// are saved, so it doubles as the pending-changes flag.
+DTMN.hasUnsavedChanges = function() {
+  const saveButton = document.getElementById("submit-form-button");
+  return saveButton !== null && !saveButton.disabled;
+};
+
+// Prompts the browser-native "leave site?" dialog on any navigation away while changes are
+// staged. The Cancel flow is exempt (it sets the suppress flag): clicking Cancel is already
+// an explicit discard, so it should not be second-guessed.
+DTMN.initUnsavedGuard = function() {
+  window.addEventListener("beforeunload", function(e) {
+    if (!DTMN.suppressUnsavedGuard && DTMN.hasUnsavedChanges()) {
+      e.preventDefault();
+      e.returnValue = "";
+    }
+  });
+};
+
+// Cancel discards staged edits by reloading the tool from saved state — the page stays in
+// Date Manager rather than bouncing back to Site Info. A sessionStorage flag survives the
+// reload so the fresh page can briefly confirm that the changes were discarded.
+DTMN.initCancelRevert = function() {
+  const cancelButton = document.getElementById("datemanager-cancel");
+  cancelButton && cancelButton.addEventListener("click", function(e) {
+    e.preventDefault();
+    DTMN.suppressUnsavedGuard = true;
+    if (DTMN.hasUnsavedChanges()) {
+      try { window.sessionStorage.setItem("dm-cancel-reverted", "1"); } catch (err) { /* storage unavailable */ }
+    }
+    window.location.reload();
+  }, false);
+
+  let reverted = false;
+  try {
+    reverted = window.sessionStorage.getItem("dm-cancel-reverted") === "1";
+    window.sessionStorage.removeItem("dm-cancel-reverted");
+  } catch (err) { /* storage unavailable */ }
+
+  if (reverted) {
+    const banner = document.getElementById("dm-cancel-banner");
+    if (banner) {
+      banner.classList.remove("d-none");
+      window.setTimeout(function() { $(banner).fadeOut(400); }, 4000);
+    }
+  }
+};
+
 // Section elements for the tools ticked in the scope row. Falls back to every section when the
 // scope row is absent so the apply paths keep working without it.
 DTMN.getScopedSections = function() {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -86,6 +86,7 @@ DTMN.initScopePicker = function() {
     DTMN.validateShiftInput();
     DTMN.validateFitInputs();
     DTMN.validateTermInputs();
+    DTMN.updateFitAnchorHints();
   };
 
   DTMN.scopeChecks.forEach(function(check) {
@@ -167,6 +168,9 @@ DTMN.showApplyFeedback = function(kind, stats) {
   }
 
   banner.classList.remove("d-none");
+
+  // Every apply changes dates, which can change which items are the fit anchors.
+  DTMN.updateFitAnchorHints();
 };
 
 // ----- Unsaved-changes guard: staged edits live only in the page until Save Changes -----
@@ -383,6 +387,48 @@ DTMN.initFitter = function(updates, notModified) {
   }, false);
 
   DTMN.validateFitInputs();
+  DTMN.updateFitAnchorHints();
+};
+
+// Show the current earliest/latest date under the two destination fields ("currently:
+// Thu, Apr 9, 2026") so the range being re-fitted — and the weekday the anchors hold today —
+// is visible before applying. Dates only: several items routinely tie for earliest/latest, so
+// naming one of them would be arbitrary. Recomputed when the scope changes and after every
+// apply, since both change the range.
+DTMN.updateFitAnchorHints = function() {
+  const firstHint = document.getElementById("dm-fit-anchor-first");
+  const lastHint = document.getElementById("dm-fit-anchor-last");
+  if (!firstHint || !lastHint) {
+    return;
+  }
+
+  let earliest = null;
+  let latest = null;
+  DTMN.getScopedSections().forEach(function(section) {
+    section.querySelectorAll("tbody input[type=hidden][data-tool][data-field]").forEach(function(hidden) {
+      if (!hidden.value) {
+        return;
+      }
+      const useTime = hidden.dataset.tool !== "gradebookItems";
+      const parsed = DTMN.parseInputDateValue(hidden.value, useTime);
+      if (!parsed.isValid()) {
+        return;
+      }
+      if (earliest === null || parsed.valueOf() < earliest.valueOf()) { earliest = parsed; }
+      if (latest === null || parsed.valueOf() > latest.valueOf()) { latest = parsed; }
+    });
+  });
+
+  [[firstHint, earliest], [lastHint, latest]].forEach(function(pair) {
+    const hint = pair[0];
+    const anchor = pair[1];
+    if (anchor === null) {
+      hint.textContent = hint.dataset.none || "";
+    } else {
+      const when = anchor.locale(sakai.locale.userLocale).format("ddd, ll");
+      hint.textContent = DTMN.formatTemplate(hint.dataset.template || "{0}", [when]);
+    }
+  });
 };
 
 DTMN.getFitAnchors = function() {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -218,7 +218,13 @@ DTMN.initCancelRevert = function() {
     const banner = document.getElementById("dm-cancel-banner");
     if (banner) {
       banner.classList.remove("d-none");
-      window.setTimeout(function() { $(banner).fadeOut(400); }, 4000);
+      window.setTimeout(function() {
+        const animation = banner.animate({ opacity: [1, 0] }, { duration: 400, easing: "ease" });
+        animation.finished.then(function() {
+          banner.classList.add("d-none");
+          animation.cancel();
+        });
+      }, 4000);
     }
   }
 };

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -467,7 +467,7 @@ DTMN.fillColumn = function(rootElementId, field, date, updates, notModified, fil
       return;
     }
 
-    // "Only cells that already have a date" mode: leave blanks alone.
+    // "Only update items that already have a date" mode: leave blanks alone.
     if (!fillEmpty && hiddenField.value === "") {
       return;
     }
@@ -557,7 +557,7 @@ DTMN.getTermHiddenId = function(term) {
   return "term-hidden-" + term.replaceAll("_", "-");
 };
 
-// Default term-date -> column mapping applied on load so a fresh Bulk Term Date Matrix arrives pre-checked with
+// Default term-date -> column mapping applied on load so a fresh Term Dates panel arrives pre-checked with
 // sane targets: the term's earliest date (Classes Start) fills every open/start column, and the latest
 // (Exam Ends) fills every due/close column. The instructor can tick or untick freely from there.
 DTMN.defaultTermTargets = {
@@ -632,7 +632,7 @@ DTMN.termHasActionableInput = function() {
 };
 
 // Like termHasActionableInput, but only counts a checked target whose section is currently expanded.
-// The "apply to expanded sections only" path skips collapsed sections, so without this the button could
+// The "apply only to tools expanded below" path skips collapsed sections, so without this the button could
 // be enabled while every checked column lives in a collapsed section, making the click a no-op.
 DTMN.termHasActionableInputInExpandedSections = function() {
   return DTMN.termFields.some(function(term) {

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -1290,6 +1290,21 @@ DTMN.previewToolColors = {
   lessons:        "#6c757d"
 };
 
+// FullCalendar defaults every event to white text, which fails WCAG AA on the lighter
+// accents above (cyan, teal, orange). Pick black or white per fill by relative
+// luminance — whichever contrasts more; the crossover is where the two ratios are equal.
+DTMN.previewEventTextColor = function(hex) {
+  const n = parseInt(hex.slice(1), 16);
+  const toLinear = function(c) {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const luminance = 0.2126 * toLinear((n >> 16) & 255)
+    + 0.7152 * toLinear((n >> 8) & 255)
+    + 0.0722 * toLinear(n & 255);
+  return luminance > 0.1791 ? '#000000' : '#ffffff';
+};
+
 // Read the live hidden-input values and build one FullCalendar event per non-empty
 // date. Events are all-day and keyed on the calendar day so they land squarely in the
 // day cell regardless of time zone; the time (when present) is shown in the marker text.
@@ -1316,11 +1331,13 @@ DTMN.collectPreviewEvents = function() {
     const fieldLabel = (DTMN.fieldLabels && DTMN.fieldLabels[field]) || field;
     const timeSuffix = (useTime && DTMN.hasTime(parsed)) ? ' ' + parsed.locale(sakai.locale.userLocale).format('LT') : '';
 
+    const fill = DTMN.previewToolColors[tool] || '#6c757d';
     events.push({
       title: (itemTitle ? itemTitle + ' — ' : '') + fieldLabel + timeSuffix,
       start: parsed.format('YYYY-MM-DD'),
       allDay: true,
-      color: DTMN.previewToolColors[tool] || '#6c757d'
+      color: fill,
+      textColor: DTMN.previewEventTextColor(fill)
     });
   });
   return events;

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -28,6 +28,7 @@
       <h1 th:text="#{page.instructions}">Add/Edit Options in batch</h1>
     </div>
 
+    <h2 class="h5 mt-3" th:text="#{section.shift.heading}">Shift every date by a fixed amount</h2>
     <div class="date-manager-shifter mb-3">
       <p>
         <div class="sak-banner-error d-none" id="dateShifterError">
@@ -45,6 +46,7 @@
       <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
     </div>
 
+    <h2 class="h5 mt-4" th:text="#{section.fit.heading}">Fit dates to a new term</h2>
     <div class="date-manager-fit mb-3">
       <div class="sak-banner-error d-none" id="dateFitError">
         <span th:text="#{datefit.error.range}"></span>
@@ -72,7 +74,9 @@
       <button type="button" class="btn btn-link m-2" id="fitVisibleDates" th:text="#{datefit.visible.button}" disabled></button>
     </div>
 
-    <div class="date-manager-bulk-options mb-2" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
+    <h2 class="h5 mt-4" th:text="#{section.set.heading}">Set dates directly</h2>
+    <div class="date-manager-set border rounded p-3 mb-3">
+    <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
       <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
       <label class="me-3">
         <input type="radio" name="bulk-fill-mode" value="all" checked />
@@ -182,6 +186,7 @@
       </div>
       <button type="button" class="btn btn-link m-2" id="applyTermDatesAll" th:text="#{termdates.all.button}" disabled></button>
       <button type="button" class="btn btn-link m-2" id="applyTermDatesVisible" th:text="#{termdates.visible.button}" disabled></button>
+    </div>
     </div>
 
     <form id="date-manager-form" method="POST">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -45,6 +45,33 @@
       <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
     </div>
 
+    <div class="date-manager-fit mb-3">
+      <div class="sak-banner-error d-none" id="dateFitError">
+        <span th:text="#{datefit.error.range}"></span>
+      </div>
+      <p th:text="#{datefit.instructions}">Re-anchor every dated item to a new term.</p>
+      <div class="row g-2 align-items-end">
+        <div class="col-auto">
+          <label class="form-label mb-1 d-block" for="dateFitFirst" th:text="#{datefit.first.label}">New first date</label>
+          <input type="text" class="form-control form-control-sm" id="dateFitFirst" th:attr="aria-label=#{datefit.first.label}" />
+          <input type="hidden" id="dateFitFirstHidden" />
+        </div>
+        <div class="col-auto">
+          <label class="form-label mb-1 d-block" for="dateFitLast" th:text="#{datefit.last.label}">New last date</label>
+          <input type="text" class="form-control form-control-sm" id="dateFitLast" th:attr="aria-label=#{datefit.last.label}" />
+          <input type="hidden" id="dateFitLastHidden" />
+        </div>
+        <div class="col-auto">
+          <label class="mb-1">
+            <input type="checkbox" id="dateFitSnap" checked />
+            <span th:text="#{datefit.snap.label}" th:remove="tag">Snap to weeks (keep each item's weekday &amp; time)</span>
+          </label>
+        </div>
+      </div>
+      <button type="button" class="btn btn-link m-2" id="fitAllDates" th:text="#{datefit.all.button}" disabled></button>
+      <button type="button" class="btn btn-link m-2" id="fitVisibleDates" th:text="#{datefit.visible.button}" disabled></button>
+    </div>
+
     <div class="date-manager-bulk-options mb-2" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
       <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
       <label class="me-3">
@@ -385,6 +412,7 @@
 
           DTMN.initDatePicker(updates, notModified);
           DTMN.initShifter(updates, notModified);
+          DTMN.initFitter(updates, notModified);
           DTMN.initColumnBulkSetters(updates, notModified);
           DTMN.initTermDates(updates, notModified);
 

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -28,8 +28,8 @@
     <div class="page-header border-bottom d-flex justify-content-between align-items-center flex-wrap gap-2">
       <h1 class="mb-0" th:text="#{page.title}">Date Manager</h1>
       <div class="date-manager-actions">
-        <a id="exportDates" class="btn-link" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
-        <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
+        <a id="exportDates" class="btn btn-secondary btn-sm" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
+        <a id="importDates" class="btn btn-secondary btn-sm" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
       </div>
     </div>
 
@@ -67,7 +67,7 @@
                 <span id="date-diff-result" class="fw-bold" aria-live="polite" th:attr="data-template=#{datediff.result}"></span>
               </div>
               <div class="col-auto">
-                <button type="button" class="btn btn-outline-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
+                <button type="button" class="btn btn-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
               </div>
             </div>
             <p class="small mt-2 mb-0" th:text="#{datediff.note}">Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
@@ -83,8 +83,8 @@
               <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
             </label>
           </p>
-          <button class="btn btn-link m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
-          <button class="btn btn-link m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
+          <button class="btn btn-secondary m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
+          <button class="btn btn-secondary m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
         </div>
       </div>
     </div>
@@ -120,8 +120,8 @@
               </label>
             </div>
           </div>
-          <button type="button" class="btn btn-link m-2" id="fit-all-dates" th:text="#{datefit.all.button}" disabled></button>
-          <button type="button" class="btn btn-link m-2" id="fit-visible-dates" th:text="#{datefit.visible.button}" disabled></button>
+          <button type="button" class="btn btn-secondary m-2" id="fit-all-dates" th:text="#{datefit.all.button}" disabled></button>
+          <button type="button" class="btn btn-secondary m-2" id="fit-visible-dates" th:text="#{datefit.visible.button}" disabled></button>
         </div>
       </div>
     </div>
@@ -243,8 +243,8 @@
           </tbody>
         </table>
       </div>
-      <button type="button" class="btn btn-link m-2" id="apply-term-dates-all" th:text="#{termdates.all.button}" disabled></button>
-      <button type="button" class="btn btn-link m-2" id="apply-term-dates-visible" th:text="#{termdates.visible.button}" disabled></button>
+      <button type="button" class="btn btn-secondary m-2" id="apply-term-dates-all" th:text="#{termdates.all.button}" disabled></button>
+      <button type="button" class="btn btn-secondary m-2" id="apply-term-dates-visible" th:text="#{termdates.visible.button}" disabled></button>
     </div>
         </div>
       </div>
@@ -360,7 +360,7 @@
             id="datemanager-preview"
             aria-controls="modal-calendar-preview"
             th:text="#{button.calendar.preview}">Visual Preview</button>
-        <button type="button" class="btn btn-link" id="datemanager-cancel" th:text="#{button.cancel}">Cancel</button>
+        <button type="button" class="btn btn-secondary" id="datemanager-cancel" th:text="#{button.cancel}">Cancel</button>
       </div>
 
       <span id="datemanager-confirm-description" class="visually-hidden" th:text="#{modal.confirm.description}"></span>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -36,21 +36,6 @@
     <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
     <p class="small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
 
-    <!-- Governs every column fill on the page: the term-date matrix in the card below AND the
-         per-column setters in the item section headers. Kept outside the collapsible cards so the
-         active mode is always visible. -->
-    <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
-      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
-      <label class="me-3">
-        <input type="radio" name="bulk-fill-mode" value="existing" checked />
-        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
-      </label>
-      <label>
-        <input type="radio" name="bulk-fill-mode" value="all" />
-        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
-      </label>
-    </div>
-
     <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
          further down. The collapsed Shift / Fit / Set-dates cards live here. Export/Import sit in the
          page header, top-right, since they act on the whole site rather than the in-page edits. -->
@@ -150,6 +135,20 @@
       <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-set">
     <p class="small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
+
+    <!-- Governs the matrix applies below only; the per-column setters in the item section headers
+         carry their own "Fill Empty" checkbox instead. -->
+    <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
+      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
+      <label class="me-3">
+        <input type="radio" name="bulk-fill-mode" value="existing" checked />
+        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
+      </label>
+      <label>
+        <input type="radio" name="bulk-fill-mode" value="all" />
+        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
+      </label>
+    </div>
 
     <div class="date-manager-term mb-3">
       <p th:text="#{termdates.instructions}">Enter your term dates, tick which columns each one should fill, then apply. Overlapping ticks apply top to bottom, so a lower row wins. Remember to click Save Changes at the bottom of the page.</p>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -42,10 +42,10 @@
     <div class="card">
       <div class="card-header">
         <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-shift" class="collapsed" aria-expanded="false"><span th:text="#{section.shift.heading}">Shift every date by a fixed amount</span></a>
+          <a data-bs-toggle="collapse" href="#dm-batch-shift" aria-expanded="true"><span th:text="#{section.shift.heading}">Shift every date by a fixed amount</span></a>
         </h4>
       </div>
-      <div id="dm-batch-shift" class="collapse">
+      <div id="dm-batch-shift" class="collapse show">
         <div class="card-body date-manager-shifter">
           <div class="sak-banner-error d-none" id="dateShifterError">
             <span th:text="#{dateshifter.error.nonnumeric}"></span>
@@ -66,7 +66,7 @@
     <div class="card">
       <div class="card-header">
         <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-fit" class="collapsed" aria-expanded="false"><span th:text="#{section.fit.heading}">Fit dates to a new term</span></a>
+          <a data-bs-toggle="collapse" href="#dm-batch-fit" class="collapsed" aria-expanded="false"><span th:text="#{section.fit.heading}">Smart Shift</span></a>
         </h4>
       </div>
       <div id="dm-batch-fit" class="collapse">
@@ -102,7 +102,7 @@
     <div class="card">
       <div class="card-header">
         <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Set dates directly</span></a>
+          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Bulk Anchor</span></a>
         </h4>
       </div>
       <div id="dm-batch-set" class="collapse">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -3,12 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <style>
-      /* Helper notes: de-emphasize by size only, not color, so they keep full
-         WCAG AA contrast in dark mode (Bootstrap's text-muted gray fails on the
-         dark card background). --sakai-text-color-1 flips near-white in dark. */
-      .Mrphs-sakai-datemanager-tool .dm-note { color: var(--sakai-text-color-1); }
-    </style>
   </head>
   <body class="portalBody Mrphs-portalBody Mrphs-sakai-datemanager-tool">
     <link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
@@ -40,7 +34,7 @@
     </div>
 
     <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
-    <p class="dm-note small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
+    <p class="small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
 
     <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
          further down. The collapsed Shift / Fit / Set-dates cards live here. Export/Import sit in the
@@ -55,7 +49,7 @@
       </div>
       <div id="dm-batch-shift" class="collapse show" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-shifter">
-          <p class="dm-note small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.</p>
+          <p class="small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.</p>
           <div class="date-manager-datediff mb-3">
             <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Calculate the number of days between two dates with the utility below to apply a fixed integer shift to all dates</label>
             <div class="row g-2 align-items-end">
@@ -76,7 +70,7 @@
                 <button type="button" class="btn btn-outline-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
               </div>
             </div>
-            <p class="dm-note small mt-2 mb-0" th:text="#{datediff.note}">Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
+            <p class="small mt-2 mb-0" th:text="#{datediff.note}">Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
           </div>
 
           <div class="sak-banner-error d-none" id="dateShifterError">
@@ -103,7 +97,7 @@
       </div>
       <div id="dm-batch-fit" class="collapse" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-fit">
-          <p class="dm-note small mb-2" th:text="#{datefit.help}">This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.</p>
+          <p class="small mb-2" th:text="#{datefit.help}">This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.</p>
           <div class="sak-banner-error d-none" id="date-fit-error">
             <span th:text="#{datefit.error.range}"></span>
           </div>
@@ -140,7 +134,7 @@
       </div>
       <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-set">
-    <p class="dm-note small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
+    <p class="small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
       <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
       <label class="me-3">
@@ -259,7 +253,7 @@
 
     <hr class="my-4" />
     <h2 class="h5" th:text="#{section.items.heading}">Edit individual items</h2>
-    <p class="dm-note small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
+    <p class="small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
 
     <form id="date-manager-form" method="POST">
       <div class="sak-banner-error d-none" id="form-errors">
@@ -400,7 +394,7 @@
               <button type="button" class="btn btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-              <p class="dm-note small" th:text="#{calendar.preview.help}"></p>
+              <p class="small" th:text="#{calendar.preview.help}"></p>
               <p id="datemanager-calendar-empty" class="d-none" th:text="#{calendar.preview.empty}"></p>
               <div id="datemanager-calendar"></div>
             </div>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -24,20 +24,21 @@
     <script th:src="@{/js/initDatePicker.js}"></script>
     <meta http-equiv="Content-Style-Type" content="text/css" />
 
-    <div class="page-header border-bottom">
-      <h1 th:text="#{page.instructions}">Add/Edit Options in batch</h1>
+    <div class="page-header border-bottom d-flex justify-content-between align-items-center flex-wrap gap-2">
+      <h1 class="mb-0" th:text="#{page.title}">Date Manager</h1>
+      <div class="date-manager-actions">
+        <a id="exportDates" class="btn-link" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
+        <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
+      </div>
     </div>
 
     <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
     <p class="text-muted small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
 
     <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
-         further down. Export/Import plus the collapsed Shift / Fit / Set-dates cards live here. -->
+         further down. The collapsed Shift / Fit / Set-dates cards live here. Export/Import sit in the
+         page header, top-right, since they act on the whole site rather than the in-page edits. -->
     <div class="dm-batch-tools border-start border-4 border-primary ps-3 mb-4">
-      <div class="date-manager-actions mb-3">
-        <a id="exportDates" class="btn-link" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
-        <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
-      </div>
 
     <div class="card">
       <div class="card-header">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -28,54 +28,81 @@
       <h1 th:text="#{page.instructions}">Add/Edit Options in batch</h1>
     </div>
 
-    <h2 class="h5 mt-3" th:text="#{section.shift.heading}">Shift every date by a fixed amount</h2>
-    <div class="date-manager-shifter mb-3">
-      <p>
-        <div class="sak-banner-error d-none" id="dateShifterError">
-          <span th:text="#{dateshifter.error.nonnumeric}"></span>
-        </div>
-        <label>
-          <span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
-          <input id="dateShifterDays" type="text" />
-          <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
-        </label>
-      </p>
-      <button class="btn btn-link m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
-      <button class="btn btn-link m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
+    <!-- Export/Import stay visible. The batch-edit tools below are each collapsed by default so the
+         per-tool editing sections (the normal grid) are what shows when the page loads. -->
+    <div class="date-manager-actions mb-3">
       <a id="exportDates" class="btn-link" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
       <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
     </div>
 
-    <h2 class="h5 mt-4" th:text="#{section.fit.heading}">Fit dates to a new term</h2>
-    <div class="date-manager-fit mb-3">
-      <div class="sak-banner-error d-none" id="dateFitError">
-        <span th:text="#{datefit.error.range}"></span>
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">
+          <a data-bs-toggle="collapse" href="#dm-batch-shift" class="collapsed" aria-expanded="false"><span th:text="#{section.shift.heading}">Shift every date by a fixed amount</span></a>
+        </h4>
       </div>
-      <p th:text="#{datefit.instructions}">Re-anchor every dated item to a new term.</p>
-      <div class="row g-2 align-items-end">
-        <div class="col-auto">
-          <label class="form-label mb-1 d-block" for="dateFitFirst" th:text="#{datefit.first.label}">New first date</label>
-          <input type="text" class="form-control form-control-sm" id="dateFitFirst" th:attr="aria-label=#{datefit.first.label}" />
-          <input type="hidden" id="dateFitFirstHidden" />
-        </div>
-        <div class="col-auto">
-          <label class="form-label mb-1 d-block" for="dateFitLast" th:text="#{datefit.last.label}">New last date</label>
-          <input type="text" class="form-control form-control-sm" id="dateFitLast" th:attr="aria-label=#{datefit.last.label}" />
-          <input type="hidden" id="dateFitLastHidden" />
-        </div>
-        <div class="col-auto">
-          <label class="mb-1">
-            <input type="checkbox" id="dateFitSnap" checked />
-            <span th:text="#{datefit.snap.label}" th:remove="tag">Snap to weeks (keep each item's weekday &amp; time)</span>
-          </label>
+      <div id="dm-batch-shift" class="collapse">
+        <div class="card-body date-manager-shifter">
+          <div class="sak-banner-error d-none" id="dateShifterError">
+            <span th:text="#{dateshifter.error.nonnumeric}"></span>
+          </div>
+          <p>
+            <label>
+              <span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
+              <input id="dateShifterDays" type="text" />
+              <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
+            </label>
+          </p>
+          <button class="btn btn-link m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
+          <button class="btn btn-link m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
         </div>
       </div>
-      <button type="button" class="btn btn-link m-2" id="fitAllDates" th:text="#{datefit.all.button}" disabled></button>
-      <button type="button" class="btn btn-link m-2" id="fitVisibleDates" th:text="#{datefit.visible.button}" disabled></button>
     </div>
 
-    <h2 class="h5 mt-4" th:text="#{section.set.heading}">Set dates directly</h2>
-    <div class="date-manager-set border rounded p-3 mb-3">
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">
+          <a data-bs-toggle="collapse" href="#dm-batch-fit" class="collapsed" aria-expanded="false"><span th:text="#{section.fit.heading}">Fit dates to a new term</span></a>
+        </h4>
+      </div>
+      <div id="dm-batch-fit" class="collapse">
+        <div class="card-body date-manager-fit">
+          <div class="sak-banner-error d-none" id="dateFitError">
+            <span th:text="#{datefit.error.range}"></span>
+          </div>
+          <p th:text="#{datefit.instructions}">Re-anchor every dated item to a new term.</p>
+          <div class="row g-2 align-items-end">
+            <div class="col-auto">
+              <label class="form-label mb-1 d-block" for="dateFitFirst" th:text="#{datefit.first.label}">New first date</label>
+              <input type="text" class="form-control form-control-sm" id="dateFitFirst" th:attr="aria-label=#{datefit.first.label}" />
+              <input type="hidden" id="dateFitFirstHidden" />
+            </div>
+            <div class="col-auto">
+              <label class="form-label mb-1 d-block" for="dateFitLast" th:text="#{datefit.last.label}">New last date</label>
+              <input type="text" class="form-control form-control-sm" id="dateFitLast" th:attr="aria-label=#{datefit.last.label}" />
+              <input type="hidden" id="dateFitLastHidden" />
+            </div>
+            <div class="col-auto">
+              <label class="mb-1">
+                <input type="checkbox" id="dateFitSnap" checked />
+                <span th:text="#{datefit.snap.label}" th:remove="tag">Snap to weeks (keep each item's weekday &amp; time)</span>
+              </label>
+            </div>
+          </div>
+          <button type="button" class="btn btn-link m-2" id="fitAllDates" th:text="#{datefit.all.button}" disabled></button>
+          <button type="button" class="btn btn-link m-2" id="fitVisibleDates" th:text="#{datefit.visible.button}" disabled></button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h4 class="card-title">
+          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Set dates directly</span></a>
+        </h4>
+      </div>
+      <div id="dm-batch-set" class="collapse">
+        <div class="card-body date-manager-set">
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
       <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
       <label class="me-3">
@@ -187,6 +214,8 @@
       <button type="button" class="btn btn-link m-2" id="applyTermDatesAll" th:text="#{termdates.all.button}" disabled></button>
       <button type="button" class="btn btn-link m-2" id="applyTermDatesVisible" th:text="#{termdates.visible.button}" disabled></button>
     </div>
+        </div>
+      </div>
     </div>
 
     <form id="date-manager-form" method="POST">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -53,11 +53,11 @@
           <a data-bs-toggle="collapse" href="#dm-batch-shift" aria-expanded="true"><span th:text="#{section.shift.heading}">Shift every date by a fixed amount</span></a>
         </h4>
       </div>
-      <div id="dm-batch-shift" class="collapse show">
+      <div id="dm-batch-shift" class="collapse show" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-shifter">
-          <p class="dm-note small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board. To re-space items to fit a new term, use Smart Shift below instead.</p>
+          <p class="dm-note small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.</p>
           <div class="date-manager-datediff mb-3">
-            <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Days between two dates</label>
+            <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Calculate the number of days between two dates with the utility below to apply a fixed integer shift to all dates</label>
             <div class="row g-2 align-items-end">
               <div class="col-auto">
                 <label class="form-label mb-1 d-block" for="date-diff-from" th:text="#{datediff.from.label}">From</label>
@@ -101,7 +101,7 @@
           <a data-bs-toggle="collapse" href="#dm-batch-fit" class="collapsed" aria-expanded="false"><span th:text="#{section.fit.heading}">Smart Shift</span></a>
         </h4>
       </div>
-      <div id="dm-batch-fit" class="collapse">
+      <div id="dm-batch-fit" class="collapse" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-fit">
           <p class="dm-note small mb-2" th:text="#{datefit.help}">This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.</p>
           <div class="sak-banner-error d-none" id="date-fit-error">
@@ -138,7 +138,7 @@
           <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Bulk Anchor</span></a>
         </h4>
       </div>
-      <div id="dm-batch-set" class="collapse">
+      <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-set">
     <p class="dm-note small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -28,12 +28,16 @@
       <h1 th:text="#{page.instructions}">Add/Edit Options in batch</h1>
     </div>
 
-    <!-- Export/Import stay visible. The batch-edit tools below are each collapsed by default so the
-         per-tool editing sections (the normal grid) are what shows when the page loads. -->
-    <div class="date-manager-actions mb-3">
-      <a id="exportDates" class="btn-link" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
-      <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
-    </div>
+    <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
+    <p class="text-muted small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
+
+    <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
+         further down. Export/Import plus the collapsed Shift / Fit / Set-dates cards live here. -->
+    <div class="dm-batch-tools border-start border-4 border-primary ps-3 mb-4">
+      <div class="date-manager-actions mb-3">
+        <a id="exportDates" class="btn-link" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
+        <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
+      </div>
 
     <div class="card">
       <div class="card-header">
@@ -217,6 +221,11 @@
         </div>
       </div>
     </div>
+    </div>
+
+    <hr class="my-4" />
+    <h2 class="h5" th:text="#{section.items.heading}">Edit individual items</h2>
+    <p class="text-muted small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
 
     <form id="date-manager-form" method="POST">
       <div class="sak-banner-error d-none" id="form-errors">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -18,6 +18,7 @@
         includeLatestJQuery('datemanager/index.html');
         includeWebjarLibrary('momentjs');
         includeWebjarLibrary('moment-timezone/0.5.33/builds/moment-timezone-with-data.min.js');
+        includeWebjarLibrary('fullcalendar');
       /*]]>*/
     </script>
     <script src="/library/js/lang-datepicker/lang-datepicker.js"></script>
@@ -351,6 +352,10 @@
             th:text="#{button.save}"
             disabled>
         </button>
+        <button type="button" class="btn btn-secondary"
+            id="datemanager-preview"
+            aria-controls="modal-calendar-preview"
+            th:text="#{button.calendar.preview}">Visual Preview</button>
         <button type="button" class="btn btn-link" id="datemanager-cancel" th:text="#{button.cancel}">Cancel</button>
       </div>
 
@@ -370,6 +375,24 @@
             <div class="modal-footer act">
               <button type="button" class="btn btn-primary" id="modal-btn-confirm" th:text="#{button.save}">Save Changes</button>
               <button type="button" class="btn btn-secondary" id="modal-btn-cancel" th:text="#{button.cancel}">Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Read-only calendar preview: plots every date currently entered below into a month grid so the
+           user can visually sanity-check a shift/fit/anchor before choosing Save Changes. -->
+      <div class="modal fade" tabindex="-1" aria-hidden="true" aria-labelledby="datemanager-preview-title" id="modal-calendar-preview">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 id="datemanager-preview-title" th:text="#{calendar.preview.title}" class="modal-title">Calendar preview of all dates</h5>
+              <button type="button" class="btn btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <p class="text-muted small" th:text="#{calendar.preview.help}"></p>
+              <p id="datemanager-calendar-empty" class="d-none" th:text="#{calendar.preview.empty}"></p>
+              <div id="datemanager-calendar"></div>
             </div>
           </div>
         </div>
@@ -476,12 +499,25 @@
 
           var notModified = [];
 
+          // Localized labels for each editable date column, used by the calendar preview to name markers
+          // ("<item title> — <field label>"). Reuses the same column keys the table headers render with.
+          DTMN.fieldLabels = {
+            open_date: /*[[#{column.open.date}]]*/ 'Open Date',
+            due_date: /*[[#{column.due.date}]]*/ 'Due Date',
+            accept_until: /*[[#{column.accept.until}]]*/ 'Accept Until Date',
+            feedback_start: /*[[#{column.feedback.start.date}]]*/ 'Show Feedback On',
+            feedback_end: /*[[#{column.feedback.end.date}]]*/ 'Show Feedback Until',
+            signup_begins: /*[[#{column.signup.begins.date}]]*/ 'Sign-up Begins Date',
+            signup_deadline: /*[[#{column.signup.deadline.date}]]*/ 'Sign-up Ends Date'
+          };
+
           DTMN.initDatePicker(updates, notModified);
           DTMN.initShifter(updates, notModified);
           DTMN.initDateDiff();
           DTMN.initFitter(updates, notModified);
           DTMN.initColumnBulkSetters(updates, notModified);
           DTMN.initTermDates(updates, notModified);
+          DTMN.initCalendarPreview();
 
           function printErrors() {
             $('.errors').empty();

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -139,7 +139,7 @@
     <!-- Governs the matrix applies below only; the per-column setters in the item section headers
          carry their own "Fill Empty" checkbox instead. -->
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
-      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
+      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When the term dates below fill a column:</span>
       <label class="me-3">
         <input type="radio" name="bulk-fill-mode" value="existing" checked />
         <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -3,6 +3,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <style>
+      /* Helper notes: de-emphasize by size only, not color, so they keep full
+         WCAG AA contrast in dark mode (Bootstrap's text-muted gray fails on the
+         dark card background). --sakai-text-color-1 flips near-white in dark. */
+      .Mrphs-sakai-datemanager-tool .dm-note { color: var(--sakai-text-color-1); }
+    </style>
   </head>
   <body class="portalBody Mrphs-portalBody Mrphs-sakai-datemanager-tool">
     <link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
@@ -34,7 +40,7 @@
     </div>
 
     <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
-    <p class="text-muted small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
+    <p class="dm-note small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
 
     <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
          further down. The collapsed Shift / Fit / Set-dates cards live here. Export/Import sit in the
@@ -49,20 +55,8 @@
       </div>
       <div id="dm-batch-shift" class="collapse show">
         <div class="card-body date-manager-shifter">
-          <div class="sak-banner-error d-none" id="dateShifterError">
-            <span th:text="#{dateshifter.error.nonnumeric}"></span>
-          </div>
-          <p>
-            <label>
-              <span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
-              <input id="dateShifterDays" type="text" />
-              <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
-            </label>
-          </p>
-          <button class="btn btn-link m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
-          <button class="btn btn-link m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
-
-          <div class="date-manager-datediff mt-3">
+          <p class="dm-note small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board. To re-space items to fit a new term, use Smart Shift below instead.</p>
+          <div class="date-manager-datediff mb-3">
             <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Days between two dates</label>
             <div class="row g-2 align-items-end">
               <div class="col-auto">
@@ -82,7 +76,21 @@
                 <button type="button" class="btn btn-outline-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
               </div>
             </div>
+            <p class="dm-note small mt-2 mb-0" th:text="#{datediff.note}">Note: this only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
           </div>
+
+          <div class="sak-banner-error d-none" id="dateShifterError">
+            <span th:text="#{dateshifter.error.nonnumeric}"></span>
+          </div>
+          <p>
+            <label>
+              <span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
+              <input id="dateShifterDays" type="text" />
+              <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
+            </label>
+          </p>
+          <button class="btn btn-link m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
+          <button class="btn btn-link m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
         </div>
       </div>
     </div>
@@ -95,6 +103,7 @@
       </div>
       <div id="dm-batch-fit" class="collapse">
         <div class="card-body date-manager-fit">
+          <p class="dm-note small mb-2" th:text="#{datefit.help}">This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.</p>
           <div class="sak-banner-error d-none" id="date-fit-error">
             <span th:text="#{datefit.error.range}"></span>
           </div>
@@ -131,6 +140,7 @@
       </div>
       <div id="dm-batch-set" class="collapse">
         <div class="card-body date-manager-set">
+    <p class="dm-note small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
       <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
       <label class="me-3">
@@ -249,7 +259,7 @@
 
     <hr class="my-4" />
     <h2 class="h5" th:text="#{section.items.heading}">Edit individual items</h2>
-    <p class="text-muted small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
+    <p class="dm-note small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
 
     <form id="date-manager-form" method="POST">
       <div class="sak-banner-error d-none" id="form-errors">
@@ -390,7 +400,7 @@
               <button type="button" class="btn btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-              <p class="text-muted small" th:text="#{calendar.preview.help}"></p>
+              <p class="dm-note small" th:text="#{calendar.preview.help}"></p>
               <p id="datemanager-calendar-empty" class="d-none" th:text="#{calendar.preview.empty}"></p>
               <div id="datemanager-calendar"></div>
             </div>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -36,6 +36,21 @@
     <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
     <p class="small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
 
+    <!-- Governs every column fill on the page: the term-date matrix in the card below AND the
+         per-column setters in the item section headers. Kept outside the collapsible cards so the
+         active mode is always visible. -->
+    <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
+      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
+      <label class="me-3">
+        <input type="radio" name="bulk-fill-mode" value="all" checked />
+        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
+      </label>
+      <label>
+        <input type="radio" name="bulk-fill-mode" value="existing" />
+        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
+      </label>
+    </div>
+
     <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
          further down. The collapsed Shift / Fit / Set-dates cards live here. Export/Import sit in the
          page header, top-right, since they act on the whole site rather than the in-page edits. -->
@@ -135,17 +150,6 @@
       <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">
         <div class="card-body date-manager-set">
     <p class="small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
-    <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
-      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
-      <label class="me-3">
-        <input type="radio" name="bulk-fill-mode" value="all" checked />
-        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
-      </label>
-      <label>
-        <input type="radio" name="bulk-fill-mode" value="existing" />
-        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
-      </label>
-    </div>
 
     <div class="date-manager-term mb-3">
       <p th:text="#{termdates.instructions}">Enter your term dates, tick which columns each one should fill, then apply. Overlapping ticks apply top to bottom, so a lower row wins. Remember to click Save Changes at the bottom of the page.</p>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -45,23 +45,116 @@
       <a id="importDates" class="btn-link" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
     </div>
 
-    <div th:if="${bulkDateFields != null and !bulkDateFields.isEmpty()}" class="date-manager-setter mb-3">
-      <div class="sak-banner-error d-none" id="dateBulkSetterError">
-        <span data-error="empty" th:text="#{datesetter.error.empty}"></span>
-        <span data-error="dateonly" class="d-none" th:text="#{datesetter.error.dateonly}"></span>
+    <div class="date-manager-bulk-options mb-2" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
+      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
+      <label class="me-3">
+        <input type="radio" name="bulk-fill-mode" value="all" checked />
+        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
+      </label>
+      <label>
+        <input type="radio" name="bulk-fill-mode" value="existing" />
+        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
+      </label>
+    </div>
+
+    <div class="date-manager-term mb-3">
+      <p th:text="#{termdates.instructions}">Enter your term dates, tick which columns each one should fill, then apply. Overlapping ticks apply top to bottom, so a lower row wins. Remember to click Save Changes at the bottom of the page.</p>
+      <div class="table-responsive">
+        <table class="table table-bordered table-sm align-middle table-datemanager-term">
+          <thead>
+            <tr>
+              <th rowspan="2" class="align-bottom" th:text="#{termdates.column.header}">Term date</th>
+              <th th:if="${assignments != null}" colspan="3" class="text-center" th:text="${assignmentsToolTitle}">Assignments</th>
+              <th th:if="${assessments != null}" colspan="5" class="text-center" th:text="${assessmentsToolTitle}">Tests &amp; Quizzes</th>
+              <th th:if="${signupMeetings != null}" colspan="4" class="text-center" th:text="${signupMeetingsToolTitle}">Sign up</th>
+              <th th:if="${gradebookItems != null}" colspan="1" class="text-center" th:text="${gradebookItemsToolTitle}">Gradebook</th>
+              <th th:if="${resources != null}" colspan="2" class="text-center" th:text="${resourcesToolTitle}">Resources</th>
+              <th th:if="${calendarEvents != null}" colspan="2" class="text-center" th:text="${calendarEventsToolTitle}">Calendar</th>
+              <th th:if="${forums != null}" colspan="2" class="text-center" th:text="${forumsToolTitle}">Forums</th>
+              <th th:if="${announcements != null}" colspan="2" class="text-center" th:text="${announcementsToolTitle}">Announcements</th>
+              <th th:if="${lessons != null}" colspan="1" class="text-center" th:text="${lessonsToolTitle}">Lessons</th>
+            </tr>
+            <tr>
+              <th:block th:if="${assignments != null}">
+                <th class="text-center" th:text="#{column.open.date}">Open Date</th>
+                <th class="text-center" th:text="#{column.due.date}">Due Date</th>
+                <th class="text-center" th:text="#{column.accept.until}">Accept Until Date</th>
+              </th:block>
+              <th:block th:if="${assessments != null}">
+                <th class="text-center" th:text="#{column.available.date}">Available Date</th>
+                <th class="text-center" th:text="#{column.due.date}">Due Date</th>
+                <th class="text-center" th:text="#{column.assessments.accept.until}">Late Submission Deadline</th>
+                <th class="text-center" th:text="#{column.feedback.start.date}">Show Feedback Date</th>
+                <th class="text-center" th:text="#{column.feedback.end.date}">Hide Feedback Date</th>
+              </th:block>
+              <th:block th:if="${signupMeetings != null}">
+                <th class="text-center" th:text="#{column.start.date}">Start Date</th>
+                <th class="text-center" th:text="#{column.end.date}">End Date</th>
+                <th class="text-center" th:text="#{column.signup.begins.date}">Sign-up Begin Date</th>
+                <th class="text-center" th:text="#{column.signup.deadline.date}">Sign-up End Date</th>
+              </th:block>
+              <th:block th:if="${gradebookItems != null}">
+                <th class="text-center" th:text="#{column.due.date}">Due Date</th>
+              </th:block>
+              <th:block th:if="${resources != null}">
+                <th class="text-center" th:text="#{column.show.from.date}">Show From Date</th>
+                <th class="text-center" th:text="#{column.show.until}">Show Until Date</th>
+              </th:block>
+              <th:block th:if="${calendarEvents != null}">
+                <th class="text-center" th:text="#{column.start.date}">Start Date</th>
+                <th class="text-center" th:text="#{column.end.date}">End Date</th>
+              </th:block>
+              <th:block th:if="${forums != null}">
+                <th class="text-center" th:text="#{column.open.date}">Open Date</th>
+                <th class="text-center" th:text="#{column.close.date}">Close Date</th>
+              </th:block>
+              <th:block th:if="${announcements != null}">
+                <th class="text-center" th:text="#{column.start.date}">Start Date</th>
+                <th class="text-center" th:text="#{column.end.date}">End Date</th>
+              </th:block>
+              <th:block th:if="${lessons != null}">
+                <th class="text-center" th:text="#{column.hide.until}">Hide Until Date</th>
+              </th:block>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row" class="text-nowrap">
+                <label class="form-label mb-1 d-block" for="term-input-classes-start" th:text="#{termdates.classes.start}">Classes Start</label>
+                <input type="text" class="form-control form-control-sm term-input" id="term-input-classes-start" th:attr="aria-label=#{termdates.classes.start}" />
+                <input type="hidden" id="term-hidden-classes-start" />
+              </th>
+              <th:block th:replace="~{tool_fragment :: termCells('classes_start')}"></th:block>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">
+                <label class="form-label mb-1 d-block" for="term-input-classes-end" th:text="#{termdates.classes.end}">Classes End</label>
+                <input type="text" class="form-control form-control-sm term-input" id="term-input-classes-end" th:attr="aria-label=#{termdates.classes.end}" />
+                <input type="hidden" id="term-hidden-classes-end" />
+              </th>
+              <th:block th:replace="~{tool_fragment :: termCells('classes_end')}"></th:block>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">
+                <label class="form-label mb-1 d-block" for="term-input-exam-begins" th:text="#{termdates.exam.begins}">Exam Begins</label>
+                <input type="text" class="form-control form-control-sm term-input" id="term-input-exam-begins" th:attr="aria-label=#{termdates.exam.begins}" />
+                <input type="hidden" id="term-hidden-exam-begins" />
+              </th>
+              <th:block th:replace="~{tool_fragment :: termCells('exam_begins')}"></th:block>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">
+                <label class="form-label mb-1 d-block" for="term-input-exam-ends" th:text="#{termdates.exam.ends}">Exam Ends</label>
+                <input type="text" class="form-control form-control-sm term-input" id="term-input-exam-ends" th:attr="aria-label=#{termdates.exam.ends}" />
+                <input type="hidden" id="term-hidden-exam-ends" />
+              </th>
+              <th:block th:replace="~{tool_fragment :: termCells('exam_ends')}"></th:block>
+            </tr>
+          </tbody>
+        </table>
       </div>
-      <p th:text="#{datesetter.instructions}">Enter one or more dates below, then apply them to all items or expanded sections only. Remember to click Save Changes at the bottom of the page to save your adjustments.</p>
-      <div class="row g-3">
-        <div th:each="field : ${bulkDateFields}" class="col-sm-6 col-lg-3"
-             th:with="inputId=${'bulk-' + #strings.replace(field, '_', '-')}">
-          <label class="form-label" th:for="${inputId}"
-                 th:text="#{${T(org.sakaiproject.datemanager.api.DateManagerConstants).BULK_DATE_FIELD_LABEL_KEYS.get(field)}}">Date</label>
-          <input th:id="${inputId}" type="text" class="form-control bulk-date-input" />
-          <input th:id="${'bulk-hidden-' + #strings.replace(field, '_', '-')}" type="hidden" th:attr="data-field=${field}" />
-        </div>
-      </div>
-      <button class="btn btn-link m-2" id="applyAllDates" th:text="#{datesetter.all.button}" disabled></button>
-      <button class="btn btn-link m-2" id="applyVisibleDates" th:text="#{datesetter.visible.button}" disabled></button>
+      <button type="button" class="btn btn-link m-2" id="applyTermDatesAll" th:text="#{termdates.all.button}" disabled></button>
+      <button type="button" class="btn btn-link m-2" id="applyTermDatesVisible" th:text="#{termdates.visible.button}" disabled></button>
     </div>
 
     <form id="date-manager-form" method="POST">
@@ -290,11 +383,10 @@
 
           var notModified = [];
 
-          DTMN.bulkFields = /*[[${bulkDateFields}]]*/ [];
-
           DTMN.initDatePicker(updates, notModified);
           DTMN.initShifter(updates, notModified);
-          DTMN.initBulkSetter(updates, notModified);
+          DTMN.initColumnBulkSetters(updates, notModified);
+          DTMN.initTermDates(updates, notModified);
 
           function printErrors() {
             $('.errors').empty();

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -252,7 +252,7 @@
     </div>
 
     <hr class="my-4" />
-    <h2 class="h5" th:text="#{section.items.heading}">Edit individual items</h2>
+    <h2 class="h5" th:text="#{section.items.heading}">Edit dates by item or column</h2>
     <p class="small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
 
     <form id="date-manager-form" method="POST">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -76,7 +76,7 @@
                 <button type="button" class="btn btn-outline-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
               </div>
             </div>
-            <p class="dm-note small mt-2 mb-0" th:text="#{datediff.note}">Note: this only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
+            <p class="dm-note small mt-2 mb-0" th:text="#{datediff.note}">Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
           </div>
 
           <div class="sak-banner-error d-none" id="dateShifterError">
@@ -135,7 +135,7 @@
     <div class="card">
       <div class="card-header">
         <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Bulk Anchor</span></a>
+          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Bulk Term Date Matrix</span></a>
         </h4>
       </div>
       <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -42,12 +42,12 @@
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
       <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When applying a date to a column:</span>
       <label class="me-3">
-        <input type="radio" name="bulk-fill-mode" value="all" checked />
-        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
+        <input type="radio" name="bulk-fill-mode" value="existing" checked />
+        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
       </label>
       <label>
-        <input type="radio" name="bulk-fill-mode" value="existing" />
-        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
+        <input type="radio" name="bulk-fill-mode" value="all" />
+        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
       </label>
     </div>
 

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -71,30 +71,30 @@
       </div>
       <div id="dm-batch-fit" class="collapse">
         <div class="card-body date-manager-fit">
-          <div class="sak-banner-error d-none" id="dateFitError">
+          <div class="sak-banner-error d-none" id="date-fit-error">
             <span th:text="#{datefit.error.range}"></span>
           </div>
           <p th:text="#{datefit.instructions}">Re-anchor every dated item to a new term.</p>
           <div class="row g-2 align-items-end">
             <div class="col-auto">
-              <label class="form-label mb-1 d-block" for="dateFitFirst" th:text="#{datefit.first.label}">New first date</label>
-              <input type="text" class="form-control form-control-sm" id="dateFitFirst" th:attr="aria-label=#{datefit.first.label}" />
-              <input type="hidden" id="dateFitFirstHidden" />
+              <label class="form-label mb-1 d-block" for="date-fit-first" th:text="#{datefit.first.label}">New first date</label>
+              <input type="text" class="form-control form-control-sm" id="date-fit-first" th:attr="aria-label=#{datefit.first.label}" />
+              <input type="hidden" id="date-fit-first-hidden" />
             </div>
             <div class="col-auto">
-              <label class="form-label mb-1 d-block" for="dateFitLast" th:text="#{datefit.last.label}">New last date</label>
-              <input type="text" class="form-control form-control-sm" id="dateFitLast" th:attr="aria-label=#{datefit.last.label}" />
-              <input type="hidden" id="dateFitLastHidden" />
+              <label class="form-label mb-1 d-block" for="date-fit-last" th:text="#{datefit.last.label}">New last date</label>
+              <input type="text" class="form-control form-control-sm" id="date-fit-last" th:attr="aria-label=#{datefit.last.label}" />
+              <input type="hidden" id="date-fit-last-hidden" />
             </div>
             <div class="col-auto">
               <label class="mb-1">
-                <input type="checkbox" id="dateFitSnap" checked />
+                <input type="checkbox" id="date-fit-snap" checked />
                 <span th:text="#{datefit.snap.label}" th:remove="tag">Snap to weeks (keep each item's weekday &amp; time)</span>
               </label>
             </div>
           </div>
-          <button type="button" class="btn btn-link m-2" id="fitAllDates" th:text="#{datefit.all.button}" disabled></button>
-          <button type="button" class="btn btn-link m-2" id="fitVisibleDates" th:text="#{datefit.visible.button}" disabled></button>
+          <button type="button" class="btn btn-link m-2" id="fit-all-dates" th:text="#{datefit.all.button}" disabled></button>
+          <button type="button" class="btn btn-link m-2" id="fit-visible-dates" th:text="#{datefit.visible.button}" disabled></button>
         </div>
       </div>
     </div>
@@ -215,8 +215,8 @@
           </tbody>
         </table>
       </div>
-      <button type="button" class="btn btn-link m-2" id="applyTermDatesAll" th:text="#{termdates.all.button}" disabled></button>
-      <button type="button" class="btn btn-link m-2" id="applyTermDatesVisible" th:text="#{termdates.visible.button}" disabled></button>
+      <button type="button" class="btn btn-link m-2" id="apply-term-dates-all" th:text="#{termdates.all.button}" disabled></button>
+      <button type="button" class="btn btn-link m-2" id="apply-term-dates-visible" th:text="#{termdates.visible.button}" disabled></button>
     </div>
         </div>
       </div>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -59,6 +59,28 @@
           </p>
           <button class="btn btn-link m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
           <button class="btn btn-link m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
+
+          <div class="date-manager-datediff mt-3">
+            <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Days between two dates</label>
+            <div class="row g-2 align-items-end">
+              <div class="col-auto">
+                <label class="form-label mb-1 d-block" for="date-diff-from" th:text="#{datediff.from.label}">From</label>
+                <input type="text" class="form-control form-control-sm" id="date-diff-from" th:attr="aria-label=#{datediff.from.label}" />
+                <input type="hidden" id="date-diff-from-hidden" />
+              </div>
+              <div class="col-auto">
+                <label class="form-label mb-1 d-block" for="date-diff-to" th:text="#{datediff.to.label}">To</label>
+                <input type="text" class="form-control form-control-sm" id="date-diff-to" th:attr="aria-label=#{datediff.to.label}" />
+                <input type="hidden" id="date-diff-to-hidden" />
+              </div>
+              <div class="col-auto">
+                <span id="date-diff-result" class="fw-bold" aria-live="polite" th:attr="data-template=#{datediff.result}"></span>
+              </div>
+              <div class="col-auto">
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -455,6 +477,7 @@
 
           DTMN.initDatePicker(updates, notModified);
           DTMN.initShifter(updates, notModified);
+          DTMN.initDateDiff();
           DTMN.initFitter(updates, notModified);
           DTMN.initColumnBulkSetters(updates, notModified);
           DTMN.initTermDates(updates, notModified);

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -33,108 +33,119 @@
       </div>
     </div>
 
-    <h2 class="h5 mt-3" th:text="#{section.batch.heading}">Bulk editing tools</h2>
-    <p class="small mb-2" th:text="#{section.batch.help}">Set or shift many dates at once. Your changes appear in the item sections below.</p>
+    <form id="date-manager-form" method="POST">
+      <div class="sak-banner-error d-none" id="form-errors">
+        <span th:text="#{errors.instruction}">Your update could not be saved due to the following errors:</span>
+        <ul></ul>
+      </div>
 
-    <!-- Bulk tools, grouped behind a coloured accent bar to set them apart from the item sections
-         further down. The collapsed Shift / Fit / Set-dates cards live here. Export/Import sit in the
+      <div class="sak-banner-success d-none" id="form-success">
+        <span th:text="#{success.message}">The dates were updated successfully.</span>
+      </div>
+
+      <div class="sak-banner-info d-none" id="export-success">
+        <span th:text="#{success.export}">The dates were exported successfully. Please note the following considerations:</span>
+        <ul class="m-0">
+          <li th:text="#{success.export.1}">The fields marked as required cannot be left blank.</li>
+          <li th:text="#{success.export.2}">The fields marked as optional can be left blank.</li>
+          <li th:text="#{success.export.3}">The fields not marked as required or optional can only be modified if they already have a value or left blank if they do not.</li>
+          <li th:text="#{success.export.4}">Only modify the date fields. Do not modify the rest of the fields.</li>
+          <li th:text="#{success.export.5}">Do not change the date format.</li>
+        </ul>
+      </div>
+
+    <ul class="nav nav-tabs mt-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="dm-tab-bulk-btn" data-bs-toggle="tab" data-bs-target="#dm-tab-bulk" type="button" role="tab" aria-controls="dm-tab-bulk" aria-selected="true" th:text="#{section.batch.heading}">Bulk Edit</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="dm-tab-items-btn" data-bs-toggle="tab" data-bs-target="#dm-tab-items" type="button" role="tab" aria-controls="dm-tab-items" aria-selected="false" th:text="#{section.items.heading}">Edit Individual Items</button>
+      </li>
+    </ul>
+    <div class="tab-content">
+    <div class="tab-pane fade show active pt-3" id="dm-tab-bulk" role="tabpanel" aria-labelledby="dm-tab-bulk-btn">
+    <p class="small mb-2" th:text="#{section.batch.help}">Pick how you want to move dates, choose which tools to apply to, and apply.</p>
+
+    <!-- Bulk tools, grouped behind a coloured accent bar. The radios show one method's panel at a
+         time; the scope row picks which tool sections the apply acts on. Export/Import sit in the
          page header, top-right, since they act on the whole site rather than the in-page edits. -->
     <div class="dm-batch-tools border-start border-4 border-primary ps-3 mb-4">
 
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-shift" aria-expanded="true"><span th:text="#{section.shift.heading}">Shift every date by a fixed amount</span></a>
-        </h4>
-      </div>
-      <div id="dm-batch-shift" class="collapse show" data-bs-parent=".dm-batch-tools">
-        <div class="card-body date-manager-shifter">
-          <p class="small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.</p>
-          <div class="date-manager-datediff mb-3">
-            <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Not sure how many days to shift? Pick your old term's start date and your new term's start date, and the day count is calculated for you.</label>
-            <div class="row g-2 align-items-end">
-              <div class="col-auto">
-                <label class="form-label mb-1 d-block" for="date-diff-from" th:text="#{datediff.from.label}">From</label>
-                <input type="text" class="form-control form-control-sm" id="date-diff-from" th:attr="aria-label=#{datediff.from.label}" />
-                <input type="hidden" id="date-diff-from-hidden" />
-              </div>
-              <div class="col-auto">
-                <label class="form-label mb-1 d-block" for="date-diff-to" th:text="#{datediff.to.label}">To</label>
-                <input type="text" class="form-control form-control-sm" id="date-diff-to" th:attr="aria-label=#{datediff.to.label}" />
-                <input type="hidden" id="date-diff-to-hidden" />
-              </div>
-              <div class="col-auto">
-                <span id="date-diff-result" class="fw-bold" aria-live="polite" th:attr="data-template=#{datediff.result}"></span>
-              </div>
-              <div class="col-auto">
-                <button type="button" class="btn btn-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Copy into shift amount</button>
-              </div>
-            </div>
-            <p class="small mt-2 mb-0" th:text="#{datediff.note}">These two dates are only used for counting — nothing changes until the day count is copied into the shift amount below and you click Apply.</p>
-          </div>
+    <div class="dm-bulk-mode mb-3" role="radiogroup" th:attr="aria-label=#{section.batch.heading}">
+      <label class="me-3">
+        <input type="radio" name="dm-bulk-mode" value="dm-bulk-panel-shift" checked />
+        <span th:text="#{section.shift.heading}" th:remove="tag">Shift dates by a number of days</span>
+      </label>
+      <label class="me-3">
+        <input type="radio" name="dm-bulk-mode" value="dm-bulk-panel-fit" />
+        <span th:text="#{section.fit.heading}" th:remove="tag">Fit dates to a new term</span>
+      </label>
+      <label>
+        <input type="radio" name="dm-bulk-mode" value="dm-bulk-panel-set" />
+        <span th:text="#{section.set.heading}" th:remove="tag">Set dates from term milestones</span>
+      </label>
+    </div>
 
-          <div class="sak-banner-error d-none" id="dateShifterError">
-            <span th:text="#{dateshifter.error.nonnumeric}"></span>
+    <div id="dm-bulk-panel-shift" class="dm-bulk-panel date-manager-shifter">
+      <p class="small mb-2" th:text="#{dateshifter.help}">Moves every date by the same number of days — ideal when your items are already spaced correctly relative to each other.</p>
+      <div class="date-manager-datediff mb-3">
+        <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Pick your old and new term start dates and the number of days to shift is calculated for you — or type the day count directly below.</label>
+        <div class="row g-2 align-items-end">
+          <div class="col-auto">
+            <label class="form-label mb-1 d-block" for="date-diff-from" th:text="#{datediff.from.label}">Old term start</label>
+            <input type="text" class="form-control form-control-sm" id="date-diff-from" th:attr="aria-label=#{datediff.from.label}" />
+            <input type="hidden" id="date-diff-from-hidden" />
           </div>
-          <p>
-            <label>
-              <span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
-              <input id="dateShifterDays" type="text" />
-              <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
-            </label>
-          </p>
-          <button class="btn btn-secondary m-2" id="shiftAllDates" th:text="#{dateshifter.all.button}" disabled></button>
-          <button class="btn btn-secondary m-2" id="shiftVisibleDates" th:text="#{dateshifter.visible.button}" disabled></button>
+          <div class="col-auto">
+            <label class="form-label mb-1 d-block" for="date-diff-to" th:text="#{datediff.to.label}">New term start</label>
+            <input type="text" class="form-control form-control-sm" id="date-diff-to" th:attr="aria-label=#{datediff.to.label}" />
+            <input type="hidden" id="date-diff-to-hidden" />
+          </div>
+          <div class="col-auto">
+            <span id="date-diff-result" class="fw-bold" aria-live="polite" th:attr="data-template=#{datediff.result}"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="sak-banner-error d-none" id="dateShifterError">
+        <span th:text="#{dateshifter.error.nonnumeric}"></span>
+      </div>
+      <p>
+        <label>
+          <span th:text="#{dateshifter.label.before}" th:remove="tag"></span>
+          <input id="dateShifterDays" type="text" />
+          <span th:text="#{dateshifter.label.after}" th:remove="tag"></span>
+        </label>
+      </p>
+    </div>
+
+    <div id="dm-bulk-panel-fit" class="dm-bulk-panel date-manager-fit d-none">
+      <p class="small mb-2" th:text="#{datefit.help}">Pins your earliest dated item to the new first date, your latest to the new last date, and spreads everything in between to fit — ideal for items spaced evenly through the term. Items with no date stay blank.</p>
+      <div class="sak-banner-error d-none" id="date-fit-error">
+        <span th:text="#{datefit.error.range}"></span>
+      </div>
+      <div class="row g-2 align-items-end">
+        <div class="col-auto">
+          <label class="form-label mb-1 d-block" for="date-fit-first" th:text="#{datefit.first.label}">New first date</label>
+          <input type="text" class="form-control form-control-sm" id="date-fit-first" th:attr="aria-label=#{datefit.first.label}" />
+          <input type="hidden" id="date-fit-first-hidden" />
+        </div>
+        <div class="col-auto">
+          <label class="form-label mb-1 d-block" for="date-fit-last" th:text="#{datefit.last.label}">New last date</label>
+          <input type="text" class="form-control form-control-sm" id="date-fit-last" th:attr="aria-label=#{datefit.last.label}" />
+          <input type="hidden" id="date-fit-last-hidden" />
+        </div>
+        <div class="col-auto">
+          <label class="mb-1">
+            <input type="checkbox" id="date-fit-snap" checked />
+            <span th:text="#{datefit.snap.label}" th:remove="tag">Snap to weeks (keep each item's weekday &amp; time)</span>
+          </label>
         </div>
       </div>
     </div>
 
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-fit" class="collapsed" aria-expanded="false"><span th:text="#{section.fit.heading}">Smart Shift</span></a>
-        </h4>
-      </div>
-      <div id="dm-batch-fit" class="collapse" data-bs-parent=".dm-batch-tools">
-        <div class="card-body date-manager-fit">
-          <p class="small mb-2" th:text="#{datefit.help}">This tool is ideal for items that are evenly spaced throughout the term: set a beginning and end date and every item in between is automatically positioned cleanly within that range. The in-between dates are recalculated to fit even as you change the end date.</p>
-          <div class="sak-banner-error d-none" id="date-fit-error">
-            <span th:text="#{datefit.error.range}"></span>
-          </div>
-          <p th:text="#{datefit.instructions}">Re-anchor every dated item to a new term.</p>
-          <div class="row g-2 align-items-end">
-            <div class="col-auto">
-              <label class="form-label mb-1 d-block" for="date-fit-first" th:text="#{datefit.first.label}">New first date</label>
-              <input type="text" class="form-control form-control-sm" id="date-fit-first" th:attr="aria-label=#{datefit.first.label}" />
-              <input type="hidden" id="date-fit-first-hidden" />
-            </div>
-            <div class="col-auto">
-              <label class="form-label mb-1 d-block" for="date-fit-last" th:text="#{datefit.last.label}">New last date</label>
-              <input type="text" class="form-control form-control-sm" id="date-fit-last" th:attr="aria-label=#{datefit.last.label}" />
-              <input type="hidden" id="date-fit-last-hidden" />
-            </div>
-            <div class="col-auto">
-              <label class="mb-1">
-                <input type="checkbox" id="date-fit-snap" checked />
-                <span th:text="#{datefit.snap.label}" th:remove="tag">Snap to weeks (keep each item's weekday &amp; time)</span>
-              </label>
-            </div>
-          </div>
-          <button type="button" class="btn btn-secondary m-2" id="fit-all-dates" th:text="#{datefit.all.button}" disabled></button>
-          <button type="button" class="btn btn-secondary m-2" id="fit-visible-dates" th:text="#{datefit.visible.button}" disabled></button>
-        </div>
-      </div>
-    </div>
-
-    <div class="card">
-      <div class="card-header">
-        <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Term Dates</span></a>
-        </h4>
-      </div>
-      <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">
-        <div class="card-body date-manager-set">
-    <p class="small mb-2" th:text="#{bulk.help}">This tool is ideal for courses where all items open at the same time and close at the same time: set your term dates once and apply them across every column.</p>
+    <div id="dm-bulk-panel-set" class="dm-bulk-panel date-manager-set d-none">
+    <p class="small mb-2" th:text="#{bulk.help}">Enter your term's key dates once — first and last day of classes, exam window — and fill whole date columns with them. Ideal when many items share the same dates.</p>
 
     <!-- Governs the matrix applies below only; the per-column setters in the item section headers
          carry their own "Fill Empty" checkbox instead. -->
@@ -246,38 +257,65 @@
           </tbody>
         </table>
       </div>
-      <button type="button" class="btn btn-secondary m-2" id="apply-term-dates-all" th:text="#{termdates.all.button}" disabled></button>
-      <button type="button" class="btn btn-secondary m-2" id="apply-term-dates-visible" th:text="#{termdates.visible.button}" disabled></button>
-    </div>
-        </div>
-      </div>
     </div>
     </div>
 
-    <hr class="my-4" />
-    <h2 class="h5" th:text="#{section.items.heading}">Edit dates by item or column</h2>
+    <!-- Which tool sections the active method's Apply acts on: explicit, visible scoping in
+         place of the old "tools expanded below" behaviour. Only tools present on the page render. -->
+    <div class="dm-scope mt-3 mb-2">
+      <span class="fw-bold me-2" th:text="#{bulk.scope.label}">Apply to:</span>
+      <label class="me-3">
+        <input type="checkbox" id="dm-scope-all" checked />
+        <span th:text="#{bulk.scope.all}" th:remove="tag">All tools</span>
+      </label>
+      <label class="me-3" th:if="${assignments != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-assignments" checked />
+        <span th:text="${assignmentsToolTitle + ' (' + #lists.size(assignments) + ')'}" th:remove="tag">Assignments</span>
+      </label>
+      <label class="me-3" th:if="${assessments != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-assessments" checked />
+        <span th:text="${assessmentsToolTitle + ' (' + #lists.size(assessments) + ')'}" th:remove="tag">Tests &amp; Quizzes</span>
+      </label>
+      <label class="me-3" th:if="${signupMeetings != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-signup" checked />
+        <span th:text="${signupMeetingsToolTitle + ' (' + #lists.size(signupMeetings) + ')'}" th:remove="tag">Sign up</span>
+      </label>
+      <label class="me-3" th:if="${gradebookItems != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-gradebook" checked />
+        <span th:text="${gradebookItemsToolTitle + ' (' + #lists.size(gradebookItems) + ')'}" th:remove="tag">Gradebook</span>
+      </label>
+      <label class="me-3" th:if="${resources != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-resources" checked />
+        <span th:text="${resourcesToolTitle + ' (' + #lists.size(resources) + ')'}" th:remove="tag">Resources</span>
+      </label>
+      <label class="me-3" th:if="${calendarEvents != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-calendar" checked />
+        <span th:text="${calendarEventsToolTitle + ' (' + #lists.size(calendarEvents) + ')'}" th:remove="tag">Calendar</span>
+      </label>
+      <label class="me-3" th:if="${forums != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-forums" checked />
+        <span th:text="${forumsToolTitle + ' (' + #lists.size(forums) + ')'}" th:remove="tag">Forums</span>
+      </label>
+      <label class="me-3" th:if="${announcements != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-announcements" checked />
+        <span th:text="${announcementsToolTitle + ' (' + #lists.size(announcements) + ')'}" th:remove="tag">Announcements</span>
+      </label>
+      <label class="me-3" th:if="${lessons != null}">
+        <input type="checkbox" class="dm-scope-tool" data-root="collapse-lessons" checked />
+        <span th:text="${lessonsToolTitle + ' (' + #lists.size(lessons) + ')'}" th:remove="tag">Lessons</span>
+      </label>
+    </div>
+
+    <div class="mb-2">
+      <button type="button" class="btn btn-primary dm-bulk-apply" id="dm-apply-shift" data-dm-panel="dm-bulk-panel-shift" th:text="#{bulk.apply.shift}" disabled>Apply shift</button>
+      <button type="button" class="btn btn-primary dm-bulk-apply d-none" id="dm-apply-fit" data-dm-panel="dm-bulk-panel-fit" th:text="#{bulk.apply.fit}" disabled>Apply fit</button>
+      <button type="button" class="btn btn-primary dm-bulk-apply d-none" id="dm-apply-term" data-dm-panel="dm-bulk-panel-set" th:text="#{bulk.apply.term}" disabled>Apply term dates</button>
+    </div>
+    </div>
+    </div>
+
+    <div class="tab-pane fade pt-3" id="dm-tab-items" role="tabpanel" aria-labelledby="dm-tab-items-btn">
     <p class="small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
-
-    <form id="date-manager-form" method="POST">
-      <div class="sak-banner-error d-none" id="form-errors">
-        <span th:text="#{errors.instruction}">Your update could not be saved due to the following errors:</span>
-        <ul></ul>
-      </div>
-
-      <div class="sak-banner-success d-none" id="form-success">
-        <span th:text="#{success.message}">The dates were updated successfully.</span>
-      </div>
-
-      <div class="sak-banner-info d-none" id="export-success">
-        <span th:text="#{success.export}">The dates were exported successfully. Please note the following considerations:</span>
-        <ul class="m-0">
-          <li th:text="#{success.export.1}">The fields marked as required cannot be left blank.</li>
-          <li th:text="#{success.export.2}">The fields marked as optional can be left blank.</li>
-          <li th:text="#{success.export.3}">The fields not marked as required or optional can only be modified if they already have a value or left blank if they do not.</li>
-          <li th:text="#{success.export.4}">Only modify the date fields. Do not modify the rest of the fields.</li>
-          <li th:text="#{success.export.5}">Do not change the date format.</li>
-        </ul>
-      </div>
 
       <div th:if="${assignments != null}" class="card">
         <div class="card-header">
@@ -351,6 +389,8 @@
         </div>
         <div th:replace="~{tool_fragment :: tool_fragment(items=${lessons}, toolId='lessons', collapseId='collapse-lessons')}"></div>
       </div>
+    </div>
+    </div>
 
       <div class="act">
         <button class="btn btn-primary"
@@ -518,9 +558,12 @@
             signup_deadline: /*[[#{column.signup.deadline.date}]]*/ 'Sign-up Ends Date'
           };
 
+          DTMN.previewSpanButtonText = /*[[#{calendar.preview.span.button}]]*/ 'Overview';
+
           DTMN.initDatePicker(updates, notModified);
+          DTMN.initBulkModeRadios();
+          DTMN.initScopePicker();
           DTMN.initShifter(updates, notModified);
-          DTMN.initDateDiff();
           DTMN.initFitter(updates, notModified);
           DTMN.initColumnBulkSetters(updates, notModified);
           DTMN.initTermDates(updates, notModified);

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -25,7 +25,7 @@
     <script th:src="@{/js/initDatePicker.js}"></script>
     <meta http-equiv="Content-Style-Type" content="text/css" />
 
-    <div class="page-header border-bottom d-flex justify-content-between align-items-center flex-wrap gap-2">
+    <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-2">
       <h1 class="mb-0" th:text="#{page.title}">Date Manager</h1>
       <div class="date-manager-actions">
         <a id="exportDates" class="btn btn-secondary btn-sm" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -27,10 +27,16 @@
 
     <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-2">
       <h1 class="mb-0" th:text="#{page.title}">Date Manager</h1>
-      <div class="date-manager-actions">
-        <a id="exportDates" class="btn btn-secondary btn-sm" th:text="#{dateshifter.export.dates.csv}" th:href="@{/date-manager/export}">Export Dates</a>
-        <a id="importDates" class="btn btn-secondary btn-sm" th:text="#{dateshifter.import.dates.csv}" th:href="@{/date-manager/page/import}">Import Dates</a>
-      </div>
+      <!-- Standard Sakai intra-tool menu chips (same pattern as Postem, Site Group Manager, …)
+           kept top-right per the T&L mockup, so Export/Import read like every other tool's actions. -->
+      <ul class="navIntraTool date-manager-actions" role="menu">
+        <li role="menuitem">
+          <span><a id="exportDates" href="#" th:href="@{/date-manager/export}" th:text="#{dateshifter.export.dates.csv}">Export Dates</a></span>
+        </li>
+        <li role="menuitem">
+          <span><a id="importDates" href="#" th:href="@{/date-manager/page/import}" th:text="#{dateshifter.import.dates.csv}">Import Dates</a></span>
+        </li>
+      </ul>
     </div>
 
     <form id="date-manager-form" method="POST">
@@ -60,14 +66,14 @@
 
     <ul class="nav nav-tabs mt-3" role="tablist">
       <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="dm-tab-bulk-btn" data-bs-toggle="tab" data-bs-target="#dm-tab-bulk" type="button" role="tab" aria-controls="dm-tab-bulk" aria-selected="true" th:text="#{section.batch.heading}">Bulk Edit</button>
+        <button class="nav-link active" id="dm-tab-items-btn" data-bs-toggle="tab" data-bs-target="#dm-tab-items" type="button" role="tab" aria-controls="dm-tab-items" aria-selected="true" th:text="#{section.items.heading}">Edit Individual Items</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="dm-tab-items-btn" data-bs-toggle="tab" data-bs-target="#dm-tab-items" type="button" role="tab" aria-controls="dm-tab-items" aria-selected="false" th:text="#{section.items.heading}">Edit Individual Items</button>
+        <button class="nav-link" id="dm-tab-bulk-btn" data-bs-toggle="tab" data-bs-target="#dm-tab-bulk" type="button" role="tab" aria-controls="dm-tab-bulk" aria-selected="false" th:text="#{section.batch.heading}">Bulk Edit</button>
       </li>
     </ul>
     <div class="tab-content">
-    <div class="tab-pane fade show active pt-3" id="dm-tab-bulk" role="tabpanel" aria-labelledby="dm-tab-bulk-btn">
+    <div class="tab-pane fade pt-3" id="dm-tab-bulk" role="tabpanel" aria-labelledby="dm-tab-bulk-btn">
     <p class="small mb-2" th:text="#{section.batch.help}">Pick how you want to move dates, choose which tools to apply to, and apply.</p>
 
     <!-- Bulk tools, grouped behind a coloured accent bar. The radios show one method's panel at a
@@ -174,56 +180,56 @@
           <thead>
             <tr>
               <th rowspan="2" class="align-bottom" th:text="#{termdates.column.header}">Term date</th>
-              <th th:if="${assignments != null}" colspan="3" class="text-center" th:text="${assignmentsToolTitle}">Assignments</th>
-              <th th:if="${assessments != null}" colspan="5" class="text-center" th:text="${assessmentsToolTitle}">Tests &amp; Quizzes</th>
-              <th th:if="${signupMeetings != null}" colspan="4" class="text-center" th:text="${signupMeetingsToolTitle}">Sign up</th>
-              <th th:if="${gradebookItems != null}" colspan="1" class="text-center" th:text="${gradebookItemsToolTitle}">Gradebook</th>
-              <th th:if="${resources != null}" colspan="2" class="text-center" th:text="${resourcesToolTitle}">Resources</th>
-              <th th:if="${calendarEvents != null}" colspan="2" class="text-center" th:text="${calendarEventsToolTitle}">Calendar</th>
-              <th th:if="${forums != null}" colspan="2" class="text-center" th:text="${forumsToolTitle}">Forums</th>
-              <th th:if="${announcements != null}" colspan="2" class="text-center" th:text="${announcementsToolTitle}">Announcements</th>
-              <th th:if="${lessons != null}" colspan="1" class="text-center" th:text="${lessonsToolTitle}">Lessons</th>
+              <th th:if="${assignments != null}" colspan="3" class="text-center dm-mx-assignments dm-mx-first" th:text="${assignmentsToolTitle}">Assignments</th>
+              <th th:if="${assessments != null}" colspan="5" class="text-center dm-mx-assessments dm-mx-first" th:text="${assessmentsToolTitle}">Tests &amp; Quizzes</th>
+              <th th:if="${signupMeetings != null}" colspan="4" class="text-center dm-mx-signup dm-mx-first" th:text="${signupMeetingsToolTitle}">Sign up</th>
+              <th th:if="${gradebookItems != null}" colspan="1" class="text-center dm-mx-gradebook dm-mx-first" th:text="${gradebookItemsToolTitle}">Gradebook</th>
+              <th th:if="${resources != null}" colspan="2" class="text-center dm-mx-resources dm-mx-first" th:text="${resourcesToolTitle}">Resources</th>
+              <th th:if="${calendarEvents != null}" colspan="2" class="text-center dm-mx-calendar dm-mx-first" th:text="${calendarEventsToolTitle}">Calendar</th>
+              <th th:if="${forums != null}" colspan="2" class="text-center dm-mx-forums dm-mx-first" th:text="${forumsToolTitle}">Forums</th>
+              <th th:if="${announcements != null}" colspan="2" class="text-center dm-mx-announcements dm-mx-first" th:text="${announcementsToolTitle}">Announcements</th>
+              <th th:if="${lessons != null}" colspan="1" class="text-center dm-mx-lessons dm-mx-first" th:text="${lessonsToolTitle}">Lessons</th>
             </tr>
             <tr>
               <th:block th:if="${assignments != null}">
-                <th class="text-center" th:text="#{column.open.date}">Open Date</th>
-                <th class="text-center" th:text="#{column.due.date}">Due Date</th>
-                <th class="text-center" th:text="#{column.accept.until}">Accept Until Date</th>
+                <th class="text-center dm-mx-assignments dm-mx-first" th:text="#{column.open.date}">Open Date</th>
+                <th class="text-center dm-mx-assignments" th:text="#{column.due.date}">Due Date</th>
+                <th class="text-center dm-mx-assignments" th:text="#{column.accept.until}">Accept Until Date</th>
               </th:block>
               <th:block th:if="${assessments != null}">
-                <th class="text-center" th:text="#{column.available.date}">Available Date</th>
-                <th class="text-center" th:text="#{column.due.date}">Due Date</th>
-                <th class="text-center" th:text="#{column.assessments.accept.until}">Late Submission Deadline</th>
-                <th class="text-center" th:text="#{column.feedback.start.date}">Show Feedback Date</th>
-                <th class="text-center" th:text="#{column.feedback.end.date}">Hide Feedback Date</th>
+                <th class="text-center dm-mx-assessments dm-mx-first" th:text="#{column.available.date}">Available Date</th>
+                <th class="text-center dm-mx-assessments" th:text="#{column.due.date}">Due Date</th>
+                <th class="text-center dm-mx-assessments" th:text="#{column.assessments.accept.until}">Late Submission Deadline</th>
+                <th class="text-center dm-mx-assessments" th:text="#{column.feedback.start.date}">Show Feedback Date</th>
+                <th class="text-center dm-mx-assessments" th:text="#{column.feedback.end.date}">Hide Feedback Date</th>
               </th:block>
               <th:block th:if="${signupMeetings != null}">
-                <th class="text-center" th:text="#{column.start.date}">Start Date</th>
-                <th class="text-center" th:text="#{column.end.date}">End Date</th>
-                <th class="text-center" th:text="#{column.signup.begins.date}">Sign-up Begin Date</th>
-                <th class="text-center" th:text="#{column.signup.deadline.date}">Sign-up End Date</th>
+                <th class="text-center dm-mx-signup dm-mx-first" th:text="#{column.start.date}">Start Date</th>
+                <th class="text-center dm-mx-signup" th:text="#{column.end.date}">End Date</th>
+                <th class="text-center dm-mx-signup" th:text="#{column.signup.begins.date}">Sign-up Begin Date</th>
+                <th class="text-center dm-mx-signup" th:text="#{column.signup.deadline.date}">Sign-up End Date</th>
               </th:block>
               <th:block th:if="${gradebookItems != null}">
-                <th class="text-center" th:text="#{column.due.date}">Due Date</th>
+                <th class="text-center dm-mx-gradebook dm-mx-first" th:text="#{column.due.date}">Due Date</th>
               </th:block>
               <th:block th:if="${resources != null}">
-                <th class="text-center" th:text="#{column.show.from.date}">Show From Date</th>
-                <th class="text-center" th:text="#{column.show.until}">Show Until Date</th>
+                <th class="text-center dm-mx-resources dm-mx-first" th:text="#{column.show.from.date}">Show From Date</th>
+                <th class="text-center dm-mx-resources" th:text="#{column.show.until}">Show Until Date</th>
               </th:block>
               <th:block th:if="${calendarEvents != null}">
-                <th class="text-center" th:text="#{column.start.date}">Start Date</th>
-                <th class="text-center" th:text="#{column.end.date}">End Date</th>
+                <th class="text-center dm-mx-calendar dm-mx-first" th:text="#{column.start.date}">Start Date</th>
+                <th class="text-center dm-mx-calendar" th:text="#{column.end.date}">End Date</th>
               </th:block>
               <th:block th:if="${forums != null}">
-                <th class="text-center" th:text="#{column.open.date}">Open Date</th>
-                <th class="text-center" th:text="#{column.close.date}">Close Date</th>
+                <th class="text-center dm-mx-forums dm-mx-first" th:text="#{column.open.date}">Open Date</th>
+                <th class="text-center dm-mx-forums" th:text="#{column.close.date}">Close Date</th>
               </th:block>
               <th:block th:if="${announcements != null}">
-                <th class="text-center" th:text="#{column.start.date}">Start Date</th>
-                <th class="text-center" th:text="#{column.end.date}">End Date</th>
+                <th class="text-center dm-mx-announcements dm-mx-first" th:text="#{column.start.date}">Start Date</th>
+                <th class="text-center dm-mx-announcements" th:text="#{column.end.date}">End Date</th>
               </th:block>
               <th:block th:if="${lessons != null}">
-                <th class="text-center" th:text="#{column.hide.until}">Hide Until Date</th>
+                <th class="text-center dm-mx-lessons dm-mx-first" th:text="#{column.hide.until}">Hide Until Date</th>
               </th:block>
             </tr>
           </thead>
@@ -266,8 +272,9 @@
     </div>
     </div>
 
-    <!-- Which tool sections the active method's Apply acts on: explicit, visible scoping in
-         place of the old "tools expanded below" behaviour. Only tools present on the page render. -->
+    <!-- Which tool sections the shift/fit Apply acts on: explicit, visible scoping in place of
+         the old "tools expanded below" behaviour. Only tools present on the page render. Hidden
+         for the milestone matrix, whose checkbox grid already targets tools column by column. -->
     <div class="dm-scope mt-3 mb-2">
       <span class="fw-bold d-block mb-1" th:text="#{bulk.scope.label}">Apply to:</span>
       <label class="d-block">
@@ -328,7 +335,7 @@
     </div>
     </div>
 
-    <div class="tab-pane fade pt-3" id="dm-tab-items" role="tabpanel" aria-labelledby="dm-tab-items-btn">
+    <div class="tab-pane fade show active pt-3" id="dm-tab-items" role="tabpanel" aria-labelledby="dm-tab-items-btn">
     <p class="small" th:text="#{section.items.help}">Expand a tool to review or adjust each item's dates.</p>
 
       <div th:if="${assignments != null}" class="card">
@@ -406,7 +413,9 @@
     </div>
     </div>
 
-      <div class="act">
+      <!-- Separated from the tab content by a rule and extra space: these actions commit or
+           discard the staged edits from BOTH tabs, unlike the applies inside the Bulk Edit tab. -->
+      <div class="act mt-4 pt-3 border-top">
         <button class="btn btn-primary"
             aria-controls="modal-confirm"
             id="submit-form-button"

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -313,9 +313,9 @@
     </div>
 
     <div class="mb-2">
-      <button type="button" class="btn btn-primary dm-bulk-apply" id="dm-apply-shift" data-dm-panel="dm-bulk-panel-shift" th:text="#{bulk.apply.shift}" disabled>Apply shift</button>
-      <button type="button" class="btn btn-primary dm-bulk-apply d-none" id="dm-apply-fit" data-dm-panel="dm-bulk-panel-fit" th:text="#{bulk.apply.fit}" disabled>Apply fit</button>
-      <button type="button" class="btn btn-primary dm-bulk-apply d-none" id="dm-apply-term" data-dm-panel="dm-bulk-panel-set" th:text="#{bulk.apply.term}" disabled>Apply term dates</button>
+      <button type="button" class="btn dm-bulk-apply" id="dm-apply-shift" data-dm-panel="dm-bulk-panel-shift" th:text="#{bulk.apply.shift}" disabled>Apply shift</button>
+      <button type="button" class="btn dm-bulk-apply d-none" id="dm-apply-fit" data-dm-panel="dm-bulk-panel-fit" th:text="#{bulk.apply.fit}" disabled>Apply fit</button>
+      <button type="button" class="btn dm-bulk-apply d-none" id="dm-apply-term" data-dm-panel="dm-bulk-panel-set" th:text="#{bulk.apply.term}" disabled>Apply term dates</button>
     </div>
 
     <!-- Summarises what the last apply actually did (counts, tools, skipped blanks, narrowed scope)
@@ -413,11 +413,11 @@
             th:text="#{button.save}"
             disabled>
         </button>
-        <button type="button" class="btn btn-secondary"
+        <button type="button" class="btn"
             id="datemanager-preview"
             aria-controls="modal-calendar-preview"
             th:text="#{button.calendar.preview}">Visual Preview</button>
-        <button type="button" class="btn btn-secondary" id="datemanager-cancel" th:text="#{button.cancel}">Cancel</button>
+        <button type="button" class="btn" id="datemanager-cancel" th:text="#{button.cancel}">Cancel</button>
       </div>
 
       <span id="datemanager-confirm-description" class="visually-hidden" th:text="#{modal.confirm.description}"></span>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -51,7 +51,7 @@
         <div class="card-body date-manager-shifter">
           <p class="small mb-2" th:text="#{dateshifter.help}">This tool is ideal when your items are already correctly spaced relative to each other and can all be moved together by the same fixed number of days across the board.</p>
           <div class="date-manager-datediff mb-3">
-            <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Calculate the number of days between two dates with the utility below to apply a fixed integer shift to all dates</label>
+            <label class="form-label mb-1 d-block fw-bold" th:text="#{datediff.label}">Not sure how many days to shift? Pick your old term's start date and your new term's start date, and the day count is calculated for you.</label>
             <div class="row g-2 align-items-end">
               <div class="col-auto">
                 <label class="form-label mb-1 d-block" for="date-diff-from" th:text="#{datediff.from.label}">From</label>
@@ -67,10 +67,10 @@
                 <span id="date-diff-result" class="fw-bold" aria-live="polite" th:attr="data-template=#{datediff.result}"></span>
               </div>
               <div class="col-auto">
-                <button type="button" class="btn btn-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Use as shift</button>
+                <button type="button" class="btn btn-secondary btn-sm" id="date-diff-apply" th:text="#{datediff.button}" disabled>Copy into shift amount</button>
               </div>
             </div>
-            <p class="small mt-2 mb-0" th:text="#{datediff.note}">Note: this is just a convenient datediff utility — it only loads the whole-day count into the shift field below. That raw integer day shift is what actually takes effect when applied — the From/To dates themselves are not applied.</p>
+            <p class="small mt-2 mb-0" th:text="#{datediff.note}">These two dates are only used for counting — nothing changes until the day count is copied into the shift amount below and you click Apply.</p>
           </div>
 
           <div class="sak-banner-error d-none" id="dateShifterError">
@@ -129,7 +129,7 @@
     <div class="card">
       <div class="card-header">
         <h4 class="card-title">
-          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Bulk Term Date Matrix</span></a>
+          <a data-bs-toggle="collapse" href="#dm-batch-set" class="collapsed" aria-expanded="false"><span th:text="#{section.set.heading}">Term Dates</span></a>
         </h4>
       </div>
       <div id="dm-batch-set" class="collapse" data-bs-parent=".dm-batch-tools">
@@ -139,19 +139,19 @@
     <!-- Governs the matrix applies below only; the per-column setters in the item section headers
          carry their own "Fill Empty" checkbox instead. -->
     <div class="date-manager-bulk-options mb-3" role="radiogroup" th:attr="aria-label=#{bulk.fill.mode.label}">
-      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When the term dates below fill a column:</span>
+      <span class="me-2 fw-bold" th:text="#{bulk.fill.mode.label}">When a term date fills a column:</span>
       <label class="me-3">
         <input type="radio" name="bulk-fill-mode" value="existing" checked />
-        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only cells that already have a date</span>
+        <span th:text="#{bulk.fill.mode.existing}" th:remove="tag">Only update items that already have a date (blanks stay blank)</span>
       </label>
       <label>
         <input type="radio" name="bulk-fill-mode" value="all" />
-        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every cell (empty and existing)</span>
+        <span th:text="#{bulk.fill.mode.all}" th:remove="tag">Fill every item, even ones with no date yet</span>
       </label>
     </div>
 
     <div class="date-manager-term mb-3">
-      <p th:text="#{termdates.instructions}">Enter your term dates, tick which columns each one should fill, then apply. Overlapping ticks apply top to bottom, so a lower row wins. Remember to click Save Changes at the bottom of the page.</p>
+      <p th:text="#{termdates.instructions}">Enter your new term's dates, then tick which date columns each one should fill. If two ticked rows target the same column, the lower row wins. Remember to click Save Changes at the bottom of the page.</p>
       <div class="table-responsive">
         <table class="table table-bordered table-sm align-middle table-datemanager-term">
           <thead>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -43,6 +43,10 @@
         <span th:text="#{success.message}">The dates were updated successfully.</span>
       </div>
 
+      <div class="sak-banner-info d-none" id="dm-cancel-banner" aria-live="polite">
+        <span th:text="#{cancel.reverted}">All unsaved changes were discarded — dates are back to their last saved values.</span>
+      </div>
+
       <div class="sak-banner-info d-none" id="export-success">
         <span th:text="#{success.export}">The dates were exported successfully. Please note the following considerations:</span>
         <ul class="m-0">
@@ -581,6 +585,8 @@
           };
 
           DTMN.initDatePicker(updates, notModified);
+          DTMN.initUnsavedGuard();
+          DTMN.initCancelRevert();
           DTMN.initBulkModeRadios();
           DTMN.initScopePicker();
           DTMN.initShifter(updates, notModified);
@@ -615,6 +621,7 @@
             $('#form-success').removeClass('d-none').css('display', '');
             $('#export-success').addClass('d-none').css('display', '');
             $('#form-errors').addClass('d-none');
+            $('#dm-apply-feedback').addClass('d-none');
             $('.ajax-error').removeClass('ajax-error');
             $('.errors').each(function(idx, elt) {
               $(elt).text('');
@@ -707,10 +714,6 @@
             });
           }
 
-          $('#datemanager-cancel').click(function(e) {
-            e.preventDefault;
-            window.location = window.location.href.replace('/sakai.datemanager.helper', '');
-          });
 
           
           $('#exportDates').click(function(e) {

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -311,6 +311,14 @@
       <button type="button" class="btn btn-primary dm-bulk-apply d-none" id="dm-apply-fit" data-dm-panel="dm-bulk-panel-fit" th:text="#{bulk.apply.fit}" disabled>Apply fit</button>
       <button type="button" class="btn btn-primary dm-bulk-apply d-none" id="dm-apply-term" data-dm-panel="dm-bulk-panel-set" th:text="#{bulk.apply.term}" disabled>Apply term dates</button>
     </div>
+
+    <!-- Summarises what the last apply actually did (counts, tools, skipped blanks, narrowed scope)
+         since the affected grid lives on the other tab. -->
+    <div class="sak-banner-info d-none" id="dm-apply-feedback" aria-live="polite">
+      <span id="dm-apply-feedback-msg"></span>
+      <span id="dm-apply-feedback-scope" class="d-none fw-bold"></span>
+      <span th:text="#{bulk.applied.review}">Review the changes on the Edit Individual Items tab or with the Visual Preview below, then click Save Changes.</span>
+    </div>
     </div>
     </div>
 
@@ -559,6 +567,18 @@
           };
 
           DTMN.previewSpanButtonText = /*[[#{calendar.preview.span.button}]]*/ 'Overview';
+
+          // Localized templates for the post-apply feedback banner and the scope-narrowed
+          // suffix on the apply buttons. {n} placeholders are substituted client-side.
+          DTMN.bulkFeedbackText = {
+            shift: /*[[#{bulk.applied.shift}]]*/ 'Shifted {0} date(s) in {1} tool(s).',
+            fit: /*[[#{bulk.applied.fit}]]*/ 'Re-fitted {0} date(s) in {1} tool(s).',
+            term: /*[[#{bulk.applied.term}]]*/ 'Set {0} date(s) in {1} tool(s).',
+            termBlanks: /*[[#{bulk.applied.term.blanks}]]*/ '{0} blank date cell(s) were left blank.',
+            scope: /*[[#{bulk.applied.scope}]]*/ 'Applied only to: {0}.',
+            none: /*[[#{bulk.applied.none}]]*/ 'No dates were changed.',
+            applySuffix: /*[[#{bulk.apply.scope.suffix}]]*/ '({0} of {1} tools)'
+          };
 
           DTMN.initDatePicker(updates, notModified);
           DTMN.initBulkModeRadios();

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -130,14 +130,16 @@
       </div>
       <div class="row g-2 align-items-end">
         <div class="col-auto">
-          <label class="form-label mb-1 d-block" for="date-fit-first" th:text="#{datefit.first.label}">New first date</label>
+          <label class="form-label mb-1 d-block" for="date-fit-first" th:text="#{datefit.first.label}">Move earliest dated item to</label>
           <input type="text" class="form-control form-control-sm" id="date-fit-first" th:attr="aria-label=#{datefit.first.label}" />
           <input type="hidden" id="date-fit-first-hidden" />
+          <div><small id="dm-fit-anchor-first" aria-live="polite" th:attr="data-template=#{datefit.anchor.current},data-none=#{datefit.anchor.none}"></small></div>
         </div>
         <div class="col-auto">
-          <label class="form-label mb-1 d-block" for="date-fit-last" th:text="#{datefit.last.label}">New last date</label>
+          <label class="form-label mb-1 d-block" for="date-fit-last" th:text="#{datefit.last.label}">Move latest dated item to</label>
           <input type="text" class="form-control form-control-sm" id="date-fit-last" th:attr="aria-label=#{datefit.last.label}" />
           <input type="hidden" id="date-fit-last-hidden" />
+          <div><small id="dm-fit-anchor-last" aria-live="polite" th:attr="data-template=#{datefit.anchor.current},data-none=#{datefit.anchor.none}"></small></div>
         </div>
         <div class="col-auto">
           <label class="mb-1">
@@ -267,44 +269,44 @@
     <!-- Which tool sections the active method's Apply acts on: explicit, visible scoping in
          place of the old "tools expanded below" behaviour. Only tools present on the page render. -->
     <div class="dm-scope mt-3 mb-2">
-      <span class="fw-bold me-2" th:text="#{bulk.scope.label}">Apply to:</span>
-      <label class="me-3">
+      <span class="fw-bold d-block mb-1" th:text="#{bulk.scope.label}">Apply to:</span>
+      <label class="d-block">
         <input type="checkbox" id="dm-scope-all" checked />
         <span th:text="#{bulk.scope.all}" th:remove="tag">All tools</span>
       </label>
-      <label class="me-3" th:if="${assignments != null}">
+      <label class="d-block ms-3" th:if="${assignments != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-assignments" checked />
         <span th:text="${assignmentsToolTitle + ' (' + #lists.size(assignments) + ')'}" th:remove="tag">Assignments</span>
       </label>
-      <label class="me-3" th:if="${assessments != null}">
+      <label class="d-block ms-3" th:if="${assessments != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-assessments" checked />
         <span th:text="${assessmentsToolTitle + ' (' + #lists.size(assessments) + ')'}" th:remove="tag">Tests &amp; Quizzes</span>
       </label>
-      <label class="me-3" th:if="${signupMeetings != null}">
+      <label class="d-block ms-3" th:if="${signupMeetings != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-signup" checked />
         <span th:text="${signupMeetingsToolTitle + ' (' + #lists.size(signupMeetings) + ')'}" th:remove="tag">Sign up</span>
       </label>
-      <label class="me-3" th:if="${gradebookItems != null}">
+      <label class="d-block ms-3" th:if="${gradebookItems != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-gradebook" checked />
         <span th:text="${gradebookItemsToolTitle + ' (' + #lists.size(gradebookItems) + ')'}" th:remove="tag">Gradebook</span>
       </label>
-      <label class="me-3" th:if="${resources != null}">
+      <label class="d-block ms-3" th:if="${resources != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-resources" checked />
         <span th:text="${resourcesToolTitle + ' (' + #lists.size(resources) + ')'}" th:remove="tag">Resources</span>
       </label>
-      <label class="me-3" th:if="${calendarEvents != null}">
+      <label class="d-block ms-3" th:if="${calendarEvents != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-calendar" checked />
         <span th:text="${calendarEventsToolTitle + ' (' + #lists.size(calendarEvents) + ')'}" th:remove="tag">Calendar</span>
       </label>
-      <label class="me-3" th:if="${forums != null}">
+      <label class="d-block ms-3" th:if="${forums != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-forums" checked />
         <span th:text="${forumsToolTitle + ' (' + #lists.size(forums) + ')'}" th:remove="tag">Forums</span>
       </label>
-      <label class="me-3" th:if="${announcements != null}">
+      <label class="d-block ms-3" th:if="${announcements != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-announcements" checked />
         <span th:text="${announcementsToolTitle + ' (' + #lists.size(announcements) + ')'}" th:remove="tag">Announcements</span>
       </label>
-      <label class="me-3" th:if="${lessons != null}">
+      <label class="d-block ms-3" th:if="${lessons != null}">
         <input type="checkbox" class="dm-scope-tool" data-root="collapse-lessons" checked />
         <span th:text="${lessonsToolTitle + ' (' + #lists.size(lessons) + ')'}" th:remove="tag">Lessons</span>
       </label>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -1,7 +1,8 @@
 <div th:fragment="tool_fragment" th:id="${collapseId}" class="collapse">
 	<div class="card-body">
 		<p th:if="${items == null or items.isEmpty()}" th:text="#{items.empty}">There are no items to modify in this tool.</p>
-		<table th:unless="${items == null or items.isEmpty()}" class="table table-condensed table-striped table-bordered table-datemanager">
+		<div th:unless="${items == null or items.isEmpty()}" class="table-responsive">
+		<table class="table table-condensed table-striped table-bordered table-datemanager">
 			<thead>
 				<tr>
 					<th th:text="#{column.title}">Title</th>
@@ -164,6 +165,7 @@
 				</th:block>
 			</tbody>
 		</table>
+		</div>
 	</div>
 </div>
 
@@ -181,45 +183,45 @@
 <!-- Checkbox cells for one term-date row of the term dates panel. Renders one checkbox per editable
      date column of every section present on the page, in the same order as the panel column headers.
      Each checkbox carries the target section root id and column field so JS can fill that column. -->
-<th:block th:fragment="termCells(term)">
+<th:block th:fragment="termCells(term)" th:with="termLabel=${term == 'classes_start' ? #messages.msg('termdates.classes.start') : term == 'classes_end' ? #messages.msg('termdates.classes.end') : term == 'exam_begins' ? #messages.msg('termdates.exam.begins') : #messages.msg('termdates.exam.ends')}">
 	<th:block th:if="${assignments != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='due_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='accept_until'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='open_date',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.open.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='due_date',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='accept_until',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.accept.until')}" /></td>
 	</th:block>
 	<th:block th:if="${assessments != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='due_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='accept_until'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_start'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_end'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='open_date',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.available.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='due_date',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='accept_until',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.assessments.accept.until')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_start',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.feedback.start.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_end',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.feedback.end.date')}" /></td>
 	</th:block>
 	<th:block th:if="${signupMeetings != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='due_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_begins'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_deadline'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='open_date',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='due_date',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_begins',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.signup.begins.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_deadline',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.signup.deadline.date')}" /></td>
 	</th:block>
 	<th:block th:if="${gradebookItems != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-gradebook',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-gradebook',data-field='due_date',aria-label=${termLabel + ' - ' + gradebookItemsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
 	</th:block>
 	<th:block th:if="${resources != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='open_date',aria-label=${termLabel + ' - ' + resourcesToolTitle + ' - ' + #messages.msg('column.show.from.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='due_date',aria-label=${termLabel + ' - ' + resourcesToolTitle + ' - ' + #messages.msg('column.show.until')}" /></td>
 	</th:block>
 	<th:block th:if="${calendarEvents != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='open_date',aria-label=${termLabel + ' - ' + calendarEventsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='due_date',aria-label=${termLabel + ' - ' + calendarEventsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
 	</th:block>
 	<th:block th:if="${forums != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='open_date',aria-label=${termLabel + ' - ' + forumsToolTitle + ' - ' + #messages.msg('column.open.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='due_date',aria-label=${termLabel + ' - ' + forumsToolTitle + ' - ' + #messages.msg('column.close.date')}" /></td>
 	</th:block>
 	<th:block th:if="${announcements != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='open_date'" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='open_date',aria-label=${termLabel + ' - ' + announcementsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='due_date',aria-label=${termLabel + ' - ' + announcementsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
 	</th:block>
 	<th:block th:if="${lessons != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-lessons',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-lessons',data-field='open_date',aria-label=${termLabel + ' - ' + lessonsToolTitle + ' - ' + #messages.msg('column.hide.until')}" /></td>
 	</th:block>
 </th:block>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -175,7 +175,7 @@
 	<input type="text" class="form-control bulk-col-input" th:id="${'bulkcol-' + cid}"
 		th:attr="data-tool=${toolId},data-field=${field},aria-label=#{datesetter.column.aria},placeholder=#{datesetter.column.placeholder}" />
 	<input type="hidden" class="bulk-col-hidden" th:id="${'bulkcol-hidden-' + cid}" th:attr="data-tool=${toolId},data-field=${field}" />
-	<button type="button" class="btn btn-outline-secondary bulk-col-apply" th:attr="data-tool=${toolId},data-field=${field},title=#{datesetter.column.button.title},aria-label=#{datesetter.column.button.title}">
+	<button type="button" class="btn btn-secondary bulk-col-apply" th:attr="data-tool=${toolId},data-field=${field},title=#{datesetter.column.button.title},aria-label=#{datesetter.column.button.title}">
 		<i class="fa fa-arrow-down" aria-hidden="true"></i>
 	</button>
 </div>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -169,8 +169,9 @@
 	</div>
 </div>
 
-<!-- Per-column bulk setter rendered inside each editable date column header. Fills every row of that one
-     column in that one section with the entered date (overwrites existing values). -->
+<!-- Per-column bulk setter rendered inside each editable date column header. Fills that one column in
+     that one section with the entered date: always overwrites existing values, and also fills blank
+     cells when its "Fill Empty" checkbox is ticked (unticked by default). -->
 <div th:fragment="bulkColSetter(toolId, field)" class="bulk-col-setter input-group input-group-sm mt-1 fw-normal" th:with="cid=${toolId + '-' + field}">
 	<input type="text" class="form-control bulk-col-input" th:id="${'bulkcol-' + cid}"
 		th:attr="data-tool=${toolId},data-field=${field},aria-label=#{datesetter.column.aria}" />
@@ -178,6 +179,10 @@
 	<button type="button" class="btn btn-secondary bulk-col-apply" th:attr="data-tool=${toolId},data-field=${field},title=#{datesetter.column.button.title},aria-label=#{datesetter.column.button.title}">
 		<i class="fa fa-arrow-down" aria-hidden="true"></i>
 	</button>
+	<label class="w-100 mt-1 mb-0 small text-start">
+		<input type="checkbox" class="bulk-col-fill-empty me-1" th:attr="title=#{datesetter.column.fillempty.title}" />
+		<span th:text="#{datesetter.column.fillempty}" th:remove="tag">Fill Empty</span>
+	</label>
 </div>
 
 <!-- Checkbox cells for one term-date row of the term dates panel. Renders one checkbox per editable

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -7,39 +7,39 @@
 					<th th:text="#{column.title}">Title</th>
 					<th:block th:switch="${toolId}">
 						<th:block th:case="'gradebookItems'"></th:block>
-						<th th:case="'assignments'" th:text="#{column.open.date}" class="field-required" title="Required">Open Date</th>
-						<th th:case="'assessments'" th:text="#{column.available.date}" class="field-required" title="Required">Available Date</th>
-						<th th:case="'signupMeetings'" th:text="#{column.start.date}" class="field-required" title="Required">Start Date</th>
-						<th th:case="'resources'" th:text="#{column.show.from.date}">Show From Date</th>
-						<th th:case="'calendarEvents'" th:text="#{column.start.date}" class="field-required" title="Required">Start Date</th>
-						<th th:case="'forums'" th:text="#{column.open.date}">Open Date</th>
-						<th th:case="'announcements'" th:text="#{column.start.date}">Start Date</th>
-						<th th:case="'lessons'" th:text="#{column.hide.until}">Hide Until Date</th>
+						<th th:case="'assignments'" class="field-required" title="Required"><div th:text="#{column.open.date}">Open Date</div><th:block th:replace="~{:: bulkColSetter('assignments','open_date')}"></th:block></th>
+						<th th:case="'assessments'" class="field-required" title="Required"><div th:text="#{column.available.date}">Available Date</div><th:block th:replace="~{:: bulkColSetter('assessments','open_date')}"></th:block></th>
+						<th th:case="'signupMeetings'" class="field-required" title="Required"><div th:text="#{column.start.date}">Start Date</div><th:block th:replace="~{:: bulkColSetter('signupMeetings','open_date')}"></th:block></th>
+						<th th:case="'resources'"><div th:text="#{column.show.from.date}">Show From Date</div><th:block th:replace="~{:: bulkColSetter('resources','open_date')}"></th:block></th>
+						<th th:case="'calendarEvents'" class="field-required" title="Required"><div th:text="#{column.start.date}">Start Date</div><th:block th:replace="~{:: bulkColSetter('calendarEvents','open_date')}"></th:block></th>
+						<th th:case="'forums'"><div th:text="#{column.open.date}">Open Date</div><th:block th:replace="~{:: bulkColSetter('forums','open_date')}"></th:block></th>
+						<th th:case="'announcements'"><div th:text="#{column.start.date}">Start Date</div><th:block th:replace="~{:: bulkColSetter('announcements','open_date')}"></th:block></th>
+						<th th:case="'lessons'"><div th:text="#{column.hide.until}">Hide Until Date</div><th:block th:replace="~{:: bulkColSetter('lessons','open_date')}"></th:block></th>
 					</th:block>
 					<th:block th:switch="${toolId}">
 						<th:block th:case="'lessons'"></th:block>
-						<th th:case="'assignments'" th:text="#{column.due.date}" class="field-required" title="Required">Due Date</th>
-						<th th:case="'assessments'" th:text="#{column.due.date}">Due Date</th>
-						<th th:case="'signupMeetings'" th:text="#{column.end.date}" class="field-required" title="Required">End Date</th>
-						<th th:case="'gradebookItems'" th:text="#{column.due.date}">Due Date</th>
-						<th th:case="'resources'" th:text="#{column.show.until}">Show Until Date</th>
-						<th th:case="'calendarEvents'" th:text="#{column.end.date}" class="field-required" title="Required">End Date</th>
-						<th th:case="'forums'" th:text="#{column.close.date}">Close Date</th>
-						<th th:case="'announcements'" th:text="#{column.end.date}">End Date</th>
+						<th th:case="'assignments'" class="field-required" title="Required"><div th:text="#{column.due.date}">Due Date</div><th:block th:replace="~{:: bulkColSetter('assignments','due_date')}"></th:block></th>
+						<th th:case="'assessments'"><div th:text="#{column.due.date}">Due Date</div><th:block th:replace="~{:: bulkColSetter('assessments','due_date')}"></th:block></th>
+						<th th:case="'signupMeetings'" class="field-required" title="Required"><div th:text="#{column.end.date}">End Date</div><th:block th:replace="~{:: bulkColSetter('signupMeetings','due_date')}"></th:block></th>
+						<th th:case="'gradebookItems'"><div th:text="#{column.due.date}">Due Date</div><th:block th:replace="~{:: bulkColSetter('gradebookItems','due_date')}"></th:block></th>
+						<th th:case="'resources'"><div th:text="#{column.show.until}">Show Until Date</div><th:block th:replace="~{:: bulkColSetter('resources','due_date')}"></th:block></th>
+						<th th:case="'calendarEvents'" class="field-required" title="Required"><div th:text="#{column.end.date}">End Date</div><th:block th:replace="~{:: bulkColSetter('calendarEvents','due_date')}"></th:block></th>
+						<th th:case="'forums'"><div th:text="#{column.close.date}">Close Date</div><th:block th:replace="~{:: bulkColSetter('forums','due_date')}"></th:block></th>
+						<th th:case="'announcements'"><div th:text="#{column.end.date}">End Date</div><th:block th:replace="~{:: bulkColSetter('announcements','due_date')}"></th:block></th>
 					</th:block>
 					<th:block th:switch="${toolId}">
-						<th th:case="'assignments'" th:text="#{column.accept.until}" class="field-required" title="Required">Accept Until Date</th>
-						<th th:case="'assessments'" th:text="#{column.assessments.accept.until}">Late Submission Deadline</th>
+						<th th:case="'assignments'" class="field-required" title="Required"><div th:text="#{column.accept.until}">Accept Until Date</div><th:block th:replace="~{:: bulkColSetter('assignments','accept_until')}"></th:block></th>
+						<th th:case="'assessments'"><div th:text="#{column.assessments.accept.until}">Late Submission Deadline</div><th:block th:replace="~{:: bulkColSetter('assessments','accept_until')}"></th:block></th>
 						<th:block th:case="*"></th:block>
 					</th:block>
 					<th:block th:switch="${toolId}">
-						<th th:case="'assessments'" th:text="#{column.feedback.start.date}">Show Feedback On</th>
-						<th th:case="'signupMeetings'" th:text="#{column.signup.begins.date}" class="field-required" title="Required">Sign-up Begins Date</th>
+						<th th:case="'assessments'"><div th:text="#{column.feedback.start.date}">Show Feedback On</div><th:block th:replace="~{:: bulkColSetter('assessments','feedback_start')}"></th:block></th>
+						<th th:case="'signupMeetings'" class="field-required" title="Required"><div th:text="#{column.signup.begins.date}">Sign-up Begins Date</div><th:block th:replace="~{:: bulkColSetter('signupMeetings','signup_begins')}"></th:block></th>
 						<th:block th:case="*"></th:block>
 					</th:block>
 					<th:block th:switch="${toolId}">
-						<th th:case="'assessments'" th:text="#{column.feedback.end.date}">Show Feedback Until</th>
-						<th th:case="'signupMeetings'" th:text="#{column.signup.deadline.date}" class="field-required" title="Required">Sign-up Ends Date</th>
+						<th th:case="'assessments'"><div th:text="#{column.feedback.end.date}">Show Feedback Until</div><th:block th:replace="~{:: bulkColSetter('assessments','feedback_end')}"></th:block></th>
+						<th th:case="'signupMeetings'" class="field-required" title="Required"><div th:text="#{column.signup.deadline.date}">Sign-up Ends Date</div><th:block th:replace="~{:: bulkColSetter('signupMeetings','signup_deadline')}"></th:block></th>
 						<th:block th:case="*"></th:block>
 					</th:block>
 				</tr>
@@ -151,7 +151,7 @@
 									<a tabindex="0" href="javascript:void(0)" title="Clear Date">
 										<i class="fa fa-times-circle ui-datapicker-clear-date-icon" aria-hidden="true"></i>
 									</a>
-									<input type="hidden" th:value="${item.signup_deadline}" th:data-null-date="${item.signup_deadline} ? false : true" 
+									<input type="hidden" th:value="${item.signup_deadline}" th:data-null-date="${item.signup_deadline} ? false : true"
 									th:attr="data-idx=${iter.index},data-tool=${toolId}" data-field="signup_deadline" />
 									<div><small class="text-muted day-of-week"></small></div>
 									<div><small class="errors"></small></div>
@@ -166,3 +166,60 @@
 		</table>
 	</div>
 </div>
+
+<!-- Per-column bulk setter rendered inside each editable date column header. Fills every row of that one
+     column in that one section with the entered date (overwrites existing values). -->
+<div th:fragment="bulkColSetter(toolId, field)" class="bulk-col-setter input-group input-group-sm mt-1 fw-normal" th:with="cid=${toolId + '-' + field}">
+	<input type="text" class="form-control bulk-col-input" th:id="${'bulkcol-' + cid}"
+		th:attr="data-tool=${toolId},data-field=${field},aria-label=#{datesetter.column.aria},placeholder=#{datesetter.column.placeholder}" />
+	<input type="hidden" class="bulk-col-hidden" th:id="${'bulkcol-hidden-' + cid}" th:attr="data-tool=${toolId},data-field=${field}" />
+	<button type="button" class="btn btn-outline-secondary bulk-col-apply" th:attr="data-tool=${toolId},data-field=${field},title=#{datesetter.column.button.title},aria-label=#{datesetter.column.button.title}">
+		<i class="fa fa-arrow-down" aria-hidden="true"></i>
+	</button>
+</div>
+
+<!-- Checkbox cells for one term-date row of the term dates panel. Renders one checkbox per editable
+     date column of every section present on the page, in the same order as the panel column headers.
+     Each checkbox carries the target section root id and column field so JS can fill that column. -->
+<th:block th:fragment="termCells(term)">
+	<th:block th:if="${assignments != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='accept_until'" /></td>
+	</th:block>
+	<th:block th:if="${assessments != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='accept_until'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_start'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_end'" /></td>
+	</th:block>
+	<th:block th:if="${signupMeetings != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='due_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_begins'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_deadline'" /></td>
+	</th:block>
+	<th:block th:if="${gradebookItems != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-gradebook',data-field='due_date'" /></td>
+	</th:block>
+	<th:block th:if="${resources != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='due_date'" /></td>
+	</th:block>
+	<th:block th:if="${calendarEvents != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='due_date'" /></td>
+	</th:block>
+	<th:block th:if="${forums != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='due_date'" /></td>
+	</th:block>
+	<th:block th:if="${announcements != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='open_date'" /></td>
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='due_date'" /></td>
+	</th:block>
+	<th:block th:if="${lessons != null}">
+		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-lessons',data-field='open_date'" /></td>
+	</th:block>
+</th:block>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -173,7 +173,7 @@
      column in that one section with the entered date (overwrites existing values). -->
 <div th:fragment="bulkColSetter(toolId, field)" class="bulk-col-setter input-group input-group-sm mt-1 fw-normal" th:with="cid=${toolId + '-' + field}">
 	<input type="text" class="form-control bulk-col-input" th:id="${'bulkcol-' + cid}"
-		th:attr="data-tool=${toolId},data-field=${field},aria-label=#{datesetter.column.aria},placeholder=#{datesetter.column.placeholder}" />
+		th:attr="data-tool=${toolId},data-field=${field},aria-label=#{datesetter.column.aria}" />
 	<input type="hidden" class="bulk-col-hidden" th:id="${'bulkcol-hidden-' + cid}" th:attr="data-tool=${toolId},data-field=${field}" />
 	<button type="button" class="btn btn-secondary bulk-col-apply" th:attr="data-tool=${toolId},data-field=${field},title=#{datesetter.column.button.title},aria-label=#{datesetter.column.button.title}">
 		<i class="fa fa-arrow-down" aria-hidden="true"></i>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -181,7 +181,7 @@
 	</button>
 	<label class="w-100 mt-1 mb-0 small text-start">
 		<input type="checkbox" class="bulk-col-fill-empty me-1" th:attr="title=#{datesetter.column.fillempty.title}" />
-		<span th:text="#{datesetter.column.fillempty}" th:remove="tag">Fill Empty</span>
+		<span th:text="#{datesetter.column.fillempty}" th:remove="tag">Fill ALL (including empty cells)</span>
 	</label>
 </div>
 

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -190,43 +190,43 @@
      Each checkbox carries the target section root id and column field so JS can fill that column. -->
 <th:block th:fragment="termCells(term)" th:with="termLabel=${term == 'classes_start' ? #messages.msg('termdates.classes.start') : term == 'classes_end' ? #messages.msg('termdates.classes.end') : term == 'exam_begins' ? #messages.msg('termdates.exam.begins') : #messages.msg('termdates.exam.ends')}">
 	<th:block th:if="${assignments != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='open_date',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.open.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='due_date',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='accept_until',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.accept.until')}" /></td>
+		<td class="text-center dm-mx-assignments dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='open_date',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.open.date')}" /></td>
+		<td class="text-center dm-mx-assignments"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='due_date',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
+		<td class="text-center dm-mx-assignments"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assignments',data-field='accept_until',aria-label=${termLabel + ' - ' + assignmentsToolTitle + ' - ' + #messages.msg('column.accept.until')}" /></td>
 	</th:block>
 	<th:block th:if="${assessments != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='open_date',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.available.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='due_date',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='accept_until',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.assessments.accept.until')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_start',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.feedback.start.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_end',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.feedback.end.date')}" /></td>
+		<td class="text-center dm-mx-assessments dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='open_date',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.available.date')}" /></td>
+		<td class="text-center dm-mx-assessments"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='due_date',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
+		<td class="text-center dm-mx-assessments"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='accept_until',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.assessments.accept.until')}" /></td>
+		<td class="text-center dm-mx-assessments"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_start',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.feedback.start.date')}" /></td>
+		<td class="text-center dm-mx-assessments"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-assessments',data-field='feedback_end',aria-label=${termLabel + ' - ' + assessmentsToolTitle + ' - ' + #messages.msg('column.feedback.end.date')}" /></td>
 	</th:block>
 	<th:block th:if="${signupMeetings != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='open_date',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='due_date',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_begins',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.signup.begins.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_deadline',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.signup.deadline.date')}" /></td>
+		<td class="text-center dm-mx-signup dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='open_date',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
+		<td class="text-center dm-mx-signup"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='due_date',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
+		<td class="text-center dm-mx-signup"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_begins',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.signup.begins.date')}" /></td>
+		<td class="text-center dm-mx-signup"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-signup',data-field='signup_deadline',aria-label=${termLabel + ' - ' + signupMeetingsToolTitle + ' - ' + #messages.msg('column.signup.deadline.date')}" /></td>
 	</th:block>
 	<th:block th:if="${gradebookItems != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-gradebook',data-field='due_date',aria-label=${termLabel + ' - ' + gradebookItemsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
+		<td class="text-center dm-mx-gradebook dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-gradebook',data-field='due_date',aria-label=${termLabel + ' - ' + gradebookItemsToolTitle + ' - ' + #messages.msg('column.due.date')}" /></td>
 	</th:block>
 	<th:block th:if="${resources != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='open_date',aria-label=${termLabel + ' - ' + resourcesToolTitle + ' - ' + #messages.msg('column.show.from.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='due_date',aria-label=${termLabel + ' - ' + resourcesToolTitle + ' - ' + #messages.msg('column.show.until')}" /></td>
+		<td class="text-center dm-mx-resources dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='open_date',aria-label=${termLabel + ' - ' + resourcesToolTitle + ' - ' + #messages.msg('column.show.from.date')}" /></td>
+		<td class="text-center dm-mx-resources"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-resources',data-field='due_date',aria-label=${termLabel + ' - ' + resourcesToolTitle + ' - ' + #messages.msg('column.show.until')}" /></td>
 	</th:block>
 	<th:block th:if="${calendarEvents != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='open_date',aria-label=${termLabel + ' - ' + calendarEventsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='due_date',aria-label=${termLabel + ' - ' + calendarEventsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
+		<td class="text-center dm-mx-calendar dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='open_date',aria-label=${termLabel + ' - ' + calendarEventsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
+		<td class="text-center dm-mx-calendar"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-calendar',data-field='due_date',aria-label=${termLabel + ' - ' + calendarEventsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
 	</th:block>
 	<th:block th:if="${forums != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='open_date',aria-label=${termLabel + ' - ' + forumsToolTitle + ' - ' + #messages.msg('column.open.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='due_date',aria-label=${termLabel + ' - ' + forumsToolTitle + ' - ' + #messages.msg('column.close.date')}" /></td>
+		<td class="text-center dm-mx-forums dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='open_date',aria-label=${termLabel + ' - ' + forumsToolTitle + ' - ' + #messages.msg('column.open.date')}" /></td>
+		<td class="text-center dm-mx-forums"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-forums',data-field='due_date',aria-label=${termLabel + ' - ' + forumsToolTitle + ' - ' + #messages.msg('column.close.date')}" /></td>
 	</th:block>
 	<th:block th:if="${announcements != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='open_date',aria-label=${termLabel + ' - ' + announcementsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='due_date',aria-label=${termLabel + ' - ' + announcementsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
+		<td class="text-center dm-mx-announcements dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='open_date',aria-label=${termLabel + ' - ' + announcementsToolTitle + ' - ' + #messages.msg('column.start.date')}" /></td>
+		<td class="text-center dm-mx-announcements"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-announcements',data-field='due_date',aria-label=${termLabel + ' - ' + announcementsToolTitle + ' - ' + #messages.msg('column.end.date')}" /></td>
 	</th:block>
 	<th:block th:if="${lessons != null}">
-		<td class="text-center"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-lessons',data-field='open_date',aria-label=${termLabel + ' - ' + lessonsToolTitle + ' - ' + #messages.msg('column.hide.until')}" /></td>
+		<td class="text-center dm-mx-lessons dm-mx-first"><input type="checkbox" class="term-target" th:attr="data-term=${term},data-root='collapse-lessons',data-field='open_date',aria-label=${termLabel + ' - ' + lessonsToolTitle + ' - ' + #messages.msg('column.hide.until')}" /></td>
 	</th:block>
 </th:block>

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/tool_fragment.html
@@ -181,7 +181,7 @@
 	</button>
 	<label class="w-100 mt-1 mb-0 small text-start">
 		<input type="checkbox" class="bulk-col-fill-empty me-1" th:attr="title=#{datesetter.column.fillempty.title}" />
-		<span th:text="#{datesetter.column.fillempty}" th:remove="tag">Fill ALL (including empty cells)</span>
+		<span th:text="#{datesetter.column.fillempty}" th:remove="tag">Also fill empty cells</span>
 	</label>
 </div>
 

--- a/site-manage/datemanager/tool/src/test/js/.gitignore
+++ b/site-manage/datemanager/tool/src/test/js/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/site-manage/datemanager/tool/src/test/js/README.md
+++ b/site-manage/datemanager/tool/src/test/js/README.md
@@ -27,8 +27,8 @@ On Windows (cmd), run `set TZ=UTC && node --test`, or use Git Bash / WSL.
 ## What is and isn't covered
 
 - **Covered:** `parseInputDateValue`, `parseDatePickerInputValue`, `snapToSourceWeekday`,
-  `computeFittedDate`, `getDatePickerInputValue` / `getHiddenDateValue`, `momentInUserZone`,
-  `getUserTimeZone`.
+  `computeFittedDate`, `computeRowFittedDates`, `computeDayDiff`,
+  `getDatePickerInputValue` / `getHiddenDateValue`.
 - **Not covered:** DOM/jQuery glue (fill, apply, collapse, attach, init/validate). Those
   need a jsdom or Playwright harness and are out of scope for this suite.
 

--- a/site-manage/datemanager/tool/src/test/js/README.md
+++ b/site-manage/datemanager/tool/src/test/js/README.md
@@ -12,14 +12,17 @@ apply silently no-op).
 
 ## Run
 
-Requires **Node 18+** (uses the built-in `node:test` runner). The only dependency is
-`moment-timezone`, pinned to the same version the tool loads at runtime.
+Requires **Node 18+** (uses the built-in `node:test` runner). The only dependency is `moment`.
+The date logic is timezone-agnostic (wall-clock only — Sakai resolves the zone server-side), and the
+`test` script pins `TZ=UTC` for deterministic wall-clock math.
 
 ```sh
 cd site-manage/datemanager/tool/src/test/js
 npm install
-npm test          # or: node --test
+npm test          # runs: TZ=UTC node --test
 ```
+
+On Windows (cmd), run `set TZ=UTC && node --test`, or use Git Bash / WSL.
 
 ## What is and isn't covered
 
@@ -29,6 +32,5 @@ npm test          # or: node --test
 - **Not covered:** DOM/jQuery glue (fill, apply, collapse, attach, init/validate). Those
   need a jsdom or Playwright harness and are out of scope for this suite.
 
-`loadDtmn.js` loads the browser script into a Node `vm` context with `moment-timezone`
-and a stub `sakai.locale.userTimeZone` injected, then returns the populated `DTMN`
-object — so the tests exercise the real shipped code with the real date library.
+`loadDtmn.js` loads the browser script into a Node `vm` context with `moment` injected, then returns
+the populated `DTMN` object — so the tests exercise the real shipped code with the real date library.

--- a/site-manage/datemanager/tool/src/test/js/README.md
+++ b/site-manage/datemanager/tool/src/test/js/README.md
@@ -1,0 +1,34 @@
+# DateManager JS unit tests
+
+Standalone unit tests for the **pure date logic** in
+`../../main/resources/static/js/initDatePicker.js` (the DateManager client-side
+engine): timezone-offset parsing, weekday snapping, the Smart Shift proportional
+fit, and format round-trips.
+
+These are **not part of the Maven build** — the WAR plugin only packages
+`src/main/webapp`, so nothing here is ever shipped. They exist to guard the tricky
+date math against regression (e.g. the timezone-offset parse bug that made the bulk
+apply silently no-op).
+
+## Run
+
+Requires **Node 18+** (uses the built-in `node:test` runner). The only dependency is
+`moment-timezone`, pinned to the same version the tool loads at runtime.
+
+```sh
+cd site-manage/datemanager/tool/src/test/js
+npm install
+npm test          # or: node --test
+```
+
+## What is and isn't covered
+
+- **Covered:** `parseInputDateValue`, `parseDatePickerInputValue`, `snapToSourceWeekday`,
+  `computeFittedDate`, `getDatePickerInputValue` / `getHiddenDateValue`, `momentInUserZone`,
+  `getUserTimeZone`.
+- **Not covered:** DOM/jQuery glue (fill, apply, collapse, attach, init/validate). Those
+  need a jsdom or Playwright harness and are out of scope for this suite.
+
+`loadDtmn.js` loads the browser script into a Node `vm` context with `moment-timezone`
+and a stub `sakai.locale.userTimeZone` injected, then returns the populated `DTMN`
+object — so the tests exercise the real shipped code with the real date library.

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-// Unit tests for the PURE date logic in initDatePicker.js. DOM/jQuery glue (fill, apply, collapse,
-// attach) is intentionally not covered here - see README.md. Run with: node --test
+// Unit tests for the PURE date logic in initDatePicker.js. The logic is intentionally timezone-agnostic
+// (wall-clock only; Sakai resolves the zone server-side via UserTimeService), so these tests do plain
+// wall-clock assertions. Run under TZ=UTC (see package.json) for determinism. DOM/jQuery glue (fill,
+// apply, collapse, attach) is intentionally not covered here - see README.md. Run: npm test
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const { loadDtmn } = require("./loadDtmn");
 
-const ZONE = "America/New_York";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-const { DTMN, moment } = loadDtmn(ZONE);
-// Build a moment in the same zone the script is configured with, from the same library instance.
-const mtz = (s) => moment.tz(s, ZONE);
+const { DTMN, moment } = loadDtmn();
+// Build a moment from a wall-clock string the same way the tool does (strict, no timezone).
+const mom = (s) => moment(s, ["YYYY-MM-DDTHH:mm:ss", "YYYY-MM-DD"], true);
 
 // ---------------------------------------------------------------------------
 // parseInputDateValue - the regression guard for the timezone-offset bug.
@@ -79,12 +80,28 @@ test("documents the bug: parseDatePickerInputValue (strict, no offset token) rej
 });
 
 // ---------------------------------------------------------------------------
+// Wall-clock fidelity: parse then format must not shift the value (no timezone math).
+// ---------------------------------------------------------------------------
+
+test("datetime round-trips through parse and the hidden/visible formatters", () => {
+  const parsed = DTMN.parseDatePickerInputValue("2026-09-01T09:30:00", true);
+  assert.equal(DTMN.getHiddenDateValue(parsed, true), "2026-09-01T09:30:00");
+  assert.equal(DTMN.getDatePickerInputValue(parsed, true), "2026-09-01T09:30");
+});
+
+test("date-only round-trips through parse and the formatters", () => {
+  const parsed = DTMN.parseDatePickerInputValue("2026-09-01", false);
+  assert.equal(DTMN.getHiddenDateValue(parsed, false), "2026-09-01");
+  assert.equal(DTMN.getDatePickerInputValue(parsed, false), "2026-09-01");
+});
+
+// ---------------------------------------------------------------------------
 // snapToSourceWeekday - keep each item's own weekday + clock time, move by whole days (<= 3).
 // ---------------------------------------------------------------------------
 
 test("snapToSourceWeekday lands on the source weekday nearest the target, carrying source's time", () => {
-  const source = mtz("2026-09-14T09:30:15"); // a Monday
-  const target = mtz("2026-09-16T00:00:00"); // a Wednesday, 2 days later
+  const source = mom("2026-09-14T09:30:15"); // a Monday
+  const target = mom("2026-09-16T00:00:00"); // a Wednesday, 2 days later
   const result = DTMN.snapToSourceWeekday(target, source);
 
   assert.equal(result.day(), source.day());
@@ -95,8 +112,7 @@ test("snapToSourceWeekday lands on the source weekday nearest the target, carryi
 });
 
 test("snapToSourceWeekday never moves more than 3 days and preserves the weekday for all combos", () => {
-  // Cover every weekday-pair: target shifts through a full week, source through a full week.
-  const monday = mtz("2026-09-14T00:00:00");
+  const monday = mom("2026-09-14T00:00:00");
   for (let t = 0; t < 7; t++) {
     const target = monday.clone().add(t, "days");
     for (let s = 0; s < 7; s++) {
@@ -116,8 +132,8 @@ test("snapToSourceWeekday never moves more than 3 days and preserves the weekday
 });
 
 test("snapToSourceWeekday keeps same-weekday items a whole number of weeks apart", () => {
-  const source = mtz("2026-09-16T10:00:00"); // Wednesday
-  const target1 = mtz("2026-09-14T00:00:00"); // Monday
+  const source = mom("2026-09-16T10:00:00"); // Wednesday
+  const target1 = mom("2026-09-14T00:00:00"); // Monday
   const target2 = target1.clone().add(14, "days"); // Monday, two weeks on
 
   const r1 = DTMN.snapToSourceWeekday(target1, source);
@@ -131,7 +147,7 @@ test("snapToSourceWeekday keeps same-weekday items a whole number of weeks apart
 // computeFittedDate - the extracted Smart Shift per-cell mapping.
 // ---------------------------------------------------------------------------
 
-const anchors = () => ({ first: mtz("2026-07-01T00:00:00"), last: mtz("2026-09-19T00:00:00") });
+const anchors = () => ({ first: mom("2026-07-01T00:00:00"), last: mom("2026-09-19T00:00:00") });
 
 test("computeFittedDate maps the earliest cell exactly onto the new first date", () => {
   const a = anchors();
@@ -141,7 +157,6 @@ test("computeFittedDate maps the earliest cell exactly onto the new first date",
 
 test("computeFittedDate maps the latest cell exactly onto the new last date", () => {
   const a = anchors();
-  // currentMs == oldStart + oldSpan == oldEnd  ->  frac == 1
   const result = DTMN.computeFittedDate(2000, 1000, 1000, a, false, null);
   assert.equal(result.valueOf(), a.last.valueOf());
 });
@@ -155,7 +170,6 @@ test("computeFittedDate collapses everything onto the new first date when the ol
 test("computeFittedDate places a middle cell proportionally when snap is off", () => {
   const a = anchors();
   const newSpan = a.last.valueOf() - a.first.valueOf();
-  // frac = 0.5
   const result = DTMN.computeFittedDate(1500, 1000, 1000, a, false, null);
   assert.equal(result.valueOf(), a.first.valueOf() + newSpan / 2);
 });
@@ -163,7 +177,7 @@ test("computeFittedDate places a middle cell proportionally when snap is off", (
 test("computeFittedDate snaps a middle cell to the source weekday, staying near the proportional target", () => {
   const a = anchors();
   const newSpan = a.last.valueOf() - a.first.valueOf();
-  const source = mtz("2026-08-12T13:00:00"); // arbitrary mid-term Wednesday
+  const source = mom("2026-08-12T13:00:00"); // arbitrary mid-term Wednesday
   const result = DTMN.computeFittedDate(1500, 1000, 1000, a, true, source);
 
   assert.equal(result.day(), source.day());
@@ -176,43 +190,6 @@ test("computeFittedDate: the LATEST date wins the end anchor regardless of colum
   // This is the behaviour that confused us during manual testing: an assignment's open date that
   // happened to be later than its due/accept dates correctly received the new LAST date.
   const a = anchors();
-  const oldStart = 100;
-  const oldSpan = 900; // oldEnd = 1000
-  const openIsLatest = DTMN.computeFittedDate(1000, oldStart, oldSpan, a, false, null);
+  const openIsLatest = DTMN.computeFittedDate(1000, 100, 900, a, false, null);
   assert.equal(openIsLatest.valueOf(), a.last.valueOf());
-});
-
-// ---------------------------------------------------------------------------
-// Format <-> parse round-trips.
-// ---------------------------------------------------------------------------
-
-test("datetime round-trips through parse and the hidden/visible formatters", () => {
-  const parsed = DTMN.parseDatePickerInputValue("2026-09-01T09:30:00", true);
-  assert.equal(DTMN.getHiddenDateValue(parsed, true), "2026-09-01T09:30:00");
-  assert.equal(DTMN.getDatePickerInputValue(parsed, true), "2026-09-01T09:30");
-});
-
-test("date-only round-trips through parse and the formatters", () => {
-  const parsed = DTMN.parseDatePickerInputValue("2026-09-01", false);
-  assert.equal(DTMN.getHiddenDateValue(parsed, false), "2026-09-01");
-  assert.equal(DTMN.getDatePickerInputValue(parsed, false), "2026-09-01");
-});
-
-// ---------------------------------------------------------------------------
-// momentInUserZone / getUserTimeZone.
-// ---------------------------------------------------------------------------
-
-test("momentInUserZone preserves the instant and applies the configured zone offset", () => {
-  const instant = mtz("2026-09-01T12:00:00").valueOf(); // EDT, -04:00
-  const m = DTMN.momentInUserZone(instant);
-  assert.equal(m.valueOf(), instant);
-  assert.equal(m.utcOffset(), -240);
-});
-
-test("getUserTimeZone reflects sakai.locale.userTimeZone, and a different zone changes the offset", () => {
-  assert.equal(DTMN.getUserTimeZone(), ZONE);
-
-  const utc = loadDtmn("UTC");
-  const instant = utc.moment.tz("2026-09-01T12:00:00", "UTC").valueOf();
-  assert.equal(utc.DTMN.momentInUserZone(instant).utcOffset(), 0);
 });

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -195,6 +195,63 @@ test("computeFittedDate: the LATEST date wins the end anchor regardless of colum
 });
 
 // ---------------------------------------------------------------------------
+// computeRowFittedDates - per-row snap guard: snapping must never reorder an item's own dates
+// (the server rejects due-before-open on save) or leave the new term window.
+// ---------------------------------------------------------------------------
+
+const rowCell = (m) => ({ current: m, currentMs: m.valueOf() });
+
+test("computeRowFittedDates falls back to proportional when snapping would invert open/due under compression", () => {
+  // 16-week course squeezed into 4 weeks: open Fri 09:00 / due the following Mon 17:00 snap to
+  // their own weekdays independently, which used to yield due BEFORE open for every such item -
+  // an unsaveable state. The row must fall back to proportional placement instead.
+  const a = { first: mom("2026-09-01T00:00:00"), last: mom("2026-09-28T00:00:00") }; // 4 weeks
+  const oldStart = mom("2026-01-05T00:00:00").valueOf();
+  const oldSpan = mom("2026-04-27T00:00:00").valueOf() - oldStart; // ~16 weeks
+  const open = rowCell(mom("2026-03-06T09:00:00")); // Friday
+  const due = rowCell(mom("2026-03-09T17:00:00")); // the following Monday
+
+  // premise: independent per-cell snapping really does invert this pair
+  const cellSnappedOpen = DTMN.computeFittedDate(open.currentMs, oldStart, oldSpan, a, true, open.current);
+  const cellSnappedDue = DTMN.computeFittedDate(due.currentMs, oldStart, oldSpan, a, true, due.current);
+  assert.ok(cellSnappedOpen.valueOf() > cellSnappedDue.valueOf(), "scenario must trigger the inversion hazard");
+
+  const out = DTMN.computeRowFittedDates([open, due], oldStart, oldSpan, a, true);
+
+  assert.ok(out[0].valueOf() <= out[1].valueOf(), "open must not pass due");
+  assert.ok(out[0].valueOf() >= a.first.valueOf(), "stays inside the new window (start)");
+  assert.ok(out[1].valueOf() <= a.last.valueOf(), "stays inside the new window (end)");
+});
+
+test("computeRowFittedDates keeps weekday snapping on a same-length rollover", () => {
+  // fall -> spring, identical length: snapping is safe, so it must stay active and both cells
+  // keep their weekday and clock time.
+  const oldStart = mom("2026-09-07T00:00:00").valueOf(); // Monday
+  const oldSpan = mom("2026-12-28T00:00:00").valueOf() - oldStart; // 112 days
+  const a = { first: mom("2027-01-04T00:00:00"), last: mom("2027-04-26T00:00:00") }; // 112 days
+  const open = rowCell(mom("2026-10-09T09:00:00")); // Friday
+  const due = rowCell(mom("2026-10-12T17:00:00")); // Monday
+
+  const out = DTMN.computeRowFittedDates([open, due], oldStart, oldSpan, a, true);
+
+  assert.equal(out[0].day(), 5, "open keeps its Friday");
+  assert.equal(out[0].hours(), 9);
+  assert.equal(out[1].day(), 1, "due keeps its Monday");
+  assert.equal(out[1].hours(), 17);
+  assert.ok(out[0].valueOf() < out[1].valueOf(), "row order preserved");
+});
+
+test("computeRowFittedDates without snap returns the plain proportional placement", () => {
+  const a = anchors();
+  const cell = rowCell(mom("2026-08-12T13:00:00"));
+  const out = DTMN.computeRowFittedDates([cell], 1000, 1000, a, false);
+  assert.equal(
+    out[0].valueOf(),
+    DTMN.computeFittedDate(cell.currentMs, 1000, 1000, a, false, null).valueOf()
+  );
+});
+
+// ---------------------------------------------------------------------------
 // computeDayDiff - the date-difference helper feeding the shift field.
 // ---------------------------------------------------------------------------
 

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests for the PURE date logic in initDatePicker.js. DOM/jQuery glue (fill, apply, collapse,
+// attach) is intentionally not covered here - see README.md. Run with: node --test
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { loadDtmn } = require("./loadDtmn");
+
+const ZONE = "America/New_York";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const { DTMN, moment } = loadDtmn(ZONE);
+// Build a moment in the same zone the script is configured with, from the same library instance.
+const mtz = (s) => moment.tz(s, ZONE);
+
+// ---------------------------------------------------------------------------
+// parseInputDateValue - the regression guard for the timezone-offset bug.
+// ---------------------------------------------------------------------------
+
+test("parseInputDateValue strips a positive offset and keeps the wall-clock time", () => {
+  const d = DTMN.parseInputDateValue("2026-09-01T09:00:00+02:00", true);
+  assert.ok(d.isValid());
+  assert.equal(d.hours(), 9);
+  assert.equal(d.minutes(), 0);
+  assert.equal(d.format("YYYY-MM-DDTHH:mm:ss"), "2026-09-01T09:00:00");
+});
+
+test("parseInputDateValue strips a negative offset", () => {
+  const d = DTMN.parseInputDateValue("2026-09-01T09:00:00-05:00", true);
+  assert.ok(d.isValid());
+  assert.equal(d.format("YYYY-MM-DDTHH:mm:ss"), "2026-09-01T09:00:00");
+});
+
+test("parseInputDateValue strips a Z suffix", () => {
+  const d = DTMN.parseInputDateValue("2026-09-01T09:00:00Z", true);
+  assert.ok(d.isValid());
+  assert.equal(d.format("YYYY-MM-DDTHH:mm:ss"), "2026-09-01T09:00:00");
+});
+
+test("parseInputDateValue with useTime=false yields a valid date-only moment from a datetime+offset", () => {
+  // Gradebook columns are date-only, but localDatePicker still stores a full datetime+offset.
+  const d = DTMN.parseInputDateValue("2026-09-01T00:00:00+02:00", false);
+  assert.ok(d.isValid());
+  assert.equal(d.format("YYYY-MM-DD"), "2026-09-01");
+});
+
+test("parseInputDateValue still parses a value that has no offset", () => {
+  const d = DTMN.parseInputDateValue("2026-09-01T09:00:00", true);
+  assert.ok(d.isValid());
+  assert.equal(d.format("YYYY-MM-DDTHH:mm:ss"), "2026-09-01T09:00:00");
+});
+
+test("parseInputDateValue returns an invalid moment for an empty value", () => {
+  assert.equal(DTMN.parseInputDateValue("", true).isValid(), false);
+});
+
+test("documents the bug: parseDatePickerInputValue (strict, no offset token) rejects the offset string", () => {
+  // This is exactly why parseInputDateValue exists: the raw strict parser cannot read the
+  // localDatePicker hidden value, which is what made every apply silently no-op.
+  const raw = DTMN.parseDatePickerInputValue("2026-09-01T09:00:00+02:00", true);
+  assert.equal(raw.isValid(), false);
+  // ...and the wrapper fixes it.
+  assert.equal(DTMN.parseInputDateValue("2026-09-01T09:00:00+02:00", true).isValid(), true);
+});
+
+// ---------------------------------------------------------------------------
+// snapToSourceWeekday - keep each item's own weekday + clock time, move by whole days (<= 3).
+// ---------------------------------------------------------------------------
+
+test("snapToSourceWeekday lands on the source weekday nearest the target, carrying source's time", () => {
+  const source = mtz("2026-09-14T09:30:15"); // a Monday
+  const target = mtz("2026-09-16T00:00:00"); // a Wednesday, 2 days later
+  const result = DTMN.snapToSourceWeekday(target, source);
+
+  assert.equal(result.day(), source.day());
+  assert.equal(result.hours(), 9);
+  assert.equal(result.minutes(), 30);
+  assert.equal(result.seconds(), 15);
+  assert.equal(result.format("YYYY-MM-DD"), "2026-09-14");
+});
+
+test("snapToSourceWeekday never moves more than 3 days and preserves the weekday for all combos", () => {
+  // Cover every weekday-pair: target shifts through a full week, source through a full week.
+  const monday = mtz("2026-09-14T00:00:00");
+  for (let t = 0; t < 7; t++) {
+    const target = monday.clone().add(t, "days");
+    for (let s = 0; s < 7; s++) {
+      const source = monday.clone().add(s, "days").hours(8).minutes(5).seconds(0);
+      const result = DTMN.snapToSourceWeekday(target, source);
+
+      assert.equal(result.day(), source.day(), `weekday preserved (t=${t}, s=${s})`);
+      assert.equal(result.hours(), 8);
+      assert.equal(result.minutes(), 5);
+
+      const dayShift = Math.round(
+        (result.clone().startOf("day").valueOf() - target.clone().startOf("day").valueOf()) / DAY_MS
+      );
+      assert.ok(dayShift >= -3 && dayShift <= 3, `within +/-3 days (t=${t}, s=${s}, shift=${dayShift})`);
+    }
+  }
+});
+
+test("snapToSourceWeekday keeps same-weekday items a whole number of weeks apart", () => {
+  const source = mtz("2026-09-16T10:00:00"); // Wednesday
+  const target1 = mtz("2026-09-14T00:00:00"); // Monday
+  const target2 = target1.clone().add(14, "days"); // Monday, two weeks on
+
+  const r1 = DTMN.snapToSourceWeekday(target1, source);
+  const r2 = DTMN.snapToSourceWeekday(target2, source);
+
+  const diffDays = Math.round((r2.startOf("day").valueOf() - r1.startOf("day").valueOf()) / DAY_MS);
+  assert.equal(diffDays % 7, 0);
+});
+
+// ---------------------------------------------------------------------------
+// computeFittedDate - the extracted Smart Shift per-cell mapping.
+// ---------------------------------------------------------------------------
+
+const anchors = () => ({ first: mtz("2026-07-01T00:00:00"), last: mtz("2026-09-19T00:00:00") });
+
+test("computeFittedDate maps the earliest cell exactly onto the new first date", () => {
+  const a = anchors();
+  const result = DTMN.computeFittedDate(1000, 1000, 1000, a, false, null);
+  assert.equal(result.valueOf(), a.first.valueOf());
+});
+
+test("computeFittedDate maps the latest cell exactly onto the new last date", () => {
+  const a = anchors();
+  // currentMs == oldStart + oldSpan == oldEnd  ->  frac == 1
+  const result = DTMN.computeFittedDate(2000, 1000, 1000, a, false, null);
+  assert.equal(result.valueOf(), a.last.valueOf());
+});
+
+test("computeFittedDate collapses everything onto the new first date when the old span is zero", () => {
+  const a = anchors();
+  const result = DTMN.computeFittedDate(5000, 5000, 0, a, false, null);
+  assert.equal(result.valueOf(), a.first.valueOf());
+});
+
+test("computeFittedDate places a middle cell proportionally when snap is off", () => {
+  const a = anchors();
+  const newSpan = a.last.valueOf() - a.first.valueOf();
+  // frac = 0.5
+  const result = DTMN.computeFittedDate(1500, 1000, 1000, a, false, null);
+  assert.equal(result.valueOf(), a.first.valueOf() + newSpan / 2);
+});
+
+test("computeFittedDate snaps a middle cell to the source weekday, staying near the proportional target", () => {
+  const a = anchors();
+  const newSpan = a.last.valueOf() - a.first.valueOf();
+  const source = mtz("2026-08-12T13:00:00"); // arbitrary mid-term Wednesday
+  const result = DTMN.computeFittedDate(1500, 1000, 1000, a, true, source);
+
+  assert.equal(result.day(), source.day());
+  const proportional = a.first.valueOf() + newSpan / 2;
+  const shiftDays = Math.abs(result.valueOf() - proportional) / DAY_MS;
+  assert.ok(shiftDays <= 3.5, `snap stays within ~half a week of the proportional target (shift=${shiftDays})`);
+});
+
+test("computeFittedDate: the LATEST date wins the end anchor regardless of column role", () => {
+  // This is the behaviour that confused us during manual testing: an assignment's open date that
+  // happened to be later than its due/accept dates correctly received the new LAST date.
+  const a = anchors();
+  const oldStart = 100;
+  const oldSpan = 900; // oldEnd = 1000
+  const openIsLatest = DTMN.computeFittedDate(1000, oldStart, oldSpan, a, false, null);
+  assert.equal(openIsLatest.valueOf(), a.last.valueOf());
+});
+
+// ---------------------------------------------------------------------------
+// Format <-> parse round-trips.
+// ---------------------------------------------------------------------------
+
+test("datetime round-trips through parse and the hidden/visible formatters", () => {
+  const parsed = DTMN.parseDatePickerInputValue("2026-09-01T09:30:00", true);
+  assert.equal(DTMN.getHiddenDateValue(parsed, true), "2026-09-01T09:30:00");
+  assert.equal(DTMN.getDatePickerInputValue(parsed, true), "2026-09-01T09:30");
+});
+
+test("date-only round-trips through parse and the formatters", () => {
+  const parsed = DTMN.parseDatePickerInputValue("2026-09-01", false);
+  assert.equal(DTMN.getHiddenDateValue(parsed, false), "2026-09-01");
+  assert.equal(DTMN.getDatePickerInputValue(parsed, false), "2026-09-01");
+});
+
+// ---------------------------------------------------------------------------
+// momentInUserZone / getUserTimeZone.
+// ---------------------------------------------------------------------------
+
+test("momentInUserZone preserves the instant and applies the configured zone offset", () => {
+  const instant = mtz("2026-09-01T12:00:00").valueOf(); // EDT, -04:00
+  const m = DTMN.momentInUserZone(instant);
+  assert.equal(m.valueOf(), instant);
+  assert.equal(m.utcOffset(), -240);
+});
+
+test("getUserTimeZone reflects sakai.locale.userTimeZone, and a different zone changes the offset", () => {
+  assert.equal(DTMN.getUserTimeZone(), ZONE);
+
+  const utc = loadDtmn("UTC");
+  const instant = utc.moment.tz("2026-09-01T12:00:00", "UTC").valueOf();
+  assert.equal(utc.DTMN.momentInUserZone(instant).utcOffset(), 0);
+});

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -193,3 +193,21 @@ test("computeFittedDate: the LATEST date wins the end anchor regardless of colum
   const openIsLatest = DTMN.computeFittedDate(1000, 100, 900, a, false, null);
   assert.equal(openIsLatest.valueOf(), a.last.valueOf());
 });
+
+// ---------------------------------------------------------------------------
+// computeDayDiff - the date-difference helper feeding the shift field.
+// ---------------------------------------------------------------------------
+
+test("computeDayDiff returns signed whole days between two dates", () => {
+  assert.equal(DTMN.computeDayDiff(mom("2026-01-06"), mom("2026-01-20")), 14);
+  assert.equal(DTMN.computeDayDiff(mom("2026-01-20"), mom("2026-01-06")), -14);
+  assert.equal(DTMN.computeDayDiff(mom("2026-01-06"), mom("2026-01-06")), 0);
+});
+
+test("computeDayDiff counts calendar days, ignoring time of day", () => {
+  assert.equal(DTMN.computeDayDiff(mom("2026-01-06T23:00:00"), mom("2026-01-07T01:00:00")), 1);
+});
+
+test("computeDayDiff counts whole days across a month boundary", () => {
+  assert.equal(DTMN.computeDayDiff(mom("2026-01-25"), mom("2026-02-05")), 11);
+});

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -15,15 +15,18 @@
  */
 
 // Unit tests for the PURE date logic in initDatePicker.js. The logic is intentionally timezone-agnostic
-// (wall-clock only; Sakai resolves the zone server-side via UserTimeService), so these tests do plain
-// wall-clock assertions. Run under TZ=UTC (see package.json) for determinism. DOM/jQuery glue (fill,
-// apply, collapse, attach) is intentionally not covered here - see README.md. Run: npm test
+// (wall-clock only; Sakai resolves the zone server-side via UserTimeService), so these tests assert on
+// wall-clock values, never on epoch instants. To prove the timezone independence, npm test runs this
+// whole file twice: once under TZ=UTC and once under TZ=Europe/Stockholm, a DST-observing zone (see
+// package.json) - every assertion must hold in both. DOM/jQuery glue (fill, apply, collapse, attach)
+// is intentionally not covered here - see README.md. Run: npm test
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const { loadDtmn } = require("./loadDtmn");
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const WALL = "YYYY-MM-DDTHH:mm:ss";
 
 const { DTMN, moment } = loadDtmn();
 // Build a moment from a wall-clock string the same way the tool does (strict, no timezone).
@@ -152,37 +155,37 @@ const anchors = () => ({ first: mom("2026-07-01T00:00:00"), last: mom("2026-09-1
 test("computeFittedDate maps the earliest cell exactly onto the new first date", () => {
   const a = anchors();
   const result = DTMN.computeFittedDate(1000, 1000, 1000, a, false, null);
-  assert.equal(result.valueOf(), a.first.valueOf());
+  assert.equal(result.format(WALL), a.first.format(WALL));
 });
 
 test("computeFittedDate maps the latest cell exactly onto the new last date", () => {
   const a = anchors();
   const result = DTMN.computeFittedDate(2000, 1000, 1000, a, false, null);
-  assert.equal(result.valueOf(), a.last.valueOf());
+  assert.equal(result.format(WALL), a.last.format(WALL));
 });
 
 test("computeFittedDate collapses everything onto the new first date when the old span is zero", () => {
   const a = anchors();
   const result = DTMN.computeFittedDate(5000, 5000, 0, a, false, null);
-  assert.equal(result.valueOf(), a.first.valueOf());
+  assert.equal(result.format(WALL), a.first.format(WALL));
 });
 
 test("computeFittedDate places a middle cell proportionally when snap is off", () => {
   const a = anchors();
-  const newSpan = a.last.valueOf() - a.first.valueOf();
   const result = DTMN.computeFittedDate(1500, 1000, 1000, a, false, null);
-  assert.equal(result.valueOf(), a.first.valueOf() + newSpan / 2);
+  // the wall-clock midpoint of Jul 1 -> Sep 19 (80 days)
+  assert.equal(result.format(WALL), "2026-08-10T00:00:00");
 });
 
 test("computeFittedDate snaps a middle cell to the source weekday, staying near the proportional target", () => {
   const a = anchors();
-  const newSpan = a.last.valueOf() - a.first.valueOf();
   const source = mom("2026-08-12T13:00:00"); // arbitrary mid-term Wednesday
   const result = DTMN.computeFittedDate(1500, 1000, 1000, a, true, source);
 
   assert.equal(result.day(), source.day());
-  const proportional = a.first.valueOf() + newSpan / 2;
-  const shiftDays = Math.abs(result.valueOf() - proportional) / DAY_MS;
+  const firstMs = DTMN.wallClockMs(a.first);
+  const proportionalMs = firstMs + (DTMN.wallClockMs(a.last) - firstMs) / 2;
+  const shiftDays = Math.abs(DTMN.wallClockMs(result) - proportionalMs) / DAY_MS;
   assert.ok(shiftDays <= 3.5, `snap stays within ~half a week of the proportional target (shift=${shiftDays})`);
 });
 
@@ -191,7 +194,35 @@ test("computeFittedDate: the LATEST date wins the end anchor regardless of colum
   // happened to be later than its due/accept dates correctly received the new LAST date.
   const a = anchors();
   const openIsLatest = DTMN.computeFittedDate(1000, 100, 900, a, false, null);
-  assert.equal(openIsLatest.valueOf(), a.last.valueOf());
+  assert.equal(openIsLatest.format(WALL), a.last.format(WALL));
+});
+
+// ---------------------------------------------------------------------------
+// DST independence - fitting is wall-clock math, so the result must be the same clock time in
+// every browser timezone. These scenarios straddle the European DST transitions (2026-03-29 and
+// 2026-10-25); under the Europe/Stockholm run they fail against epoch-instant interpolation.
+// ---------------------------------------------------------------------------
+
+test("computeFittedDate keeps the wall-clock midpoint when the OLD range crosses a DST change", () => {
+  // Maintainer repro: midpoint of Mar 1 -> Apr 1 09:00 fitted into May 1 -> Jun 1 09:00 must be
+  // exactly May 16 21:00, not 21:30, regardless of the browser timezone.
+  const a = { first: mom("2026-05-01T09:00:00"), last: mom("2026-06-01T09:00:00") };
+  const oldStart = DTMN.wallClockMs(mom("2026-03-01T09:00:00"));
+  const oldSpan = DTMN.wallClockMs(mom("2026-04-01T09:00:00")) - oldStart;
+  const mid = DTMN.wallClockMs(mom("2026-03-16T21:00:00")); // wall-clock midpoint of the old range
+
+  const result = DTMN.computeFittedDate(mid, oldStart, oldSpan, a, false, null);
+
+  assert.equal(result.format(WALL), "2026-05-16T21:00:00");
+});
+
+test("computeFittedDate can land in a clock time that does not exist locally (spring-forward gap)", () => {
+  // 02:30 on 2026-03-29 does not exist in Europe/Stockholm; wall-clock fitting must still be able
+  // to produce it instead of letting the browser zone shift it.
+  const a = { first: mom("2026-03-28T02:30:00"), last: mom("2026-03-30T02:30:00") };
+  const result = DTMN.computeFittedDate(1, 0, 2, a, false, null); // frac 0.5 -> the midpoint
+
+  assert.equal(result.format(WALL), "2026-03-29T02:30:00");
 });
 
 // ---------------------------------------------------------------------------
@@ -199,35 +230,35 @@ test("computeFittedDate: the LATEST date wins the end anchor regardless of colum
 // (the server rejects due-before-open on save) or leave the new term window.
 // ---------------------------------------------------------------------------
 
-const rowCell = (m) => ({ current: m, currentMs: m.valueOf() });
+const rowCell = (m) => ({ current: m, currentMs: DTMN.wallClockMs(m) });
 
 test("computeRowFittedDates falls back to proportional when snapping would invert open/due under compression", () => {
   // 16-week course squeezed into 4 weeks: open Fri 09:00 / due the following Mon 17:00 snap to
   // their own weekdays independently, which used to yield due BEFORE open for every such item -
   // an unsaveable state. The row must fall back to proportional placement instead.
   const a = { first: mom("2026-09-01T00:00:00"), last: mom("2026-09-28T00:00:00") }; // 4 weeks
-  const oldStart = mom("2026-01-05T00:00:00").valueOf();
-  const oldSpan = mom("2026-04-27T00:00:00").valueOf() - oldStart; // ~16 weeks
+  const oldStart = DTMN.wallClockMs(mom("2026-01-05T00:00:00"));
+  const oldSpan = DTMN.wallClockMs(mom("2026-04-27T00:00:00")) - oldStart; // ~16 weeks
   const open = rowCell(mom("2026-03-06T09:00:00")); // Friday
   const due = rowCell(mom("2026-03-09T17:00:00")); // the following Monday
 
   // premise: independent per-cell snapping really does invert this pair
   const cellSnappedOpen = DTMN.computeFittedDate(open.currentMs, oldStart, oldSpan, a, true, open.current);
   const cellSnappedDue = DTMN.computeFittedDate(due.currentMs, oldStart, oldSpan, a, true, due.current);
-  assert.ok(cellSnappedOpen.valueOf() > cellSnappedDue.valueOf(), "scenario must trigger the inversion hazard");
+  assert.ok(DTMN.wallClockMs(cellSnappedOpen) > DTMN.wallClockMs(cellSnappedDue), "scenario must trigger the inversion hazard");
 
   const out = DTMN.computeRowFittedDates([open, due], oldStart, oldSpan, a, true);
 
-  assert.ok(out[0].valueOf() <= out[1].valueOf(), "open must not pass due");
-  assert.ok(out[0].valueOf() >= a.first.valueOf(), "stays inside the new window (start)");
-  assert.ok(out[1].valueOf() <= a.last.valueOf(), "stays inside the new window (end)");
+  assert.ok(DTMN.wallClockMs(out[0]) <= DTMN.wallClockMs(out[1]), "open must not pass due");
+  assert.ok(DTMN.wallClockMs(out[0]) >= DTMN.wallClockMs(a.first), "stays inside the new window (start)");
+  assert.ok(DTMN.wallClockMs(out[1]) <= DTMN.wallClockMs(a.last), "stays inside the new window (end)");
 });
 
 test("computeRowFittedDates keeps weekday snapping on a same-length rollover", () => {
   // fall -> spring, identical length: snapping is safe, so it must stay active and both cells
   // keep their weekday and clock time.
-  const oldStart = mom("2026-09-07T00:00:00").valueOf(); // Monday
-  const oldSpan = mom("2026-12-28T00:00:00").valueOf() - oldStart; // 112 days
+  const oldStart = DTMN.wallClockMs(mom("2026-09-07T00:00:00")); // Monday
+  const oldSpan = DTMN.wallClockMs(mom("2026-12-28T00:00:00")) - oldStart; // 112 days
   const a = { first: mom("2027-01-04T00:00:00"), last: mom("2027-04-26T00:00:00") }; // 112 days
   const open = rowCell(mom("2026-10-09T09:00:00")); // Friday
   const due = rowCell(mom("2026-10-12T17:00:00")); // Monday
@@ -238,7 +269,7 @@ test("computeRowFittedDates keeps weekday snapping on a same-length rollover", (
   assert.equal(out[0].hours(), 9);
   assert.equal(out[1].day(), 1, "due keeps its Monday");
   assert.equal(out[1].hours(), 17);
-  assert.ok(out[0].valueOf() < out[1].valueOf(), "row order preserved");
+  assert.ok(DTMN.wallClockMs(out[0]) < DTMN.wallClockMs(out[1]), "row order preserved");
 });
 
 test("computeRowFittedDates without snap returns the plain proportional placement", () => {
@@ -246,9 +277,25 @@ test("computeRowFittedDates without snap returns the plain proportional placemen
   const cell = rowCell(mom("2026-08-12T13:00:00"));
   const out = DTMN.computeRowFittedDates([cell], 1000, 1000, a, false);
   assert.equal(
-    out[0].valueOf(),
-    DTMN.computeFittedDate(cell.currentMs, 1000, 1000, a, false, null).valueOf()
+    out[0].format(WALL),
+    DTMN.computeFittedDate(cell.currentMs, 1000, 1000, a, false, null).format(WALL)
   );
+});
+
+test("computeRowFittedDates keeps exact wall-clock times when the NEW term crosses a DST change", () => {
+  // Old term sits entirely inside European summer time; the new term spans the fall-back on
+  // 2026-10-25. Equal 56-day spans mean each cell keeps its day-offset and clock time exactly -
+  // epoch-instant interpolation would smear these by the transition hour under the Stockholm run.
+  const oldStart = DTMN.wallClockMs(mom("2026-07-06T00:00:00")); // Monday
+  const oldSpan = DTMN.wallClockMs(mom("2026-08-31T00:00:00")) - oldStart; // 56 days
+  const a = { first: mom("2026-10-05T00:00:00"), last: mom("2026-11-30T00:00:00") }; // 56 days
+  const open = rowCell(mom("2026-07-31T09:00:00")); // Friday
+  const due = rowCell(mom("2026-08-03T17:00:00")); // Monday
+
+  const out = DTMN.computeRowFittedDates([open, due], oldStart, oldSpan, a, false);
+
+  assert.equal(out[0].format(WALL), "2026-10-30T09:00:00");
+  assert.equal(out[1].format(WALL), "2026-11-02T17:00:00");
 });
 
 // ---------------------------------------------------------------------------

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -268,3 +268,78 @@ test("computeDayDiff counts calendar days, ignoring time of day", () => {
 test("computeDayDiff counts whole days across a month boundary", () => {
   assert.equal(DTMN.computeDayDiff(mom("2026-01-25"), mom("2026-02-05")), 11);
 });
+
+// ---------------------------------------------------------------------------
+// applyDateDiff - the term start pickers feeding the shift field live.
+// ---------------------------------------------------------------------------
+
+// applyDateDiff only reads/writes DTMN-held element handles, so a fresh DTMN with plain object
+// stand-ins exercises the wiring without a DOM.
+function diffFixture(fromValue, toValue, shiftValue) {
+  const { DTMN: dtmn } = loadDtmn();
+  dtmn.diffFromHidden = { value: fromValue };
+  dtmn.diffToHidden = { value: toValue };
+  dtmn.diffResult = { textContent: "", dataset: { template: "{0} day(s)" } };
+  dtmn.shiftInput = { value: shiftValue };
+  dtmn.validateCalls = 0;
+  dtmn.validateShiftInput = () => { dtmn.validateCalls++; };
+  return dtmn;
+}
+
+test("applyDateDiff loads the day count into the shift field and shows the result", () => {
+  const dtmn = diffFixture("2026-01-06", "2026-03-31", "");
+  dtmn.applyDateDiff();
+  assert.equal(dtmn.shiftInput.value, 84);
+  assert.equal(dtmn.diffResult.textContent, "84 day(s)");
+  assert.equal(dtmn.validateCalls, 1);
+});
+
+test("applyDateDiff leaves the shift field alone while a date is missing", () => {
+  const dtmn = diffFixture("2026-01-06", "", "12");
+  dtmn.applyDateDiff();
+  assert.equal(dtmn.shiftInput.value, "12");
+  assert.equal(dtmn.diffResult.textContent, "");
+  assert.equal(dtmn.validateCalls, 0);
+});
+
+test("applyDateDiff shows but does not load a span beyond the shifter's +/-9999 day limit", () => {
+  const dtmn = diffFixture("1990-01-01", "2026-01-01", "12");
+  dtmn.applyDateDiff();
+  assert.equal(dtmn.shiftInput.value, "12");
+  assert.ok(dtmn.diffResult.textContent.length > 0);
+  assert.equal(dtmn.validateCalls, 0);
+});
+
+// ---------------------------------------------------------------------------
+// computePreviewRange - the whole-month span behind the calendar preview's Overview view.
+// ---------------------------------------------------------------------------
+
+test("computePreviewRange covers first to last event in whole months", () => {
+  const range = DTMN.computePreviewRange([
+    { start: "2026-01-15" },
+    { start: "2026-03-02" },
+    { start: "2026-02-10" },
+  ]);
+  assert.equal(range.earliest, "2026-01-15");
+  assert.equal(range.start, "2026-01-01");
+  assert.equal(range.end, "2026-04-01");
+});
+
+test("computePreviewRange of a single date spans exactly that month", () => {
+  const range = DTMN.computePreviewRange([{ start: "2026-06-20" }]);
+  assert.equal(range.start, "2026-06-01");
+  assert.equal(range.end, "2026-07-01");
+});
+
+test("computePreviewRange clamps very long spans to a year", () => {
+  const range = DTMN.computePreviewRange([
+    { start: "2026-01-15" },
+    { start: "2029-05-01" },
+  ]);
+  assert.equal(range.start, "2026-01-01");
+  assert.equal(range.end, "2027-01-01");
+});
+
+test("computePreviewRange returns null with no events", () => {
+  assert.equal(DTMN.computePreviewRange([]), null);
+});

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -343,3 +343,14 @@ test("computePreviewRange clamps very long spans to a year", () => {
 test("computePreviewRange returns null with no events", () => {
   assert.equal(DTMN.computePreviewRange([]), null);
 });
+
+// ---------------------------------------------------------------------------
+// formatTemplate - placeholder substitution for banner/button templates.
+// ---------------------------------------------------------------------------
+
+test("formatTemplate substitutes indexed placeholders, including repeats", () => {
+  assert.equal(DTMN.formatTemplate("Shifted {0} date(s) in {1} tool(s).", [39, 7]),
+    "Shifted 39 date(s) in 7 tool(s).");
+  assert.equal(DTMN.formatTemplate("{0} and {0} again, then {1}", ["a", "b"]),
+    "a and a again, then b");
+});

--- a/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
+++ b/site-manage/datemanager/tool/src/test/js/initDatePicker.test.js
@@ -354,3 +354,35 @@ test("formatTemplate substitutes indexed placeholders, including repeats", () =>
   assert.equal(DTMN.formatTemplate("{0} and {0} again, then {1}", ["a", "b"]),
     "a and a again, then b");
 });
+
+// ---------------------------------------------------------------------------
+// previewEventTextColor - accessible text on the calendar preview markers.
+// ---------------------------------------------------------------------------
+
+// WCAG relative-luminance contrast ratio, computed independently of the implementation.
+const contrast = (hexA, hexB) => {
+  const lum = (hex) => {
+    const n = parseInt(hex.slice(1), 16);
+    const lin = (c) => {
+      const s = c / 255;
+      return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * lin((n >> 16) & 255) + 0.7152 * lin((n >> 8) & 255) + 0.0722 * lin(n & 255);
+  };
+  const [hi, lo] = [lum(hexA), lum(hexB)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+test("previewEventTextColor keeps white text on dark fills and switches to black on light ones", () => {
+  assert.equal(DTMN.previewEventTextColor("#6f42c1"), "#ffffff");
+  assert.equal(DTMN.previewEventTextColor("#0dcaf0"), "#000000");
+  assert.equal(DTMN.previewEventTextColor("#20c997"), "#000000");
+  assert.equal(DTMN.previewEventTextColor("#fd7e14"), "#000000");
+});
+
+test("every preview tool color meets WCAG AA (4.5:1) with its chosen text color", () => {
+  for (const [tool, fill] of Object.entries(DTMN.previewToolColors)) {
+    const text = DTMN.previewEventTextColor(fill);
+    assert.ok(contrast(fill, text) >= 4.5, `${tool} ${fill} with ${text} text is below 4.5:1`);
+  }
+});

--- a/site-manage/datemanager/tool/src/test/js/loadDtmn.js
+++ b/site-manage/datemanager/tool/src/test/js/loadDtmn.js
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-// Test-only helper: load the browser script initDatePicker.js into Node so its pure date
-// functions can be unit tested. The script is a plain browser global (it does `var DTMN = ...`
-// and attaches functions, with no module.exports) and only touches document/$/moment INSIDE
-// function bodies, so it loads cleanly in a vm context as long as we provide the globals its
-// functions read at call time: `moment` (moment-timezone) and `sakai.locale.userTimeZone`.
+// Test-only helper: load the browser script initDatePicker.js into Node so its pure date functions
+// can be unit tested. The script is a plain browser global (it does `var DTMN = ...` and attaches
+// functions, with no module.exports) and only touches document/$/moment INSIDE function bodies, so it
+// loads cleanly in a vm context as long as we provide `moment`. The date logic is deliberately
+// timezone-agnostic (wall-clock only - Sakai resolves the zone server-side), so plain `moment` is all
+// that's needed; run the suite under TZ=UTC (see package.json) for deterministic wall-clock math.
 
 const fs = require("fs");
 const path = require("path");
 const vm = require("vm");
-const moment = require("moment-timezone");
+const moment = require("moment");
 
 const SCRIPT_PATH = path.resolve(
   __dirname,
@@ -31,23 +32,19 @@ const SCRIPT_PATH = path.resolve(
 );
 
 /**
- * Load a fresh DTMN object with the given user timezone in scope.
+ * Load a fresh DTMN object.
  *
- * @param {string} userTimeZone IANA zone fed to sakai.locale.userTimeZone (default America/New_York).
- * @returns {{DTMN: object, moment: import("moment-timezone")}} the populated DTMN plus the same
- *          moment-timezone instance the script uses, so tests build inputs from the identical library.
+ * @returns {{DTMN: object, moment: import("moment")}} the populated DTMN plus the same moment instance
+ *          the script uses, so tests build inputs from the identical library.
  */
-function loadDtmn(userTimeZone = "America/New_York") {
+function loadDtmn() {
   const source = fs.readFileSync(SCRIPT_PATH, "utf8");
 
-  const sandbox = {
-    moment,
-    sakai: { locale: { userTimeZone } },
-    console,
-  };
-  // The script reads globalThis.sakai?.locale?.userTimeZone; in a vm context globalThis is the
-  // sandbox itself, so `sakai` above is reachable that way too.
+  const sandbox = { moment, console };
+  // In a vm context globalThis is the sandbox itself; provide a minimal sakai stub so any incidental
+  // sakai.locale lookups elsewhere in the script can't throw.
   sandbox.globalThis = sandbox;
+  sandbox.sakai = { locale: {} };
 
   vm.createContext(sandbox);
   vm.runInContext(source, sandbox, { filename: SCRIPT_PATH });

--- a/site-manage/datemanager/tool/src/test/js/loadDtmn.js
+++ b/site-manage/datemanager/tool/src/test/js/loadDtmn.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Test-only helper: load the browser script initDatePicker.js into Node so its pure date
+// functions can be unit tested. The script is a plain browser global (it does `var DTMN = ...`
+// and attaches functions, with no module.exports) and only touches document/$/moment INSIDE
+// function bodies, so it loads cleanly in a vm context as long as we provide the globals its
+// functions read at call time: `moment` (moment-timezone) and `sakai.locale.userTimeZone`.
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const moment = require("moment-timezone");
+
+const SCRIPT_PATH = path.resolve(
+  __dirname,
+  "../../main/resources/static/js/initDatePicker.js"
+);
+
+/**
+ * Load a fresh DTMN object with the given user timezone in scope.
+ *
+ * @param {string} userTimeZone IANA zone fed to sakai.locale.userTimeZone (default America/New_York).
+ * @returns {{DTMN: object, moment: import("moment-timezone")}} the populated DTMN plus the same
+ *          moment-timezone instance the script uses, so tests build inputs from the identical library.
+ */
+function loadDtmn(userTimeZone = "America/New_York") {
+  const source = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+  const sandbox = {
+    moment,
+    sakai: { locale: { userTimeZone } },
+    console,
+  };
+  // The script reads globalThis.sakai?.locale?.userTimeZone; in a vm context globalThis is the
+  // sandbox itself, so `sakai` above is reachable that way too.
+  sandbox.globalThis = sandbox;
+
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: SCRIPT_PATH });
+
+  if (!sandbox.DTMN) {
+    throw new Error("initDatePicker.js did not define DTMN when loaded");
+  }
+  return { DTMN: sandbox.DTMN, moment };
+}
+
+module.exports = { loadDtmn };

--- a/site-manage/datemanager/tool/src/test/js/package-lock.json
+++ b/site-manage/datemanager/tool/src/test/js/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "datemanager-js-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datemanager-js-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "moment-timezone": "0.5.33"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    }
+  }
+}

--- a/site-manage/datemanager/tool/src/test/js/package-lock.json
+++ b/site-manage/datemanager/tool/src/test/js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "datemanager-js-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "moment-timezone": "0.5.33"
+        "moment": "2.30.1"
       }
     },
     "node_modules/moment": {
@@ -17,19 +17,6 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
       "engines": {
         "node": "*"
       }

--- a/site-manage/datemanager/tool/src/test/js/package.json
+++ b/site-manage/datemanager/tool/src/test/js/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "datemanager-js-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Standalone unit tests for the DateManager client-side date logic (initDatePicker.js). Not part of the Maven build.",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "moment-timezone": "0.5.33"
+  }
+}

--- a/site-manage/datemanager/tool/src/test/js/package.json
+++ b/site-manage/datemanager/tool/src/test/js/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Standalone unit tests for the DateManager client-side date logic (initDatePicker.js). Not part of the Maven build.",
   "scripts": {
-    "test": "node --test"
+    "test": "TZ=UTC node --test"
   },
   "devDependencies": {
-    "moment-timezone": "0.5.33"
+    "moment": "2.30.1"
   }
 }

--- a/site-manage/datemanager/tool/src/test/js/package.json
+++ b/site-manage/datemanager/tool/src/test/js/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "description": "Standalone unit tests for the DateManager client-side date logic (initDatePicker.js). Not part of the Maven build.",
   "scripts": {
-    "test": "TZ=UTC node --test"
+    "test": "npm run test:utc && npm run test:dst",
+    "test:utc": "TZ=UTC node --test",
+    "test:dst": "TZ=Europe/Stockholm node --test"
   },
   "devDependencies": {
     "moment": "2.30.1"


### PR DESCRIPTION
> **Title note:** once I have a Jira key this should become
> `SAK-##### DateManager add term-rollover date tools (per-column fill, Smart Shift, Bulk Anchor)`
> to match the `<issue key> <component> <brief description>` convention. See the Jira note at the bottom.

## Summary

Follow-up to #14504 (SAK-52523, *DateManager add bulk date setter controls*). That PR added a global bulk
setter; this one builds on it to make **rolling a copied course into a new term** fast and intuitive. When a
site is copied from a previous term, an instructor needs an easy way to re-set every date for the new academic
calendar — this adds three complementary tools plus a layout that keeps them out of the way of per-item editing.

## What's new

- **Per-column bulk fill** — each editable date column header gets a small date box + a ↓ button that fills
  every row of that one column, in that one section, with the entered date.
- **Bulk Anchor** — a term-date matrix (Classes Start, Classes End, Exam Begins, Exam Ends) with a checkbox
  per column across every tool, so one named date can be mapped onto whichever columns you tick. Overlapping
  ticks apply top-to-bottom (lower row wins).
- **Smart Shift** — re-anchors *all* dated items between a new **first** and **last** date: the earliest date
  lands on the new first, the latest on the new last, and everything in between is spread proportionally. With
  **Snap to weeks** on, each item keeps its own weekday and time-of-day and moves only by whole weeks, so the
  weekly cadence of a copied course survives a move into a shorter/longer term. (Distinct from the existing
  offset shifter, which keeps spacing exact but lets the end float.)
- **Fill-mode toggle** — apply to *every* cell (empty + existing) or *only cells that already have a date*.
- **Layout** — the batch tools are grouped behind a coloured accent bar under a "Bulk editing tools" heading,
  each in a collapsible card (the raw offset shifter expanded by default), and separated by a rule from the
  per-tool "Edit individual items" sections, so the editing grid is what you see on load.

## Bug fix included

`localDatePicker` writes its hidden field as ISO8601 **with a timezone offset** (e.g.
`2026-09-01T09:00:00+02:00`), but the apply paths parsed it with offset-less strict formats, so every apply
silently no-op'd. Added `DTMN.parseInputDateValue` which strips the trailing offset (and the time for date-only
gradebook fields) before parsing in the user's Sakai timezone. All date math goes through
`moment.tz(..., userTimeZone)` with a guarded fallback.

## Tests

- **Automated:** a standalone `node --test` unit suite under `tool/src/test/js/` (20 tests) covering the pure
  date logic — `parseInputDateValue` (regression guard for the offset bug), `snapToSourceWeekday`,
  `computeFittedDate` (the Smart Shift math, extracted from `fitDates` for testability), format round-trips, and
  timezone handling. It loads the shipped `initDatePicker.js` into a Node `vm` context with the real
  `moment-timezone`, so it exercises the actual code. **It is intentionally not wired into the Maven build** (the
  WAR packages `src/main/webapp` only) — happy to wire it into CI via `frontend-maven-plugin` if you'd like.
  Run with `cd site-manage/datemanager/tool/src/test/js && npm install && npm test`.
- **Manual:** I manually tested this end-to-end on a local Sakai test site — per-column fill (all vs
  existing-only), Smart Shift (multi-item spread + weekly snap), Bulk Anchor matrix, gradebook date-only
  handling, and the save/confirm flow.

## Compliance with the prior review (#14504)

I went back through the CodeRabbit findings on #14504 since this touches the same files, and confirmed:
timezone math runs in the Sakai user zone (not the browser), `getUserTimeZone()` is guarded with optional
chaining, the apply path uses the proper formatter and syncs the hidden field, gradebook columns are treated as
date-only, inputs are self-closing, and the new element IDs are kebab-case.

## Jira / tracking note

@ern — I don't yet have a Sakai Jira account, so this PR doesn't carry a `SAK-` key. I've completed the
Apereo CLA, and as I mentioned I'd like to do this properly for future contributions: **could I be invited to
the Sakai Jira (Atlassian Cloud) so I can file a ticket and track this work?** Once I have the key I'll rename
the branch/commits and update this PR title to the `SAK-#####` convention. Thanks for the help on the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped bulk date editing with shift, Smart Shift/fit, term-date matrices, and fill modes.
  * Added FullCalendar Visual Preview, per-column controls, and improved Apply, Fill Empty, and cancel feedback.
* **Bug Fixes**
  * Improved wall-clock date handling, validation, date fitting, and cleared-value updates.
* **Tests**
  * Expanded date logic, accessibility, and end-to-end coverage.
* **Documentation**
  * Added JavaScript test setup and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->