### PR TITLE
SAK-34476 Samigo: block feedback dates that reveal answers after submission

### DIFF
--- a/docker/tomcat/conf/context.xml
+++ b/docker/tomcat/conf/context.xml
@@ -1,7 +1,7 @@
 <Context>
     <JarScanner>
         <!-- This is to speedup startup so that tomcat doesn't scan as much -->
-        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
+        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,jakarta.faces-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
     </JarScanner>
 </Context>
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -322,6 +322,9 @@ retract_earlier_than_due=The Late Submission Deadline cannot be earlier than the
 retract_required_with_auto_submit=The Late Submission Deadline and Due Date must be set to force submission of saved student work after the Late Submission Deadline.
 due_required_with_auto_submit=The Due Date must be set to force submission of saved student work after the Due Date.
 due_null_with_retract_date=Please specify a Due Date if the assessment has a Late Submission Deadline.
+feedback_date_earlier_than_deadline=The Show Feedback Date cannot be earlier than the latest date students can submit ({0}); students taking the assessment after the Show Feedback Date would see the feedback, including correct answers, while taking it. To intentionally show feedback during the assessment, select "Yes, show the student feedback while they are taking the assessment" instead.
+feedback_date_blocked_publish="{0}" was not published: feedback is shown to the student on specific dates, but the Show Feedback Date is earlier than the latest date students can submit (or no Due Date / Late Submission Deadline is set). Adjust the dates in its Settings, or select "Yes, show the student feedback while they are taking the assessment" instead.
+feedback_date_requires_deadline=To show feedback to the student on specific dates, the assessment needs a final submission deadline: a Due Date, or a Late Submission Deadline when late submissions are accepted. Enter one, or select "Yes, show the student feedback while they are taking the assessment" to show feedback during the assessment.
 open_window_less_than_time_limit=The assessment's time limit extends past its Final Submission Deadline. Please reduce the time limit, or extend the deadline accordingly.
 
 # Secure delivery support

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -153,6 +153,9 @@ public class AssessmentSettingsBean extends SpringBeanAutowiringSupport implemen
   private Date retractDate;
   private Date feedbackDate;
   @Getter @Setter private Date feedbackEndDate;
+  // SAK-34476 true when the last save was rejected because of the feedback date, so the
+  // settings page can open the Grading and Feedback panel the instructor needs to fix
+  @Getter @Setter private boolean feedbackDateInError = false;
   private boolean feedbackScoreThresholdEnabled = false;
   @Getter @Setter private String feedbackScoreThreshold;
   private Integer timeLimit = 0; // in seconds, calculated from timedHours & timedMinutes

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -148,6 +148,9 @@ public class PublishedAssessmentSettingsBean extends SpringBeanAutowiringSupport
   private Date retractDate;
   private Date feedbackDate;
   @Getter @Setter private Date feedbackEndDate;
+  // SAK-34476 true when the last save was rejected because of the feedback date, so the
+  // settings page can open the Grading and Feedback panel the instructor needs to fix
+  @Getter @Setter private boolean feedbackDateInError = false;
   @Setter private boolean feedbackScoreThresholdEnabled = false;
   @Getter @Setter private String feedbackScoreThreshold;
   private Integer timeLimit; // in seconds, calculated from timedHours & timedMinutes

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/ConfirmPublishAssessmentListener.java
@@ -61,6 +61,7 @@ import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.PublishRepublishNotificationBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.FeedbackDateValidator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -119,6 +120,7 @@ public class ConfirmPublishAssessmentListener
     //proceed to look for error, save assessment setting and confirm publish
     //#2a - look for error: check if core assessment title is unique
     boolean error=false;
+		assessmentSettings.setFeedbackDateInError(false);
 
     String assessmentName = TextFormat.convertPlaintextToFormattedTextNoHighUnicode(assessmentSettings.getTitle());
     if(assessmentName!=null &&(assessmentName.trim()).equals("")){
@@ -349,6 +351,12 @@ public class ConfirmPublishAssessmentListener
 					context.addMessage(null,new FacesMessage(feedbackDateErr));
 					error=true;
 				}
