### PR TITLE
SAK-52707 Samigo: never reveal by-date feedback during an active take

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2025,12 +2025,24 @@ public class DeliveryBean implements Serializable {
   }
 
   public boolean getShowFeedbackLink() {
-      return ("reviewAssessment".equals(getActionString())
-              || "takeAssessment".equals(getActionString())
-              || "takeAssessmentViaUrl".equals(getActionString())
-              || "previewAssessment".equals(getActionString()))
-             && ! ("1".equals(getNavigation()) && getPageContents().getIsNoParts())
-             && (getFeedbackComponent().getShowImmediate() || feedbackOnDate);
+      boolean takingAssessment = "takeAssessment".equals(getActionString())
+              || "takeAssessmentViaUrl".equals(getActionString());
+      boolean reviewingOrPreviewing = "reviewAssessment".equals(getActionString())
+              || "previewAssessment".equals(getActionString());
+      if (!takingAssessment && !reviewingOrPreviewing) {
+          return false;
+      }
+      if ("1".equals(getNavigation()) && getPageContents().getIsNoParts()) {
+          return false;
+      }
+      // SAK-34476 while a student is actively taking the assessment, only Immediate Feedback
+      // shows feedback mid-take. "On specific dates" feedback is for review after submission, so
+      // feedbackOnDate must not surface the Feedback link during a take (also covers post-deadline
+      // retakes/resubmits, where feedbackOnDate has since flipped true).
+      if (takingAssessment) {
+          return getFeedbackComponent().getShowImmediate();
+      }
+      return getFeedbackComponent().getShowImmediate() || feedbackOnDate;
   }
 
   public boolean getShowReturnToAssessmentLink() {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -2035,8 +2035,8 @@ public class DeliveryBean implements Serializable {
       if ("1".equals(getNavigation()) && getPageContents().getIsNoParts()) {
           return false;
       }
-      // SAK-34476 while a student is actively taking the assessment, only Immediate Feedback
-      // shows feedback mid-take. "On specific dates" feedback is for review after submission, so
+      // While a student is actively taking the assessment, only Immediate Feedback shows
+      // feedback mid-take. "On specific dates" feedback is for review after submission, so
       // feedbackOnDate must not surface the Feedback link during a take (also covers post-deadline
       // retakes/resubmits, where feedbackOnDate has since flipped true).
       if (takingAssessment) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -2639,8 +2639,17 @@ public class DeliveryActionListener
     delivery.setNoFeedback("false");
     switch (action){
     case 1: // take assessment
-    case 2: // preview assessment
     case 5: // take assessment via url
+            // SAK-34476 do not trust the showfeedbacknow request parameter on its own: while
+            // actively taking, feedback is only served when Immediate Feedback is configured.
+            // This is the server-side entitlement check behind the (hidden) Feedback link, so a
+            // forged parameter cannot reveal "on specific dates" feedback during a take.
+            if (showfeedbacknow != null && showfeedbacknow.equals("true")
+                && delivery.getFeedbackComponent() != null && delivery.getFeedbackComponent().getShowImmediate()) {
+              delivery.setFeedback("true");
+            }
+            break;
+    case 2: // preview assessment
             if (showfeedbacknow != null && showfeedbacknow.equals("true")) {
               delivery.setFeedback("true");
             }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -2640,7 +2640,7 @@ public class DeliveryActionListener
     switch (action){
     case 1: // take assessment
     case 5: // take assessment via url
-            // SAK-34476 do not trust the showfeedbacknow request parameter on its own: while
+            // Do not trust the showfeedbacknow request parameter on its own: while
             // actively taking, feedback is only served when Immediate Feedback is configured.
             // This is the server-side entitlement check behind the (hidden) Feedback link, so a
             // forged parameter cannot reveal "on specific dates" feedback during a take.


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52707

> **Draft / first pass for discussion.** This is a focused delivery-side change and I'm opening it to get eyes on the approach before polishing. I'm not certain it fully fits Sakai's security model or that gating purely on Immediate Feedback won't have side effects on flows I haven't exercised — see "Open questions" below. Feedback very welcome on whether this is the right layer to enforce at.

## Problem

While a student is actively taking an assessment, whether feedback (correct answers, question-level feedback) is shown is decided from client-supplied input with no server-side entitlement check:

- `DeliveryActionListener.setFeedbackMode(...)` sets `delivery.feedback = "true"` for take / take-via-url actions whenever the request carries `showfeedbacknow=true`, with no check that feedback is actually available. The item JSPs then render correct answers and question-level feedback off `delivery.feedback` alone.
- `DeliveryBean.getShowFeedbackLink()` rendered the mid-take Feedback link when `getShowImmediate() || feedbackOnDate`. `feedbackOnDate` is true whenever feedback delivery is "on specific dates" and that date has passed — so the hidden link was the only thing enforcing policy.

Result: a crafted request can reveal feedback mid-take even on a correctly configured "on specific dates" assessment, and through the normal UI on a post-deadline retake/resubmit once the feedback date has passed. This is the delivery-side companion to SAK-34476 (authoring-side date validation, #14735), which prevents the *misconfiguration* but does not close this gap on a properly configured assessment.

## Approach in this pass

"On specific dates" feedback is intended for review after submission; only Immediate Feedback is meant to display feedback during a take. So during an active take, gate on Immediate Feedback in both places:

- `getShowFeedbackLink()` — for take / take-via-url, return the link only when `getShowImmediate()`; `feedbackOnDate` no longer surfaces it mid-take. Preview and review are unchanged (they still honor `feedbackOnDate`).
- `setFeedbackMode()` — for take / take-via-url, honor `showfeedbacknow=true` only when `getShowImmediate()` is also true, so a forged parameter is ignored. Preview (case 2), review (case 3), and grade (case 4) are untouched.

Two files, no new bundle strings or schema changes.

## What this deliberately does *not* do

- No delivery-time enforcement of the *authoring* rule (feedback date vs. submission deadline) — that stays on the authoring side in SAK-34476/#14735, per the ticket discussion that rejected silently overriding instructor settings at delivery.
- Does not touch how feedback is shown in review/history after submission.

## Open questions for reviewers

- **Is delivery the right layer, and is "Immediate Feedback only during a take" the correct policy?** It matches the ticket's stated intent, but I'd like confirmation it doesn't contradict an intended use of by-date feedback mid-take that I'm not aware of.
- **Preview parity.** Preview (instructor) still trusts `showfeedbacknow` unconditionally (case 2). That seems right since preview is instructor-only, but flagging it explicitly.
- **Post-deadline retake behavior change.** A legitimate post-deadline retake of a by-date assessment no longer shows the Feedback link mid-retake. I believe that's the intended fix, but it is a user-visible behavior change worth a second opinion.
- **Coverage of take entry points.** I've matched action modes 1 (take) and 5 (take-via-url) and the two take action strings; if there are other delivery entry points that should count as "taking," they need the same gate.

## Testing so far

- Manual forge check against a running instance: on an assessment whose feedback date is correctly in the future, a `showfeedbacknow=true` POST during a take previously returned item feedback including correct-answer text; with this change it does not.
- Not yet added automated coverage — `setFeedbackMode` / `getShowFeedbackLink` have no existing unit harness and need JSF/bean wiring; happy to add tests if the approach is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined when the feedback link appears during assessment taking, review, and preview flows.
  * Fixed “take assessment via URL” behavior so feedback is only enabled when immediate feedback is available.
  * Kept feedback hidden for non-applicable views and for no-parts navigation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->