### PR TITLE
NOJIRA docker: scan jakarta.faces jars so JSF tools initialize

### DIFF
--- a/docker/tomcat/conf/context.xml
+++ b/docker/tomcat/conf/context.xml
@@ -1,7 +1,7 @@
 <Context>
     <JarScanner>
         <!-- This is to speedup startup so that tomcat doesn't scan as much -->
-        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
+        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,jakarta.faces-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
     </JarScanner>
 </Context>
 


### PR DESCRIPTION
## Problem

The docker dev environment's `tomcat/conf/context.xml` disables Tomcat jar scanning for startup speed and allowlists the JSF implementation by its old artifact name (`javax.faces-*.jar`). The Mojarra artifact shipped on master is now `jakarta.faces-*.jar`, so it never gets scanned, Mojarra's `ConfigureListener` never registers, and every JSF webapp (Tests & Quizzes, Podcasts, Sign-up, …) fails on first request with:

```
java.lang.IllegalStateException: Could not find backup for factory javax.faces.lifecycle.LifecycleFactory
javax.faces.FactoryFinderInstance.logNoFactory Application was not properly initialized at startup, could not find Factory: javax.faces.lifecycle.LifecycleFactory
```

Anyone standing up the docker dev environment from current master hits this on every JSF tool.

## Fix

One line: add `jakarta.faces-*.jar` to the `tldScan` allowlist (keeping the old `javax.faces-*.jar` pattern for older builds). Verified in the docker dev env: after a restart, Mojarra initializes for all JSF contexts (`Initializing Mojarra 2.3.21 for context '/samigo-app'`, etc.) and Tests & Quizzes loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated application server scanning rules to recognize both Jakarta Faces and Javax Faces libraries, improving compatibility with newer deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->