+				// SAK-34476 a feedback date earlier than the last submission deadline reveals feedback mid-take
+				if (!FeedbackDateValidator.isFeedbackDateAfterDeadline(assessmentSettings.getFeedbackDate(), assessmentSettings.getDueDate(),
+						assessmentSettings.getRetractDate(), assessmentSettings.getLateHandling(), assessmentSettings.getExtendedTimes(), context)) {
+					error=true;
+					assessmentSettings.setFeedbackDateInError(true);
+				}
 			}
 
 			if(!assessmentSettings.getIsValidFeedbackDate()){
@@ -391,7 +399,16 @@ public class ConfirmPublishAssessmentListener
     		}
     		else {
     			assessmentSettings.setNoGroupSelectedError(false);
-    		} 
+    		}
+    	}
+
+    	// SAK-34476 publishing straight from the assessment list skips the settings-form checks,
+    	// so the stored dates have to be validated here as well
+    	if ("2".equals(assessmentSettings.getFeedbackDelivery())
+    			&& !FeedbackDateValidator.isFeedbackDateAfterDeadline(assessmentSettings.getFeedbackDate(), assessmentSettings.getDueDate(),
+    					assessmentSettings.getRetractDate(), assessmentSettings.getLateHandling(), assessmentSettings.getExtendedTimes(), context)) {
+    		error=true;
+    		assessmentSettings.setFeedbackDateInError(true);
     	}
     }
     

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/PublishAssessmentListener.java
@@ -22,6 +22,7 @@
 package org.sakaiproject.tool.assessment.ui.listener.author;
 
 import java.text.MessageFormat;
+import java.util.Date;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
@@ -71,6 +72,7 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedMetaData;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentFeedbackIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
@@ -95,6 +97,7 @@ import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.PublishRepublishNotificationBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.FeedbackDateValidator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.cover.ToolManager;
 import org.sakaiproject.util.ResourceLoader;
@@ -202,6 +205,10 @@ public class PublishAssessmentListener
                     AssessmentFacade assessmentFacade = assessmentService.getAssessment(assessmentId);
 
                     if (((AssessmentFacade) assessment).isSelected()) {
+                        // SAK-34476 bulk publish never passes through the settings checks, so validate the stored dates here
+                        if (!feedbackDateSafeToPublish(assessmentFacade)) {
+                            continue;
+                        }
                         assessmentList.remove(assessmentFacade);
                         assessmentFacade = assessmentService.ensureUniquePublishedTitleForPublish(assessmentFacade);
                         assessmentSettings.setAssessment(assessmentFacade);
@@ -220,6 +227,29 @@ public class PublishAssessmentListener
 	  } finally {
 		  repeatedPublishLock.unlock();
 	  }
+  }
+
+  /**
+   * SAK-34476 refuse to publish an assessment whose "on specific dates" feedback date falls
+   * before the last moment a student can submit - it would reveal feedback mid-take.
+   */
+  private boolean feedbackDateSafeToPublish(AssessmentFacade assessment) {
+    AssessmentFeedbackIfc feedback = assessment.getAssessmentFeedback();
+    AssessmentAccessControlIfc control = assessment.getAssessmentAccessControl();
+    if (feedback == null || control == null || !AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(feedback.getFeedbackDelivery())
+            || control.getFeedbackDate() == null) {
+      return true;
+    }
+    List<ExtendedTime> extendedTimes = PersistenceService.getInstance().getExtendedTimeFacade().getEntriesForAss(assessment.getData());
+    Date deadline = FeedbackDateValidator.latestSubmissionDeadline(control.getDueDate(), control.getRetractDate(),
+            String.valueOf(control.getLateHandling()), extendedTimes);
+    if (deadline == null || control.getFeedbackDate().before(deadline)) {
+      String msg = MessageFormat.format(ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages",
+              "feedback_date_blocked_publish"), assessment.getTitle());
+      FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(msg));
+      return false;
+    }
+    return true;
   }
 
   private void publishOne(AuthorBean author, AssessmentFacade assessment, AssessmentSettingsBean assessmentSettings, AssessmentService assessmentService, AuthorizationBean authorization, boolean repeatedPublish) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
