### PR TITLE
SAK-52697 Site Info Add Participants: accept delimited/smart email lists

### DIFF
--- a/site-manage/site-manage-participant-helper/pom.xml
+++ b/site-manage/site-manage-participant-helper/pom.xml
@@ -88,6 +88,11 @@
             <version>${project.version}</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -57,7 +57,7 @@ add.multiple.nonofficial = Note: Enter multiples each on separate line (no punct
 delimiter.label = Input format
 delimiter.line = One entry per line
 delimiter.delimited = Delimited list (comma, semicolon, or line break)
-delimiter.smart = Smart detect (extract email addresses from pasted text)
+delimiter.smart = Smart parse (auto-detect emails or usernames from pasted text, any separator)
 
 # Account-type radio choices for the official Add Participants textarea
 accounttype.label = These entries are

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -58,6 +58,12 @@ delimiter.label = Input format
 delimiter.line = One entry per line
 delimiter.delimited = Delimited list (comma, semicolon, or line break)
 delimiter.smart = Smart detect (extract email addresses from pasted text)
+
+# Account-type radio choices for the official Add Participants textarea
+accounttype.label = These entries are
+accounttype.auto = Auto-detect (email or username)
+accounttype.email = Email addresses
+accounttype.username = Usernames
 add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name. 
 ### (moot) add.guests = Guest(s) email address
 ### (moot) add.external = (external participants, ex. jdoe@yahoo.com):

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -28,6 +28,7 @@ java.cannotedit = Cannot edit courses.
 java.guest = Alert: Please enter username(s), or guest email address(es) to add to this site
 java.user = User
 java.username = ''{0}'' is not a valid username.
+java.emailnotfound = No registered user was found with the email address ''{0}''.
 java.notemailid = ''{0}'' is not an email id.
 java.emailaddress = ''{0}'' is not a valid email address.
 java.skipped = ''{0}'' was skipped because it could not be recognized as a complete email address. Check the address for typos.

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -51,26 +51,14 @@ add.official.instruction = Go to Site Info > Edit Class Roster(s) > Add Roster(s
 ### (moot) add.enter = Enter the participants below that you would like to add to your site. You may enter more than one name in each text area below by putting each one on a separate line (no commas).
 ### (moot) add.unames = Username(s)
 add.multiple = Note: Enter one or more entries, separated by line break, comma, or semicolon.
-add.multiple.nonofficial = Note: Enter one or more email addresses, separated by line break, comma, or semicolon. To also set a name, choose "One entry per line" above and use: email, last name, first name — e.g. jdoe@yahoo.com,Doe,John
-
-# Input-format radio choices for each Add Participants textarea
-delimiter.label = Input format
-delimiter.line = One entry per line
-delimiter.delimited = Delimited list (comma, semicolon, or line break)
-delimiter.smart = Smart parse (auto-detect emails or usernames from pasted text, any separator)
+add.multiple.nonofficial = Note: Enter one or more email addresses, separated by line break, comma, or semicolon. To also set a name, put one person per line as: email, last name, first name — e.g. jdoe@yahoo.com,Doe,John
 
 # Live "parsed count" indicator shown under each textarea (rendered client-side in Add.html).
 # #N# = total, #E# = emails, #U# = usernames; substituted at runtime. Translators may reorder freely.
 add.count.emails = #N# emails detected
 add.count.usernames = #N# usernames detected
 add.count.mixed = #N# entries detected (#E# emails, #U# usernames)
-
-# Account-type radio choices for the official Add Participants textarea
-accounttype.label = These entries are
-accounttype.auto = Auto-detect (email or username)
-accounttype.email = Email addresses
-accounttype.username = Usernames
-add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name. 
+add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name.
 ### (moot) add.guests = Guest(s) email address
 ### (moot) add.external = (external participants, ex. jdoe@yahoo.com):
 add.participants = Participant Roles

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -30,7 +30,7 @@ java.user = User
 java.username = ''{0}'' is not a valid username.
 java.notemailid = ''{0}'' is not an email id.
 java.emailaddress = ''{0}'' is not a valid email address.
-java.skipped = ''{0}'' was skipped because it could not be recognized as a complete email address. Check the address for typos, and enter usernames on their own line.
+java.skipped = ''{0}'' was skipped because it could not be recognized as a complete email address. Check the address for typos.
 java.roletype = Please choose the role type.
 java.username.multiple = ''{0}'' matches multiple users in record. Please select from the following usernames: {1} 
 

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -30,6 +30,7 @@ java.user = User
 java.username = ''{0}'' is not a valid username.
 java.notemailid = ''{0}'' is not an email id.
 java.emailaddress = ''{0}'' is not a valid email address.
+java.skipped = ''{0}'' was skipped because it could not be recognized as a complete email address. Check the address for typos, and enter usernames on their own line.
 java.roletype = Please choose the role type.
 java.username.multiple = ''{0}'' matches multiple users in record. Please select from the following usernames: {1} 
 
@@ -58,6 +59,7 @@ add.multiple.nonofficial = Note: Enter one or more email addresses, separated by
 add.count.emails = #N# emails detected
 add.count.usernames = #N# usernames detected
 add.count.mixed = #N# entries detected (#E# emails, #U# usernames)
+add.count.skipped = #S# skipped (not a complete email address)
 add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name.
 ### (moot) add.guests = Guest(s) email address
 ### (moot) add.external = (external participants, ex. jdoe@yahoo.com):

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -31,6 +31,7 @@ java.username = ''{0}'' is not a valid username.
 java.notemailid = ''{0}'' is not an email id.
 java.emailaddress = ''{0}'' is not a valid email address.
 java.skipped = ''{0}'' was skipped because it could not be recognized as a complete email address. Check the address for typos.
+java.unmatched = Note: the following text did not match any registered username and was not added: {0}
 java.roletype = Please choose the role type.
 java.username.multiple = ''{0}'' matches multiple users in record. Please select from the following usernames: {1} 
 

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -52,6 +52,12 @@ add.official.instruction = Go to Site Info > Edit Class Roster(s) > Add Roster(s
 ### (moot) add.unames = Username(s)
 add.multiple = Note: Enter multiples each on separate line (no punctuation)
 add.multiple.nonofficial = Note: Enter multiples each on separate line (no punctuation). Email address first, optionally followed by last name, first name, all separated by commas, e.g. jdoe@yahoo.com,Doe,John
+
+# Input-format radio choices for each Add Participants textarea
+delimiter.label = Input format
+delimiter.line = One entry per line
+delimiter.delimited = Delimited list (comma, semicolon, or line break)
+delimiter.smart = Smart detect (extract email addresses from pasted text)
 add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name. 
 ### (moot) add.guests = Guest(s) email address
 ### (moot) add.external = (external participants, ex. jdoe@yahoo.com):

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -50,14 +50,20 @@ add.official1 = Officially enrolled students automatically become participants w
 add.official.instruction = Go to Site Info > Edit Class Roster(s) > Add Roster(s) to add your roster now if you haven't already.
 ### (moot) add.enter = Enter the participants below that you would like to add to your site. You may enter more than one name in each text area below by putting each one on a separate line (no commas).
 ### (moot) add.unames = Username(s)
-add.multiple = Note: Enter multiples each on separate line (no punctuation)
-add.multiple.nonofficial = Note: Enter multiples each on separate line (no punctuation). Email address first, optionally followed by last name, first name, all separated by commas, e.g. jdoe@yahoo.com,Doe,John
+add.multiple = Note: Enter one or more entries, separated by line break, comma, or semicolon.
+add.multiple.nonofficial = Note: Enter one or more email addresses, separated by line break, comma, or semicolon. To also set a name, choose "One entry per line" above and use: email, last name, first name — e.g. jdoe@yahoo.com,Doe,John
 
 # Input-format radio choices for each Add Participants textarea
 delimiter.label = Input format
 delimiter.line = One entry per line
 delimiter.delimited = Delimited list (comma, semicolon, or line break)
 delimiter.smart = Smart parse (auto-detect emails or usernames from pasted text, any separator)
+
+# Live "parsed count" indicator shown under each textarea (rendered client-side in Add.html).
+# #N# = total, #E# = emails, #U# = usernames; substituted at runtime. Translators may reorder freely.
+add.count.emails = #N# emails detected
+add.count.usernames = #N# usernames detected
+add.count.mixed = #N# entries detected (#E# emails, #U# usernames)
 
 # Account-type radio choices for the official Add Participants textarea
 accounttype.label = These entries are

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -55,11 +55,12 @@ add.multiple = Note: Enter one or more entries, separated by line break, comma, 
 add.multiple.nonofficial = Note: Enter one or more email addresses, separated by line break, comma, or semicolon. To also set a name, put one person per line as: email, last name, first name — e.g. jdoe@yahoo.com,Doe,John
 
 # Live "parsed count" indicator shown under each textarea (rendered client-side in Add.html).
-# #N# = total, #E# = emails, #U# = usernames; substituted at runtime. Translators may reorder freely.
+# #N# = total, #E# = emails, #U# = usernames, #S#/#ITEMS# = skipped count and quoted skipped
+# fragments; substituted at runtime. Translators may reorder freely.
 add.count.emails = #N# emails detected
 add.count.usernames = #N# usernames detected
 add.count.mixed = #N# entries detected (#E# emails, #U# usernames)
-add.count.skipped = #S# skipped (not a complete email address)
+add.count.skipped = #S# skipped (not a complete email address): #ITEMS#
 add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name.
 ### (moot) add.guests = Guest(s) email address
 ### (moot) add.external = (external participants, ex. jdoe@yahoo.com):

--- a/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
+++ b/site-manage/site-manage-participant-helper/src/bundle/org/sakaiproject/site/tool/participant/bundle/sitesetupgeneric.properties
@@ -63,7 +63,6 @@ add.count.emails = #N# emails detected
 add.count.usernames = #N# usernames detected
 add.count.mixed = #N# entries detected (#E# emails, #U# usernames)
 add.count.skipped = #S# skipped (not a complete email address): #ITEMS#
-add.multiple.nonofficial.alert.more={0} contains strings more than email address, last name, first name.
 ### (moot) add.guests = Guest(s) email address
 ### (moot) add.external = (external participants, ex. jdoe@yahoo.com):
 add.participants = Participant Roles

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
@@ -92,8 +94,11 @@ public class SiteAddParticipantHandler {
     @Setter @Getter public String emailNotiChoice = Boolean.FALSE.toString();
     private List<String> invalidDomains;
     @Getter @Setter public String nonOfficialAccountParticipant = null;
+    // input format for each account textarea: "line" (one entry per line) or "delimited" (comma/semicolon/line-break separated)
+    @Getter @Setter public String nonOfficialDelimiter = "line";
     @Setter private UserNotificationProvider notiProvider;
     @Getter @Setter public String officialAccountParticipant = null;
+    @Getter @Setter public String officialDelimiter = "line";
     @Getter @Setter public List<String> officialAccountEidOnly = new ArrayList<>();
     // realm for the site
     public AuthzGroup realm = null;
@@ -647,8 +652,10 @@ public class SiteAddParticipantHandler {
 		String nonOfficialAccounts;
 
 		// check that there is something with which to work
-		officialAccounts = StringUtils.trimToNull(officialAccountParticipant);
-		nonOfficialAccounts = StringUtils.trimToNull(nonOfficialAccountParticipant);
+		// normalize any delimited (comma/semicolon) blob to one-entry-per-line first, so the
+		// per-line parsing below is reused unchanged (see normalizeDelimited)
+		officialAccounts = StringUtils.trimToNull(normalizeDelimited(officialAccountParticipant, officialDelimiter));
+		nonOfficialAccounts = StringUtils.trimToNull(normalizeDelimited(nonOfficialAccountParticipant, nonOfficialDelimiter));
 		StringBuilder updatedOfficialAccountParticipant = new StringBuilder();
 		StringBuilder updatedNonOfficialAccountParticipant = new StringBuilder();
 
@@ -954,7 +961,51 @@ public class SiteAddParticipantHandler {
 		}
 	}
 
-	private String[] parseAccountIntoParts(String account) {
+	// matches an email-format token anywhere within a blob of pasted text (used by "smart" mode)
+	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
+
+	/**
+	 * Normalize a pasted account textarea to one entry per CRLF-separated line, according to the
+	 * chosen input format, so the existing per-line parsing handles it unchanged:
+	 * <ul>
+	 *   <li>{@code "line"} (default) &mdash; returned unchanged, preserving the non-official
+	 *       {@code email,lastName,firstName} per-line format.</li>
+	 *   <li>{@code "delimited"} &mdash; any run of comma / semicolon / whitespace (space, tab, or
+	 *       line break) becomes a single CRLF, so a list separated by any one of those delimiters is
+	 *       split into entries.</li>
+	 *   <li>{@code "smart"} &mdash; every email-format token is extracted from the blob (ignoring any
+	 *       surrounding text, punctuation, or delimiters); non-email tokens such as bare usernames
+	 *       are dropped. Extracted addresses are still validated downstream.</li>
+	 * </ul>
+	 *
+	 * @param raw  the raw textarea value (may be null)
+	 * @param mode the selected format: "line", "delimited", or "smart"
+	 * @return the text normalized to CRLF-separated entries, or the raw value unchanged
+	 */
+	// package-private for unit testing
+	String normalizeDelimited(String raw, String mode) {
+		if (raw == null) {
+			return null;
+		}
+		if ("smart".equals(mode)) {
+			Matcher m = EMAIL_EXTRACT_PATTERN.matcher(raw);
+			StringBuilder sb = new StringBuilder();
+			while (m.find()) {
+				if (sb.length() > 0) {
+					sb.append("\r\n");
+				}
+				sb.append(m.group());
+			}
+			return sb.toString();
+		}
+		if ("delimited".equals(mode)) {
+			return raw.trim().replaceAll("[,;\\s]+", "\r\n");
+		}
+		return raw;
+	}
+
+	// package-private for unit testing
+	String[] parseAccountIntoParts(String account) {
 		if (StringUtils.isBlank(account)) {
 			return null;
 		}
@@ -986,7 +1037,8 @@ public class SiteAddParticipantHandler {
 		return !StringUtils.endsWithAny( domain, invalidDomains.toArray(new String[0]) );
 	}
 
-	private boolean isValidMail(String email) {
+	// package-private for unit testing
+	boolean isValidMail(String email) {
 		if (email == null || email.isEmpty()) return false;
 		
 		email = email.trim();
@@ -1031,6 +1083,8 @@ public class SiteAddParticipantHandler {
 		officialAccountParticipant = null;
 		officialAccountEidOnly = new ArrayList<>();
 		nonOfficialAccountParticipant = null;
+		officialDelimiter = "line";
+		nonOfficialDelimiter = "line";
 		roleChoice = "sameRole";
 		statusChoice = "active";
 		sameRoleChoice = null;

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -94,11 +94,11 @@ public class SiteAddParticipantHandler {
     @Setter @Getter public String emailNotiChoice = Boolean.FALSE.toString();
     private List<String> invalidDomains;
     @Getter @Setter public String nonOfficialAccountParticipant = null;
-    // input format for each account textarea: "line" (one entry per line) or "delimited" (comma/semicolon/line-break separated)
-    @Getter @Setter public String nonOfficialDelimiter = "line";
+    // input format for each account textarea: "smart" (auto-detect, default), "delimited" (comma/semicolon/whitespace separated), or "line" (one entry per line)
+    @Getter @Setter public String nonOfficialDelimiter = "smart";
     @Setter private UserNotificationProvider notiProvider;
     @Getter @Setter public String officialAccountParticipant = null;
-    @Getter @Setter public String officialDelimiter = "line";
+    @Getter @Setter public String officialDelimiter = "smart";
     // how to interpret official-account entries: "auto" (detect by @), "email", or "username"
     @Getter @Setter public String officialAccountType = "auto";
     @Getter @Setter public List<String> officialAccountEidOnly = new ArrayList<>();
@@ -1003,13 +1003,15 @@ public class SiteAddParticipantHandler {
 	 *   <li>{@code "delimited"} &mdash; any run of comma / semicolon / whitespace (space, tab, or
 	 *       line break) becomes a single CRLF, so a list separated by any one of those delimiters is
 	 *       split into entries.</li>
-	 *   <li>{@code "smart"} &mdash; every email-format token is extracted from the blob (ignoring any
-	 *       surrounding text, punctuation, or delimiters); non-email tokens such as bare usernames
-	 *       are dropped. Extracted addresses are still validated downstream.</li>
+	 *   <li>{@code "smart"} (default) &mdash; auto-detect the content at the blob level: if the paste
+	 *       contains an {@code @}, treat it as an email blob and extract every email-format token,
+	 *       ignoring surrounding names / punctuation / delimiters; otherwise treat it as a username
+	 *       list and split on any delimiter. Either way the extracted entries are validated
+	 *       downstream and the per-entry lookup routes emails vs usernames.</li>
 	 * </ul>
 	 *
 	 * @param raw  the raw textarea value (may be null)
-	 * @param mode the selected format: "line", "delimited", or "smart"
+	 * @param mode the selected format: "smart", "delimited", or "line"
 	 * @return the text normalized to CRLF-separated entries, or the raw value unchanged
 	 */
 	// package-private for unit testing
@@ -1018,15 +1020,20 @@ public class SiteAddParticipantHandler {
 			return null;
 		}
 		if ("smart".equals(mode)) {
-			Matcher m = EMAIL_EXTRACT_PATTERN.matcher(raw);
-			StringBuilder sb = new StringBuilder();
-			while (m.find()) {
-				if (sb.length() > 0) {
-					sb.append("\r\n");
+			if (raw.contains(EMAIL_CHAR)) {
+				// looks like an email blob: pull out every address, ignoring names / brackets / junk
+				Matcher m = EMAIL_EXTRACT_PATTERN.matcher(raw);
+				StringBuilder sb = new StringBuilder();
+				while (m.find()) {
+					if (sb.length() > 0) {
+						sb.append("\r\n");
+					}
+					sb.append(m.group());
 				}
-				sb.append(m.group());
+				return sb.toString();
 			}
-			return sb.toString();
+			// no @ anywhere: treat as a username list separated by any delimiter
+			return raw.trim().replaceAll("[,;\\s]+", "\r\n");
 		}
 		if ("delimited".equals(mode)) {
 			return raw.trim().replaceAll("[,;\\s]+", "\r\n");
@@ -1113,8 +1120,8 @@ public class SiteAddParticipantHandler {
 		officialAccountParticipant = null;
 		officialAccountEidOnly = new ArrayList<>();
 		nonOfficialAccountParticipant = null;
-		officialDelimiter = "line";
-		nonOfficialDelimiter = "line";
+		officialDelimiter = "smart";
+		nonOfficialDelimiter = "smart";
 		officialAccountType = "auto";
 		roleChoice = "sameRole";
 		statusChoice = "active";

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -982,6 +982,16 @@ public class SiteAddParticipantHandler {
 	private static final Pattern MAILBOX_UNIT_PATTERN =
 			Pattern.compile("[^<>,;@]*(?:,[^<>,;@]*)?<\\s*(" + EMAIL_EXTRACT_PATTERN.pattern() + ")\\s*>");
 
+	// characters a Sakai username (eid) can never contain: BaseUserDirectoryService.cleanEid()
+	// strips <>,;:\/ from every eid, and Validator.checkUserId() additionally rejects ^%*?.
+	// A token holding any of them (a URL, a path, stray markup) cannot be a username.
+	private static final String EID_IMPOSSIBLE_CHARS = "<>,;:\\/^%*?";
+
+	/** Whether a lone pasted token could syntactically be a username (eid) per the kernel's rules. */
+	private static boolean couldBeEid(String token) {
+		return StringUtils.containsNone(token, EID_IMPOSSIBLE_CHARS);
+	}
+
 	/**
 	 * Smart-parse a pasted official-account textarea into one entry per CRLF-separated line, so the
 	 * existing per-line parsing handles it unchanged. The paste is examined <em>one line at a time</em>
@@ -989,15 +999,16 @@ public class SiteAddParticipantHandler {
 	 * usernames on separate lines:
 	 * <ul>
 	 *   <li>a line containing an {@code @} is treated as an email line: {@code Name <email>}
-	 *       mailboxes and bare email tokens are extracted, display names and prose around them are
-	 *       ignored (so a messy paste like {@code John Doe <jdoe@x.com>, asmith@y.edu (Alice)}
-	 *       yields both addresses);</li>
+	 *       mailboxes and bare email tokens are extracted, a lone comma/semicolon-delimited token
+	 *       without an {@code @} is kept as a username entry (the box accepts both, so
+	 *       {@code jsmith, jdoe@x.edu} adds both), and multi-word display names / prose around the
+	 *       addresses are ignored (so a messy paste like
+	 *       {@code John Doe <jdoe@x.com>, asmith@y.edu (Alice)} yields just both addresses);</li>
 	 *   <li>a line with no {@code @} is treated as a username list and split on any run of comma /
 	 *       semicolon / whitespace.</li>
 	 * </ul>
-	 * Nothing that looks like an intended entry is dropped silently: on an email line, a leftover
-	 * token that contains an {@code @} (a mistyped address such as {@code jdoe@iu}) or that stands
-	 * alone between delimiters (such as a username mixed onto an email line) is reported back via
+	 * Nothing that looks like an intended entry is dropped silently: a leftover token that still
+	 * contains an {@code @} (a mistyped address such as {@code jdoe@iu}) is reported back via
 	 * {@code skipped} so the caller can raise a visible alert instead of quietly adding fewer
 	 * people than were pasted.
 	 *
@@ -1054,13 +1065,15 @@ public class SiteAddParticipantHandler {
 								skipped.add(token);
 							}
 						}
-					} else if (trimmedChunk.split("\\s+").length == 1) {
-						// a lone delimited token sharing a line with an email address is
-						// ambiguous (username? name fragment? broken address?) — flag it
-						// rather than guessing a user lookup or dropping it silently
-						skipped.add(trimmedChunk);
+					} else if (trimmedChunk.split("\\s+").length == 1 && couldBeEid(trimmedChunk)) {
+						// a lone delimited token without an @ is a username entry: the box
+						// accepts usernames and emails alike, so "jsmith, jdoe@x.edu" adds
+						// both (mailbox display names were already consumed above, so
+						// Outlook "Last, First <email>" pastes don't leak name fragments)
+						appendEntry(sb, trimmedChunk);
 					}
-					// multi-word chunks without an @ are name/prose fragments: ignored
+					// multi-word chunks without an @ (name/prose fragments) and lone tokens
+					// holding eid-impossible characters (URLs, paths) are ignored
 				}
 			} else {
 				// no @ on this line: treat as a username list separated by any delimiter

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -239,14 +240,34 @@ public class SiteAddParticipantHandler {
     	// reset user list
     	resetUserRolesEntries();
     	checkAddParticipant();
-    	if (targettedMessageList != null && targettedMessageList.size() > 0) {
+    	if (hasBlockingMessages()) {
     		// there is error, remain on the same page
     		return "";
     	} else {
-    		// go to next step
+    		// go to next step; advisory smart-parse notes (skipped/unmatched paste fragments)
+    		// stay in the message list and render on the next page, so they inform without
+    		// dead-ending the whole add
     		return roleChoice;
     	}
     }
+
+	// Smart-parse notes that explain what was left out of a messy paste; they must inform the
+	// user but never block the wizard while there are entries to continue with.
+	private static final Set<String> ADVISORY_MESSAGE_CODES = Set.of("java.skipped", "java.unmatched");
+
+	/** Whether the current message list holds anything beyond advisory smart-parse notes. */
+	private boolean hasBlockingMessages() {
+		if (targettedMessageList == null) {
+			return false;
+		}
+		for (int i = 0; i < targettedMessageList.size(); i++) {
+			TargettedMessage msg = targettedMessageList.messageAt(i);
+			if (!ADVISORY_MESSAGE_CODES.contains(msg.acquireMessageCode())) {
+				return true;
+			}
+		}
+		return false;
+	}
     
     private void resetTargettedMessageList() {
     	targettedMessageList.clear();
@@ -652,7 +673,8 @@ public class SiteAddParticipantHandler {
 		// smart-parse each blob into one-entry-per-line first, so the per-line parsing below is
 		// reused unchanged (see normalizeSmart / normalizeNonOfficial)
 		List<String> skippedEntries = new ArrayList<>();
-		officialAccounts = StringUtils.trimToNull(normalizeSmart(officialAccountParticipant, skippedEntries));
+		List<String> unmatchedTokens = new ArrayList<>();
+		officialAccounts = StringUtils.trimToNull(normalizeSmart(officialAccountParticipant, skippedEntries, unmatchedTokens, this::isRegisteredEid));
 		nonOfficialAccounts = StringUtils.trimToNull(normalizeNonOfficial(nonOfficialAccountParticipant, skippedEntries));
 		StringBuilder updatedOfficialAccountParticipant = new StringBuilder();
 		StringBuilder updatedNonOfficialAccountParticipant = new StringBuilder();
@@ -664,6 +686,15 @@ public class SiteAddParticipantHandler {
 					"java.skipped",
 					new Object[] {skippedEntry},
 					TargettedMessage.SEVERITY_ERROR));
+		}
+
+		// username-looking text that matched no registered account: note it, once, so the user
+		// can see why it was not added (display names and greeting words land here)
+		if (!unmatchedTokens.isEmpty()) {
+			targettedMessageList.addMessage(new TargettedMessage(
+					"java.unmatched",
+					new Object[] {String.join(", ", unmatchedTokens)},
+					TargettedMessage.SEVERITY_INFO));
 		}
 
 		// if there is no eid or nonOfficialAccount entered
@@ -992,6 +1023,16 @@ public class SiteAddParticipantHandler {
 		return StringUtils.containsNone(token, EID_IMPOSSIBLE_CHARS);
 	}
 
+	/** Whether {@code token} is a registered username (eid) in the user directory. */
+	private boolean isRegisteredEid(String token) {
+		try {
+			userDirectoryService.getUserByEid(token);
+			return true;
+		} catch (UserNotDefinedException e) {
+			return false;
+		}
+	}
+
 	/**
 	 * Smart-parse a pasted official-account textarea into one entry per CRLF-separated line, so the
 	 * existing per-line parsing handles it unchanged. The interpretation is decided for the paste
@@ -1000,12 +1041,14 @@ public class SiteAddParticipantHandler {
 	 *   <li>a paste with no {@code @} anywhere is a plain username list, split on any run of
 	 *       comma / semicolon / whitespace (the legacy contract);</li>
 	 *   <li>as soon as the paste holds email material, every line is parsed with the email rules:
-	 *       {@code Name <email>} mailboxes and bare email tokens are extracted, a lone
-	 *       comma/semicolon-delimited token without an {@code @} that could syntactically be an
-	 *       eid is kept as a username entry (the box accepts both, so {@code jsmith, jdoe@x.edu}
-	 *       adds both), and multi-word display names / prose are ignored — so a pasted request
-	 *       like {@code Hi, can you add John Doe <jdoe@x.com> and asmith@y.edu?} yields just the
-	 *       two addresses instead of shredding the sentence into bogus username lookups.</li>
+	 *       {@code Name <email>} mailboxes and bare email tokens are extracted, and the user
+	 *       directory decides what the leftover words are. A comma/semicolon-delimited chunk
+	 *       whose every whitespace-separated word could syntactically be an eid AND resolves to a
+	 *       registered user is a username list (so {@code jsmith, jdoe@x.edu} adds both, and a
+	 *       {@code instructor7 grader02} run works too); a chunk that looks like identifiers but
+	 *       does not fully resolve (a display name such as {@code John Doe}, a greeting word) is
+	 *       reported via {@code unmatched} and not added; chunks holding eid-impossible
+	 *       characters (URLs, sentence punctuation) are prose and silently ignored.</li>
 	 * </ul>
 	 * Nothing that looks like an intended entry is dropped silently: a leftover token that still
 	 * contains an {@code @} (a mistyped address such as {@code jdoe@iu}) is reported back via
@@ -1018,15 +1061,20 @@ public class SiteAddParticipantHandler {
 	 * preserves those name fields.
 	 *
 	 * @param raw the raw textarea value (may be null)
-	 * @param skipped collects pasted fragments that looked like intended entries but could not be
-	 *                parsed, so the caller can alert on them
+	 * @param skipped collects pasted fragments that looked like intended email entries but could
+	 *                not be parsed, so the caller can alert on them
+	 * @param unmatched collects eid-plausible fragments that matched no registered username, so
+	 *                  the caller can note why they were not added
+	 * @param registeredEid the user-directory oracle: whether a token is a registered eid
 	 * @return the text normalized to CRLF-separated entries, or null when {@code raw} is null
 	 */
 	// package-private for unit testing
-	String normalizeSmart(String raw, List<String> skipped) {
+	String normalizeSmart(String raw, List<String> skipped, List<String> unmatched, Predicate<String> registeredEid) {
 		if (raw == null) {
 			return null;
 		}
+		// Word/Outlook pastes carry non-breaking spaces, which Java's \s does not match
+		raw = raw.replace(' ', ' ');
 		StringBuilder sb = new StringBuilder();
 		if (!raw.contains(EMAIL_CHAR)) {
 			// no @ anywhere in the paste: a plain username list separated by any delimiter
@@ -1070,15 +1118,38 @@ public class SiteAddParticipantHandler {
 							skipped.add(token);
 						}
 					}
-				} else if (trimmedChunk.split("\\s+").length == 1 && couldBeEid(trimmedChunk)) {
-					// a lone delimited token without an @ is a username entry: the box
-					// accepts usernames and emails alike, so "jsmith, jdoe@x.edu" adds
-					// both (mailbox display names were already consumed above, so
-					// Outlook "Last, First <email>" pastes don't leak name fragments)
-					appendEntry(sb, trimmedChunk);
+					continue;
 				}
-				// multi-word chunks without an @ (name/prose fragments) and lone tokens
-				// holding eid-impossible characters (URLs, paths) are ignored
+				// no @ in this chunk: candidate username(s). The user directory is the ground
+				// truth: when every whitespace-separated word could be an eid AND resolves to a
+				// registered user, the chunk is a username list; when it is eid-plausible but
+				// does not fully resolve, it is a display name / greeting word and is reported
+				// via unmatched; when it holds eid-impossible characters it is prose, ignored.
+				String[] words = trimmedChunk.split("\\s+");
+				boolean allPlausible = true;
+				for (String word : words) {
+					if (!couldBeEid(word)) {
+						allPlausible = false;
+						break;
+					}
+				}
+				if (!allPlausible) {
+					continue;
+				}
+				boolean allRegistered = true;
+				for (String word : words) {
+					if (!registeredEid.test(word)) {
+						allRegistered = false;
+						break;
+					}
+				}
+				if (allRegistered) {
+					for (String word : words) {
+						appendEntry(sb, word);
+					}
+				} else {
+					unmatched.add(trimmedChunk);
+				}
 			}
 		}
 		return sb.toString();
@@ -1118,6 +1189,8 @@ public class SiteAddParticipantHandler {
 		if (raw == null) {
 			return null;
 		}
+		// Word/Outlook pastes carry non-breaking spaces, which Java's \s does not match
+		raw = raw.replace(' ', ' ');
 		StringBuilder sb = new StringBuilder();
 		// split people on line breaks / semicolons; commas remain inside a person (field separator)
 		for (String chunk : raw.split("[;\r\n]+")) {

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -651,10 +651,20 @@ public class SiteAddParticipantHandler {
 		// check that there is something with which to work
 		// smart-parse each blob into one-entry-per-line first, so the per-line parsing below is
 		// reused unchanged (see normalizeSmart / normalizeNonOfficial)
-		officialAccounts = StringUtils.trimToNull(normalizeSmart(officialAccountParticipant));
-		nonOfficialAccounts = StringUtils.trimToNull(normalizeNonOfficial(nonOfficialAccountParticipant));
+		List<String> skippedEntries = new ArrayList<>();
+		officialAccounts = StringUtils.trimToNull(normalizeSmart(officialAccountParticipant, skippedEntries));
+		nonOfficialAccounts = StringUtils.trimToNull(normalizeNonOfficial(nonOfficialAccountParticipant, skippedEntries));
 		StringBuilder updatedOfficialAccountParticipant = new StringBuilder();
 		StringBuilder updatedNonOfficialAccountParticipant = new StringBuilder();
+
+		// anything the smart parse could not understand must fail loudly, never silently: the
+		// instructor believes everyone they pasted was added
+		for (String skippedEntry : skippedEntries) {
+			targettedMessageList.addMessage(new TargettedMessage(
+					"java.skipped",
+					new Object[] {skippedEntry},
+					TargettedMessage.SEVERITY_ERROR));
+		}
 
 		// if there is no eid or nonOfficialAccount entered
 		if (officialAccounts == null && nonOfficialAccounts == null) {
@@ -962,8 +972,15 @@ public class SiteAddParticipantHandler {
 		}
 	}
 
-	// matches an email-format token anywhere within a blob of pasted text (used by smart parsing)
-	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
+	// matches an email-format token anywhere within a blob of pasted text (used by smart parsing).
+	// The local part accepts an apostrophe (o'brien@x.edu) but must not start with one, so a
+	// single-quoted 'jdoe@x.edu' still extracts without the quote.
+	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-][A-Za-z0-9._%+'\\-]*@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
+
+	// matches an RFC-style mailbox: an optional display name (one "Last, First" comma allowed,
+	// no @ so a neighboring bare address is never swallowed as a name) followed by <email>
+	private static final Pattern MAILBOX_UNIT_PATTERN =
+			Pattern.compile("[^<>,;@]*(?:,[^<>,;@]*)?<\\s*(" + EMAIL_EXTRACT_PATTERN.pattern() + ")\\s*>");
 
 	/**
 	 * Smart-parse a pasted official-account textarea into one entry per CRLF-separated line, so the
@@ -971,37 +988,79 @@ public class SiteAddParticipantHandler {
 	 * so the legacy one-entry-per-line format keeps working, including a mixed list of emails and
 	 * usernames on separate lines:
 	 * <ul>
-	 *   <li>a line containing an {@code @} is treated as an email line and every email-format token on
-	 *       it is extracted, ignoring surrounding names / brackets / punctuation (so a messy paste like
-	 *       {@code John Doe <jdoe@x.com>, asmith@y.edu (Alice)} yields both addresses);</li>
+	 *   <li>a line containing an {@code @} is treated as an email line: {@code Name <email>}
+	 *       mailboxes and bare email tokens are extracted, display names and prose around them are
+	 *       ignored (so a messy paste like {@code John Doe <jdoe@x.com>, asmith@y.edu (Alice)}
+	 *       yields both addresses);</li>
 	 *   <li>a line with no {@code @} is treated as a username list and split on any run of comma /
 	 *       semicolon / whitespace.</li>
 	 * </ul>
-	 * Deciding per line (rather than per blob) preserves everything the pre-smart tool accepted — it
+	 * Nothing that looks like an intended entry is dropped silently: on an email line, a leftover
+	 * token that contains an {@code @} (a mistyped address such as {@code jdoe@iu}) or that stands
+	 * alone between delimiters (such as a username mixed onto an email line) is reported back via
+	 * {@code skipped} so the caller can raise a visible alert instead of quietly adding fewer
+	 * people than were pasted.
+	 *
+	 * <p>Deciding per line (rather than per blob) preserves everything the pre-smart tool accepted — it
 	 * split only on line breaks and routed each entry by the {@code @} char — while additionally
 	 * accepting other delimiters and messy email pastes. Either way the extracted entries are validated
 	 * downstream and the per-entry lookup routes emails vs usernames.
 	 *
 	 * <p>This drives the <em>official</em> box, whose entries are single tokens (an email or a
 	 * username). The non-official (guest) box carries structured {@code email,lastName,firstName}
-	 * rows, so it is normalized by {@link #normalizeNonOfficial(String)} instead, which preserves
-	 * those name fields.
+	 * rows, so it is normalized by {@link #normalizeNonOfficial(String, List)} instead, which
+	 * preserves those name fields.
 	 *
 	 * @param raw the raw textarea value (may be null)
+	 * @param skipped collects pasted fragments that looked like intended entries but could not be
+	 *                parsed, so the caller can alert on them
 	 * @return the text normalized to CRLF-separated entries, or null when {@code raw} is null
 	 */
 	// package-private for unit testing
-	String normalizeSmart(String raw) {
+	String normalizeSmart(String raw, List<String> skipped) {
 		if (raw == null) {
 			return null;
 		}
 		StringBuilder sb = new StringBuilder();
 		for (String line : raw.split("\r\n|\r|\n")) {
 			if (line.contains(EMAIL_CHAR)) {
-				// email line: pull out every address, ignoring names / brackets / junk
-				Matcher m = EMAIL_EXTRACT_PATTERN.matcher(line);
-				while (m.find()) {
-					appendEntry(sb, m.group());
+				// email line: first take every "display name <email>" mailbox, keeping the
+				// address and intentionally ignoring the display name
+				StringBuffer rest = new StringBuffer();
+				Matcher unit = MAILBOX_UNIT_PATTERN.matcher(line);
+				while (unit.find()) {
+					appendEntry(sb, unit.group(1));
+					unit.appendReplacement(rest, " ");
+				}
+				unit.appendTail(rest);
+				// then handle what's left, one comma/semicolon-separated chunk at a time
+				for (String chunk : rest.toString().split("[,;]+")) {
+					String trimmedChunk = chunk.trim();
+					if (trimmedChunk.isEmpty()) {
+						continue;
+					}
+					if (trimmedChunk.contains(EMAIL_CHAR)) {
+						// email chunk: extract the addresses; a leftover token still holding an
+						// @ is a mistyped address the user meant to add, so flag it
+						StringBuffer residue = new StringBuffer();
+						Matcher m = EMAIL_EXTRACT_PATTERN.matcher(trimmedChunk);
+						while (m.find()) {
+							appendEntry(sb, m.group());
+							m.appendReplacement(residue, " ");
+						}
+						m.appendTail(residue);
+						for (String token : residue.toString().split("\\s+")) {
+							if (token.contains(EMAIL_CHAR)) {
+								skipped.add(token);
+							}
+						}
+					} else if (trimmedChunk.split("\\s+").length == 1) {
+						// a lone delimited token sharing a line with an email address is
+						// ambiguous (username? name fragment? broken address?) — flag it
+						// rather than guessing a user lookup or dropping it silently
+						skipped.add(trimmedChunk);
+					}
+					// multi-word chunks without an @ are name/prose fragments: ignored
 				}
 			} else {
 				// no @ on this line: treat as a username list separated by any delimiter
@@ -1038,13 +1097,17 @@ public class SiteAddParticipantHandler {
 	 *       split so each address lands on its own line.</li>
 	 * </ul>
 	 * This lets a guest paste keep structured name rows while still accepting a plain comma /
-	 * semicolon / whitespace separated list of addresses.
+	 * semicolon / whitespace separated list of addresses. In the blob case, a leftover token that
+	 * still holds an {@code @} (a mistyped address such as {@code b@y}) is reported back via
+	 * {@code skipped} so the caller can alert on it instead of dropping it silently.
 	 *
 	 * @param raw the raw textarea value (may be null)
+	 * @param skipped collects pasted fragments that looked like intended entries but could not be
+	 *                parsed, so the caller can alert on them
 	 * @return the text normalized to CRLF-separated entries, or null when {@code raw} is null
 	 */
 	// package-private for unit testing
-	String normalizeNonOfficial(String raw) {
+	String normalizeNonOfficial(String raw, List<String> skipped) {
 		if (raw == null) {
 			return null;
 		}
@@ -1062,12 +1125,21 @@ public class SiteAddParticipantHandler {
 			}
 			if (emailCount > 1) {
 				// bare email blob on one chunk: emit each address on its own line, dropping names
+				// but flagging any leftover token that still looks like a mistyped address
+				StringBuffer residue = new StringBuffer();
 				Matcher emails = EMAIL_EXTRACT_PATTERN.matcher(person);
 				while (emails.find()) {
 					if (sb.length() > 0) {
 						sb.append("\r\n");
 					}
 					sb.append(emails.group());
+					emails.appendReplacement(residue, " ");
+				}
+				emails.appendTail(residue);
+				for (String token : residue.toString().split("[,\\s]+")) {
+					if (token.contains(EMAIL_CHAR)) {
+						skipped.add(token);
+					}
 				}
 			} else {
 				// single email (with optional name fields) or an invalid line: keep it intact

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -99,6 +99,8 @@ public class SiteAddParticipantHandler {
     @Setter private UserNotificationProvider notiProvider;
     @Getter @Setter public String officialAccountParticipant = null;
     @Getter @Setter public String officialDelimiter = "line";
+    // how to interpret official-account entries: "auto" (detect by @), "email", or "username"
+    @Getter @Setter public String officialAccountType = "auto";
     @Getter @Setter public List<String> officialAccountEidOnly = new ArrayList<>();
     // realm for the site
     public AuthzGroup realm = null;
@@ -654,7 +656,7 @@ public class SiteAddParticipantHandler {
 		// check that there is something with which to work
 		// normalize any delimited (comma/semicolon) blob to one-entry-per-line first, so the
 		// per-line parsing below is reused unchanged (see normalizeDelimited)
-		officialAccounts = StringUtils.trimToNull(normalizeDelimited(officialAccountParticipant, officialDelimiter));
+		officialAccounts = StringUtils.trimToNull(normalizeDelimited(officialAccountParticipant, effectiveOfficialMode(officialAccountType, officialDelimiter)));
 		nonOfficialAccounts = StringUtils.trimToNull(normalizeDelimited(nonOfficialAccountParticipant, nonOfficialDelimiter));
 		StringBuilder updatedOfficialAccountParticipant = new StringBuilder();
 		StringBuilder updatedNonOfficialAccountParticipant = new StringBuilder();
@@ -682,8 +684,19 @@ public class SiteAddParticipantHandler {
 					StringBuilder eidsForAllMatches = new StringBuilder();
 					StringBuilder eidsForAllMatchesAlertBuffer = new StringBuilder();
 					
-					if (!officialAccount.contains(EMAIL_CHAR)) {
-						// is not of email format, then look up by eid only
+					// decide whether to look the entry up as a username (eid) only, or also by email.
+					// "username"/"email" honor the explicit Account type choice; "auto" detects by the @ char.
+					boolean lookupByEidOnly;
+					if ("username".equals(officialAccountType)) {
+						lookupByEidOnly = true;
+					} else if ("email".equals(officialAccountType)) {
+						lookupByEidOnly = false;
+					} else {
+						lookupByEidOnly = !officialAccount.contains(EMAIL_CHAR);
+					}
+
+					if (lookupByEidOnly) {
+						// look up by eid (username) only
 						try {
 							// look for user based on eid first
 							u = userDirectoryService.getUserByEid(officialAccount);
@@ -691,7 +704,7 @@ public class SiteAddParticipantHandler {
 							log.debug(messageLocator.getMessage("java.username", officialAccount), e);
 						}
 					} else {
-						// is email. Need to lookup by both eid and email address
+						// treat as email: look up by both eid and email address
 						try {
 							// look for user based on eid first
 							u = userDirectoryService.getUserByEid(officialAccount);
@@ -965,6 +978,23 @@ public class SiteAddParticipantHandler {
 	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
 
 	/**
+	 * Resolve the input format to actually use for the official box given the chosen Account type.
+	 * "Smart" extraction relies on an email-format regex, which cannot match bare usernames, so when
+	 * the user has explicitly declared usernames we fall back to plain delimited splitting.
+	 *
+	 * @param accountType "auto", "email", or "username"
+	 * @param delimiter   the chosen input format ("line", "delimited", or "smart")
+	 * @return the effective input format to pass to {@link #normalizeDelimited(String, String)}
+	 */
+	// package-private for unit testing
+	String effectiveOfficialMode(String accountType, String delimiter) {
+		if ("username".equals(accountType) && "smart".equals(delimiter)) {
+			return "delimited";
+		}
+		return delimiter;
+	}
+
+	/**
 	 * Normalize a pasted account textarea to one entry per CRLF-separated line, according to the
 	 * chosen input format, so the existing per-line parsing handles it unchanged:
 	 * <ul>
@@ -1085,6 +1115,7 @@ public class SiteAddParticipantHandler {
 		nonOfficialAccountParticipant = null;
 		officialDelimiter = "line";
 		nonOfficialDelimiter = "line";
+		officialAccountType = "auto";
 		roleChoice = "sameRole";
 		statusChoice = "active";
 		sameRoleChoice = null;

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -994,28 +994,23 @@ public class SiteAddParticipantHandler {
 
 	/**
 	 * Smart-parse a pasted official-account textarea into one entry per CRLF-separated line, so the
-	 * existing per-line parsing handles it unchanged. The paste is examined <em>one line at a time</em>
-	 * so the legacy one-entry-per-line format keeps working, including a mixed list of emails and
-	 * usernames on separate lines:
+	 * existing per-line parsing handles it unchanged. The interpretation is decided for the paste
+	 * as a whole:
 	 * <ul>
-	 *   <li>a line containing an {@code @} is treated as an email line: {@code Name <email>}
-	 *       mailboxes and bare email tokens are extracted, a lone comma/semicolon-delimited token
-	 *       without an {@code @} is kept as a username entry (the box accepts both, so
-	 *       {@code jsmith, jdoe@x.edu} adds both), and multi-word display names / prose around the
-	 *       addresses are ignored (so a messy paste like
-	 *       {@code John Doe <jdoe@x.com>, asmith@y.edu (Alice)} yields just both addresses);</li>
-	 *   <li>a line with no {@code @} is treated as a username list and split on any run of comma /
-	 *       semicolon / whitespace.</li>
+	 *   <li>a paste with no {@code @} anywhere is a plain username list, split on any run of
+	 *       comma / semicolon / whitespace (the legacy contract);</li>
+	 *   <li>as soon as the paste holds email material, every line is parsed with the email rules:
+	 *       {@code Name <email>} mailboxes and bare email tokens are extracted, a lone
+	 *       comma/semicolon-delimited token without an {@code @} that could syntactically be an
+	 *       eid is kept as a username entry (the box accepts both, so {@code jsmith, jdoe@x.edu}
+	 *       adds both), and multi-word display names / prose are ignored — so a pasted request
+	 *       like {@code Hi, can you add John Doe <jdoe@x.com> and asmith@y.edu?} yields just the
+	 *       two addresses instead of shredding the sentence into bogus username lookups.</li>
 	 * </ul>
 	 * Nothing that looks like an intended entry is dropped silently: a leftover token that still
 	 * contains an {@code @} (a mistyped address such as {@code jdoe@iu}) is reported back via
 	 * {@code skipped} so the caller can raise a visible alert instead of quietly adding fewer
 	 * people than were pasted.
-	 *
-	 * <p>Deciding per line (rather than per blob) preserves everything the pre-smart tool accepted — it
-	 * split only on line breaks and routed each entry by the {@code @} char — while additionally
-	 * accepting other delimiters and messy email pastes. Either way the extracted entries are validated
-	 * downstream and the per-entry lookup routes emails vs usernames.
 	 *
 	 * <p>This drives the <em>official</em> box, whose entries are single tokens (an email or a
 	 * username). The non-official (guest) box carries structured {@code email,lastName,firstName}
@@ -1033,58 +1028,57 @@ public class SiteAddParticipantHandler {
 			return null;
 		}
 		StringBuilder sb = new StringBuilder();
+		if (!raw.contains(EMAIL_CHAR)) {
+			// no @ anywhere in the paste: a plain username list separated by any delimiter
+			for (String token : raw.trim().split("[,;\\s]+")) {
+				if (!token.isEmpty()) {
+					appendEntry(sb, token);
+				}
+			}
+			return sb.toString();
+		}
+		// the paste holds email material: parse every line with the email rules, so prose lines
+		// of a pasted request are not shredded into bogus username lookups
 		for (String line : raw.split("\r\n|\r|\n")) {
-			if (line.contains(EMAIL_CHAR)) {
-				// email line: first take every "display name <email>" mailbox, keeping the
-				// address and intentionally ignoring the display name
-				StringBuffer rest = new StringBuffer();
-				Matcher unit = MAILBOX_UNIT_PATTERN.matcher(line);
-				while (unit.find()) {
-					appendEntry(sb, unit.group(1));
-					unit.appendReplacement(rest, " ");
+			// first take every "display name <email>" mailbox, keeping the address and
+			// intentionally ignoring the display name
+			StringBuffer rest = new StringBuffer();
+			Matcher unit = MAILBOX_UNIT_PATTERN.matcher(line);
+			while (unit.find()) {
+				appendEntry(sb, unit.group(1));
+				unit.appendReplacement(rest, " ");
+			}
+			unit.appendTail(rest);
+			// then handle what's left, one comma/semicolon-separated chunk at a time
+			for (String chunk : rest.toString().split("[,;]+")) {
+				String trimmedChunk = chunk.trim();
+				if (trimmedChunk.isEmpty()) {
+					continue;
 				}
-				unit.appendTail(rest);
-				// then handle what's left, one comma/semicolon-separated chunk at a time
-				for (String chunk : rest.toString().split("[,;]+")) {
-					String trimmedChunk = chunk.trim();
-					if (trimmedChunk.isEmpty()) {
-						continue;
+				if (trimmedChunk.contains(EMAIL_CHAR)) {
+					// email chunk: extract the addresses; a leftover token still holding an
+					// @ is a mistyped address the user meant to add, so flag it
+					StringBuffer residue = new StringBuffer();
+					Matcher m = EMAIL_EXTRACT_PATTERN.matcher(trimmedChunk);
+					while (m.find()) {
+						appendEntry(sb, m.group());
+						m.appendReplacement(residue, " ");
 					}
-					if (trimmedChunk.contains(EMAIL_CHAR)) {
-						// email chunk: extract the addresses; a leftover token still holding an
-						// @ is a mistyped address the user meant to add, so flag it
-						StringBuffer residue = new StringBuffer();
-						Matcher m = EMAIL_EXTRACT_PATTERN.matcher(trimmedChunk);
-						while (m.find()) {
-							appendEntry(sb, m.group());
-							m.appendReplacement(residue, " ");
-						}
-						m.appendTail(residue);
-						for (String token : residue.toString().split("\\s+")) {
-							if (token.contains(EMAIL_CHAR)) {
-								skipped.add(token);
-							}
-						}
-					} else if (trimmedChunk.split("\\s+").length == 1 && couldBeEid(trimmedChunk)) {
-						// a lone delimited token without an @ is a username entry: the box
-						// accepts usernames and emails alike, so "jsmith, jdoe@x.edu" adds
-						// both (mailbox display names were already consumed above, so
-						// Outlook "Last, First <email>" pastes don't leak name fragments)
-						appendEntry(sb, trimmedChunk);
-					}
-					// multi-word chunks without an @ (name/prose fragments) and lone tokens
-					// holding eid-impossible characters (URLs, paths) are ignored
-				}
-			} else {
-				// no @ on this line: treat as a username list separated by any delimiter
-				String trimmed = line.trim();
-				if (!trimmed.isEmpty()) {
-					for (String token : trimmed.split("[,;\\s]+")) {
-						if (!token.isEmpty()) {
-							appendEntry(sb, token);
+					m.appendTail(residue);
+					for (String token : residue.toString().split("\\s+")) {
+						if (token.contains(EMAIL_CHAR)) {
+							skipped.add(token);
 						}
 					}
+				} else if (trimmedChunk.split("\\s+").length == 1 && couldBeEid(trimmedChunk)) {
+					// a lone delimited token without an @ is a username entry: the box
+					// accepts usernames and emails alike, so "jsmith, jdoe@x.edu" adds
+					// both (mailbox display names were already consumed above, so
+					// Outlook "Last, First <email>" pastes don't leak name fragments)
+					appendEntry(sb, trimmedChunk);
 				}
+				// multi-word chunks without an @ (name/prose fragments) and lone tokens
+				// holding eid-impossible characters (URLs, paths) are ignored
 			}
 		}
 		return sb.toString();

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -657,7 +657,7 @@ public class SiteAddParticipantHandler {
 		// normalize any delimited (comma/semicolon) blob to one-entry-per-line first, so the
 		// per-line parsing below is reused unchanged (see normalizeDelimited)
 		officialAccounts = StringUtils.trimToNull(normalizeDelimited(officialAccountParticipant, effectiveOfficialMode(officialAccountType, officialDelimiter)));
-		nonOfficialAccounts = StringUtils.trimToNull(normalizeDelimited(nonOfficialAccountParticipant, nonOfficialDelimiter));
+		nonOfficialAccounts = StringUtils.trimToNull(normalizeNonOfficial(nonOfficialAccountParticipant, nonOfficialDelimiter));
 		StringBuilder updatedOfficialAccountParticipant = new StringBuilder();
 		StringBuilder updatedNonOfficialAccountParticipant = new StringBuilder();
 
@@ -1010,6 +1010,11 @@ public class SiteAddParticipantHandler {
 	 *       downstream and the per-entry lookup routes emails vs usernames.</li>
 	 * </ul>
 	 *
+	 * <p>This drives the <em>official</em> box, whose entries are single tokens (an email or a
+	 * username). The non-official (guest) box carries structured {@code email,lastName,firstName}
+	 * rows, so it is normalized by {@link #normalizeNonOfficial(String, String)} instead, which
+	 * preserves those name fields under smart mode.
+	 *
 	 * @param raw  the raw textarea value (may be null)
 	 * @param mode the selected format: "smart", "delimited", or "line"
 	 * @return the text normalized to CRLF-separated entries, or the raw value unchanged
@@ -1039,6 +1044,66 @@ public class SiteAddParticipantHandler {
 			return raw.trim().replaceAll("[,;\\s]+", "\r\n");
 		}
 		return raw;
+	}
+
+	/**
+	 * Normalize the non-official (guest) box, whose per-person format is
+	 * {@code email,lastName,firstName}, into one person per CRLF-separated line.
+	 * <p>Only {@code "smart"} gets special handling here; {@code "line"} and {@code "delimited"}
+	 * defer to {@link #normalizeDelimited(String, String)} unchanged. Under smart mode:
+	 * <ul>
+	 *   <li>people are separated by line breaks or semicolons (a comma stays <em>inside</em> a
+	 *       person as the field separator between email and names);</li>
+	 *   <li>a chunk holding a single email is kept intact, so its {@code ,lastName,firstName}
+	 *       fields survive downstream {@link #parseAccountIntoParts(String)};</li>
+	 *   <li>a chunk holding more than one email is treated as a bare email blob (no names) and
+	 *       split so each address lands on its own line.</li>
+	 * </ul>
+	 * This lets a guest paste keep structured name rows while still accepting a plain comma /
+	 * semicolon / whitespace separated list of addresses.
+	 *
+	 * @param raw  the raw textarea value (may be null)
+	 * @param mode the selected format: "smart", "delimited", or "line"
+	 * @return the text normalized to CRLF-separated entries, or the raw value unchanged
+	 */
+	// package-private for unit testing
+	String normalizeNonOfficial(String raw, String mode) {
+		if (raw == null) {
+			return null;
+		}
+		if (!"smart".equals(mode)) {
+			return normalizeDelimited(raw, mode);
+		}
+		StringBuilder sb = new StringBuilder();
+		// split people on line breaks / semicolons; commas remain inside a person (field separator)
+		for (String chunk : raw.split("[;\r\n]+")) {
+			String person = chunk.trim();
+			if (person.isEmpty()) {
+				continue;
+			}
+			Matcher m = EMAIL_EXTRACT_PATTERN.matcher(person);
+			int emailCount = 0;
+			while (m.find()) {
+				emailCount++;
+			}
+			if (emailCount > 1) {
+				// bare email blob on one chunk: emit each address on its own line, dropping names
+				Matcher emails = EMAIL_EXTRACT_PATTERN.matcher(person);
+				while (emails.find()) {
+					if (sb.length() > 0) {
+						sb.append("\r\n");
+					}
+					sb.append(emails.group());
+				}
+			} else {
+				// single email (with optional name fields) or an invalid line: keep it intact
+				if (sb.length() > 0) {
+					sb.append("\r\n");
+				}
+				sb.append(person);
+			}
+		}
+		return sb.toString();
 	}
 
 	// package-private for unit testing

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -94,13 +94,8 @@ public class SiteAddParticipantHandler {
     @Setter @Getter public String emailNotiChoice = Boolean.FALSE.toString();
     private List<String> invalidDomains;
     @Getter @Setter public String nonOfficialAccountParticipant = null;
-    // input format for each account textarea: "smart" (auto-detect, default), "delimited" (comma/semicolon/whitespace separated), or "line" (one entry per line)
-    @Getter @Setter public String nonOfficialDelimiter = "smart";
     @Setter private UserNotificationProvider notiProvider;
     @Getter @Setter public String officialAccountParticipant = null;
-    @Getter @Setter public String officialDelimiter = "smart";
-    // how to interpret official-account entries: "auto" (detect by @), "email", or "username"
-    @Getter @Setter public String officialAccountType = "auto";
     @Getter @Setter public List<String> officialAccountEidOnly = new ArrayList<>();
     // realm for the site
     public AuthzGroup realm = null;
@@ -654,10 +649,10 @@ public class SiteAddParticipantHandler {
 		String nonOfficialAccounts;
 
 		// check that there is something with which to work
-		// normalize any delimited (comma/semicolon) blob to one-entry-per-line first, so the
-		// per-line parsing below is reused unchanged (see normalizeDelimited)
-		officialAccounts = StringUtils.trimToNull(normalizeDelimited(officialAccountParticipant, effectiveOfficialMode(officialAccountType, officialDelimiter)));
-		nonOfficialAccounts = StringUtils.trimToNull(normalizeNonOfficial(nonOfficialAccountParticipant, nonOfficialDelimiter));
+		// smart-parse each blob into one-entry-per-line first, so the per-line parsing below is
+		// reused unchanged (see normalizeSmart / normalizeNonOfficial)
+		officialAccounts = StringUtils.trimToNull(normalizeSmart(officialAccountParticipant));
+		nonOfficialAccounts = StringUtils.trimToNull(normalizeNonOfficial(nonOfficialAccountParticipant));
 		StringBuilder updatedOfficialAccountParticipant = new StringBuilder();
 		StringBuilder updatedNonOfficialAccountParticipant = new StringBuilder();
 
@@ -684,16 +679,9 @@ public class SiteAddParticipantHandler {
 					StringBuilder eidsForAllMatches = new StringBuilder();
 					StringBuilder eidsForAllMatchesAlertBuffer = new StringBuilder();
 					
-					// decide whether to look the entry up as a username (eid) only, or also by email.
-					// "username"/"email" honor the explicit Account type choice; "auto" detects by the @ char.
-					boolean lookupByEidOnly;
-					if ("username".equals(officialAccountType)) {
-						lookupByEidOnly = true;
-					} else if ("email".equals(officialAccountType)) {
-						lookupByEidOnly = false;
-					} else {
-						lookupByEidOnly = !officialAccount.contains(EMAIL_CHAR);
-					}
+					// decide whether to look the entry up as a username (eid) only, or also by email:
+					// an entry containing @ is treated as an email, otherwise as a username.
+					boolean lookupByEidOnly = !officialAccount.contains(EMAIL_CHAR);
 
 					if (lookupByEidOnly) {
 						// look up by eid (username) only
@@ -974,83 +962,49 @@ public class SiteAddParticipantHandler {
 		}
 	}
 
-	// matches an email-format token anywhere within a blob of pasted text (used by "smart" mode)
+	// matches an email-format token anywhere within a blob of pasted text (used by smart parsing)
 	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
 
 	/**
-	 * Resolve the input format to actually use for the official box given the chosen Account type.
-	 * "Smart" extraction relies on an email-format regex, which cannot match bare usernames, so when
-	 * the user has explicitly declared usernames we fall back to plain delimited splitting.
-	 *
-	 * @param accountType "auto", "email", or "username"
-	 * @param delimiter   the chosen input format ("line", "delimited", or "smart")
-	 * @return the effective input format to pass to {@link #normalizeDelimited(String, String)}
-	 */
-	// package-private for unit testing
-	String effectiveOfficialMode(String accountType, String delimiter) {
-		if ("username".equals(accountType) && "smart".equals(delimiter)) {
-			return "delimited";
-		}
-		return delimiter;
-	}
-
-	/**
-	 * Normalize a pasted account textarea to one entry per CRLF-separated line, according to the
-	 * chosen input format, so the existing per-line parsing handles it unchanged:
-	 * <ul>
-	 *   <li>{@code "line"} (default) &mdash; returned unchanged, preserving the non-official
-	 *       {@code email,lastName,firstName} per-line format.</li>
-	 *   <li>{@code "delimited"} &mdash; any run of comma / semicolon / whitespace (space, tab, or
-	 *       line break) becomes a single CRLF, so a list separated by any one of those delimiters is
-	 *       split into entries.</li>
-	 *   <li>{@code "smart"} (default) &mdash; auto-detect the content at the blob level: if the paste
-	 *       contains an {@code @}, treat it as an email blob and extract every email-format token,
-	 *       ignoring surrounding names / punctuation / delimiters; otherwise treat it as a username
-	 *       list and split on any delimiter. Either way the extracted entries are validated
-	 *       downstream and the per-entry lookup routes emails vs usernames.</li>
-	 * </ul>
+	 * Smart-parse a pasted official-account textarea into one entry per CRLF-separated line, so the
+	 * existing per-line parsing handles it unchanged. The content is auto-detected at the blob level:
+	 * if the paste contains an {@code @}, it is treated as an email blob and every email-format token
+	 * is extracted, ignoring surrounding names / punctuation / delimiters; otherwise it is treated as
+	 * a username list and split on any run of comma / semicolon / whitespace. Either way the extracted
+	 * entries are validated downstream and the per-entry lookup routes emails vs usernames.
 	 *
 	 * <p>This drives the <em>official</em> box, whose entries are single tokens (an email or a
 	 * username). The non-official (guest) box carries structured {@code email,lastName,firstName}
-	 * rows, so it is normalized by {@link #normalizeNonOfficial(String, String)} instead, which
-	 * preserves those name fields under smart mode.
+	 * rows, so it is normalized by {@link #normalizeNonOfficial(String)} instead, which preserves
+	 * those name fields.
 	 *
-	 * @param raw  the raw textarea value (may be null)
-	 * @param mode the selected format: "smart", "delimited", or "line"
-	 * @return the text normalized to CRLF-separated entries, or the raw value unchanged
+	 * @param raw the raw textarea value (may be null)
+	 * @return the text normalized to CRLF-separated entries, or null when {@code raw} is null
 	 */
 	// package-private for unit testing
-	String normalizeDelimited(String raw, String mode) {
+	String normalizeSmart(String raw) {
 		if (raw == null) {
 			return null;
 		}
-		if ("smart".equals(mode)) {
-			if (raw.contains(EMAIL_CHAR)) {
-				// looks like an email blob: pull out every address, ignoring names / brackets / junk
-				Matcher m = EMAIL_EXTRACT_PATTERN.matcher(raw);
-				StringBuilder sb = new StringBuilder();
-				while (m.find()) {
-					if (sb.length() > 0) {
-						sb.append("\r\n");
-					}
-					sb.append(m.group());
+		if (raw.contains(EMAIL_CHAR)) {
+			// looks like an email blob: pull out every address, ignoring names / brackets / junk
+			Matcher m = EMAIL_EXTRACT_PATTERN.matcher(raw);
+			StringBuilder sb = new StringBuilder();
+			while (m.find()) {
+				if (sb.length() > 0) {
+					sb.append("\r\n");
 				}
-				return sb.toString();
+				sb.append(m.group());
 			}
-			// no @ anywhere: treat as a username list separated by any delimiter
-			return raw.trim().replaceAll("[,;\\s]+", "\r\n");
+			return sb.toString();
 		}
-		if ("delimited".equals(mode)) {
-			return raw.trim().replaceAll("[,;\\s]+", "\r\n");
-		}
-		return raw;
+		// no @ anywhere: treat as a username list separated by any delimiter
+		return raw.trim().replaceAll("[,;\\s]+", "\r\n");
 	}
 
 	/**
-	 * Normalize the non-official (guest) box, whose per-person format is
-	 * {@code email,lastName,firstName}, into one person per CRLF-separated line.
-	 * <p>Only {@code "smart"} gets special handling here; {@code "line"} and {@code "delimited"}
-	 * defer to {@link #normalizeDelimited(String, String)} unchanged. Under smart mode:
+	 * Smart-parse the non-official (guest) box, whose per-person format is
+	 * {@code email,lastName,firstName}, into one person per CRLF-separated line:
 	 * <ul>
 	 *   <li>people are separated by line breaks or semicolons (a comma stays <em>inside</em> a
 	 *       person as the field separator between email and names);</li>
@@ -1062,17 +1016,13 @@ public class SiteAddParticipantHandler {
 	 * This lets a guest paste keep structured name rows while still accepting a plain comma /
 	 * semicolon / whitespace separated list of addresses.
 	 *
-	 * @param raw  the raw textarea value (may be null)
-	 * @param mode the selected format: "smart", "delimited", or "line"
-	 * @return the text normalized to CRLF-separated entries, or the raw value unchanged
+	 * @param raw the raw textarea value (may be null)
+	 * @return the text normalized to CRLF-separated entries, or null when {@code raw} is null
 	 */
 	// package-private for unit testing
-	String normalizeNonOfficial(String raw, String mode) {
+	String normalizeNonOfficial(String raw) {
 		if (raw == null) {
 			return null;
-		}
-		if (!"smart".equals(mode)) {
-			return normalizeDelimited(raw, mode);
 		}
 		StringBuilder sb = new StringBuilder();
 		// split people on line breaks / semicolons; commas remain inside a person (field separator)
@@ -1185,9 +1135,6 @@ public class SiteAddParticipantHandler {
 		officialAccountParticipant = null;
 		officialAccountEidOnly = new ArrayList<>();
 		nonOfficialAccountParticipant = null;
-		officialDelimiter = "smart";
-		nonOfficialDelimiter = "smart";
-		officialAccountType = "auto";
 		roleChoice = "sameRole";
 		statusChoice = "active";
 		sameRoleChoice = null;

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -810,9 +810,10 @@ public class SiteAddParticipantHandler {
 							updatedOfficialAccountParticipant.append(currentOfficialAccount).append("\n");
 						}
 					} else if (eidsForAllMatches.isEmpty()) {
-						// not valid user
+						// no such user: word the error by what was entered - a well-formed email
+						// that matches no account must not be called an invalid "username"
 						targettedMessageList.addMessage(new TargettedMessage(
-								"java.username",
+								officialAccount.contains(EMAIL_CHAR) ? "java.emailnotfound" : "java.username",
 								new Object[] {officialAccount},
 								TargettedMessage.SEVERITY_ERROR));
 					}

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -967,11 +967,20 @@ public class SiteAddParticipantHandler {
 
 	/**
 	 * Smart-parse a pasted official-account textarea into one entry per CRLF-separated line, so the
-	 * existing per-line parsing handles it unchanged. The content is auto-detected at the blob level:
-	 * if the paste contains an {@code @}, it is treated as an email blob and every email-format token
-	 * is extracted, ignoring surrounding names / punctuation / delimiters; otherwise it is treated as
-	 * a username list and split on any run of comma / semicolon / whitespace. Either way the extracted
-	 * entries are validated downstream and the per-entry lookup routes emails vs usernames.
+	 * existing per-line parsing handles it unchanged. The paste is examined <em>one line at a time</em>
+	 * so the legacy one-entry-per-line format keeps working, including a mixed list of emails and
+	 * usernames on separate lines:
+	 * <ul>
+	 *   <li>a line containing an {@code @} is treated as an email line and every email-format token on
+	 *       it is extracted, ignoring surrounding names / brackets / punctuation (so a messy paste like
+	 *       {@code John Doe <jdoe@x.com>, asmith@y.edu (Alice)} yields both addresses);</li>
+	 *   <li>a line with no {@code @} is treated as a username list and split on any run of comma /
+	 *       semicolon / whitespace.</li>
+	 * </ul>
+	 * Deciding per line (rather than per blob) preserves everything the pre-smart tool accepted — it
+	 * split only on line breaks and routed each entry by the {@code @} char — while additionally
+	 * accepting other delimiters and messy email pastes. Either way the extracted entries are validated
+	 * downstream and the per-entry lookup routes emails vs usernames.
 	 *
 	 * <p>This drives the <em>official</em> box, whose entries are single tokens (an email or a
 	 * username). The non-official (guest) box carries structured {@code email,lastName,firstName}
@@ -986,20 +995,35 @@ public class SiteAddParticipantHandler {
 		if (raw == null) {
 			return null;
 		}
-		if (raw.contains(EMAIL_CHAR)) {
-			// looks like an email blob: pull out every address, ignoring names / brackets / junk
-			Matcher m = EMAIL_EXTRACT_PATTERN.matcher(raw);
-			StringBuilder sb = new StringBuilder();
-			while (m.find()) {
-				if (sb.length() > 0) {
-					sb.append("\r\n");
+		StringBuilder sb = new StringBuilder();
+		for (String line : raw.split("\r\n|\r|\n")) {
+			if (line.contains(EMAIL_CHAR)) {
+				// email line: pull out every address, ignoring names / brackets / junk
+				Matcher m = EMAIL_EXTRACT_PATTERN.matcher(line);
+				while (m.find()) {
+					appendEntry(sb, m.group());
 				}
-				sb.append(m.group());
+			} else {
+				// no @ on this line: treat as a username list separated by any delimiter
+				String trimmed = line.trim();
+				if (!trimmed.isEmpty()) {
+					for (String token : trimmed.split("[,;\\s]+")) {
+						if (!token.isEmpty()) {
+							appendEntry(sb, token);
+						}
+					}
+				}
 			}
-			return sb.toString();
 		}
-		// no @ anywhere: treat as a username list separated by any delimiter
-		return raw.trim().replaceAll("[,;\\s]+", "\r\n");
+		return sb.toString();
+	}
+
+	/** Append one parsed entry to the running CRLF-separated buffer. */
+	private static void appendEntry(StringBuilder sb, String entry) {
+		if (sb.length() > 0) {
+			sb.append("\r\n");
+		}
+		sb.append(entry);
 	}
 
 	/**

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -1005,8 +1005,13 @@ public class SiteAddParticipantHandler {
 	}
 
 	// matches an email-format token anywhere within a blob of pasted text (used by smart parsing).
-	// The local part accepts an apostrophe (o'brien@x.edu) but must not start with one, so a
-	// single-quoted 'jdoe@x.edu' still extracts without the quote.
+	// Deliberately NARROWER than RFC 5322: extraction from prose and validation of a candidate are
+	// different problems. RFC local-part specials (?=&/!#$...) would mis-capture URL fragments
+	// ("page?email=bob@x.edu" must extract bob@x.edu, not the query string), and RFC quoted local
+	// parts can hold spaces. Every extracted candidate is then validated properly - guest addresses
+	// via commons EmailValidator (RFC-grade), official ones by user-directory resolution. The local
+	// part accepts an apostrophe (o'brien@x.edu) but must not start with one, so a single-quoted
+	// 'jdoe@x.edu' still extracts without the quote. Keep in sync with EMAIL_RE in parsed-count.js.
 	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-][A-Za-z0-9._%+'\\-]*@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
 
 	// matches an RFC-style mailbox: an optional display name (one "Last, First" comma allowed,

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -1011,8 +1011,12 @@ public class SiteAddParticipantHandler {
 	// parts can hold spaces. Every extracted candidate is then validated properly - guest addresses
 	// via commons EmailValidator (RFC-grade), official ones by user-directory resolution. The local
 	// part accepts an apostrophe (o'brien@x.edu) but must not start with one, so a single-quoted
-	// 'jdoe@x.edu' still extracts without the quote. Keep in sync with EMAIL_RE in parsed-count.js.
-	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-][A-Za-z0-9._%+'\\-]*@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}");
+	// 'jdoe@x.edu' still extracts without the quote. The trailing lookahead rejects a match that is
+	// only a PREFIX of a longer address-like token (jdoe@example.com123 must surface whole as a
+	// skipped fragment, not silently add jdoe@example.com); the apostrophe is deliberately absent
+	// from that guard so the quoted form above keeps matching before its closing quote.
+	// Keep in sync with EMAIL_RE in parsed-count.js.
+	private static final Pattern EMAIL_EXTRACT_PATTERN = Pattern.compile("[A-Za-z0-9._%+\\-][A-Za-z0-9._%+'\\-]*@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}(?![A-Za-z0-9_%+\\-@])");
 
 	// matches an RFC-style mailbox: an optional display name (one "Last, First" comma allowed,
 	// no @ so a neighboring bare address is never swallowed as a name) followed by <email>

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandler.java
@@ -1080,7 +1080,7 @@ public class SiteAddParticipantHandler {
 			return null;
 		}
 		// Word/Outlook pastes carry non-breaking spaces, which Java's \s does not match
-		raw = raw.replace(' ', ' ');
+		raw = raw.replace('\u00A0', ' ');
 		StringBuilder sb = new StringBuilder();
 		if (!raw.contains(EMAIL_CHAR)) {
 			// no @ anywhere in the paste: a plain username list separated by any delimiter
@@ -1196,7 +1196,7 @@ public class SiteAddParticipantHandler {
 			return null;
 		}
 		// Word/Outlook pastes carry non-breaking spaces, which Java's \s does not match
-		raw = raw.replace(' ', ' ');
+		raw = raw.replace('\u00A0', ' ');
 		StringBuilder sb = new StringBuilder();
 		// split people on line breaks / semicolons; commas remain inside a person (field separator)
 		for (String chunk : raw.split("[;\r\n]+")) {

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
@@ -87,6 +87,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			// csrf token
 			UIInput.make(participantForm, "csrfToken", "#{siteAddParticipantHandler.csrfToken}", handler.csrfToken);
 			// official participant
+			makeAccountTypeSelect(participantForm, handler.officialAccountType);
 			makeDelimiterSelect(participantForm, "official", "#{siteAddParticipantHandler.officialDelimiter}", handler.officialDelimiter);
 			UIInput.make(participantForm, "officialAccountParticipant", "#{siteAddParticipantHandler.officialAccountParticipant}", handler.officialAccountParticipant);
 			UIOutput.make(participantForm, "officialAccountSectionTitle", messageLocator.getMessage("officialAccountSectionTitle"));
@@ -186,6 +187,38 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 				}
 			}
         }
+    }
+
+    /**
+     * Render a radio group (official box only) letting the user declare how to interpret the
+     * pasted entries: "auto" (detect email vs username by the @ char), "email", or "username".
+     * Mirrors the input-format radio group.
+     *
+     * @param form         the participant form container
+     * @param currentValue the handler's current officialAccountType value
+     */
+    private void makeAccountTypeSelect(UIForm form, String currentValue) {
+        String[] values = new String[]{"auto", "email", "username"};
+        String[] labels = new String[]{
+                messageLocator.getMessage("accounttype.auto"),
+                messageLocator.getMessage("accounttype.email"),
+                messageLocator.getMessage("accounttype.username")
+        };
+
+        UIMessage.make(form, "officialAccountTypeLegend", "accounttype.label");
+
+        StringList items = new StringList();
+        UISelect select = UISelect.make(form, "select-official-accounttype", null, "#{siteAddParticipantHandler.officialAccountType}", currentValue);
+        select.optionnames = UIOutputMany.make(labels);
+        String selectID = select.getFullID();
+        for (int i = 0; i < values.length; ++i) {
+            UIBranchContainer row = UIBranchContainer.make(form, "officialAccountType-row:", Integer.toString(i));
+            UISelectLabel lb = UISelectLabel.make(row, "officialAccountType-label", selectID, i);
+            UISelectChoice choice = UISelectChoice.make(row, "officialAccountType-select", selectID, i);
+            UILabelTargetDecorator.targetLabel(lb, choice);
+            items.add(values[i]);
+        }
+        select.optionlist.setValue(items.toStringArray());
     }
 
     /**

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
@@ -87,6 +87,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			// csrf token
 			UIInput.make(participantForm, "csrfToken", "#{siteAddParticipantHandler.csrfToken}", handler.csrfToken);
 			// official participant
+			makeDelimiterSelect(participantForm, "official", "#{siteAddParticipantHandler.officialDelimiter}", handler.officialDelimiter);
 			UIInput.make(participantForm, "officialAccountParticipant", "#{siteAddParticipantHandler.officialAccountParticipant}", handler.officialAccountParticipant);
 			UIOutput.make(participantForm, "officialAccountSectionTitle", messageLocator.getMessage("officialAccountSectionTitle"));
 			UIOutput.make(participantForm, "officialAccountName", messageLocator.getMessage("officialAccountName"));
@@ -101,6 +102,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			// non official participant
 			String allowAddNonOfficialParticipant = handler.getAllowNonOfficialAccount();
 			if (allowAddNonOfficialParticipant.equalsIgnoreCase("true")) {
+				makeDelimiterSelect(participantForm, "nonofficial", "#{siteAddParticipantHandler.nonOfficialDelimiter}", handler.nonOfficialDelimiter);
 				UIInput.make(participantForm, "nonOfficialAccountParticipant", "#{siteAddParticipantHandler.nonOfficialAccountParticipant}", handler.nonOfficialAccountParticipant);
 				UIOutput.make(participantForm, "nonOfficialAccountSectionTitle", messageLocator.getMessage("nonOfficialAccountSectionTitle"));
 				UIOutput.make(participantForm, "nonOfficialAccountName", messageLocator.getMessage("nonOfficialAccountName"));
@@ -184,6 +186,40 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 				}
 			}
         }
+    }
+
+    /**
+     * Render a radio group letting the user choose the input format for an account textarea:
+     * "line" (one entry per line, the default) or "delimited" (comma / semicolon / line-break
+     * separated). Mirrors the role-choice radio group above.
+     *
+     * @param form         the participant form container
+     * @param prefix       rsf id prefix, "official" or "nonofficial"
+     * @param binding      EL binding for the selected value on the handler
+     * @param currentValue the handler's current value for this field
+     */
+    private void makeDelimiterSelect(UIForm form, String prefix, String binding, String currentValue) {
+        String[] values = new String[]{"line", "delimited", "smart"};
+        String[] labels = new String[]{
+                messageLocator.getMessage("delimiter.line"),
+                messageLocator.getMessage("delimiter.delimited"),
+                messageLocator.getMessage("delimiter.smart")
+        };
+
+        UIMessage.make(form, prefix + "DelimiterLegend", "delimiter.label");
+
+        StringList items = new StringList();
+        UISelect select = UISelect.make(form, "select-" + prefix + "-delimiter", null, binding, currentValue);
+        select.optionnames = UIOutputMany.make(labels);
+        String selectID = select.getFullID();
+        for (int i = 0; i < values.length; ++i) {
+            UIBranchContainer row = UIBranchContainer.make(form, prefix + "Delimiter-row:", Integer.toString(i));
+            UISelectLabel lb = UISelectLabel.make(row, prefix + "Delimiter-label", selectID, i);
+            UISelectChoice choice = UISelectChoice.make(row, prefix + "Delimiter-select", selectID, i);
+            UILabelTargetDecorator.targetLabel(lb, choice);
+            items.add(values[i]);
+        }
+        select.optionlist.setValue(items.toStringArray());
     }
 
     public ViewParameters getViewParameters() {

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
@@ -96,6 +96,7 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			UIOutput.make(participantForm, "countEmailsTmpl", messageLocator.getMessage("add.count.emails"));
 			UIOutput.make(participantForm, "countUsernamesTmpl", messageLocator.getMessage("add.count.usernames"));
 			UIOutput.make(participantForm, "countMixedTmpl", messageLocator.getMessage("add.count.mixed"));
+			UIOutput.make(participantForm, "countSkippedTmpl", messageLocator.getMessage("add.count.skipped"));
 
 			String pickerAction = handler.getServerConfigurationString("officialAccountPickerAction");
 			if (pickerAction != null && !pickerAction.isEmpty()) {

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
@@ -87,8 +87,6 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			// csrf token
 			UIInput.make(participantForm, "csrfToken", "#{siteAddParticipantHandler.csrfToken}", handler.csrfToken);
 			// official participant
-			makeAccountTypeSelect(participantForm, handler.officialAccountType);
-			makeDelimiterSelect(participantForm, "official", "#{siteAddParticipantHandler.officialDelimiter}", handler.officialDelimiter);
 			UIInput.make(participantForm, "officialAccountParticipant", "#{siteAddParticipantHandler.officialAccountParticipant}", handler.officialAccountParticipant);
 			UIOutput.make(participantForm, "officialAccountSectionTitle", messageLocator.getMessage("officialAccountSectionTitle"));
 			UIOutput.make(participantForm, "officialAccountName", messageLocator.getMessage("officialAccountName"));
@@ -108,7 +106,6 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			// non official participant
 			String allowAddNonOfficialParticipant = handler.getAllowNonOfficialAccount();
 			if (allowAddNonOfficialParticipant.equalsIgnoreCase("true")) {
-				makeDelimiterSelect(participantForm, "nonofficial", "#{siteAddParticipantHandler.nonOfficialDelimiter}", handler.nonOfficialDelimiter);
 				UIInput.make(participantForm, "nonOfficialAccountParticipant", "#{siteAddParticipantHandler.nonOfficialAccountParticipant}", handler.nonOfficialAccountParticipant);
 				UIOutput.make(participantForm, "nonOfficialAccountSectionTitle", messageLocator.getMessage("nonOfficialAccountSectionTitle"));
 				UIOutput.make(participantForm, "nonOfficialAccountName", messageLocator.getMessage("nonOfficialAccountName"));
@@ -192,72 +189,6 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 				}
 			}
         }
-    }
-
-    /**
-     * Render a radio group (official box only) letting the user declare how to interpret the
-     * pasted entries: "auto" (detect email vs username by the @ char), "email", or "username".
-     * Mirrors the input-format radio group.
-     *
-     * @param form         the participant form container
-     * @param currentValue the handler's current officialAccountType value
-     */
-    private void makeAccountTypeSelect(UIForm form, String currentValue) {
-        String[] values = new String[]{"auto", "email", "username"};
-        String[] labels = new String[]{
-                messageLocator.getMessage("accounttype.auto"),
-                messageLocator.getMessage("accounttype.email"),
-                messageLocator.getMessage("accounttype.username")
-        };
-
-        UIMessage.make(form, "officialAccountTypeLegend", "accounttype.label");
-
-        StringList items = new StringList();
-        UISelect select = UISelect.make(form, "select-official-accounttype", null, "#{siteAddParticipantHandler.officialAccountType}", currentValue);
-        select.optionnames = UIOutputMany.make(labels);
-        String selectID = select.getFullID();
-        for (int i = 0; i < values.length; ++i) {
-            UIBranchContainer row = UIBranchContainer.make(form, "officialAccountType-row:", Integer.toString(i));
-            UISelectLabel lb = UISelectLabel.make(row, "officialAccountType-label", selectID, i);
-            UISelectChoice choice = UISelectChoice.make(row, "officialAccountType-select", selectID, i);
-            UILabelTargetDecorator.targetLabel(lb, choice);
-            items.add(values[i]);
-        }
-        select.optionlist.setValue(items.toStringArray());
-    }
-
-    /**
-     * Render a radio group letting the user choose the input format for an account textarea:
-     * "line" (one entry per line, the default) or "delimited" (comma / semicolon / line-break
-     * separated). Mirrors the role-choice radio group above.
-     *
-     * @param form         the participant form container
-     * @param prefix       rsf id prefix, "official" or "nonofficial"
-     * @param binding      EL binding for the selected value on the handler
-     * @param currentValue the handler's current value for this field
-     */
-    private void makeDelimiterSelect(UIForm form, String prefix, String binding, String currentValue) {
-        String[] values = new String[]{"line", "delimited", "smart"};
-        String[] labels = new String[]{
-                messageLocator.getMessage("delimiter.line"),
-                messageLocator.getMessage("delimiter.delimited"),
-                messageLocator.getMessage("delimiter.smart")
-        };
-
-        UIMessage.make(form, prefix + "DelimiterLegend", "delimiter.label");
-
-        StringList items = new StringList();
-        UISelect select = UISelect.make(form, "select-" + prefix + "-delimiter", null, binding, currentValue);
-        select.optionnames = UIOutputMany.make(labels);
-        String selectID = select.getFullID();
-        for (int i = 0; i < values.length; ++i) {
-            UIBranchContainer row = UIBranchContainer.make(form, prefix + "Delimiter-row:", Integer.toString(i));
-            UISelectLabel lb = UISelectLabel.make(row, prefix + "Delimiter-label", selectID, i);
-            UISelectChoice choice = UISelectChoice.make(row, prefix + "Delimiter-select", selectID, i);
-            UILabelTargetDecorator.targetLabel(lb, choice);
-            items.add(values[i]);
-        }
-        select.optionlist.setValue(items.toStringArray());
     }
 
     public ViewParameters getViewParameters() {

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/rsf/AddProducer.java
@@ -94,6 +94,11 @@ public class AddProducer implements ViewComponentProducer, NavigationCaseReporte
 			UIOutput.make(participantForm, "officialAccountName", messageLocator.getMessage("officialAccountName"));
 			UIOutput.make(participantForm, "officialAccountLabel", messageLocator.getMessage("officialAccountLabel"));
 
+			// localized templates for the live "parsed count" indicator (rendered client-side in Add.html)
+			UIOutput.make(participantForm, "countEmailsTmpl", messageLocator.getMessage("add.count.emails"));
+			UIOutput.make(participantForm, "countUsernamesTmpl", messageLocator.getMessage("add.count.usernames"));
+			UIOutput.make(participantForm, "countMixedTmpl", messageLocator.getMessage("add.count.mixed"));
+
 			String pickerAction = handler.getServerConfigurationString("officialAccountPickerAction");
 			if (pickerAction != null && !pickerAction.isEmpty()) {
 				UIOutput.make(participantForm, "officialAccountPickerLabel", handler.getServerConfigurationString("officialAccountPickerLabel"));

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -49,36 +51,98 @@ public class SiteAddParticipantHandlerTest {
                 .toArray(String[]::new);
     }
 
+    /** Fragments the parse flagged as skipped (each becomes a visible alert in the tool). */
+    private List<String> skipped;
+
+    /** normalizeSmart, collecting skipped fragments into {@link #skipped}. */
+    private String smart(String raw) {
+        skipped = new ArrayList<>();
+        return handler.normalizeSmart(raw, skipped);
+    }
+
+    /** normalizeNonOfficial, collecting skipped fragments into {@link #skipped}. */
+    private String nonOfficial(String raw) {
+        skipped = new ArrayList<>();
+        return handler.normalizeNonOfficial(raw, skipped);
+    }
+
     // ---- normalizeSmart: extract emails from any blob, or split a username list --------------
 
     @Test
     public void nullInputReturnsNull() {
-        assertNull(handler.normalizeSmart(null));
+        assertNull(smart(null));
     }
 
     @Test
     public void smartExtractsEmailsFromMessyBlob() {
         String blob = "Please add John Doe <jdoe@yahoo.com>, and asmith@x.edu (Alice); "
                 + "also \"bob@sub.domain.co.uk\" -- thanks!";
-        String out = handler.normalizeSmart(blob);
+        String out = smart(blob);
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com", "asmith@x.edu", "bob@sub.domain.co.uk"},
                 entries(out));
+        // prose and display names around the addresses are not "skipped entries"
+        assertTrue("expected no skipped fragments, got " + skipped, skipped.isEmpty());
     }
 
     @Test
-    public void smartEmailLineExtractsEmailsAndDropsNameFragments() {
-        // a single line that contains an '@' is an email line: only email-format tokens are kept,
-        // so bare tokens sharing the line (name fragments) are dropped
-        String out = handler.normalizeSmart("jsmith, teacher01, real@x.com");
+    public void smartEmailLineFlagsNameFragmentsAsSkipped() {
+        // a lone delimited token sharing a line with an email address is never dropped silently:
+        // it is excluded from the entries but flagged so the user gets a visible alert
+        String out = smart("jsmith, teacher01, real@x.com");
         assertArrayEquals(new String[] {"real@x.com"}, entries(out));
+        assertEquals(Arrays.asList("jsmith", "teacher01"), skipped);
+    }
+
+    @Test
+    public void smartFlagsMistypedEmailInsteadOfDroppingIt() {
+        // regression guard for the silent-drop hole: a typo'd address (missing TLD) must surface
+        // as a skipped fragment, not vanish while the rest of the paste is added
+        String out = smart("a@x.com\r\njdoe@iu\r\nb@y.com");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com"}, entries(out));
+        assertEquals(Arrays.asList("jdoe@iu"), skipped);
+    }
+
+    @Test
+    public void smartFlagsMistypedEmailSharingALineWithAValidOne() {
+        String out = smart("a@x.com jdoe@iu");
+        assertArrayEquals(new String[] {"a@x.com"}, entries(out));
+        assertEquals(Arrays.asList("jdoe@iu"), skipped);
+    }
+
+    @Test
+    public void smartConsumesOutlookLastFirstMailboxes() {
+        // Outlook recipient pastes: the display name may hold a comma ("Last, First"), quoted or
+        // not — the name must be consumed with its <email>, not leak fragments like "Doe"
+        String out = smart("\"Doe, John\" <jdoe@x.edu>; Roe, Jane <jroe@x.edu>");
+        assertArrayEquals(new String[] {"jdoe@x.edu", "jroe@x.edu"}, entries(out));
+        assertTrue("expected no skipped fragments, got " + skipped, skipped.isEmpty());
     }
 
     @Test
     public void smartUsernameListSplitsOnAnyDelimiter() {
         // no '@' anywhere: detected as a username list and split on any delimiter
-        String out = handler.normalizeSmart("jsmith, teacher01; prof.x  admin1");
+        String out = smart("jsmith, teacher01; prof.x  admin1");
         assertArrayEquals(new String[] {"jsmith", "teacher01", "prof.x", "admin1"}, entries(out));
+        assertTrue(skipped.isEmpty());
+    }
+
+    // ---- email extraction keeps RFC-valid characters ------------------------------------------
+
+    @Test
+    public void smartKeepsApostropheLocalParts() {
+        // o'brien@x.edu must extract whole: truncating to brien@x.edu could silently add a
+        // different, real user
+        String out = smart("o'brien@x.edu, d'angelo.jr@y.org");
+        assertArrayEquals(new String[] {"o'brien@x.edu", "d'angelo.jr@y.org"}, entries(out));
+        assertTrue(skipped.isEmpty());
+    }
+
+    @Test
+    public void smartDropsSurroundingSingleQuotes() {
+        String out = smart("'jdoe@x.edu'");
+        assertArrayEquals(new String[] {"jdoe@x.edu"}, entries(out));
+        assertTrue(skipped.isEmpty());
     }
 
     // ---- normalizeSmart: legacy one-entry-per-line formats must keep working -----------------
@@ -87,7 +151,7 @@ public class SiteAddParticipantHandlerTest {
     public void smartKeepsLegacyMixedEmailAndUsernameLines() {
         // regression guard: the pre-smart tool split on line breaks and routed each line by the '@'
         // char, so a mixed list of usernames and emails, one per line, must still add ALL of them
-        String out = handler.normalizeSmart("jsmith\r\njdoe@x.com\r\nteacher01\r\nasmith@y.edu");
+        String out = smart("jsmith\r\njdoe@x.com\r\nteacher01\r\nasmith@y.edu");
         assertArrayEquals(
                 new String[] {"jsmith", "jdoe@x.com", "teacher01", "asmith@y.edu"},
                 entries(out));
@@ -95,13 +159,13 @@ public class SiteAddParticipantHandlerTest {
 
     @Test
     public void smartKeepsLegacyOneUsernamePerLine() {
-        String out = handler.normalizeSmart("jsmith\r\nteacher01\r\nadmin1");
+        String out = smart("jsmith\r\nteacher01\r\nadmin1");
         assertArrayEquals(new String[] {"jsmith", "teacher01", "admin1"}, entries(out));
     }
 
     @Test
     public void smartKeepsLegacyOneEmailPerLine() {
-        String out = handler.normalizeSmart("a@x.com\r\nb@y.com\r\nc@z.com");
+        String out = smart("a@x.com\r\nb@y.com\r\nc@z.com");
         assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
     }
 
@@ -109,7 +173,7 @@ public class SiteAddParticipantHandlerTest {
     public void smartExtractsMultipleEmailsFromASingleLine() {
         // improvement over legacy: a line with several addresses (any delimiter) is split, not
         // rejected as one invalid entry
-        String out = handler.normalizeSmart("a@x.com b@y.com\r\nc@z.com");
+        String out = smart("a@x.com b@y.com\r\nc@z.com");
         assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
     }
 
@@ -118,7 +182,7 @@ public class SiteAddParticipantHandlerTest {
     @Test
     public void nonOfficialKeepsStructuredRowIntact() {
         // regression: a legacy guest row must NOT be flattened to the email
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John");
+        String out = nonOfficial("jdoe@yahoo.com,Doe,John");
         assertArrayEquals(new String[] {"jdoe@yahoo.com,Doe,John"}, entries(out));
         // and the name fields still survive the downstream per-line parse
         assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John"},
@@ -127,7 +191,7 @@ public class SiteAddParticipantHandlerTest {
 
     @Test
     public void nonOfficialKeepsMultipleStructuredLines() {
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John\r\nasmith@x.edu,Smith,Alice");
+        String out = nonOfficial("jdoe@yahoo.com,Doe,John\r\nasmith@x.edu,Smith,Alice");
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com,Doe,John", "asmith@x.edu,Smith,Alice"},
                 entries(out));
@@ -136,7 +200,7 @@ public class SiteAddParticipantHandlerTest {
     @Test
     public void nonOfficialSeparatesPeopleOnSemicolonsKeepingNames() {
         // semicolons separate people; the comma inside each person stays as the field separator
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John; asmith@x.edu,Smith,Alice");
+        String out = nonOfficial("jdoe@yahoo.com,Doe,John; asmith@x.edu,Smith,Alice");
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com,Doe,John", "asmith@x.edu,Smith,Alice"},
                 entries(out));
@@ -145,13 +209,30 @@ public class SiteAddParticipantHandlerTest {
     @Test
     public void nonOfficialSplitsBareEmailBlob() {
         // no names: a comma/whitespace list of addresses on one line becomes one email per line
-        String out = handler.normalizeNonOfficial("a@x.com, b@y.com c@z.com");
+        String out = nonOfficial("a@x.com, b@y.com c@z.com");
         assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+        assertTrue(skipped.isEmpty());
+    }
+
+    @Test
+    public void nonOfficialFlagsMistypedEmailInBlob() {
+        // a typo'd address inside a multi-address blob must surface as skipped, not vanish
+        String out = nonOfficial("a@x.com, b@y c@z.net");
+        assertArrayEquals(new String[] {"a@x.com", "c@z.net"}, entries(out));
+        assertEquals(Arrays.asList("b@y"), skipped);
+    }
+
+    @Test
+    public void nonOfficialKeepsApostropheLocalPartsInBlob() {
+        // regression guard: truncating o'brien@x.edu to brien@x.edu would invite a stranger
+        String out = nonOfficial("o'brien@x.edu, o'malley@y.edu");
+        assertArrayEquals(new String[] {"o'brien@x.edu", "o'malley@y.edu"}, entries(out));
+        assertTrue(skipped.isEmpty());
     }
 
     @Test
     public void nonOfficialHandlesMixOfStructuredRowsAndBlobLine() {
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John\r\na@x.com, b@y.com");
+        String out = nonOfficial("jdoe@yahoo.com,Doe,John\r\na@x.com, b@y.com");
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com,Doe,John", "a@x.com", "b@y.com"},
                 entries(out));
@@ -159,7 +240,7 @@ public class SiteAddParticipantHandlerTest {
 
     @Test
     public void nonOfficialNullReturnsNull() {
-        assertNull(handler.normalizeNonOfficial(null));
+        assertNull(nonOfficial(null));
     }
 
     // ---- parseAccountIntoParts: non-official email,lastName,firstName ------------------------
@@ -225,7 +306,7 @@ public class SiteAddParticipantHandlerTest {
     @Test
     public void smartExtractionProducesValidatableEmails() {
         String blob = "team: alice@x.edu; bob@y.org,  carol@z.net";
-        for (String eid : entries(handler.normalizeSmart(blob))) {
+        for (String eid : entries(smart(blob))) {
             assertTrue("expected extracted token to validate: " + eid, handler.isValidMail(eid));
         }
     }

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -27,8 +27,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Focused unit tests for the pasted-input handling in {@link SiteAddParticipantHandler}:
- * the input-format normalization ("line" / "delimited" / "smart"), the non-official
+ * Focused unit tests for the pasted-input handling in {@link SiteAddParticipantHandler}: the
+ * smart-parse normalization of the official box, the non-official
  * {@code email,lastName,firstName} parsing, and email validation. These methods are pure
  * (no injected services), so the handler is exercised directly.
  */
@@ -49,62 +49,18 @@ public class SiteAddParticipantHandlerTest {
                 .toArray(String[]::new);
     }
 
-    // ---- normalizeDelimited: line mode (default, backward compatible) ----------------------
+    // ---- normalizeSmart: extract emails from any blob, or split a username list --------------
 
     @Test
-    public void lineModeReturnsRawUnchanged() {
-        String raw = "jdoe@yahoo.com,Doe,John\r\nasmith@x.edu";
-        // line mode must not touch the text, preserving the email,last,first per-line format
-        assertEquals(raw, handler.normalizeDelimited(raw, "line"));
+    public void nullInputReturnsNull() {
+        assertNull(handler.normalizeSmart(null));
     }
-
-    @Test
-    public void nullInputReturnsNullInEveryMode() {
-        assertNull(handler.normalizeDelimited(null, "line"));
-        assertNull(handler.normalizeDelimited(null, "delimited"));
-        assertNull(handler.normalizeDelimited(null, "smart"));
-    }
-
-    @Test
-    public void unknownModeFallsBackToRaw() {
-        String raw = "a@x.com,b@y.com";
-        assertEquals(raw, handler.normalizeDelimited(raw, "bogus"));
-    }
-
-    // ---- normalizeDelimited: delimited mode ------------------------------------------------
-
-    @Test
-    public void delimitedSplitsOnCommas() {
-        String out = handler.normalizeDelimited("a@x.com,b@y.com,c@z.com", "delimited");
-        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
-    }
-
-    @Test
-    public void delimitedSplitsOnSemicolons() {
-        String out = handler.normalizeDelimited("a@x.com;b@y.com;c@z.com", "delimited");
-        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
-    }
-
-    @Test
-    public void delimitedHandlesMixedDelimitersWhitespaceAndEmptyRuns() {
-        // commas, semicolons, spaces, newlines and repeated/trailing delimiters all collapse
-        String out = handler.normalizeDelimited("a@x.com, b@y.com;;\n  c@z.com , ", "delimited");
-        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
-    }
-
-    @Test
-    public void delimitedSplitsOnPlainWhitespace() {
-        String out = handler.normalizeDelimited("a@x.com b@y.com\tc@z.com", "delimited");
-        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
-    }
-
-    // ---- normalizeDelimited: smart mode (extract emails from any blob) ----------------------
 
     @Test
     public void smartExtractsEmailsFromMessyBlob() {
         String blob = "Please add John Doe <jdoe@yahoo.com>, and asmith@x.edu (Alice); "
                 + "also \"bob@sub.domain.co.uk\" -- thanks!";
-        String out = handler.normalizeDelimited(blob, "smart");
+        String out = handler.normalizeSmart(blob);
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com", "asmith@x.edu", "bob@sub.domain.co.uk"},
                 entries(out));
@@ -114,32 +70,23 @@ public class SiteAddParticipantHandlerTest {
     public void smartEmailBlobExtractsEmailsAndDropsStrayUsernames() {
         // the blob contains an '@', so it is detected as an email blob: only email-format tokens
         // are kept (a bare username mixed into an email blob is dropped)
-        String out = handler.normalizeDelimited("jsmith, teacher01, real@x.com", "smart");
+        String out = handler.normalizeSmart("jsmith, teacher01, real@x.com");
         assertArrayEquals(new String[] {"real@x.com"}, entries(out));
     }
 
     @Test
     public void smartUsernameListSplitsOnAnyDelimiter() {
         // no '@' anywhere: detected as a username list and split on any delimiter
-        String out = handler.normalizeDelimited("jsmith, teacher01; prof.x  admin1", "smart");
+        String out = handler.normalizeSmart("jsmith, teacher01; prof.x  admin1");
         assertArrayEquals(new String[] {"jsmith", "teacher01", "prof.x", "admin1"}, entries(out));
     }
 
-    @Test
-    public void smartDefaultsAreSelected() {
-        // Smart parse is the default input format for both boxes
-        SiteAddParticipantHandler fresh = new SiteAddParticipantHandler();
-        assertEquals("smart", fresh.officialDelimiter);
-        assertEquals("smart", fresh.nonOfficialDelimiter);
-        assertEquals("auto", fresh.officialAccountType);
-    }
-
-    // ---- normalizeNonOfficial: guest box keeps email,lastName,firstName under smart -----------
+    // ---- normalizeNonOfficial: guest box keeps email,lastName,firstName ----------------------
 
     @Test
-    public void nonOfficialSmartKeepsStructuredRowIntact() {
-        // regression: with smart the default, a legacy guest row must NOT be flattened to the email
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John", "smart");
+    public void nonOfficialKeepsStructuredRowIntact() {
+        // regression: a legacy guest row must NOT be flattened to the email
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John");
         assertArrayEquals(new String[] {"jdoe@yahoo.com,Doe,John"}, entries(out));
         // and the name fields still survive the downstream per-line parse
         assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John"},
@@ -147,50 +94,40 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
-    public void nonOfficialSmartKeepsMultipleStructuredLines() {
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John\r\nasmith@x.edu,Smith,Alice", "smart");
+    public void nonOfficialKeepsMultipleStructuredLines() {
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John\r\nasmith@x.edu,Smith,Alice");
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com,Doe,John", "asmith@x.edu,Smith,Alice"},
                 entries(out));
     }
 
     @Test
-    public void nonOfficialSmartSeparatesPeopleOnSemicolonsKeepingNames() {
+    public void nonOfficialSeparatesPeopleOnSemicolonsKeepingNames() {
         // semicolons separate people; the comma inside each person stays as the field separator
-        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John; asmith@x.edu,Smith,Alice", "smart");
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John; asmith@x.edu,Smith,Alice");
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com,Doe,John", "asmith@x.edu,Smith,Alice"},
                 entries(out));
     }
 
     @Test
-    public void nonOfficialSmartSplitsBareEmailBlob() {
+    public void nonOfficialSplitsBareEmailBlob() {
         // no names: a comma/whitespace list of addresses on one line becomes one email per line
-        String out = handler.normalizeNonOfficial("a@x.com, b@y.com c@z.com", "smart");
+        String out = handler.normalizeNonOfficial("a@x.com, b@y.com c@z.com");
         assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
     }
 
     @Test
-    public void nonOfficialSmartHandlesMixOfStructuredRowsAndBlobLine() {
-        String out = handler.normalizeNonOfficial(
-                "jdoe@yahoo.com,Doe,John\r\na@x.com, b@y.com", "smart");
+    public void nonOfficialHandlesMixOfStructuredRowsAndBlobLine() {
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John\r\na@x.com, b@y.com");
         assertArrayEquals(
                 new String[] {"jdoe@yahoo.com,Doe,John", "a@x.com", "b@y.com"},
                 entries(out));
     }
 
     @Test
-    public void nonOfficialNonSmartModesDeferToNormalizeDelimited() {
-        String raw = "jdoe@yahoo.com,Doe,John\r\nasmith@x.edu";
-        assertEquals(handler.normalizeDelimited(raw, "line"),
-                handler.normalizeNonOfficial(raw, "line"));
-        assertEquals(handler.normalizeDelimited(raw, "delimited"),
-                handler.normalizeNonOfficial(raw, "delimited"));
-    }
-
-    @Test
     public void nonOfficialNullReturnsNull() {
-        assertNull(handler.normalizeNonOfficial(null, "smart"));
+        assertNull(handler.normalizeNonOfficial(null));
     }
 
     // ---- parseAccountIntoParts: non-official email,lastName,firstName ------------------------
@@ -251,29 +188,12 @@ public class SiteAddParticipantHandlerTest {
         assertFalse(handler.isValidMail("spaces in@email.com"));
     }
 
-    // ---- effectiveOfficialMode: Account type vs input format interaction --------------------
-
-    @Test
-    public void usernameWithSmartFallsBackToDelimited() {
-        // smart extraction is email-regex based and cannot match bare usernames
-        assertEquals("delimited", handler.effectiveOfficialMode("username", "smart"));
-    }
-
-    @Test
-    public void otherAccountTypesKeepChosenInputFormat() {
-        assertEquals("smart", handler.effectiveOfficialMode("auto", "smart"));
-        assertEquals("smart", handler.effectiveOfficialMode("email", "smart"));
-        assertEquals("line", handler.effectiveOfficialMode("username", "line"));
-        assertEquals("delimited", handler.effectiveOfficialMode("username", "delimited"));
-        assertEquals("delimited", handler.effectiveOfficialMode("auto", "delimited"));
-    }
-
     // ---- end-to-end of the parsing seam: smart extraction feeds email-only accounts ---------
 
     @Test
     public void smartExtractionProducesValidatableEmails() {
         String blob = "team: alice@x.edu; bob@y.org,  carol@z.net";
-        for (String eid : entries(handler.normalizeDelimited(blob, "smart"))) {
+        for (String eid : entries(handler.normalizeSmart(blob))) {
             assertTrue("expected extracted token to validate: " + eid, handler.isValidMail(eid));
         }
     }

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -54,10 +55,18 @@ public class SiteAddParticipantHandlerTest {
     /** Fragments the parse flagged as skipped (each becomes a visible alert in the tool). */
     private List<String> skipped;
 
-    /** normalizeSmart, collecting skipped fragments into {@link #skipped}. */
+    /** Eid-plausible fragments that matched no registered username (noted, not added). */
+    private List<String> unmatched;
+
+    /** Stand-in for the user directory: the eids "registered" on this fake instance. */
+    private static final Set<String> REGISTERED_EIDS = Set.of(
+            "jsmith", "teacher01", "prof.x", "admin1", "instructor7", "grader02", "first.last");
+
+    /** normalizeSmart against {@link #REGISTERED_EIDS}, collecting {@link #skipped}/{@link #unmatched}. */
     private String smart(String raw) {
         skipped = new ArrayList<>();
-        return handler.normalizeSmart(raw, skipped);
+        unmatched = new ArrayList<>();
+        return handler.normalizeSmart(raw, skipped, unmatched, REGISTERED_EIDS::contains);
     }
 
     /** normalizeNonOfficial, collecting skipped fragments into {@link #skipped}. */
@@ -86,43 +95,65 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
-    public void smartEmailLineKeepsBareTokensAsUsernames() {
-        // the box accepts usernames AND emails, so a lone delimited token without an @ sharing a
-        // line with an email address is kept as a username entry, not dropped or flagged
+    public void smartEmailLineKeepsRegisteredUsernames() {
+        // the box accepts usernames AND emails: a delimited no-@ token that resolves to a
+        // registered eid is a username entry
         String out = smart("jsmith, teacher01, real@x.com");
         assertArrayEquals(new String[] {"jsmith", "teacher01", "real@x.com"}, entries(out));
         assertTrue("expected no skipped fragments, got " + skipped, skipped.isEmpty());
+        assertTrue("expected no unmatched fragments, got " + unmatched, unmatched.isEmpty());
     }
 
     @Test
-    public void smartEmailLineIgnoresMultiWordNameFragments() {
-        // an unbracketed multi-word fragment (a display name) is ignored, not guessed at as
-        // usernames — only lone tokens count as deliberate entries
+    public void smartUsernameWithPeriodResolves() {
+        // eids like first.last are legal (a period is not an eid-impossible character)
+        String out = smart("first.last, jdoe@x.edu");
+        assertArrayEquals(new String[] {"first.last", "jdoe@x.edu"}, entries(out));
+        assertTrue(unmatched.isEmpty());
+    }
+
+    @Test
+    public void smartWordRunResolvesWhenEveryWordIsRegistered() {
+        // all-words-resolve: a whitespace run is a username list only when EVERY word resolves,
+        // so "instructor7 grader02" works but a display name can never partially match
+        String out = smart("instructor7 grader02\r\njdoe@x.edu");
+        assertArrayEquals(new String[] {"instructor7", "grader02", "jdoe@x.edu"}, entries(out));
+        assertTrue(unmatched.isEmpty());
+    }
+
+    @Test
+    public void smartDisplayNameRunGoesToUnmatchedNotLookup() {
+        // "John Doe" is eid-plausible but does not fully resolve (even if a real user "john"
+        // existed, "doe" would not): reported as unmatched, never partially added
         String out = smart("John Doe, jdoe@x.edu");
         assertArrayEquals(new String[] {"jdoe@x.edu"}, entries(out));
+        assertEquals(Arrays.asList("John Doe"), unmatched);
         assertTrue(skipped.isEmpty());
     }
 
     @Test
     public void smartIgnoresProseLinesInAnEmailPaste() {
         // pasting a whole request email must not shred greeting/prose lines (which hold no @)
-        // into bogus username lookups: with email material present, multi-word runs are prose
+        // into bogus lookups: unresolved words are noted as unmatched, punctuated prose ignored
         String out = smart("Hi, can you add these folks from my course?\r\n"
                 + "\"O'Brien, Pat\" <p.o'brien@iu.edu>; Roe, Jane <jroe@iu.edu>\r\n"
                 + "also carol.white@iu.edu (Carol) and bob@iu -- thanks!");
         assertArrayEquals(
-                new String[] {"Hi", "p.o'brien@iu.edu", "jroe@iu.edu", "carol.white@iu.edu"},
+                new String[] {"p.o'brien@iu.edu", "jroe@iu.edu", "carol.white@iu.edu"},
                 entries(out));
         assertEquals(Arrays.asList("bob@iu"), skipped);
+        // "Hi" was username-shaped but unregistered; the punctuated sentence was plain prose
+        assertEquals(Arrays.asList("Hi"), unmatched);
     }
 
     @Test
     public void smartEmailLineIgnoresTokensThatCannotBeUsernames() {
-        // a lone token holding characters a Sakai eid can never contain (cleanEid strips <>,;:\/
-        // and Validator.checkUserId rejects ^%*?) is signature/prose junk, not a username lookup
+        // a token holding characters a Sakai eid can never contain (cleanEid strips <>,;:\/
+        // and Validator.checkUserId rejects ^%*?) is signature/prose junk: no lookup, no note
         String out = smart("https://cal.example.edu/book-me, jdoe@x.edu");
         assertArrayEquals(new String[] {"jdoe@x.edu"}, entries(out));
         assertTrue(skipped.isEmpty());
+        assertTrue(unmatched.isEmpty());
     }
 
     @Test

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -180,6 +180,23 @@ public class SiteAddParticipantHandlerTest {
         assertFalse(handler.isValidMail("spaces in@email.com"));
     }
 
+    // ---- effectiveOfficialMode: Account type vs input format interaction --------------------
+
+    @Test
+    public void usernameWithSmartFallsBackToDelimited() {
+        // smart extraction is email-regex based and cannot match bare usernames
+        assertEquals("delimited", handler.effectiveOfficialMode("username", "smart"));
+    }
+
+    @Test
+    public void otherAccountTypesKeepChosenInputFormat() {
+        assertEquals("smart", handler.effectiveOfficialMode("auto", "smart"));
+        assertEquals("smart", handler.effectiveOfficialMode("email", "smart"));
+        assertEquals("line", handler.effectiveOfficialMode("username", "line"));
+        assertEquals("delimited", handler.effectiveOfficialMode("username", "delimited"));
+        assertEquals("delimited", handler.effectiveOfficialMode("auto", "delimited"));
+    }
+
     // ---- end-to-end of the parsing seam: smart extraction feeds email-only accounts ---------
 
     @Test

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -134,6 +134,65 @@ public class SiteAddParticipantHandlerTest {
         assertEquals("auto", fresh.officialAccountType);
     }
 
+    // ---- normalizeNonOfficial: guest box keeps email,lastName,firstName under smart -----------
+
+    @Test
+    public void nonOfficialSmartKeepsStructuredRowIntact() {
+        // regression: with smart the default, a legacy guest row must NOT be flattened to the email
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John", "smart");
+        assertArrayEquals(new String[] {"jdoe@yahoo.com,Doe,John"}, entries(out));
+        // and the name fields still survive the downstream per-line parse
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John"},
+                handler.parseAccountIntoParts(entries(out)[0]));
+    }
+
+    @Test
+    public void nonOfficialSmartKeepsMultipleStructuredLines() {
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John\r\nasmith@x.edu,Smith,Alice", "smart");
+        assertArrayEquals(
+                new String[] {"jdoe@yahoo.com,Doe,John", "asmith@x.edu,Smith,Alice"},
+                entries(out));
+    }
+
+    @Test
+    public void nonOfficialSmartSeparatesPeopleOnSemicolonsKeepingNames() {
+        // semicolons separate people; the comma inside each person stays as the field separator
+        String out = handler.normalizeNonOfficial("jdoe@yahoo.com,Doe,John; asmith@x.edu,Smith,Alice", "smart");
+        assertArrayEquals(
+                new String[] {"jdoe@yahoo.com,Doe,John", "asmith@x.edu,Smith,Alice"},
+                entries(out));
+    }
+
+    @Test
+    public void nonOfficialSmartSplitsBareEmailBlob() {
+        // no names: a comma/whitespace list of addresses on one line becomes one email per line
+        String out = handler.normalizeNonOfficial("a@x.com, b@y.com c@z.com", "smart");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+    }
+
+    @Test
+    public void nonOfficialSmartHandlesMixOfStructuredRowsAndBlobLine() {
+        String out = handler.normalizeNonOfficial(
+                "jdoe@yahoo.com,Doe,John\r\na@x.com, b@y.com", "smart");
+        assertArrayEquals(
+                new String[] {"jdoe@yahoo.com,Doe,John", "a@x.com", "b@y.com"},
+                entries(out));
+    }
+
+    @Test
+    public void nonOfficialNonSmartModesDeferToNormalizeDelimited() {
+        String raw = "jdoe@yahoo.com,Doe,John\r\nasmith@x.edu";
+        assertEquals(handler.normalizeDelimited(raw, "line"),
+                handler.normalizeNonOfficial(raw, "line"));
+        assertEquals(handler.normalizeDelimited(raw, "delimited"),
+                handler.normalizeNonOfficial(raw, "delimited"));
+    }
+
+    @Test
+    public void nonOfficialNullReturnsNull() {
+        assertNull(handler.normalizeNonOfficial(null, "smart"));
+    }
+
     // ---- parseAccountIntoParts: non-official email,lastName,firstName ------------------------
 
     @Test

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -86,12 +86,30 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
-    public void smartEmailLineFlagsNameFragmentsAsSkipped() {
-        // a lone delimited token sharing a line with an email address is never dropped silently:
-        // it is excluded from the entries but flagged so the user gets a visible alert
+    public void smartEmailLineKeepsBareTokensAsUsernames() {
+        // the box accepts usernames AND emails, so a lone delimited token without an @ sharing a
+        // line with an email address is kept as a username entry, not dropped or flagged
         String out = smart("jsmith, teacher01, real@x.com");
-        assertArrayEquals(new String[] {"real@x.com"}, entries(out));
-        assertEquals(Arrays.asList("jsmith", "teacher01"), skipped);
+        assertArrayEquals(new String[] {"jsmith", "teacher01", "real@x.com"}, entries(out));
+        assertTrue("expected no skipped fragments, got " + skipped, skipped.isEmpty());
+    }
+
+    @Test
+    public void smartEmailLineIgnoresMultiWordNameFragments() {
+        // an unbracketed multi-word fragment (a display name) is ignored, not guessed at as
+        // usernames — only lone tokens count as deliberate entries
+        String out = smart("John Doe, jdoe@x.edu");
+        assertArrayEquals(new String[] {"jdoe@x.edu"}, entries(out));
+        assertTrue(skipped.isEmpty());
+    }
+
+    @Test
+    public void smartEmailLineIgnoresTokensThatCannotBeUsernames() {
+        // a lone token holding characters a Sakai eid can never contain (cleanEid strips <>,;:\/
+        // and Validator.checkUserId rejects ^%*?) is signature/prose junk, not a username lookup
+        String out = smart("https://cal.example.edu/book-me, jdoe@x.edu");
+        assertArrayEquals(new String[] {"jdoe@x.edu"}, entries(out));
+        assertTrue(skipped.isEmpty());
     }
 
     @Test

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -104,6 +104,19 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
+    public void smartIgnoresProseLinesInAnEmailPaste() {
+        // pasting a whole request email must not shred greeting/prose lines (which hold no @)
+        // into bogus username lookups: with email material present, multi-word runs are prose
+        String out = smart("Hi, can you add these folks from my course?\r\n"
+                + "\"O'Brien, Pat\" <p.o'brien@iu.edu>; Roe, Jane <jroe@iu.edu>\r\n"
+                + "also carol.white@iu.edu (Carol) and bob@iu -- thanks!");
+        assertArrayEquals(
+                new String[] {"Hi", "p.o'brien@iu.edu", "jroe@iu.edu", "carol.white@iu.edu"},
+                entries(out));
+        assertEquals(Arrays.asList("bob@iu"), skipped);
+    }
+
+    @Test
     public void smartEmailLineIgnoresTokensThatCannotBeUsernames() {
         // a lone token holding characters a Sakai eid can never contain (cleanEid strips <>,;:\/
         // and Validator.checkUserId rejects ^%*?) is signature/prose junk, not a username lookup

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -67,9 +67,9 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
-    public void smartEmailBlobExtractsEmailsAndDropsStrayUsernames() {
-        // the blob contains an '@', so it is detected as an email blob: only email-format tokens
-        // are kept (a bare username mixed into an email blob is dropped)
+    public void smartEmailLineExtractsEmailsAndDropsNameFragments() {
+        // a single line that contains an '@' is an email line: only email-format tokens are kept,
+        // so bare tokens sharing the line (name fragments) are dropped
         String out = handler.normalizeSmart("jsmith, teacher01, real@x.com");
         assertArrayEquals(new String[] {"real@x.com"}, entries(out));
     }
@@ -79,6 +79,38 @@ public class SiteAddParticipantHandlerTest {
         // no '@' anywhere: detected as a username list and split on any delimiter
         String out = handler.normalizeSmart("jsmith, teacher01; prof.x  admin1");
         assertArrayEquals(new String[] {"jsmith", "teacher01", "prof.x", "admin1"}, entries(out));
+    }
+
+    // ---- normalizeSmart: legacy one-entry-per-line formats must keep working -----------------
+
+    @Test
+    public void smartKeepsLegacyMixedEmailAndUsernameLines() {
+        // regression guard: the pre-smart tool split on line breaks and routed each line by the '@'
+        // char, so a mixed list of usernames and emails, one per line, must still add ALL of them
+        String out = handler.normalizeSmart("jsmith\r\njdoe@x.com\r\nteacher01\r\nasmith@y.edu");
+        assertArrayEquals(
+                new String[] {"jsmith", "jdoe@x.com", "teacher01", "asmith@y.edu"},
+                entries(out));
+    }
+
+    @Test
+    public void smartKeepsLegacyOneUsernamePerLine() {
+        String out = handler.normalizeSmart("jsmith\r\nteacher01\r\nadmin1");
+        assertArrayEquals(new String[] {"jsmith", "teacher01", "admin1"}, entries(out));
+    }
+
+    @Test
+    public void smartKeepsLegacyOneEmailPerLine() {
+        String out = handler.normalizeSmart("a@x.com\r\nb@y.com\r\nc@z.com");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+    }
+
+    @Test
+    public void smartExtractsMultipleEmailsFromASingleLine() {
+        // improvement over legacy: a line with several addresses (any delimiter) is split, not
+        // rejected as one invalid entry
+        String out = handler.normalizeSmart("a@x.com b@y.com\r\nc@z.com");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
     }
 
     // ---- normalizeNonOfficial: guest box keeps email,lastName,firstName ----------------------

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -111,15 +111,27 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
-    public void smartIgnoresNonEmailTokensLikeBareUsernames() {
-        // bare usernames have no '@' and are not extracted in smart mode
+    public void smartEmailBlobExtractsEmailsAndDropsStrayUsernames() {
+        // the blob contains an '@', so it is detected as an email blob: only email-format tokens
+        // are kept (a bare username mixed into an email blob is dropped)
         String out = handler.normalizeDelimited("jsmith, teacher01, real@x.com", "smart");
         assertArrayEquals(new String[] {"real@x.com"}, entries(out));
     }
 
     @Test
-    public void smartWithNoEmailsYieldsEmpty() {
-        assertEquals(0, entries(handler.normalizeDelimited("no addresses here", "smart")).length);
+    public void smartUsernameListSplitsOnAnyDelimiter() {
+        // no '@' anywhere: detected as a username list and split on any delimiter
+        String out = handler.normalizeDelimited("jsmith, teacher01; prof.x  admin1", "smart");
+        assertArrayEquals(new String[] {"jsmith", "teacher01", "prof.x", "admin1"}, entries(out));
+    }
+
+    @Test
+    public void smartDefaultsAreSelected() {
+        // Smart parse is the default input format for both boxes
+        SiteAddParticipantHandler fresh = new SiteAddParticipantHandler();
+        assertEquals("smart", fresh.officialDelimiter);
+        assertEquals("smart", fresh.nonOfficialDelimiter);
+        assertEquals("auto", fresh.officialAccountType);
     }
 
     // ---- parseAccountIntoParts: non-official email,lastName,firstName ------------------------

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.site.tool.helper.participant.impl;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Focused unit tests for the pasted-input handling in {@link SiteAddParticipantHandler}:
+ * the input-format normalization ("line" / "delimited" / "smart"), the non-official
+ * {@code email,lastName,firstName} parsing, and email validation. These methods are pure
+ * (no injected services), so the handler is exercised directly.
+ */
+public class SiteAddParticipantHandlerTest {
+
+    private SiteAddParticipantHandler handler;
+
+    @Before
+    public void setUp() {
+        handler = new SiteAddParticipantHandler();
+    }
+
+    /** Split a normalized blob the same way checkAddParticipant() does, dropping blank entries. */
+    private String[] entries(String normalized) {
+        return Arrays.stream(normalized.split("\r\n"))
+                .map(s -> s.replaceAll("[\t\r\n]", "").trim())
+                .filter(s -> !s.isEmpty())
+                .toArray(String[]::new);
+    }
+
+    // ---- normalizeDelimited: line mode (default, backward compatible) ----------------------
+
+    @Test
+    public void lineModeReturnsRawUnchanged() {
+        String raw = "jdoe@yahoo.com,Doe,John\r\nasmith@x.edu";
+        // line mode must not touch the text, preserving the email,last,first per-line format
+        assertEquals(raw, handler.normalizeDelimited(raw, "line"));
+    }
+
+    @Test
+    public void nullInputReturnsNullInEveryMode() {
+        assertNull(handler.normalizeDelimited(null, "line"));
+        assertNull(handler.normalizeDelimited(null, "delimited"));
+        assertNull(handler.normalizeDelimited(null, "smart"));
+    }
+
+    @Test
+    public void unknownModeFallsBackToRaw() {
+        String raw = "a@x.com,b@y.com";
+        assertEquals(raw, handler.normalizeDelimited(raw, "bogus"));
+    }
+
+    // ---- normalizeDelimited: delimited mode ------------------------------------------------
+
+    @Test
+    public void delimitedSplitsOnCommas() {
+        String out = handler.normalizeDelimited("a@x.com,b@y.com,c@z.com", "delimited");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+    }
+
+    @Test
+    public void delimitedSplitsOnSemicolons() {
+        String out = handler.normalizeDelimited("a@x.com;b@y.com;c@z.com", "delimited");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+    }
+
+    @Test
+    public void delimitedHandlesMixedDelimitersWhitespaceAndEmptyRuns() {
+        // commas, semicolons, spaces, newlines and repeated/trailing delimiters all collapse
+        String out = handler.normalizeDelimited("a@x.com, b@y.com;;\n  c@z.com , ", "delimited");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+    }
+
+    @Test
+    public void delimitedSplitsOnPlainWhitespace() {
+        String out = handler.normalizeDelimited("a@x.com b@y.com\tc@z.com", "delimited");
+        assertArrayEquals(new String[] {"a@x.com", "b@y.com", "c@z.com"}, entries(out));
+    }
+
+    // ---- normalizeDelimited: smart mode (extract emails from any blob) ----------------------
+
+    @Test
+    public void smartExtractsEmailsFromMessyBlob() {
+        String blob = "Please add John Doe <jdoe@yahoo.com>, and asmith@x.edu (Alice); "
+                + "also \"bob@sub.domain.co.uk\" -- thanks!";
+        String out = handler.normalizeDelimited(blob, "smart");
+        assertArrayEquals(
+                new String[] {"jdoe@yahoo.com", "asmith@x.edu", "bob@sub.domain.co.uk"},
+                entries(out));
+    }
+
+    @Test
+    public void smartIgnoresNonEmailTokensLikeBareUsernames() {
+        // bare usernames have no '@' and are not extracted in smart mode
+        String out = handler.normalizeDelimited("jsmith, teacher01, real@x.com", "smart");
+        assertArrayEquals(new String[] {"real@x.com"}, entries(out));
+    }
+
+    @Test
+    public void smartWithNoEmailsYieldsEmpty() {
+        assertEquals(0, entries(handler.normalizeDelimited("no addresses here", "smart")).length);
+    }
+
+    // ---- parseAccountIntoParts: non-official email,lastName,firstName ------------------------
+
+    @Test
+    public void parseEmailOnly() {
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "", ""},
+                handler.parseAccountIntoParts("jdoe@yahoo.com"));
+    }
+
+    @Test
+    public void parseEmailWithLastName() {
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", ""},
+                handler.parseAccountIntoParts("jdoe@yahoo.com,Doe"));
+    }
+
+    @Test
+    public void parseEmailWithLastAndFirstName() {
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John"},
+                handler.parseAccountIntoParts("jdoe@yahoo.com,Doe,John"));
+    }
+
+    @Test
+    public void parseTrimsWhitespaceAndTrailingDotsOnEmail() {
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John"},
+                handler.parseAccountIntoParts(" jdoe@yahoo.com. , Doe , John "));
+    }
+
+    @Test
+    public void parseKeepsOnlyFirstThreeCommaParts() {
+        // split(",", 3): anything past the second comma stays inside the firstName field
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John,Q"},
+                handler.parseAccountIntoParts("jdoe@yahoo.com,Doe,John,Q"));
+    }
+
+    @Test
+    public void parseBlankReturnsNull() {
+        assertNull(handler.parseAccountIntoParts("   "));
+        assertNull(handler.parseAccountIntoParts(""));
+        assertNull(handler.parseAccountIntoParts(null));
+    }
+
+    // ---- isValidMail -----------------------------------------------------------------------
+
+    @Test
+    public void validEmailsPass() {
+        assertTrue(handler.isValidMail("jdoe@yahoo.com"));
+        assertTrue(handler.isValidMail("  first.last+tag@sub.domain.co.uk  "));
+    }
+
+    @Test
+    public void invalidEmailsFail() {
+        assertFalse(handler.isValidMail(null));
+        assertFalse(handler.isValidMail(""));
+        assertFalse(handler.isValidMail("not-an-email"));
+        assertFalse(handler.isValidMail("missing@domain"));
+        assertFalse(handler.isValidMail("@no-local.com"));
+        assertFalse(handler.isValidMail("spaces in@email.com"));
+    }
+
+    // ---- end-to-end of the parsing seam: smart extraction feeds email-only accounts ---------
+
+    @Test
+    public void smartExtractionProducesValidatableEmails() {
+        String blob = "team: alice@x.edu; bob@y.org,  carol@z.net";
+        for (String eid : entries(handler.normalizeDelimited(blob, "smart"))) {
+            assertTrue("expected extracted token to validate: " + eid, handler.isValidMail(eid));
+        }
+    }
+}

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -207,6 +207,15 @@ public class SiteAddParticipantHandlerTest {
         assertTrue(skipped.isEmpty());
     }
 
+    @Test
+    public void smartFlagsEmailWithTrailingJunkInsteadOfExtractingAPrefix() {
+        // jdoe@example.com123 must not silently become jdoe@example.com (a different, possibly
+        // real mailbox): the whole token surfaces as skipped so the user can fix it
+        String out = smart("a@x.com, jdoe@example.com123");
+        assertArrayEquals(new String[] {"a@x.com"}, entries(out));
+        assertEquals(Arrays.asList("jdoe@example.com123"), skipped);
+    }
+
     // ---- normalizeSmart: legacy one-entry-per-line formats must keep working -----------------
 
     @Test
@@ -282,6 +291,13 @@ public class SiteAddParticipantHandlerTest {
         String out = nonOfficial("a@x.com, b@y c@z.net");
         assertArrayEquals(new String[] {"a@x.com", "c@z.net"}, entries(out));
         assertEquals(Arrays.asList("b@y"), skipped);
+    }
+
+    @Test
+    public void nonOfficialFlagsEmailWithTrailingJunkInBlob() {
+        String out = nonOfficial("a@x.com, jdoe@example.com123, c@z.net");
+        assertArrayEquals(new String[] {"a@x.com", "c@z.net"}, entries(out));
+        assertEquals(Arrays.asList("jdoe@example.com123"), skipped);
     }
 
     @Test

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/SiteAddParticipantHandlerTest.java
@@ -293,6 +293,15 @@ public class SiteAddParticipantHandlerTest {
     }
 
     @Test
+    public void nonOfficialNormalizesNonBreakingSpacesInStructuredRow() {
+        // Word/Outlook pastes carry U+00A0 after the commas; String.trim() does not remove it,
+        // so without normalization the guest's name fields would keep a leading NBSP
+        String out = nonOfficial("jdoe@yahoo.com,\u00A0Doe,\u00A0John");
+        assertArrayEquals(new String[] {"jdoe@yahoo.com", "Doe", "John"},
+                handler.parseAccountIntoParts(entries(out)[0]));
+    }
+
+    @Test
     public void nonOfficialHandlesMixOfStructuredRowsAndBlobLine() {
         String out = nonOfficial("jdoe@yahoo.com,Doe,John\r\na@x.com, b@y.com");
         assertArrayEquals(

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -62,6 +62,27 @@
 		return raw.split(/\r\n|\r|\n/).map(function (s) { return s.trim(); }).filter(Boolean);
 	}
 
+	// non-official (guest) box mirror of SiteAddParticipantHandler.normalizeNonOfficial: smart mode
+	// keeps structured "email,lastName,firstName" rows intact (one person per line/semicolon) and
+	// only splits a chunk that holds more than one email. "line"/"delimited" defer to normalize().
+	function normalizeNonOfficial(raw, mode) {
+		raw = raw || "";
+		if (!raw.trim()) return [];
+		if (mode !== "smart") return normalize(raw, mode);
+		var out = [];
+		raw.split(/[;\r\n]+/).forEach(function (chunk) {
+			var person = chunk.trim();
+			if (!person) return;
+			var emails = person.match(EMAIL_RE) || [];
+			if (emails.length > 1) {
+				emails.forEach(function (e) { out.push(e); });
+			} else {
+				out.push(person);
+			}
+		});
+		return out;
+	}
+
 	function classify(entries, accountType) {
 		var e = 0, u = 0;
 		entries.forEach(function (entry) {
@@ -83,7 +104,7 @@
 		return templates.usernames.replace("#N#", c.u);
 	}
 
-	function wire(templates, outputId, delimiterName, accountTypeName) {
+	function wire(templates, outputId, delimiterName, accountTypeName, nonOfficial) {
 		var out = document.getElementById(outputId);
 		if (!out) return;
 		var ta = textareaFor(out);
@@ -92,7 +113,8 @@
 		function update() {
 			var delimiter = checkedValue(delimiterName);
 			var accountType = accountTypeName ? checkedValue(accountTypeName) : null;
-			var entries = normalize(ta.value, effectiveMode(accountType, delimiter));
+			var mode = effectiveMode(accountType, delimiter);
+			var entries = nonOfficial ? normalizeNonOfficial(ta.value, mode) : normalize(ta.value, mode);
 			out.textContent = format(templates, classify(entries, accountType));
 		}
 
@@ -109,7 +131,7 @@
 			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)")
 		};
 		wire(templates, "officialAccountCount", "officialDelimiter", "officialAccountType");
-		wire(templates, "nonOfficialAccountCount", "nonOfficialDelimiter", null);
+		wire(templates, "nonOfficialAccountCount", "nonOfficialDelimiter", null, true);
 	}
 
 	if (document.readyState === "loading") {

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -1,0 +1,106 @@
+/*
+ * Live "parsed count" indicator for the Add Participants textareas.
+ *
+ * Mirrors SiteAddParticipantHandler.normalizeDelimited / effectiveOfficialMode so the user
+ * sees how many entries were parsed out of their paste. Loaded as an external file (rather than
+ * inline) because the template is processed by RSF/IKAT as XML, which mangles inline scripts
+ * containing '<', '>' or '&&'.
+ *
+ * Keep EMAIL_RE in sync with EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler.
+ */
+(function () {
+	"use strict";
+
+	var EMAIL_RE = /[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
+
+	function txt(id, fallback) {
+		var el = document.getElementById(id);
+		var s = el ? (el.textContent || "").trim() : "";
+		return s || fallback;
+	}
+
+	function checkedValue(name) {
+		var el = document.querySelector('input[name="' + name + '"]:checked');
+		return el ? el.value : null;
+	}
+
+	// usernames can't be regex-extracted, so username+smart falls back to delimited
+	function effectiveMode(accountType, delimiter) {
+		if (accountType === "username" && delimiter === "smart") return "delimited";
+		return delimiter || "smart";
+	}
+
+	// returns the list of entries the server would parse out of the raw textarea value
+	function normalize(raw, mode) {
+		raw = raw || "";
+		if (!raw.trim()) return [];
+		if (mode === "smart") {
+			if (raw.indexOf("@") >= 0) return raw.match(EMAIL_RE) || [];
+			return raw.trim().split(/[,;\s]+/).filter(Boolean);
+		}
+		if (mode === "delimited") return raw.trim().split(/[,;\s]+/).filter(Boolean);
+		// "line": one entry per non-empty line
+		return raw.split(/\r\n|\r|\n/).map(function (s) { return s.trim(); }).filter(Boolean);
+	}
+
+	function classify(entries, accountType) {
+		var e = 0, u = 0;
+		entries.forEach(function (entry) {
+			var isEmail;
+			if (accountType === "email") isEmail = true;
+			else if (accountType === "username") isEmail = false;
+			else isEmail = entry.indexOf("@") >= 0;
+			if (isEmail) e++; else u++;
+		});
+		return { e: e, u: u, n: entries.length };
+	}
+
+	function format(templates, c) {
+		if (c.n === 0) return "";
+		if (c.e > 0 && c.u > 0) {
+			return templates.mixed.replace("#N#", c.n).replace("#E#", c.e).replace("#U#", c.u);
+		}
+		if (c.u === 0) return templates.emails.replace("#N#", c.e);
+		return templates.usernames.replace("#N#", c.u);
+	}
+
+	function wire(templates, textareaId, delimiterName, accountTypeName, outputId) {
+		var ta = document.getElementById(textareaId);
+		var out = document.getElementById(outputId);
+		if (!ta || !out) return;
+
+		function update() {
+			var delimiter = checkedValue(delimiterName);
+			var accountType = accountTypeName ? checkedValue(accountTypeName) : null;
+			var entries = normalize(ta.value, effectiveMode(accountType, delimiter));
+			out.textContent = format(templates, classify(entries, accountType));
+		}
+
+		ta.addEventListener("input", update);
+		document.querySelectorAll('input[name="' + delimiterName + '"]').forEach(function (r) {
+			r.addEventListener("change", update);
+		});
+		if (accountTypeName) {
+			document.querySelectorAll('input[name="' + accountTypeName + '"]').forEach(function (r) {
+				r.addEventListener("change", update);
+			});
+		}
+		update();
+	}
+
+	function init() {
+		var templates = {
+			emails: txt("countEmailsTmpl", "#N# emails detected"),
+			usernames: txt("countUsernamesTmpl", "#N# usernames detected"),
+			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)")
+		};
+		wire(templates, "officialAccountParticipant", "officialDelimiter", "officialAccountType", "officialAccountCount");
+		wire(templates, "nonOfficialAccountParticipant", "nonOfficialDelimiter", null, "nonOfficialAccountCount");
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", init);
+	} else {
+		init();
+	}
+})();

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -13,7 +13,9 @@
 (function () {
 	"use strict";
 
-	var EMAIL_RE = /[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
+	var EMAIL_RE = /[A-Za-z0-9._%+\-][A-Za-z0-9._%+'\-]*@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
+	// an RFC-style mailbox: optional display name (one "Last, First" comma allowed, no @) + <email>
+	var MAILBOX_RE = new RegExp("[^<>,;@]*(?:,[^<>,;@]*)?<\\s*(" + EMAIL_RE.source + ")\\s*>", "g");
 
 	/**
 	 * Read the trimmed text content of an element, falling back to a default when the element is
@@ -51,49 +53,78 @@
 	}
 
 	/**
-	 * Mirror of SiteAddParticipantHandler.normalizeSmart for the official box: return the list of
-	 * entries the server would parse out of the raw textarea value. Each line is handled on its own so
-	 * a mixed email/username list keeps working: a line with an "@" has its emails extracted; a line
-	 * without an "@" is split into usernames on any delimiter.
+	 * Mirror of SiteAddParticipantHandler.normalizeSmart for the official box: return the entries
+	 * the server would parse out of the raw textarea value, plus the fragments it would flag as
+	 * skipped. Each line is handled on its own so a mixed email/username list keeps working: on a
+	 * line with an "@", "Name <email>" mailboxes and bare addresses are extracted, while a leftover
+	 * token holding an "@" (a mistyped address) or standing alone between delimiters is skipped;
+	 * a line without an "@" is split into usernames on any delimiter.
 	 * @param {string} raw the raw textarea value
-	 * @returns {string[]} the parsed entries (empty when the input is blank)
+	 * @returns {{entries: string[], skipped: string[]}} parsed entries and skipped fragments
 	 */
 	function normalize(raw) {
 		raw = raw || "";
-		if (!raw.trim()) return [];
-		var out = [];
+		var out = [], skipped = [];
+		if (!raw.trim()) return { entries: out, skipped: skipped };
 		raw.split(/\r\n|\r|\n/).forEach(function (line) {
 			if (line.indexOf("@") >= 0) {
-				(line.match(EMAIL_RE) || []).forEach(function (e) { out.push(e); });
+				// first take every "display name <email>" mailbox, keeping only the address
+				var rest = line.replace(MAILBOX_RE, function (m, email) {
+					out.push(email);
+					return " ";
+				});
+				rest.split(/[,;]+/).forEach(function (chunk) {
+					var c = chunk.trim();
+					if (!c) return;
+					if (c.indexOf("@") >= 0) {
+						var residue = c.replace(EMAIL_RE, function (email) {
+							out.push(email);
+							return " ";
+						});
+						residue.split(/\s+/).forEach(function (t) {
+							if (t.indexOf("@") >= 0) skipped.push(t);
+						});
+					} else if (c.split(/\s+/).length === 1) {
+						skipped.push(c);
+					}
+					// multi-word chunks without an @ are name/prose fragments: ignored
+				});
 			} else {
 				line.trim().split(/[,;\s]+/).filter(Boolean).forEach(function (u) { out.push(u); });
 			}
 		});
-		return out;
+		return { entries: out, skipped: skipped };
 	}
 
 	/**
 	 * Mirror of SiteAddParticipantHandler.normalizeNonOfficial for the non-official (guest) box.
 	 * Keeps structured "email,lastName,firstName" rows intact (one person per line or semicolon) and
-	 * only splits a chunk that holds more than one email.
+	 * only splits a chunk that holds more than one email; in that blob case, a leftover token still
+	 * holding an "@" (a mistyped address) is flagged as skipped.
 	 * @param {string} raw the raw textarea value
-	 * @returns {string[]} one entry per guest (empty when the input is blank)
+	 * @returns {{entries: string[], skipped: string[]}} one entry per guest, plus skipped fragments
 	 */
 	function normalizeNonOfficial(raw) {
 		raw = raw || "";
-		if (!raw.trim()) return [];
-		var out = [];
+		var out = [], skipped = [];
+		if (!raw.trim()) return { entries: out, skipped: skipped };
 		raw.split(/[;\r\n]+/).forEach(function (chunk) {
 			var person = chunk.trim();
 			if (!person) return;
 			var emails = person.match(EMAIL_RE) || [];
 			if (emails.length > 1) {
-				emails.forEach(function (e) { out.push(e); });
+				var residue = person.replace(EMAIL_RE, function (email) {
+					out.push(email);
+					return " ";
+				});
+				residue.split(/[,\s]+/).forEach(function (t) {
+					if (t.indexOf("@") >= 0) skipped.push(t);
+				});
 			} else {
 				out.push(person);
 			}
 		});
-		return out;
+		return { entries: out, skipped: skipped };
 	}
 
 	/**
@@ -111,18 +142,28 @@
 
 	/**
 	 * Render the count message from the localized templates, choosing the emails-only,
-	 * usernames-only, or mixed phrasing based on the tally.
-	 * @param {{emails: string, usernames: string, mixed: string}} templates localized strings
+	 * usernames-only, or mixed phrasing based on the tally, with a skipped-fragment warning
+	 * appended when the parse had to skip anything.
+	 * @param {{emails: string, usernames: string, mixed: string, skipped: string}} templates localized strings
 	 * @param {{e: number, u: number, n: number}} c the tally from {@link classify}
-	 * @returns {string} the display text (empty when there are no entries)
+	 * @param {number} skippedCount how many fragments the parse flagged as skipped
+	 * @returns {string} the display text (empty when there is nothing to report)
 	 */
-	function format(templates, c) {
-		if (c.n === 0) return "";
-		if (c.e > 0 && c.u > 0) {
-			return templates.mixed.replace("#N#", c.n).replace("#E#", c.e).replace("#U#", c.u);
+	function format(templates, c, skippedCount) {
+		var parts = [];
+		if (c.n > 0) {
+			if (c.e > 0 && c.u > 0) {
+				parts.push(templates.mixed.replace("#N#", c.n).replace("#E#", c.e).replace("#U#", c.u));
+			} else if (c.u === 0) {
+				parts.push(templates.emails.replace("#N#", c.e));
+			} else {
+				parts.push(templates.usernames.replace("#N#", c.u));
+			}
 		}
-		if (c.u === 0) return templates.emails.replace("#N#", c.e);
-		return templates.usernames.replace("#N#", c.u);
+		if (skippedCount > 0) {
+			parts.push(templates.skipped.replace("#S#", skippedCount));
+		}
+		return parts.join(" — ");
 	}
 
 	/**
@@ -137,15 +178,18 @@
 		var out = document.getElementById(outputId);
 		if (!out) return;
 		var ta = textareaFor(out);
-		if (!ta) return;
+		// a textarea belongs to at most one count output: when RSF omits a textarea (e.g. guest
+		// accounts disabled), its orphaned count element must not latch onto the other textarea
+		if (!ta || ta.dataset.parsedCountFor) return;
+		ta.dataset.parsedCountFor = outputId;
 
 		/**
 		 * Recompute and render the count from the textarea's current value.
 		 * @returns {void}
 		 */
 		function update() {
-			var entries = nonOfficial ? normalizeNonOfficial(ta.value) : normalize(ta.value);
-			out.textContent = format(templates, classify(entries));
+			var parsed = nonOfficial ? normalizeNonOfficial(ta.value) : normalize(ta.value);
+			out.textContent = format(templates, classify(parsed.entries), parsed.skipped.length);
 		}
 
 		ta.addEventListener("input", update);
@@ -160,7 +204,8 @@
 		var templates = {
 			emails: txt("countEmailsTmpl", "#N# emails detected"),
 			usernames: txt("countUsernamesTmpl", "#N# usernames detected"),
-			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)")
+			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)"),
+			skipped: txt("countSkippedTmpl", "#S# skipped (not a complete email address)")
 		};
 		wire(templates, "officialAccountCount");
 		wire(templates, "nonOfficialAccountCount", true);

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -16,6 +16,10 @@
 	var EMAIL_RE = /[A-Za-z0-9._%+\-][A-Za-z0-9._%+'\-]*@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
 	// an RFC-style mailbox: optional display name (one "Last, First" comma allowed, no @) + <email>
 	var MAILBOX_RE = new RegExp("[^<>,;@]*(?:,[^<>,;@]*)?<\\s*(" + EMAIL_RE.source + ")\\s*>", "g");
+	// characters a Sakai username (eid) can never contain — mirror of
+	// SiteAddParticipantHandler.EID_IMPOSSIBLE_CHARS (cleanEid strips <>,;:\/ and
+	// Validator.checkUserId rejects ^%*?)
+	var EID_IMPOSSIBLE_RE = /[<>,;:\\\/^%*?]/;
 
 	/**
 	 * Read the trimmed text content of an element, falling back to a default when the element is
@@ -56,9 +60,10 @@
 	 * Mirror of SiteAddParticipantHandler.normalizeSmart for the official box: return the entries
 	 * the server would parse out of the raw textarea value, plus the fragments it would flag as
 	 * skipped. Each line is handled on its own so a mixed email/username list keeps working: on a
-	 * line with an "@", "Name <email>" mailboxes and bare addresses are extracted, while a leftover
-	 * token holding an "@" (a mistyped address) or standing alone between delimiters is skipped;
-	 * a line without an "@" is split into usernames on any delimiter.
+	 * line with an "@", "Name <email>" mailboxes and bare addresses are extracted and a lone
+	 * delimited token without an "@" counts as a username, while a leftover token still holding
+	 * an "@" (a mistyped address) is skipped; a line without an "@" is split into usernames on
+	 * any delimiter.
 	 * @param {string} raw the raw textarea value
 	 * @returns {{entries: string[], skipped: string[]}} parsed entries and skipped fragments
 	 */
@@ -84,10 +89,12 @@
 						residue.split(/\s+/).forEach(function (t) {
 							if (t.indexOf("@") >= 0) skipped.push(t);
 						});
-					} else if (c.split(/\s+/).length === 1) {
-						skipped.push(c);
+					} else if (c.split(/\s+/).length === 1 && !EID_IMPOSSIBLE_RE.test(c)) {
+						// lone delimited token without an @: a username entry (box takes both)
+						out.push(c);
 					}
-					// multi-word chunks without an @ are name/prose fragments: ignored
+					// multi-word chunks without an @ (name/prose fragments) and lone tokens
+					// holding eid-impossible characters (URLs, paths) are ignored
 				});
 			} else {
 				line.trim().split(/[,;\s]+/).filter(Boolean).forEach(function (u) { out.push(u); });

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -59,11 +59,10 @@
 	/**
 	 * Mirror of SiteAddParticipantHandler.normalizeSmart for the official box: return the entries
 	 * the server would parse out of the raw textarea value, plus the fragments it would flag as
-	 * skipped. Each line is handled on its own so a mixed email/username list keeps working: on a
-	 * line with an "@", "Name <email>" mailboxes and bare addresses are extracted and a lone
-	 * delimited token without an "@" counts as a username, while a leftover token still holding
-	 * an "@" (a mistyped address) is skipped; a line without an "@" is split into usernames on
-	 * any delimiter.
+	 * skipped. A paste with no "@" anywhere is a plain username list split on any delimiter;
+	 * otherwise every line uses the email rules: "Name <email>" mailboxes and bare addresses are
+	 * extracted, a lone delimited token without an "@" counts as a username, a leftover token
+	 * still holding an "@" (a mistyped address) is skipped, and multi-word prose is ignored.
 	 * @param {string} raw the raw textarea value
 	 * @returns {{entries: string[], skipped: string[]}} parsed entries and skipped fragments
 	 */
@@ -71,34 +70,37 @@
 		raw = raw || "";
 		var out = [], skipped = [];
 		if (!raw.trim()) return { entries: out, skipped: skipped };
+		if (raw.indexOf("@") < 0) {
+			// no @ anywhere in the paste: a plain username list separated by any delimiter
+			raw.trim().split(/[,;\s]+/).filter(Boolean).forEach(function (u) { out.push(u); });
+			return { entries: out, skipped: skipped };
+		}
+		// the paste holds email material: parse every line with the email rules, so prose lines
+		// of a pasted request are not shredded into bogus username lookups
 		raw.split(/\r\n|\r|\n/).forEach(function (line) {
-			if (line.indexOf("@") >= 0) {
-				// first take every "display name <email>" mailbox, keeping only the address
-				var rest = line.replace(MAILBOX_RE, function (m, email) {
-					out.push(email);
-					return " ";
-				});
-				rest.split(/[,;]+/).forEach(function (chunk) {
-					var c = chunk.trim();
-					if (!c) return;
-					if (c.indexOf("@") >= 0) {
-						var residue = c.replace(EMAIL_RE, function (email) {
-							out.push(email);
-							return " ";
-						});
-						residue.split(/\s+/).forEach(function (t) {
-							if (t.indexOf("@") >= 0) skipped.push(t);
-						});
-					} else if (c.split(/\s+/).length === 1 && !EID_IMPOSSIBLE_RE.test(c)) {
-						// lone delimited token without an @: a username entry (box takes both)
-						out.push(c);
-					}
-					// multi-word chunks without an @ (name/prose fragments) and lone tokens
-					// holding eid-impossible characters (URLs, paths) are ignored
-				});
-			} else {
-				line.trim().split(/[,;\s]+/).filter(Boolean).forEach(function (u) { out.push(u); });
-			}
+			// first take every "display name <email>" mailbox, keeping only the address
+			var rest = line.replace(MAILBOX_RE, function (m, email) {
+				out.push(email);
+				return " ";
+			});
+			rest.split(/[,;]+/).forEach(function (chunk) {
+				var c = chunk.trim();
+				if (!c) return;
+				if (c.indexOf("@") >= 0) {
+					var residue = c.replace(EMAIL_RE, function (email) {
+						out.push(email);
+						return " ";
+					});
+					residue.split(/\s+/).forEach(function (t) {
+						if (t.indexOf("@") >= 0) skipped.push(t);
+					});
+				} else if (c.split(/\s+/).length === 1 && !EID_IMPOSSIBLE_RE.test(c)) {
+					// lone delimited token without an @: a username entry (box takes both)
+					out.push(c);
+				}
+				// multi-word chunks without an @ (name/prose fragments) and lone tokens
+				// holding eid-impossible characters (URLs, paths) are ignored
+			});
 		});
 		return { entries: out, skipped: skipped };
 	}

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -1,9 +1,9 @@
 /*
  * Live "parsed count" indicator for the Add Participants textareas.
  *
- * Mirrors SiteAddParticipantHandler.normalizeDelimited / effectiveOfficialMode so the user
- * sees how many entries were parsed out of their paste. Loaded as an external file (rather than
- * inline) because the template is processed by RSF/IKAT as XML, which mangles inline scripts.
+ * Mirrors SiteAddParticipantHandler.normalizeSmart / normalizeNonOfficial so the user sees how many
+ * entries were parsed out of their paste. Loaded as an external file (rather than inline) because the
+ * template is processed by RSF/IKAT as XML, which mangles inline scripts.
  *
  * RSF re-writes the id/name it renders on bound form controls, so we do NOT look the textareas
  * up by id. Instead we anchor off the static count <p> elements we control (ids RSF leaves
@@ -29,16 +29,6 @@
 	}
 
 	/**
-	 * Return the value of the currently-checked radio in a named group.
-	 * @param {string} name the radio group's name attribute
-	 * @returns {?string} the checked radio's value, or null when none is checked
-	 */
-	function checkedValue(name) {
-		var el = document.querySelector('input[name="' + name + '"]:checked');
-		return el ? el.value : null;
-	}
-
-	/**
 	 * Find the textarea associated with a count output: the nearest textarea that appears before
 	 * the output element in the DOM, walking previous siblings and then up to the parent. Needed
 	 * because RSF rewrites the ids/names it renders, so the textarea can't be looked up by id.
@@ -61,49 +51,29 @@
 	}
 
 	/**
-	 * Resolve the effective input format, mirroring SiteAddParticipantHandler.effectiveOfficialMode:
-	 * usernames can't be regex-extracted, so "username" + "smart" falls back to "delimited".
-	 * @param {?string} accountType "auto", "email", or "username" (null for the non-official box)
-	 * @param {?string} delimiter   the chosen format ("smart", "delimited", or "line")
-	 * @returns {string} the format to actually parse with (defaults to "smart")
-	 */
-	function effectiveMode(accountType, delimiter) {
-		if (accountType === "username" && delimiter === "smart") return "delimited";
-		return delimiter || "smart";
-	}
-
-	/**
-	 * Mirror of SiteAddParticipantHandler.normalizeDelimited for the official box: return the list
-	 * of entries the server would parse out of the raw textarea value.
-	 * @param {string} raw  the raw textarea value
-	 * @param {string} mode "smart" (extract emails / split usernames), "delimited", or "line"
+	 * Mirror of SiteAddParticipantHandler.normalizeSmart for the official box: return the list of
+	 * entries the server would parse out of the raw textarea value. If it contains an "@" the emails
+	 * are extracted; otherwise it is split into usernames on any delimiter.
+	 * @param {string} raw the raw textarea value
 	 * @returns {string[]} the parsed entries (empty when the input is blank)
 	 */
-	function normalize(raw, mode) {
+	function normalize(raw) {
 		raw = raw || "";
 		if (!raw.trim()) return [];
-		if (mode === "smart") {
-			if (raw.indexOf("@") >= 0) return raw.match(EMAIL_RE) || [];
-			return raw.trim().split(/[,;\s]+/).filter(Boolean);
-		}
-		if (mode === "delimited") return raw.trim().split(/[,;\s]+/).filter(Boolean);
-		// "line": one entry per non-empty line
-		return raw.split(/\r\n|\r|\n/).map(function (s) { return s.trim(); }).filter(Boolean);
+		if (raw.indexOf("@") >= 0) return raw.match(EMAIL_RE) || [];
+		return raw.trim().split(/[,;\s]+/).filter(Boolean);
 	}
 
 	/**
 	 * Mirror of SiteAddParticipantHandler.normalizeNonOfficial for the non-official (guest) box.
-	 * Under smart mode it keeps structured "email,lastName,firstName" rows intact (one person per
-	 * line or semicolon) and only splits a chunk that holds more than one email; "line"/"delimited"
-	 * defer to {@link normalize}.
-	 * @param {string} raw  the raw textarea value
-	 * @param {string} mode "smart", "delimited", or "line"
+	 * Keeps structured "email,lastName,firstName" rows intact (one person per line or semicolon) and
+	 * only splits a chunk that holds more than one email.
+	 * @param {string} raw the raw textarea value
 	 * @returns {string[]} one entry per guest (empty when the input is blank)
 	 */
-	function normalizeNonOfficial(raw, mode) {
+	function normalizeNonOfficial(raw) {
 		raw = raw || "";
 		if (!raw.trim()) return [];
-		if (mode !== "smart") return normalize(raw, mode);
 		var out = [];
 		raw.split(/[;\r\n]+/).forEach(function (chunk) {
 			var person = chunk.trim();
@@ -119,20 +89,14 @@
 	}
 
 	/**
-	 * Tally how many parsed entries are emails vs usernames, honoring an explicit account type or
-	 * auto-detecting by the presence of "@".
-	 * @param {string[]} entries      the parsed entries
-	 * @param {?string}  accountType  "email", "username", or anything else / null for auto-detect
+	 * Tally how many parsed entries are emails vs usernames, auto-detecting by the presence of "@".
+	 * @param {string[]} entries the parsed entries
 	 * @returns {{e: number, u: number, n: number}} email count, username count, and total
 	 */
-	function classify(entries, accountType) {
+	function classify(entries) {
 		var e = 0, u = 0;
 		entries.forEach(function (entry) {
-			var isEmail;
-			if (accountType === "email") isEmail = true;
-			else if (accountType === "username") isEmail = false;
-			else isEmail = entry.indexOf("@") >= 0;
-			if (isEmail) e++; else u++;
+			if (entry.indexOf("@") >= 0) e++; else u++;
 		});
 		return { e: e, u: u, n: entries.length };
 	}
@@ -154,36 +118,29 @@
 	}
 
 	/**
-	 * Wire a textarea to its live count output: recompute the count on input and on any radio
-	 * change, and render it immediately. No-op when the output or its textarea can't be found.
+	 * Wire a textarea to its live count output: recompute the count on input and render it
+	 * immediately. No-op when the output or its textarea can't be found.
 	 * @param {{emails: string, usernames: string, mixed: string}} templates localized strings
-	 * @param {string}  outputId       id of the count <p> element to update
-	 * @param {string}  delimiterName  name of the input-format radio group
-	 * @param {?string} accountTypeName name of the account-type radio group (null for guests)
-	 * @param {boolean} [nonOfficial]  true to use the name-preserving guest normalizer
+	 * @param {string}  outputId      id of the count <p> element to update
+	 * @param {boolean} [nonOfficial] true to use the name-preserving guest normalizer
 	 * @returns {void}
 	 */
-	function wire(templates, outputId, delimiterName, accountTypeName, nonOfficial) {
+	function wire(templates, outputId, nonOfficial) {
 		var out = document.getElementById(outputId);
 		if (!out) return;
 		var ta = textareaFor(out);
 		if (!ta) return;
 
 		/**
-		 * Recompute and render the count from the textarea's current value and selected options.
+		 * Recompute and render the count from the textarea's current value.
 		 * @returns {void}
 		 */
 		function update() {
-			var delimiter = checkedValue(delimiterName);
-			var accountType = accountTypeName ? checkedValue(accountTypeName) : null;
-			var mode = effectiveMode(accountType, delimiter);
-			var entries = nonOfficial ? normalizeNonOfficial(ta.value, mode) : normalize(ta.value, mode);
-			out.textContent = format(templates, classify(entries, accountType));
+			var entries = nonOfficial ? normalizeNonOfficial(ta.value) : normalize(ta.value);
+			out.textContent = format(templates, classify(entries));
 		}
 
 		ta.addEventListener("input", update);
-		// radio names may be re-written by RSF, so recompute on any change in the document
-		document.addEventListener("change", update);
 		update();
 	}
 
@@ -197,8 +154,8 @@
 			usernames: txt("countUsernamesTmpl", "#N# usernames detected"),
 			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)")
 		};
-		wire(templates, "officialAccountCount", "officialDelimiter", "officialAccountType");
-		wire(templates, "nonOfficialAccountCount", "nonOfficialDelimiter", null, true);
+		wire(templates, "officialAccountCount");
+		wire(templates, "nonOfficialAccountCount", true);
 	}
 
 	if (document.readyState === "loading") {

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -15,19 +15,36 @@
 
 	var EMAIL_RE = /[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
 
+	/**
+	 * Read the trimmed text content of an element, falling back to a default when the element is
+	 * missing or empty. Used to pull the localized count templates rendered into hidden nodes.
+	 * @param {string} id       the element id to read
+	 * @param {string} fallback text to return when the element is absent or blank
+	 * @returns {string} the element's text, or {@code fallback}
+	 */
 	function txt(id, fallback) {
 		var el = document.getElementById(id);
 		var s = el ? (el.textContent || "").trim() : "";
 		return s || fallback;
 	}
 
+	/**
+	 * Return the value of the currently-checked radio in a named group.
+	 * @param {string} name the radio group's name attribute
+	 * @returns {?string} the checked radio's value, or null when none is checked
+	 */
 	function checkedValue(name) {
 		var el = document.querySelector('input[name="' + name + '"]:checked');
 		return el ? el.value : null;
 	}
 
-	// Find the textarea associated with a count output: the nearest textarea that appears
-	// before the output element in the DOM (walking previous siblings, then up to the parent).
+	/**
+	 * Find the textarea associated with a count output: the nearest textarea that appears before
+	 * the output element in the DOM, walking previous siblings and then up to the parent. Needed
+	 * because RSF rewrites the ids/names it renders, so the textarea can't be looked up by id.
+	 * @param {Element} outputEl the count <p> element we anchor off
+	 * @returns {?HTMLTextAreaElement} the associated textarea, or null if none is found
+	 */
 	function textareaFor(outputEl) {
 		var node = outputEl;
 		while (node) {
@@ -43,13 +60,25 @@
 		return null;
 	}
 
-	// usernames can't be regex-extracted, so username+smart falls back to delimited
+	/**
+	 * Resolve the effective input format, mirroring SiteAddParticipantHandler.effectiveOfficialMode:
+	 * usernames can't be regex-extracted, so "username" + "smart" falls back to "delimited".
+	 * @param {?string} accountType "auto", "email", or "username" (null for the non-official box)
+	 * @param {?string} delimiter   the chosen format ("smart", "delimited", or "line")
+	 * @returns {string} the format to actually parse with (defaults to "smart")
+	 */
 	function effectiveMode(accountType, delimiter) {
 		if (accountType === "username" && delimiter === "smart") return "delimited";
 		return delimiter || "smart";
 	}
 
-	// returns the list of entries the server would parse out of the raw textarea value
+	/**
+	 * Mirror of SiteAddParticipantHandler.normalizeDelimited for the official box: return the list
+	 * of entries the server would parse out of the raw textarea value.
+	 * @param {string} raw  the raw textarea value
+	 * @param {string} mode "smart" (extract emails / split usernames), "delimited", or "line"
+	 * @returns {string[]} the parsed entries (empty when the input is blank)
+	 */
 	function normalize(raw, mode) {
 		raw = raw || "";
 		if (!raw.trim()) return [];
@@ -62,9 +91,15 @@
 		return raw.split(/\r\n|\r|\n/).map(function (s) { return s.trim(); }).filter(Boolean);
 	}
 
-	// non-official (guest) box mirror of SiteAddParticipantHandler.normalizeNonOfficial: smart mode
-	// keeps structured "email,lastName,firstName" rows intact (one person per line/semicolon) and
-	// only splits a chunk that holds more than one email. "line"/"delimited" defer to normalize().
+	/**
+	 * Mirror of SiteAddParticipantHandler.normalizeNonOfficial for the non-official (guest) box.
+	 * Under smart mode it keeps structured "email,lastName,firstName" rows intact (one person per
+	 * line or semicolon) and only splits a chunk that holds more than one email; "line"/"delimited"
+	 * defer to {@link normalize}.
+	 * @param {string} raw  the raw textarea value
+	 * @param {string} mode "smart", "delimited", or "line"
+	 * @returns {string[]} one entry per guest (empty when the input is blank)
+	 */
 	function normalizeNonOfficial(raw, mode) {
 		raw = raw || "";
 		if (!raw.trim()) return [];
@@ -83,6 +118,13 @@
 		return out;
 	}
 
+	/**
+	 * Tally how many parsed entries are emails vs usernames, honoring an explicit account type or
+	 * auto-detecting by the presence of "@".
+	 * @param {string[]} entries      the parsed entries
+	 * @param {?string}  accountType  "email", "username", or anything else / null for auto-detect
+	 * @returns {{e: number, u: number, n: number}} email count, username count, and total
+	 */
 	function classify(entries, accountType) {
 		var e = 0, u = 0;
 		entries.forEach(function (entry) {
@@ -95,6 +137,13 @@
 		return { e: e, u: u, n: entries.length };
 	}
 
+	/**
+	 * Render the count message from the localized templates, choosing the emails-only,
+	 * usernames-only, or mixed phrasing based on the tally.
+	 * @param {{emails: string, usernames: string, mixed: string}} templates localized strings
+	 * @param {{e: number, u: number, n: number}} c the tally from {@link classify}
+	 * @returns {string} the display text (empty when there are no entries)
+	 */
 	function format(templates, c) {
 		if (c.n === 0) return "";
 		if (c.e > 0 && c.u > 0) {
@@ -104,12 +153,26 @@
 		return templates.usernames.replace("#N#", c.u);
 	}
 
+	/**
+	 * Wire a textarea to its live count output: recompute the count on input and on any radio
+	 * change, and render it immediately. No-op when the output or its textarea can't be found.
+	 * @param {{emails: string, usernames: string, mixed: string}} templates localized strings
+	 * @param {string}  outputId       id of the count <p> element to update
+	 * @param {string}  delimiterName  name of the input-format radio group
+	 * @param {?string} accountTypeName name of the account-type radio group (null for guests)
+	 * @param {boolean} [nonOfficial]  true to use the name-preserving guest normalizer
+	 * @returns {void}
+	 */
 	function wire(templates, outputId, delimiterName, accountTypeName, nonOfficial) {
 		var out = document.getElementById(outputId);
 		if (!out) return;
 		var ta = textareaFor(out);
 		if (!ta) return;
 
+		/**
+		 * Recompute and render the count from the textarea's current value and selected options.
+		 * @returns {void}
+		 */
 		function update() {
 			var delimiter = checkedValue(delimiterName);
 			var accountType = accountTypeName ? checkedValue(accountTypeName) : null;
@@ -124,6 +187,10 @@
 		update();
 	}
 
+	/**
+	 * Read the localized count templates and wire up both the official and non-official boxes.
+	 * @returns {void}
+	 */
 	function init() {
 		var templates = {
 			emails: txt("countEmailsTmpl", "#N# emails detected"),

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -143,13 +143,15 @@
 	/**
 	 * Render the count message from the localized templates, choosing the emails-only,
 	 * usernames-only, or mixed phrasing based on the tally, with a skipped-fragment warning
-	 * appended when the parse had to skip anything.
+	 * appended when the parse had to skip anything. The skipped fragments themselves are shown
+	 * quoted (capped at five, then an ellipsis) so the user can see exactly what will not be
+	 * added. Rendered via textContent, so the raw paste fragments are safe to include.
 	 * @param {{emails: string, usernames: string, mixed: string, skipped: string}} templates localized strings
 	 * @param {{e: number, u: number, n: number}} c the tally from {@link classify}
-	 * @param {number} skippedCount how many fragments the parse flagged as skipped
+	 * @param {string[]} skipped the fragments the parse flagged as skipped
 	 * @returns {string} the display text (empty when there is nothing to report)
 	 */
-	function format(templates, c, skippedCount) {
+	function format(templates, c, skipped) {
 		var parts = [];
 		if (c.n > 0) {
 			if (c.e > 0 && c.u > 0) {
@@ -160,8 +162,12 @@
 				parts.push(templates.usernames.replace("#N#", c.u));
 			}
 		}
-		if (skippedCount > 0) {
-			parts.push(templates.skipped.replace("#S#", skippedCount));
+		if (skipped.length > 0) {
+			var items = skipped.slice(0, 5).map(function (s) { return "“" + s + "”"; }).join(", ");
+			if (skipped.length > 5) {
+				items += ", …";
+			}
+			parts.push(templates.skipped.replace("#S#", skipped.length).replace("#ITEMS#", items));
 		}
 		return parts.join(" — ");
 	}
@@ -189,7 +195,7 @@
 		 */
 		function update() {
 			var parsed = nonOfficial ? normalizeNonOfficial(ta.value) : normalize(ta.value);
-			out.textContent = format(templates, classify(parsed.entries), parsed.skipped.length);
+			out.textContent = format(templates, classify(parsed.entries), parsed.skipped);
 		}
 
 		ta.addEventListener("input", update);
@@ -205,7 +211,7 @@
 			emails: txt("countEmailsTmpl", "#N# emails detected"),
 			usernames: txt("countUsernamesTmpl", "#N# usernames detected"),
 			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)"),
-			skipped: txt("countSkippedTmpl", "#S# skipped (not a complete email address)")
+			skipped: txt("countSkippedTmpl", "#S# skipped (not a complete email address): #ITEMS#")
 		};
 		wire(templates, "officialAccountCount");
 		wire(templates, "nonOfficialAccountCount", true);

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -52,16 +52,24 @@
 
 	/**
 	 * Mirror of SiteAddParticipantHandler.normalizeSmart for the official box: return the list of
-	 * entries the server would parse out of the raw textarea value. If it contains an "@" the emails
-	 * are extracted; otherwise it is split into usernames on any delimiter.
+	 * entries the server would parse out of the raw textarea value. Each line is handled on its own so
+	 * a mixed email/username list keeps working: a line with an "@" has its emails extracted; a line
+	 * without an "@" is split into usernames on any delimiter.
 	 * @param {string} raw the raw textarea value
 	 * @returns {string[]} the parsed entries (empty when the input is blank)
 	 */
 	function normalize(raw) {
 		raw = raw || "";
 		if (!raw.trim()) return [];
-		if (raw.indexOf("@") >= 0) return raw.match(EMAIL_RE) || [];
-		return raw.trim().split(/[,;\s]+/).filter(Boolean);
+		var out = [];
+		raw.split(/\r\n|\r|\n/).forEach(function (line) {
+			if (line.indexOf("@") >= 0) {
+				(line.match(EMAIL_RE) || []).forEach(function (e) { out.push(e); });
+			} else {
+				line.trim().split(/[,;\s]+/).filter(Boolean).forEach(function (u) { out.push(u); });
+			}
+		});
+		return out;
 	}
 
 	/**

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -67,7 +67,7 @@
 	 * @returns {{entries: string[], skipped: string[]}} parsed entries and skipped fragments
 	 */
 	function normalize(raw) {
-		raw = raw || "";
+		raw = (raw || "").replace(/ /g, " "); // NBSP from Word/Outlook pastes
 		var out = [], skipped = [];
 		if (!raw.trim()) return { entries: out, skipped: skipped };
 		if (raw.indexOf("@") < 0) {
@@ -95,11 +95,15 @@
 						if (t.indexOf("@") >= 0) skipped.push(t);
 					});
 				} else if (c.split(/\s+/).length === 1 && !EID_IMPOSSIBLE_RE.test(c)) {
-					// lone delimited token without an @: a username entry (box takes both)
+					// lone delimited token without an @: counted as a username candidate. The
+					// server resolves candidates against the user directory at submit time, so
+					// this live count is an approximation (an unregistered word shows here but
+					// is reported as unmatched on submit; a registered multi-word run is added
+					// on submit though not counted here).
 					out.push(c);
 				}
 				// multi-word chunks without an @ (name/prose fragments) and lone tokens
-				// holding eid-impossible characters (URLs, paths) are ignored
+				// holding eid-impossible characters (URLs, paths) are not counted
 			});
 		});
 		return { entries: out, skipped: skipped };
@@ -114,7 +118,7 @@
 	 * @returns {{entries: string[], skipped: string[]}} one entry per guest, plus skipped fragments
 	 */
 	function normalizeNonOfficial(raw) {
-		raw = raw || "";
+		raw = (raw || "").replace(/ /g, " "); // NBSP from Word/Outlook pastes
 		var out = [], skipped = [];
 		if (!raw.trim()) return { entries: out, skipped: skipped };
 		raw.split(/[;\r\n]+/).forEach(function (chunk) {

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -3,10 +3,12 @@
  *
  * Mirrors SiteAddParticipantHandler.normalizeDelimited / effectiveOfficialMode so the user
  * sees how many entries were parsed out of their paste. Loaded as an external file (rather than
- * inline) because the template is processed by RSF/IKAT as XML, which mangles inline scripts
- * containing '<', '>' or '&&'.
+ * inline) because the template is processed by RSF/IKAT as XML, which mangles inline scripts.
  *
- * Keep EMAIL_RE in sync with EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler.
+ * RSF re-writes the id/name it renders on bound form controls, so we do NOT look the textareas
+ * up by id. Instead we anchor off the static count <p> elements we control (ids RSF leaves
+ * alone) and find each textarea by walking the DOM near it. Keep EMAIL_RE in sync with
+ * EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler.
  */
 (function () {
 	"use strict";
@@ -22,6 +24,23 @@
 	function checkedValue(name) {
 		var el = document.querySelector('input[name="' + name + '"]:checked');
 		return el ? el.value : null;
+	}
+
+	// Find the textarea associated with a count output: the nearest textarea that appears
+	// before the output element in the DOM (walking previous siblings, then up to the parent).
+	function textareaFor(outputEl) {
+		var node = outputEl;
+		while (node) {
+			var prev = node.previousElementSibling;
+			while (prev) {
+				if (prev.tagName === "TEXTAREA") return prev;
+				var inner = prev.querySelector ? prev.querySelector("textarea") : null;
+				if (inner) return inner;
+				prev = prev.previousElementSibling;
+			}
+			node = node.parentElement;
+		}
+		return null;
 	}
 
 	// usernames can't be regex-extracted, so username+smart falls back to delimited
@@ -64,10 +83,11 @@
 		return templates.usernames.replace("#N#", c.u);
 	}
 
-	function wire(templates, textareaId, delimiterName, accountTypeName, outputId) {
-		var ta = document.getElementById(textareaId);
+	function wire(templates, outputId, delimiterName, accountTypeName) {
 		var out = document.getElementById(outputId);
-		if (!ta || !out) return;
+		if (!out) return;
+		var ta = textareaFor(out);
+		if (!ta) return;
 
 		function update() {
 			var delimiter = checkedValue(delimiterName);
@@ -77,14 +97,8 @@
 		}
 
 		ta.addEventListener("input", update);
-		document.querySelectorAll('input[name="' + delimiterName + '"]').forEach(function (r) {
-			r.addEventListener("change", update);
-		});
-		if (accountTypeName) {
-			document.querySelectorAll('input[name="' + accountTypeName + '"]').forEach(function (r) {
-				r.addEventListener("change", update);
-			});
-		}
+		// radio names may be re-written by RSF, so recompute on any change in the document
+		document.addEventListener("change", update);
 		update();
 	}
 
@@ -94,8 +108,8 @@
 			usernames: txt("countUsernamesTmpl", "#N# usernames detected"),
 			mixed: txt("countMixedTmpl", "#N# entries detected (#E# emails, #U# usernames)")
 		};
-		wire(templates, "officialAccountParticipant", "officialDelimiter", "officialAccountType", "officialAccountCount");
-		wire(templates, "nonOfficialAccountParticipant", "nonOfficialDelimiter", null, "nonOfficialAccountCount");
+		wire(templates, "officialAccountCount", "officialDelimiter", "officialAccountType");
+		wire(templates, "nonOfficialAccountCount", "nonOfficialDelimiter", null);
 	}
 
 	if (document.readyState === "loading") {

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -13,6 +13,9 @@
 (function () {
 	"use strict";
 
+	// deliberately narrower than RFC 5322 - see EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler
+	// (extraction from prose must not swallow URL query strings; RFC-grade validation happens
+	// server-side on each extracted candidate). Keep byte-identical with the Java pattern.
 	var EMAIL_RE = /[A-Za-z0-9._%+\-][A-Za-z0-9._%+'\-]*@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
 	// an RFC-style mailbox: optional display name (one "Last, First" comma allowed, no @) + <email>
 	var MAILBOX_RE = new RegExp("[^<>,;@]*(?:,[^<>,;@]*)?<\\s*(" + EMAIL_RE.source + ")\\s*>", "g");

--- a/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/js/parsed-count.js
@@ -15,8 +15,10 @@
 
 	// deliberately narrower than RFC 5322 - see EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler
 	// (extraction from prose must not swallow URL query strings; RFC-grade validation happens
-	// server-side on each extracted candidate). Keep byte-identical with the Java pattern.
-	var EMAIL_RE = /[A-Za-z0-9._%+\-][A-Za-z0-9._%+'\-]*@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
+	// server-side on each extracted candidate; the trailing lookahead keeps a prefix of a longer
+	// token like jdoe@example.com123 from counting as an address). Keep byte-identical with the
+	// Java pattern.
+	var EMAIL_RE = /[A-Za-z0-9._%+\-][A-Za-z0-9._%+'\-]*@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}(?![A-Za-z0-9_%+\-@])/g;
 	// an RFC-style mailbox: optional display name (one "Last, First" comma allowed, no @) + <email>
 	var MAILBOX_RE = new RegExp("[^<>,;@]*(?:,[^<>,;@]*)?<\\s*(" + EMAIL_RE.source + ")\\s*>", "g");
 	// characters a Sakai username (eid) can never contain — mirror of
@@ -70,7 +72,7 @@
 	 * @returns {{entries: string[], skipped: string[]}} parsed entries and skipped fragments
 	 */
 	function normalize(raw) {
-		raw = (raw || "").replace(/ /g, " "); // NBSP from Word/Outlook pastes
+		raw = (raw || "").replace(/\u00A0/g, " "); // NBSP from Word/Outlook pastes
 		var out = [], skipped = [];
 		if (!raw.trim()) return { entries: out, skipped: skipped };
 		if (raw.indexOf("@") < 0) {
@@ -121,7 +123,7 @@
 	 * @returns {{entries: string[], skipped: string[]}} one entry per guest, plus skipped fragments
 	 */
 	function normalizeNonOfficial(raw) {
-		raw = (raw || "").replace(/ /g, " "); // NBSP from Word/Outlook pastes
+		raw = (raw || "").replace(/\u00A0/g, " "); // NBSP from Word/Outlook pastes
 		var out = [], skipped = [];
 		if (!raw.trim()) return { entries: out, skipped: skipped };
 		raw.split(/[;\r\n]+/).forEach(function (chunk) {

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -37,28 +37,6 @@
 			<input rsf:id="csrfToken" name="csrfToken" id="csrfToken" type="hidden"/>
 			<!-- add official account -->
 			<h3 rsf:id="officialAccountSectionTitle"></h3>
-			<!-- declare whether the official entries are emails or usernames -->
-			<span rsf:id="select-official-accounttype"></span>
-			<fieldset>
-				<legend class="nopad" rsf:id="officialAccountTypeLegend"></legend>
-				<div rsf:id="officialAccountType-row:">
-					<input rsf:id="officialAccountType-select" title="Select account type" type="radio" name="officialAccountType" value=""/>
-					<label rsf:id="officialAccountType-label" for="officialAccountType-select">
-						label
-					</label>
-				</div>
-			</fieldset>
-			<!-- choose input format for the official account textarea -->
-			<span rsf:id="select-official-delimiter"></span>
-			<fieldset>
-				<legend class="nopad" rsf:id="officialDelimiterLegend"></legend>
-				<div rsf:id="officialDelimiter-row:">
-					<input rsf:id="officialDelimiter-select" title="Select input format" type="radio" name="officialDelimiter" value=""/>
-					<label rsf:id="officialDelimiter-label" for="officialDelimiter-select">
-						label
-					</label>
-				</div>
-			</fieldset>
 			<label rsf:id="officialAccountLabel" for ="officialAccountParticipant">
 	           Official Account Label
 	        </label>
@@ -75,17 +53,6 @@
 			
 			<!-- add non-official account -->
 			<h3 rsf:id="nonOfficialAccountSectionTitle"></h3>
-			<!-- choose input format for the non-official account textarea -->
-			<span rsf:id="select-nonofficial-delimiter"></span>
-			<fieldset>
-				<legend class="nopad" rsf:id="nonofficialDelimiterLegend"></legend>
-				<div rsf:id="nonofficialDelimiter-row:">
-					<input rsf:id="nonofficialDelimiter-select" title="Select input format" type="radio" name="nonOfficialDelimiter" value=""/>
-					<label rsf:id="nonofficialDelimiter-label" for="nonofficialDelimiter-select">
-						label
-					</label>
-				</div>
-			</fieldset>
 			<label rsf:id="nonOfficialAccountLabel" for ="nonOfficialAccountParticipant">
 	           Non-Official Account Label
 	        </label>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -9,6 +9,7 @@
 	<script type="text/javascript" src="/library/js/headscripts.js"></script>
 	<script type="text/javascript">includeLatestJQuery('site-manage');</script>
 	<script type="text/javascript" src="/library/js/spinner.js"></script>
+	<script type="text/javascript" src="/sakai-site-manage-participant-helper/content/js/parsed-count.js"></script>
 </head>
 
 <body>
@@ -124,100 +125,5 @@
 		</form>
 	</div>
 </div>
-<!-- Live "parsed count" indicator: mirrors SiteAddParticipantHandler.normalizeDelimited /
-     effectiveOfficialMode so the user sees how many entries were parsed out of their paste. -->
-<script type="text/javascript">
-//<![CDATA[
-(function () {
-	// keep in sync with EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler
-	var EMAIL_RE = /[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
-
-	function txt(id, fallback) {
-		var el = document.getElementById(id);
-		var s = el ? (el.textContent || '').trim() : '';
-		return s || fallback;
-	}
-
-	function checkedValue(name) {
-		var el = document.querySelector('input[name="' + name + '"]:checked');
-		return el ? el.value : null;
-	}
-
-	// mirrors effectiveOfficialMode: usernames can't be regex-extracted, so username+smart falls back to delimited
-	function effectiveMode(accountType, delimiter) {
-		if (accountType === 'username' && delimiter === 'smart') return 'delimited';
-		return delimiter || 'smart';
-	}
-
-	// mirrors normalizeDelimited: returns the list of entries the server would parse
-	function normalize(raw, mode) {
-		raw = raw || '';
-		if (!raw.trim()) return [];
-		if (mode === 'smart') {
-			if (raw.indexOf('@') >= 0) return raw.match(EMAIL_RE) || [];
-			return raw.trim().split(/[,;\s]+/).filter(Boolean);
-		}
-		if (mode === 'delimited') return raw.trim().split(/[,;\s]+/).filter(Boolean);
-		// "line": one entry per non-empty line
-		return raw.split(/\r\n|\r|\n/).map(function (s) { return s.trim(); }).filter(Boolean);
-	}
-
-	function classify(entries, accountType) {
-		var e = 0, u = 0;
-		for (var i = 0; i < entries.length; i++) {
-			var isEmail;
-			if (accountType === 'email') isEmail = true;
-			else if (accountType === 'username') isEmail = false;
-			else isEmail = entries[i].indexOf('@') >= 0;
-			if (isEmail) e++; else u++;
-		}
-		return { e: e, u: u, n: entries.length };
-	}
-
-	// localized sentence templates; #N#/#E#/#U# are substituted with the parsed counts
-	var T = {
-		emails: txt('countEmailsTmpl', '#N# emails detected'),
-		usernames: txt('countUsernamesTmpl', '#N# usernames detected'),
-		mixed: txt('countMixedTmpl', '#N# entries detected (#E# emails, #U# usernames)')
-	};
-
-	function format(c) {
-		if (c.n === 0) return '';
-		if (c.e > 0 && c.u > 0) {
-			return T.mixed.replace('#N#', c.n).replace('#E#', c.e).replace('#U#', c.u);
-		}
-		if (c.u === 0) return T.emails.replace('#N#', c.e);
-		return T.usernames.replace('#N#', c.u);
-	}
-
-	function wire(textareaId, delimiterName, accountTypeName, outputId) {
-		var ta = document.getElementById(textareaId);
-		var out = document.getElementById(outputId);
-		if (!ta || !out) return;
-
-		function update() {
-			var delimiter = checkedValue(delimiterName);
-			var accountType = accountTypeName ? checkedValue(accountTypeName) : null;
-			var entries = normalize(ta.value, effectiveMode(accountType, delimiter));
-			out.textContent = format(classify(entries, accountType));
-		}
-
-		ta.addEventListener('input', update);
-		var radios = document.querySelectorAll('input[name="' + delimiterName + '"]');
-		for (var i = 0; i < radios.length; i++) radios[i].addEventListener('change', update);
-		if (accountTypeName) {
-			var at = document.querySelectorAll('input[name="' + accountTypeName + '"]');
-			for (var j = 0; j < at.length; j++) at[j].addEventListener('change', update);
-		}
-		update();
-	}
-
-	document.addEventListener('DOMContentLoaded', function () {
-		wire('officialAccountParticipant', 'officialDelimiter', 'officialAccountType', 'officialAccountCount');
-		wire('nonOfficialAccountParticipant', 'nonOfficialDelimiter', null, 'nonOfficialAccountCount');
-	});
-})();
-//]]>
-</script>
 </body>
 </html>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -62,9 +62,15 @@
 	           Official Account Label
 	        </label>
 	        <br/>
-	        <textarea rsf:id="officialAccountParticipant" name="officialAccountParticipant" cols="35" rows="4" id="officialAccountParticipant"></textarea>
+	        <textarea rsf:id="officialAccountParticipant" name="officialAccountParticipant" cols="35" rows="4" id="officialAccountParticipant" aria-describedby="officialAccountCount"></textarea>
 			<a href="#" onclick="rsf:id='officialAccountPickerAction'" aria-hidden="true"><strong rsf:id="officialAccountPickerLabel"></strong></a><br />
 			<p class="form-text textPanelFooter" rsf:id="msg=add.multiple"></p>
+			<p class="form-text textPanelFooter" id="officialAccountCount" role="status" aria-live="polite"></p>
+
+			<!-- localized templates used by the live parsed-count indicator below (#N#/#E#/#U# = counts) -->
+			<span id="countEmailsTmpl" rsf:id="countEmailsTmpl" hidden="hidden"></span>
+			<span id="countUsernamesTmpl" rsf:id="countUsernamesTmpl" hidden="hidden"></span>
+			<span id="countMixedTmpl" rsf:id="countMixedTmpl" hidden="hidden"></span>
 			
 			<!-- add non-official account -->
 			<h3 rsf:id="nonOfficialAccountSectionTitle"></h3>
@@ -83,8 +89,9 @@
 	           Non-Official Account Label
 	        </label>
 	        <br/>
-	        <textarea rsf:id="nonOfficialAccountParticipant" name="nonOfficialAccountParticipant" cols="35" rows="4" id="nonOfficialAccountParticipant"></textarea>
+	        <textarea rsf:id="nonOfficialAccountParticipant" name="nonOfficialAccountParticipant" cols="35" rows="4" id="nonOfficialAccountParticipant" aria-describedby="nonOfficialAccountCount"></textarea>
 			<p class="help-block textPanelFooter" rsf:id="nonOfficialAddMultiple"></p>
+			<p class="help-block textPanelFooter" id="nonOfficialAccountCount" role="status" aria-live="polite"></p>
 			
 			<!--  choose roles -->
 			<span rsf:id="select-roles"></span>
@@ -117,5 +124,100 @@
 		</form>
 	</div>
 </div>
+<!-- Live "parsed count" indicator: mirrors SiteAddParticipantHandler.normalizeDelimited /
+     effectiveOfficialMode so the user sees how many entries were parsed out of their paste. -->
+<script type="text/javascript">
+//<![CDATA[
+(function () {
+	// keep in sync with EMAIL_EXTRACT_PATTERN in SiteAddParticipantHandler
+	var EMAIL_RE = /[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g;
+
+	function txt(id, fallback) {
+		var el = document.getElementById(id);
+		var s = el ? (el.textContent || '').trim() : '';
+		return s || fallback;
+	}
+
+	function checkedValue(name) {
+		var el = document.querySelector('input[name="' + name + '"]:checked');
+		return el ? el.value : null;
+	}
+
+	// mirrors effectiveOfficialMode: usernames can't be regex-extracted, so username+smart falls back to delimited
+	function effectiveMode(accountType, delimiter) {
+		if (accountType === 'username' && delimiter === 'smart') return 'delimited';
+		return delimiter || 'smart';
+	}
+
+	// mirrors normalizeDelimited: returns the list of entries the server would parse
+	function normalize(raw, mode) {
+		raw = raw || '';
+		if (!raw.trim()) return [];
+		if (mode === 'smart') {
+			if (raw.indexOf('@') >= 0) return raw.match(EMAIL_RE) || [];
+			return raw.trim().split(/[,;\s]+/).filter(Boolean);
+		}
+		if (mode === 'delimited') return raw.trim().split(/[,;\s]+/).filter(Boolean);
+		// "line": one entry per non-empty line
+		return raw.split(/\r\n|\r|\n/).map(function (s) { return s.trim(); }).filter(Boolean);
+	}
+
+	function classify(entries, accountType) {
+		var e = 0, u = 0;
+		for (var i = 0; i < entries.length; i++) {
+			var isEmail;
+			if (accountType === 'email') isEmail = true;
+			else if (accountType === 'username') isEmail = false;
+			else isEmail = entries[i].indexOf('@') >= 0;
+			if (isEmail) e++; else u++;
+		}
+		return { e: e, u: u, n: entries.length };
+	}
+
+	// localized sentence templates; #N#/#E#/#U# are substituted with the parsed counts
+	var T = {
+		emails: txt('countEmailsTmpl', '#N# emails detected'),
+		usernames: txt('countUsernamesTmpl', '#N# usernames detected'),
+		mixed: txt('countMixedTmpl', '#N# entries detected (#E# emails, #U# usernames)')
+	};
+
+	function format(c) {
+		if (c.n === 0) return '';
+		if (c.e > 0 && c.u > 0) {
+			return T.mixed.replace('#N#', c.n).replace('#E#', c.e).replace('#U#', c.u);
+		}
+		if (c.u === 0) return T.emails.replace('#N#', c.e);
+		return T.usernames.replace('#N#', c.u);
+	}
+
+	function wire(textareaId, delimiterName, accountTypeName, outputId) {
+		var ta = document.getElementById(textareaId);
+		var out = document.getElementById(outputId);
+		if (!ta || !out) return;
+
+		function update() {
+			var delimiter = checkedValue(delimiterName);
+			var accountType = accountTypeName ? checkedValue(accountTypeName) : null;
+			var entries = normalize(ta.value, effectiveMode(accountType, delimiter));
+			out.textContent = format(classify(entries, accountType));
+		}
+
+		ta.addEventListener('input', update);
+		var radios = document.querySelectorAll('input[name="' + delimiterName + '"]');
+		for (var i = 0; i < radios.length; i++) radios[i].addEventListener('change', update);
+		if (accountTypeName) {
+			var at = document.querySelectorAll('input[name="' + accountTypeName + '"]');
+			for (var j = 0; j < at.length; j++) at[j].addEventListener('change', update);
+		}
+		update();
+	}
+
+	document.addEventListener('DOMContentLoaded', function () {
+		wire('officialAccountParticipant', 'officialDelimiter', 'officialAccountType', 'officialAccountCount');
+		wire('nonOfficialAccountParticipant', 'nonOfficialDelimiter', null, 'nonOfficialAccountCount');
+	});
+})();
+//]]>
+</script>
 </body>
 </html>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -36,6 +36,17 @@
 			<input rsf:id="csrfToken" name="csrfToken" id="csrfToken" type="hidden"/>
 			<!-- add official account -->
 			<h3 rsf:id="officialAccountSectionTitle"></h3>
+			<!-- declare whether the official entries are emails or usernames -->
+			<span rsf:id="select-official-accounttype"></span>
+			<fieldset>
+				<legend class="nopad" rsf:id="officialAccountTypeLegend"></legend>
+				<div rsf:id="officialAccountType-row:">
+					<input rsf:id="officialAccountType-select" title="Select account type" type="radio" name="officialAccountType" value=""/>
+					<label rsf:id="officialAccountType-label" for="officialAccountType-select">
+						label
+					</label>
+				</div>
+			</fieldset>
 			<!-- choose input format for the official account textarea -->
 			<span rsf:id="select-official-delimiter"></span>
 			<fieldset>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -50,6 +50,7 @@
 			<span id="countEmailsTmpl" rsf:id="countEmailsTmpl" hidden="hidden"></span>
 			<span id="countUsernamesTmpl" rsf:id="countUsernamesTmpl" hidden="hidden"></span>
 			<span id="countMixedTmpl" rsf:id="countMixedTmpl" hidden="hidden"></span>
+			<span id="countSkippedTmpl" rsf:id="countSkippedTmpl" hidden="hidden"></span>
 			
 			<!-- add non-official account -->
 			<h3 rsf:id="nonOfficialAccountSectionTitle"></h3>

--- a/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
+++ b/site-manage/site-manage-participant-helper/src/webapp/content/templates/Add.html
@@ -36,6 +36,17 @@
 			<input rsf:id="csrfToken" name="csrfToken" id="csrfToken" type="hidden"/>
 			<!-- add official account -->
 			<h3 rsf:id="officialAccountSectionTitle"></h3>
+			<!-- choose input format for the official account textarea -->
+			<span rsf:id="select-official-delimiter"></span>
+			<fieldset>
+				<legend class="nopad" rsf:id="officialDelimiterLegend"></legend>
+				<div rsf:id="officialDelimiter-row:">
+					<input rsf:id="officialDelimiter-select" title="Select input format" type="radio" name="officialDelimiter" value=""/>
+					<label rsf:id="officialDelimiter-label" for="officialDelimiter-select">
+						label
+					</label>
+				</div>
+			</fieldset>
 			<label rsf:id="officialAccountLabel" for ="officialAccountParticipant">
 	           Official Account Label
 	        </label>
@@ -46,6 +57,17 @@
 			
 			<!-- add non-official account -->
 			<h3 rsf:id="nonOfficialAccountSectionTitle"></h3>
+			<!-- choose input format for the non-official account textarea -->
+			<span rsf:id="select-nonofficial-delimiter"></span>
+			<fieldset>
+				<legend class="nopad" rsf:id="nonofficialDelimiterLegend"></legend>
+				<div rsf:id="nonofficialDelimiter-row:">
+					<input rsf:id="nonofficialDelimiter-select" title="Select input format" type="radio" name="nonOfficialDelimiter" value=""/>
+					<label rsf:id="nonofficialDelimiter-label" for="nonofficialDelimiter-select">
+						label
+					</label>
+				</div>
+			</fieldset>
 			<label rsf:id="nonOfficialAccountLabel" for ="nonOfficialAccountParticipant">
 	           Non-Official Account Label
 	        </label>


### PR DESCRIPTION
## SAK-52697 Site Info → Add Participants: accept delimited / smart email lists

https://sakaiproject.atlassian.net/browse/SAK-52697

### What
Currently the **Add Participants** helper requires one entry per line. This PR lets instructors paste account lists in the formats they actually have on hand (comma / semicolon / whitespace separated, or messy blobs that mix emails with names and punctuation) without hand-reformatting them first.

### Changes
- **Input format per box** — each account textarea gains a format: `smart` (default), `delimited`, or `line`.
  - `smart` — auto-detects at the blob level: if the paste contains an `@`, every email-format token is extracted (surrounding names/punctuation/delimiters ignored); otherwise it's treated as a username list split on any delimiter.
  - `delimited` — any run of comma / semicolon / whitespace collapses to one entry per line.
  - `line` — unchanged legacy behaviour, preserving the non-official `email,lastName,firstName` per-line format.
- **Explicit Account type radio** (`auto` / `email` / `username`) for the official box. Because smart extraction relies on an email regex that can't match bare usernames, choosing *username* falls back to plain delimited splitting (`effectiveOfficialMode`).
- **Per-entry lookup routing** — emails vs usernames (eids) are resolved appropriately; `EMAIL_EXTRACT_PATTERN` drives both the smart extraction and the auto-detection.
- **Live parsed-count** — a small note under each box shows how many entries were parsed from the paste, mirroring the server-side normalization so users get immediate feedback. Kept in an external JS file (`parsed-count.js`) because the RSF/IKAT template is processed as XML and mangles inline scripts; the script anchors off static count `<p>` elements and locates each textarea by walking the DOM, since RSF rewrites the rendered ids.
- **Tests** — `SiteAddParticipantHandlerTest` covers `normalizeDelimited` and `effectiveOfficialMode` across the smart / delimited / line modes and account types.

### Files
- `impl/.../SiteAddParticipantHandler.java` — `normalizeDelimited`, `effectiveOfficialMode`, `EMAIL_EXTRACT_PATTERN`, lookup routing
- `rsf/AddProducer.java`, `content/templates/Add.html` — format + account-type controls, input note
- `content/js/parsed-count.js` — live parsed-count
- `bundle/sitesetupgeneric.properties` — new labels/help text
- `impl/.../SiteAddParticipantHandlerTest.java` — unit tests
- `pom.xml` — test deps

### Testing
- Unit tests in `SiteAddParticipantHandlerTest`.
- Manually verified in the dev stack: pasting comma-, semicolon-, whitespace-separated and mixed email/name blobs into both official and non-official boxes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smart parsing for official and non-official participant inputs, including messy pastes and mixed legacy formats.
  * Added live “parsed count” feedback (email, username, mixed, skipped) with accessible status messaging for both input areas.
* **Bug Fixes**
  * Improved guidance behavior by treating certain results as non-blocking and refining “not found” messaging based on entered token shape.
* **Documentation**
  * Updated participant help text and validation strings, including new separator instructions and example formats.
* **Tests**
  * Added extensive JUnit coverage for normalization/parsing and added the JUnit test dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->