### PR TITLE
SAK-52672 Samigo PDF export error "Infinite table loop" when an assessment contains question attachments

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
@@ -126,15 +126,21 @@ import lombok.extern.slf4j.Slf4j;
 					//change the src ref to point to the new local temp file
 					h.put("src", temp.getCanonicalPath());
 
+					try {
+						Image imgPdf = Image.getInstance(temp.getCanonicalPath());
+						imgPdf.scaleToFit(400f, 350f);
+						h.put("width", String.valueOf((int) imgPdf.getScaledWidth()));
+						h.put("height", String.valueOf((int) imgPdf.getScaledHeight()));
+					} catch (Exception e) {
+						log.warn("Image couldn't be scaled for PDF", e);
+					}
+
 					//Spoof the interface props so that it won't try anything weird with urls
 					Map<String, Object> props = this.getInterfaceProps();
 					Map<String, Object> tempProps = new HashMap();
 					this.setInterfaceProps(tempProps);
-
 					super.startElement(tag, h);
-
 					this.setInterfaceProps(props);
-
 				}
 				catch (Exception e) {
 					log.error(e.getMessage(), e);
@@ -160,20 +166,27 @@ import lombok.extern.slf4j.Slf4j;
 			else if (src.startsWith("temp://")) {
 				try {
 					File temp = new File(src.replaceFirst("temp://", ""));
-					
+
 					//keep track of the new temp file for later cleanup
 					tempFiles.add(temp);
 
 					//change the src ref to point to the new local temp file
 					h.put("src", temp.getCanonicalPath());
 
+					try {
+						Image imgPdf = Image.getInstance(temp.getCanonicalPath());
+						imgPdf.scaleToFit(400f, 350f);
+						h.put("width", String.valueOf((int) imgPdf.getScaledWidth()));
+						h.put("height", String.valueOf((int) imgPdf.getScaledHeight()));
+					} catch (Exception e) {
+						log.warn("Image couldn't be scaled for PDF", e);
+					}
+
 					//Spoof the interface props so that it won't try anything weird with urls
 					Map<String, Object> props = this.getInterfaceProps();
 					Map<String, Object> tempProps = new HashMap();
 					this.setInterfaceProps(tempProps);
-
 					super.startElement(tag, h);
-
 					this.setInterfaceProps(props);
 				}
 				catch (Exception e) {
@@ -185,6 +198,7 @@ import lombok.extern.slf4j.Slf4j;
 				final String base64Data = src.substring(src.indexOf(",") + 1);
 				try {
 					img = Image.getInstance(Base64.getDecoder().decode(base64Data));
+					img.scaleToFit(400f, 350f);
 				} catch (Exception e) {
 					log.warn("Failed retrieving image", e.toString());
 				}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
@@ -23,7 +23,6 @@ import java.io.Reader;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.sakaiproject.component.cover.ServerConfigurationService;
@@ -122,25 +121,7 @@ import lombok.extern.slf4j.Slf4j;
 
 					//keep track of the new temp file for later cleanup
 					tempFiles.add(temp);
-
-					//change the src ref to point to the new local temp file
-					h.put("src", temp.getCanonicalPath());
-
-					try {
-						Image imgPdf = Image.getInstance(temp.getCanonicalPath());
-						imgPdf.scaleToFit(400f, 350f);
-						h.put("width", String.valueOf((int) imgPdf.getScaledWidth()));
-						h.put("height", String.valueOf((int) imgPdf.getScaledHeight()));
-					} catch (Exception e) {
-						log.warn("Image couldn't be scaled for PDF", e);
-					}
-
-					//Spoof the interface props so that it won't try anything weird with urls
-					Map<String, Object> props = this.getInterfaceProps();
-					Map<String, Object> tempProps = new HashMap();
-					this.setInterfaceProps(tempProps);
-					super.startElement(tag, h);
-					this.setInterfaceProps(props);
+					processScaledImage(temp, tag, h);
 				}
 				catch (Exception e) {
 					log.error(e.getMessage(), e);
@@ -169,25 +150,7 @@ import lombok.extern.slf4j.Slf4j;
 
 					//keep track of the new temp file for later cleanup
 					tempFiles.add(temp);
-
-					//change the src ref to point to the new local temp file
-					h.put("src", temp.getCanonicalPath());
-
-					try {
-						Image imgPdf = Image.getInstance(temp.getCanonicalPath());
-						imgPdf.scaleToFit(400f, 350f);
-						h.put("width", String.valueOf((int) imgPdf.getScaledWidth()));
-						h.put("height", String.valueOf((int) imgPdf.getScaledHeight()));
-					} catch (Exception e) {
-						log.warn("Image couldn't be scaled for PDF", e);
-					}
-
-					//Spoof the interface props so that it won't try anything weird with urls
-					Map<String, Object> props = this.getInterfaceProps();
-					Map<String, Object> tempProps = new HashMap();
-					this.setInterfaceProps(tempProps);
-					super.startElement(tag, h);
-					this.setInterfaceProps(props);
+					processScaledImage(temp, tag, h);
 				}
 				catch (Exception e) {
 					log.error(e.getMessage(), e);
@@ -227,5 +190,32 @@ import lombok.extern.slf4j.Slf4j;
 		else {
 			super.startElement(tag, h);
 		}		
+	}
+
+	private void processScaledImage(File temp, String tag, Map<String, String> h) {
+		try {
+			String imgPath = temp.getCanonicalPath();
+			h.put("src", imgPath);
+
+			Image imgPdf = Image.getInstance(imgPath);
+			if (imgPdf.getWidth() > 400f || imgPdf.getHeight() > 350f) {
+				imgPdf.scaleToFit(400f, 350f);
+			}
+			h.put("width", String.valueOf((int) imgPdf.getScaledWidth()));
+			h.put("height", String.valueOf((int) imgPdf.getScaledHeight()));
+
+			Map<String, Object> props = this.getInterfaceProps();
+			Map<String, Object> tempProps = new java.util.HashMap<>();
+
+			Map<String, Image> imgDict = new java.util.HashMap<>();
+			imgDict.put(imgPath, imgPdf);
+			tempProps.put("image_dictionary", imgDict);
+
+			this.setInterfaceProps(tempProps);
+			super.startElement(tag, h);
+			this.setInterfaceProps(props);
+		} catch (Exception e) {
+			log.error("Error processing image for PDF", e);
+		}
 	}
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
@@ -205,15 +205,20 @@ import lombok.extern.slf4j.Slf4j;
 			h.put("height", String.valueOf((int) imgPdf.getScaledHeight()));
 
 			Map<String, Object> props = this.getInterfaceProps();
-			Map<String, Object> tempProps = new java.util.HashMap<>();
+			Map<String, Object> tempProps = props == null
+					? new java.util.HashMap<>()
+					: new java.util.HashMap<>(props);
 
 			Map<String, Image> imgDict = new java.util.HashMap<>();
 			imgDict.put(imgPath, imgPdf);
 			tempProps.put("image_dictionary", imgDict);
 
 			this.setInterfaceProps(tempProps);
-			super.startElement(tag, h);
-			this.setInterfaceProps(props);
+			try {
+				super.startElement(tag, h);
+			} finally {
+				this.setInterfaceProps(props);
+			}
 		} catch (Exception e) {
 			log.error("Error processing image for PDF", e);
 		}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -1116,7 +1116,6 @@ public class PDFAssessmentBean implements Serializable {
 	 * @param resourceId The resource id of the attachment file
 	 */
 	private void appendAttachmentHtml(StringBuffer buffer, String filename, String mimeType, String resourceId) {
-		buffer.append("  ");
 		buffer.append(formattedText.escapeHtml(filename, false));
 
 		String mime = mimeType != null ? mimeType.toLowerCase() : "";
@@ -1124,7 +1123,9 @@ public class PDFAssessmentBean implements Serializable {
 			buffer.append("<br />  <img src=\"/samigo");
 			buffer.append(resourceId);
 			buffer.append("\" />");
-			buffer.append("<br />");
 		}
+
+		buffer.append("<br />");
+		buffer.append("<br />");
 	}
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -258,7 +258,7 @@ public class PDFAssessmentBean implements Serializable {
 				assessmentIntros.append(deliveryBean.getInstructorMessage());
 				assessmentIntros.append("<br />");
 			}
-			
+
 			if (deliveryBean.getAttachmentList() != null && deliveryBean.getAttachmentList().size() > 0) {
 				assessmentIntros.append("<br />");
 				assessmentIntros.append(printMessages.getString("attachments"));
@@ -268,22 +268,18 @@ public class PDFAssessmentBean implements Serializable {
 				while (assessmentAttachmentIter.hasNext()) {
 					assessmentIntros.append("<br />");
 					PublishedAssessmentAttachment assessmentAttachment = (PublishedAssessmentAttachment) assessmentAttachmentIter.next();
-					if (assessmentAttachment.getMimeType().equalsIgnoreCase("image/jpeg") || 
-							assessmentAttachment.getMimeType().equalsIgnoreCase("image/pjpeg") || 
-							assessmentAttachment.getMimeType().equalsIgnoreCase("image/gif") || 
-							assessmentAttachment.getMimeType().equalsIgnoreCase("image/png")) {
-						assessmentIntros.append("  <img src=\"/samigo");
+					assessmentIntros.append("  ");
+					assessmentIntros.append(assessmentAttachment.getFilename());
+
+					if (assessmentAttachment.getMimeType() != null && assessmentAttachment.getMimeType().toLowerCase().startsWith("image/")) {
+						assessmentIntros.append("<br />  <img src=\"/samigo");
 						assessmentIntros.append(assessmentAttachment.getResourceId());
 						assessmentIntros.append("\" />");
 					}
-					else {
-						assessmentIntros.append("  ");
-						assessmentIntros.append(assessmentAttachment.getFilename());
-					}
 				}
 			}
-			
-			setIntro(assessmentIntros.toString());	
+
+			setIntro(assessmentIntros.toString());
 		}
 		else {
 			setIntro("");
@@ -324,7 +320,6 @@ public class PDFAssessmentBean implements Serializable {
 					partIntros.append(section.getDescription());
 				}
 
-				
 				if (section.getAttachmentList() != null && section.getAttachmentList().size() > 0) {
 					partIntros.append("<br />");
 					partIntros.append(printMessages.getString("attachments"));
@@ -334,17 +329,13 @@ public class PDFAssessmentBean implements Serializable {
 					while (partAttachmentIter.hasNext()) {
 						partIntros.append("<br />");
 						PublishedSectionAttachment partAttachment = (PublishedSectionAttachment) partAttachmentIter.next();
-						if (partAttachment.getMimeType().equalsIgnoreCase("image/jpeg") ||
-								partAttachment.getMimeType().equalsIgnoreCase("image/pjpeg") ||
-								partAttachment.getMimeType().equalsIgnoreCase("image/gif") ||
-								partAttachment.getMimeType().equalsIgnoreCase("image/png")) {
-							partIntros.append("  <img src=\"/samigo");
+						partIntros.append("  ");
+						partIntros.append(partAttachment.getFilename());
+
+						if (partAttachment.getMimeType() != null && partAttachment.getMimeType().toLowerCase().startsWith("image/")) {
+							partIntros.append("<br />  <img src=\"/samigo");
 							partIntros.append(partAttachment.getResourceId());
 							partIntros.append("\" />");
-						}
-						else {
-							partIntros.append("  ");
-							partIntros.append(partAttachment.getFilename());
 						}
 					}
 				}
@@ -381,20 +372,15 @@ public class PDFAssessmentBean implements Serializable {
 					Iterator itemAttachmentIter = itemAttachmentList.iterator();
 					while (itemAttachmentIter.hasNext()) {
 						PublishedItemAttachment itemAttachment = (PublishedItemAttachment) itemAttachmentIter.next();
-						if (itemAttachment.getMimeType().equalsIgnoreCase("image/jpeg") || 
-							itemAttachment.getMimeType().equalsIgnoreCase("image/pjpeg") || 
-							itemAttachment.getMimeType().equalsIgnoreCase("image/gif") || 
-							itemAttachment.getMimeType().equalsIgnoreCase("image/png")) {
-							contentBuffer.append("  <img src=\"/samigo");
+						contentBuffer.append("  ");
+						contentBuffer.append(itemAttachment.getFilename());
+
+						if (itemAttachment.getMimeType() != null && itemAttachment.getMimeType().toLowerCase().startsWith("image/")) {
+							contentBuffer.append("<br />  <img src=\"/samigo");
 							contentBuffer.append(itemAttachment.getResourceId());
 							contentBuffer.append("\" />");
 						}
-						else {
-							contentBuffer.append("  ");
-							contentBuffer.append(itemAttachment.getFilename());
-						}
 						contentBuffer.append("<br />");
-						
 					}
 				}
 				if (TypeIfc.FILL_IN_BLANK.equals(item.getItemData().getTypeId()) || TypeIfc.FILL_IN_NUMERIC.equals(item.getItemData().getTypeId())
@@ -1000,6 +986,7 @@ public class PDFAssessmentBean implements Serializable {
 					float[] widths = {0.05f, 0.95f};
 					PdfPTable table = new PdfPTable(widths);
 					table.setWidthPercentage(100f);
+					table.setSplitLate(false);
 					PdfPCell leftCell = new PdfPCell();
 					PdfPCell rightCell = new PdfPCell();
 					leftCell.setBorderWidth(0);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -269,13 +269,7 @@ public class PDFAssessmentBean implements Serializable {
 					assessmentIntros.append("<br />");
 					PublishedAssessmentAttachment assessmentAttachment = (PublishedAssessmentAttachment) assessmentAttachmentIter.next();
 					assessmentIntros.append("  ");
-					assessmentIntros.append(assessmentAttachment.getFilename());
-
-					if (assessmentAttachment.getMimeType() != null && assessmentAttachment.getMimeType().toLowerCase().startsWith("image/")) {
-						assessmentIntros.append("<br />  <img src=\"/samigo");
-						assessmentIntros.append(assessmentAttachment.getResourceId());
-						assessmentIntros.append("\" />");
-					}
+					appendAttachmentHtml(assessmentIntros, assessmentAttachment.getFilename(), assessmentAttachment.getMimeType(), assessmentAttachment.getResourceId());
 				}
 			}
 
@@ -330,13 +324,7 @@ public class PDFAssessmentBean implements Serializable {
 						partIntros.append("<br />");
 						PublishedSectionAttachment partAttachment = (PublishedSectionAttachment) partAttachmentIter.next();
 						partIntros.append("  ");
-						partIntros.append(partAttachment.getFilename());
-
-						if (partAttachment.getMimeType() != null && partAttachment.getMimeType().toLowerCase().startsWith("image/")) {
-							partIntros.append("<br />  <img src=\"/samigo");
-							partIntros.append(partAttachment.getResourceId());
-							partIntros.append("\" />");
-						}
+						appendAttachmentHtml(partIntros, partAttachment.getFilename(), partAttachment.getMimeType(), partAttachment.getResourceId());
 					}
 				}
 			}
@@ -373,14 +361,7 @@ public class PDFAssessmentBean implements Serializable {
 					while (itemAttachmentIter.hasNext()) {
 						PublishedItemAttachment itemAttachment = (PublishedItemAttachment) itemAttachmentIter.next();
 						contentBuffer.append("  ");
-						contentBuffer.append(itemAttachment.getFilename());
-
-						if (itemAttachment.getMimeType() != null && itemAttachment.getMimeType().toLowerCase().startsWith("image/")) {
-							contentBuffer.append("<br />  <img src=\"/samigo");
-							contentBuffer.append(itemAttachment.getResourceId());
-							contentBuffer.append("\" />");
-						}
-						contentBuffer.append("<br />");
+						appendAttachmentHtml(contentBuffer, itemAttachment.getFilename(), itemAttachment.getMimeType(), itemAttachment.getResourceId());
 					}
 				}
 				if (TypeIfc.FILL_IN_BLANK.equals(item.getItemData().getTypeId()) || TypeIfc.FILL_IN_NUMERIC.equals(item.getItemData().getTypeId())
@@ -1124,6 +1105,26 @@ public class PDFAssessmentBean implements Serializable {
 		@Override
 		public Font getFont(String fontname, String encoding, boolean embedded, float size, int style, Color color, boolean cached) {
 			return super.getFont(defaultFontname, BaseFont.IDENTITY_H, embedded, size, style, color, cached);
+		}
+	}
+
+	/**
+	 * Appends the attachment html to the given StringBuffer. If the attachment is an image, it will also append an img tag to display the image.
+	 * @param buffer The StringBuffer to append the attachment html to
+	 * @param filename The name of the attachment file
+	 * @param mimeType The mime type of the attachment file
+	 * @param resourceId The resource id of the attachment file
+	 */
+	private void appendAttachmentHtml(StringBuffer buffer, String filename, String mimeType, String resourceId) {
+		buffer.append("  ");
+		buffer.append(formattedText.escapeHtml(filename, false));
+
+		String mime = mimeType != null ? mimeType.toLowerCase() : "";
+		if (mime.equals("image/jpeg") || mime.equals("image/pjpeg") || mime.equals("image/gif") || mime.equals("image/png")) {
+			buffer.append("<br />  <img src=\"/samigo");
+			buffer.append(resourceId);
+			buffer.append("\" />");
+			buffer.append("<br />");
 		}
 	}
 }


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachments in PDF exports are now rendered more consistently, showing both the attachment filename and an inline preview image when available.
  * Inline images are auto-resized to fit within the PDF page area for better readability.

* **Bug Fixes**
  * Improved two-column PDF item rendering to reduce awkward page breaks.
  * Enhanced handling of images from temporary or embedded sources, with more reliable sizing and fallback behavior when decoding or resizing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->