@@ -51,6 +51,7 @@ import org.sakaiproject.tool.assessment.ui.bean.author.AssessmentSettingsBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.FeedbackDateValidator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -83,6 +84,7 @@ public class SaveAssessmentSettingsListener
         lookupBean("assessmentSettings");
 
     boolean error=false;
+		assessmentSettings.setFeedbackDateInError(false);
     String assessmentId=String.valueOf(assessmentSettings.getAssessmentId());
     AssessmentService assessmentService = new AssessmentService();
     SaveAssessmentSettings s = new SaveAssessmentSettings();
@@ -310,6 +312,12 @@ public class SaveAssessmentSettingsListener
                 String feedbackDateErr = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.GeneralMessages","invalid_feedback_ranges");
                 context.addMessage(null,new FacesMessage(feedbackDateErr));
                 error=true;
+            }
+            // SAK-34476 a feedback date earlier than the last submission deadline reveals feedback mid-take
+            if (!FeedbackDateValidator.isFeedbackDateAfterDeadline(assessmentSettings.getFeedbackDate(), assessmentSettings.getDueDate(),
+                    assessmentSettings.getRetractDate(), assessmentSettings.getLateHandling(), assessmentSettings.getExtendedTimes(), context)) {
+                error=true;
+                assessmentSettings.setFeedbackDateInError(true);
             }
     	}
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -102,6 +102,7 @@ import org.sakaiproject.tool.assessment.ui.bean.author.PublishRepublishNotificat
 import org.sakaiproject.tool.assessment.ui.bean.author.PublishedAssessmentSettingsBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.FeedbackDateValidator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -361,6 +362,7 @@ implements ActionListener
 
 	public boolean checkPublishedSettings(PublishedAssessmentService assessmentService, PublishedAssessmentSettingsBean assessmentSettings, FacesContext context, boolean retractNow) {
 		boolean error = false;
+		assessmentSettings.setFeedbackDateInError(false);
 		// Title
 		String assessmentName = assessmentSettings.getTitle();
 		// check if name is empty
@@ -554,6 +556,13 @@ implements ActionListener
 					String feedbackDateErr = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.GeneralMessages","invalid_feedback_ranges");
 					context.addMessage(null,new FacesMessage(feedbackDateErr));
 					error=true;
+				}
+				// SAK-34476 a feedback date earlier than the last submission deadline reveals feedback mid-take;
+				// never block a retract, though - it closes the assessment and ends any leak
+				if (!retractNow && !FeedbackDateValidator.isFeedbackDateAfterDeadline(assessmentSettings.getFeedbackDate(), assessmentSettings.getDueDate(),
+						assessmentSettings.getRetractDate(), assessmentSettings.getLateHandling(), assessmentSettings.getExtendedTimes(), context)) {
+					error=true;
+					assessmentSettings.setFeedbackDateInError(true);
 				}
 			}
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/FeedbackDateValidator.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/util/FeedbackDateValidator.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2005-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.tool.assessment.util;
+
+import java.text.DateFormat;
+import java.text.MessageFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.time.api.UserTimeService;
+import org.sakaiproject.tool.assessment.data.dao.assessment.ExtendedTime;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
+import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.util.api.LocaleService;
+
+/**
+ * SAK-34476: when feedback is shown "on specific dates", a feedback date earlier than the
+ * last moment a student can submit silently behaves like immediate feedback — anyone taking
+ * the assessment after the feedback date can open the Feedback link and see the correct
+ * answers mid-take. The deadline has to account for every exception, since an extended
+ * due/retract date can reopen the assessment past an otherwise safe feedback date.
+ */
+public final class FeedbackDateValidator {
+
+    private static final String BUNDLE = "org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages";
+
+    private FeedbackDateValidator() {}
+
+    /**
+     * The latest moment any student can still submit: the due date, or the late acceptance
+     * date when late submissions are on, pushed out by the due/retract date of every
+     * exception. Null when there is no deadline at all - including when late submissions
+     * are accepted without a late acceptance date, because a student who has not submitted
+     * yet may then still begin at any time after the due date.
+     */
+    public static Date latestSubmissionDeadline(Date dueDate, Date retractDate, String lateHandling, List<ExtendedTime> extendedTimes) {
+        boolean acceptLate = AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString().equals(lateHandling);
+        // The base cohort (students without an exception). With late submissions accepted the
+        // deadline is the late acceptance date; otherwise the due date. A null here means the
+        // assessment is open-ended for regular students, so there is no safe feedback date at all.
+        Date deadline = acceptLate ? retractDate : dueDate;
+        if (deadline == null) {
+            return null;
+        }
+        if (extendedTimes != null) {
+            for (ExtendedTime entry : extendedTimes) {
+                // An exception replaces the base dates wholesale at delivery time, evaluated under
+                // the same lateHandling, so its deadline mirrors the base rule. A null here means
+                // this exception's holder is open-ended - poison the whole deadline to null.
+                Date entryDeadline = acceptLate ? entry.getRetractDate() : entry.getDueDate();
+                if (entryDeadline == null) {
+                    return null;
+                }
+                if (entryDeadline.after(deadline)) {
+                    deadline = entryDeadline;
+                }
+            }
+        }
+        return deadline;
+    }
+
+    /**
+     * Validate that the feedback date falls on or after the latest submission deadline,
+     * adding an error message to the context when it does not.
+     *
+     * @return true if the feedback date is acceptable; false if saving must be blocked
+     */
+    public static boolean isFeedbackDateAfterDeadline(Date feedbackDate, Date dueDate, Date retractDate,
+            String lateHandling, List<ExtendedTime> extendedTimes, FacesContext context) {
+        if (feedbackDate == null) {
+            // a missing or unparseable date is already reported by the existing checks
+            return true;
+        }
+        Date deadline = latestSubmissionDeadline(dueDate, retractDate, lateHandling, extendedTimes);
+        if (deadline == null) {
+            context.addMessage(null, new FacesMessage(ContextUtil.getLocalizedString(BUNDLE, "feedback_date_requires_deadline")));
+            return false;
+        }
+        if (feedbackDate.before(deadline)) {
+            UserTimeService userTimeService = ComponentManager.get(UserTimeService.class);
+            Locale locale = ComponentManager.get(LocaleService.class).getLocaleForCurrentSiteAndUser();
+            String deadlineDisplay = userTimeService.dateTimeFormat(deadline, locale, DateFormat.LONG);
+            String msg = MessageFormat.format(ContextUtil.getLocalizedString(BUNDLE, "feedback_date_earlier_than_deadline"), deadlineDisplay);
+            context.addMessage(null, new FacesMessage(msg));
+            return false;
+        }
+        return true;
+    }
+}

--- a/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/util/FeedbackDateValidatorTest.java
+++ b/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/util/FeedbackDateValidatorTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2005-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sakaiproject.tool.assessment.util;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.data.dao.assessment.ExtendedTime;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
+
+public class FeedbackDateValidatorTest {
+
+    private static final String ACCEPT_LATE = AssessmentAccessControlIfc.ACCEPT_LATE_SUBMISSION.toString();
+    private static final String NO_LATE = AssessmentAccessControlIfc.NOT_ACCEPT_LATE_SUBMISSION.toString();
+
+    private static final Date EARLIER = new Date(1_000_000L);
+    private static final Date DUE = new Date(2_000_000L);
+    private static final Date RETRACT = new Date(3_000_000L);
+    private static final Date LATER = new Date(4_000_000L);
+
+    private ExtendedTime entry(Date due, Date retract) {
+        ExtendedTime e = new ExtendedTime();
+        e.setDueDate(due);
+        e.setRetractDate(retract);
+        return e;
+    }
+
+    // --- base cohort (no exceptions) ---
+
+    @Test
+    public void deadlineIsDueDateWithoutLateHandling() {
+        assertEquals(DUE, FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, NO_LATE, Collections.emptyList()));
+    }
+
+    @Test
+    public void deadlineIsRetractDateWhenLateSubmissionsAccepted() {
+        assertEquals(RETRACT, FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, ACCEPT_LATE, Collections.emptyList()));
+    }
+
+    @Test
+    public void noDeadlineWhenLateAcceptedWithoutRetractDate() {
+        // late submissions accepted with no late acceptance date: a first submission
+        // is allowed at any time after the due date, so there is no final deadline
+        assertNull(FeedbackDateValidator.latestSubmissionDeadline(DUE, null, ACCEPT_LATE, null));
+    }
+
+    @Test
+    public void noDeadlineWhenNoDueDateAndNotAcceptingLate() {
+        assertNull(FeedbackDateValidator.latestSubmissionDeadline(null, RETRACT, NO_LATE, Collections.emptyList()));
+    }
+
+    @Test
+    public void deadlineIsNullWhenNoDatesAnywhere() {
+        assertNull(FeedbackDateValidator.latestSubmissionDeadline(null, null, NO_LATE, Collections.emptyList()));
+    }
+
+    @Test
+    public void nullOrUnknownLateHandlingFallsBackToDueDate() {
+        assertEquals(DUE, FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, null, Collections.emptyList()));
+        assertEquals(DUE, FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, "not-a-code", Collections.emptyList()));
+    }
+
+    @Test
+    public void nullExceptionListLeavesBaseDeadlineIntact() {
+        assertEquals(DUE, FeedbackDateValidator.latestSubmissionDeadline(DUE, null, NO_LATE, null));
+    }
+
+    // --- exceptions extending a finite base deadline ---
+
+    @Test
+    public void exceptionDueDateExtendsDeadlineWhenNotAcceptingLate() {
+        // not accepting late: an exception's deadline is its due date (its retract is irrelevant)
+        assertEquals(LATER, FeedbackDateValidator.latestSubmissionDeadline(DUE, null, NO_LATE,
+                Collections.singletonList(entry(LATER, EARLIER))));
+    }
+
+    @Test
+    public void exceptionRetractDateExtendsDeadlineWhenLateAccepted() {
+        // accepting late: an exception's deadline is its retract date (its due is irrelevant)
+        assertEquals(LATER, FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, ACCEPT_LATE,
+                Collections.singletonList(entry(EARLIER, LATER))));
+    }
+
+    @Test
+    public void earlierExceptionDoesNotShrinkDeadline() {
+        assertEquals(RETRACT, FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, ACCEPT_LATE,
+                Collections.singletonList(entry(DUE, EARLIER))));
+    }
+
+    // --- open-ended cohorts must poison the deadline to null (SAK-34476 completeness) ---
+
+    @Test
+    public void openEndedBaseIsNotRescuedByAnException() {
+        // regular students are open-ended (no due date, not accepting late); an exception with a
+        // finite date must NOT make the assessment look bounded - regular students still leak
+        assertNull(FeedbackDateValidator.latestSubmissionDeadline(null, null, NO_LATE,
+                Collections.singletonList(entry(LATER, null))));
+    }
+
+    @Test
+    public void nullRetractExceptionPoisonsDeadlineWhenLateAccepted() {
+        // accepting late + an exception holder with no retract date is open-ended for that holder
+        assertNull(FeedbackDateValidator.latestSubmissionDeadline(DUE, RETRACT, ACCEPT_LATE,
+                Collections.singletonList(entry(DUE, null))));
+    }
+
+    // --- isFeedbackDateAfterDeadline: the accepting paths never touch the FacesContext (only the
+    // rejecting paths call context.addMessage), so a null context both exercises the happy path and
+    // asserts that no message is emitted. The rejecting paths need live JSF/bundle wiring and are
+    // covered by manual QA. ---
+
+    @Test
+    public void feedbackDateEqualToDeadlineIsAllowed() {
+        assertTrue(FeedbackDateValidator.isFeedbackDateAfterDeadline(
+                new Date(DUE.getTime()), DUE, RETRACT, NO_LATE, Collections.emptyList(), null));
+    }
+
+    @Test
+    public void feedbackDateAfterDeadlineIsAllowed() {
+        assertTrue(FeedbackDateValidator.isFeedbackDateAfterDeadline(
+                LATER, DUE, RETRACT, NO_LATE, Collections.emptyList(), null));
+    }
+
+    @Test
+    public void nullFeedbackDateIsLeftToExistingChecks() {
+        assertTrue(FeedbackDateValidator.isFeedbackDateAfterDeadline(
+                null, DUE, null, ACCEPT_LATE, null, null));
+    }
+}

--- a/samigo/samigo-app/src/webapp/js/authoring.js
+++ b/samigo/samigo-app/src/webapp/js/authoring.js
@@ -902,3 +902,16 @@ function changeStatusCorrectResponseCheckbox() {
 
   hideCorrectResponse.style.display = (hideCorrectResponse.style.display == "none") ? "block" : "none";
 }
+
+// SAK-34476 When a settings save was rejected because of the feedback date, return the index
+// of the accordion panel that holds the feedback date field so the caller can open it and put
+// the field to fix in front of the instructor. Returns defaultPanel when the flag is false or
+// the panel can't be located. Shared by authorSettings.jsp and publishedSettings.jsp.
+function openFeedbackPanelOnError(feedbackDateInError, defaultPanel) {
+  if (!feedbackDateInError) {
+    return defaultPanel;
+  }
+  const feedbackPanel = $("[id='assessmentSettingsAction:feedbackDate']").closest("div[id^='__hide_division']:not([id$='_container'])");
+  const feedbackPanelIndex = $("#jqueryui-accordion").children("div[id^='__hide_division']:not([id$='_container'])").index(feedbackPanel);
+  return feedbackPanelIndex >= 0 ? feedbackPanelIndex : defaultPanel;
+}

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -62,16 +62,9 @@
           if (window.sessionStorage && window.sessionStorage.getItem(itemName)) {
               accordionPanel = parseInt(window.sessionStorage.getItem(itemName));
           }
-          // SAK-34476 open the Grading and Feedback panel when the save was rejected
-          // because of the feedback date, so the field to fix is in front of the instructor
-          const feedbackDateInError = <h:outputText value="#{assessmentSettings.feedbackDateInError}"/>;
-          if (feedbackDateInError) {
-              const feedbackPanel = $("[id='assessmentSettingsAction:feedbackDate']").closest("div[id^='__hide_division']:not([id$='_container'])");
-              const feedbackPanelIndex = $("#jqueryui-accordion").children("div[id^='__hide_division']:not([id$='_container'])").index(feedbackPanel);
-              if (feedbackPanelIndex >= 0) {
-                  accordionPanel = feedbackPanelIndex;
-              }
-          }
+          // SAK-34476 open the Grading and Feedback panel when the save was rejected because of
+          // the feedback date, so the field to fix is in front of the instructor
+          accordionPanel = openFeedbackPanelOnError(<h:outputText value="#{assessmentSettings.feedbackDateInError}"/>, accordionPanel);
           $("#jqueryui-accordion").accordion({
               heightStyle: "content",
               activate: function(event, ui) {

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -62,6 +62,16 @@
           if (window.sessionStorage && window.sessionStorage.getItem(itemName)) {
               accordionPanel = parseInt(window.sessionStorage.getItem(itemName));
           }
+          // SAK-34476 open the Grading and Feedback panel when the save was rejected
+          // because of the feedback date, so the field to fix is in front of the instructor
+          const feedbackDateInError = <h:outputText value="#{assessmentSettings.feedbackDateInError}"/>;
+          if (feedbackDateInError) {
+              const feedbackPanel = $("[id='assessmentSettingsAction:feedbackDate']").closest("div[id^='__hide_division']:not([id$='_container'])");
+              const feedbackPanelIndex = $("#jqueryui-accordion").children("div[id^='__hide_division']:not([id$='_container'])").index(feedbackPanel);
+              if (feedbackPanelIndex >= 0) {
+                  accordionPanel = feedbackPanelIndex;
+              }
+          }
           $("#jqueryui-accordion").accordion({
               heightStyle: "content",
               activate: function(event, ui) {

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -62,16 +62,9 @@
           if (window.sessionStorage && window.sessionStorage.getItem(itemName)) {
               accordionPanel = parseInt(window.sessionStorage.getItem(itemName));
           }
-          // SAK-34476 open the Grading and Feedback panel when the save was rejected
-          // because of the feedback date, so the field to fix is in front of the instructor
-          const feedbackDateInError = <h:outputText value="#{publishedSettings.feedbackDateInError}"/>;
-          if (feedbackDateInError) {
-              const feedbackPanel = $("[id='assessmentSettingsAction:feedbackDate']").closest("div[id^='__hide_division']:not([id$='_container'])");
-              const feedbackPanelIndex = $("#jqueryui-accordion").children("div[id^='__hide_division']:not([id$='_container'])").index(feedbackPanel);
-              if (feedbackPanelIndex >= 0) {
-                  accordionPanel = feedbackPanelIndex;
-              }
-          }
+          // SAK-34476 open the Grading and Feedback panel when the save was rejected because of
+          // the feedback date, so the field to fix is in front of the instructor
+          accordionPanel = openFeedbackPanelOnError(<h:outputText value="#{publishedSettings.feedbackDateInError}"/>, accordionPanel);
           $("#jqueryui-accordion").accordion({
               heightStyle: "content",
               activate: function(event, ui) {

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -62,6 +62,16 @@
           if (window.sessionStorage && window.sessionStorage.getItem(itemName)) {
               accordionPanel = parseInt(window.sessionStorage.getItem(itemName));
           }
+          // SAK-34476 open the Grading and Feedback panel when the save was rejected
+          // because of the feedback date, so the field to fix is in front of the instructor
+          const feedbackDateInError = <h:outputText value="#{publishedSettings.feedbackDateInError}"/>;
+          if (feedbackDateInError) {
+              const feedbackPanel = $("[id='assessmentSettingsAction:feedbackDate']").closest("div[id^='__hide_division']:not([id$='_container'])");
+              const feedbackPanelIndex = $("#jqueryui-accordion").children("div[id^='__hide_division']:not([id$='_container'])").index(feedbackPanel);
+              if (feedbackPanelIndex >= 0) {
+                  accordionPanel = feedbackPanelIndex;
+              }
+          }
           $("#jqueryui-accordion").accordion({
               heightStyle: "content",
               activate: function(event, ui) {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-34476

## Problem

With Feedback Delivery set to "displayed to the student at a specific date", Samigo never checks that the feedback date falls after the assessment's final submission deadline. If the feedback date is in the past while the assessment is still open — the classic case is duplicating or importing last term's assessment and updating the due date but forgetting the feedback date — every student taking it after that date gets a "Show Feedback" link mid-take that reveals correct answers and per-question scores (the Table of Contents shows running scores too). Two instructors at UVA hit exactly this and reported it as a bug; the T&L and UX calls agreed the fix is to prevent the configuration at save time (see ticket comments for the agreed spec).

## Fix

New `FeedbackDateValidator` computes the **latest submission deadline** — due date, or the late acceptance date when late submissions are enabled, pushed out by the due/retract date of every extended-time exception — and blocks saving/publishing when the feedback date falls before it (or when no deadline exists at all), per the spec in the ticket. When any cohort (base students or an exception holder) is open-ended, there is no safe feedback date, so the save is blocked with a message asking for a deadline; this matches delivery behavior, where a null exception date means "no cutoff" rather than "fall back to the base date".

The check runs on **every path that can produce the bad state**, several of which skip the settings-form validations entirely today:

- draft Settings → **Save** (also closes the ticket's Publish-Confirmation → Edit Settings → Save loophole)
- draft Settings → **Save Settings and Publish**
- assessment list → Actions → **Publish** (runs `ConfirmPublishAssessmentListener` with `isFromAssessmentSettings=false`, which previously skipped all date checks)
- assessment list → checkboxes → **Publish Selected** (went straight to `publishOne()` with no validation; blocked per assessment, named in the message)
- published assessment Settings → **Save**

The error messages tell the instructor the deadline (formatted with `UserTimeService` in the site/user locale) and point to the "Yes, show the student feedback while they are taking the assessment" option for anyone who wants mid-take feedback on purpose. On rejection the Grading and Feedback settings panel is auto-expanded so the instructor lands on the field to fix.

**Retract is deliberately exempted** (`!retractNow`): retracting closes the assessment and ends any leak, so it must never be blocked by this check — otherwise an instructor couldn't shut down a leaking assessment.

## Known limitations (intentional — scoped to the authoring paths this ticket describes)

- **Republish of a retracted-for-edit assessment is left alone.** `ConfirmRepublishAssessmentListener` only re-checks scores (its date-check call has been commented out for years). An assessment republished without editing keeps dates that were validated on their last save, so the residual exposure is limited to data saved before this fix — consistent with not retroactively validating existing published data. Flagging rather than expanding scope; happy to follow up if reviewers prefer it guarded too.
- **Existing published assessments** with a stale feedback date keep their current behavior until an instructor next edits their settings; there is no delivery-time enforcement (per the ticket discussion, silently overriding instructor settings at delivery was rejected). The delivery-side weakness that makes the mid-take reveal possible at all — the take screen trusts a `showfeedbacknow` request parameter — is SAK-52707 and is best fixed there.
- **Date Manager** edits Samigo dates through its own service (`DateManagerServiceImpl.updateAssessments`, plus its CSV import) and performs no feedback-vs-deadline check, so it can still move a published assessment into the bad state — tracked separately in SAK-43763.
- **`PATCH /api/sites/{siteId}/entities`** (webapi `SiteEntityController`) can likewise move a published assessment's due date or rewrite its extended-time exceptions past an existing feedback date with no validation.
- **Lessons Common Cartridge import** is the one caller of `publishAssessment` outside the publish listener; it blanks the access control on import, so dates are normally null, but it does bypass this validation.
- **Exception holders on a "no late submissions" assessment**: delivery treats an extended-time student whose entry has no retract date as accept-late indefinitely (`DeliveryBean.isAcceptLateSubmission`), so such a student who never submitted can still begin after the feedback date. Guarding that here would block feedback-by-date on every no-late assessment with exceptions, so it is left to the delivery-side fix (SAK-52707).

## Testing

- New `FeedbackDateValidatorTest` (15 tests) covers the deadline computation: base due/retract with and without late handling, null deadlines, exceptions extending (but never shrinking) the deadline, open-ended cohorts poisoning the deadline, and the feedback-date comparison boundaries (equal-to-deadline allowed).
- Manually verified on a local instance: each path above blocks with the message when the feedback date is stale and proceeds normally once the date is corrected (or a different feedback option is selected); Retract still works on an assessment with a stale feedback date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure “feedback by specific dates” can’t be scheduled before the latest student submission deadline.
  * Settings UI now automatically opens the Feedback/Grading panel when feedback-date validation fails.

* **Bug Fixes**
  * Publishing and saving are blocked when feedback dates violate the deadline rule (with retract handling preserved where applicable).
  * Bulk publish skips affected assessments and displays a localized error message.
  * Published settings now retains the error state to open the correct panel.

* **Tests**
  * Added unit tests covering deadline calculation and feedback-date validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->