### PR TITLE
SAK-52267 Samigo: automatic late penalty (flat or per-day) with per-submission waiver

### DIFF
--- a/docker/tomcat/conf/context.xml
+++ b/docker/tomcat/conf/context.xml
@@ -1,7 +1,7 @@
 <Context>
     <JarScanner>
         <!-- This is to speedup startup so that tomcat doesn't scan as much -->
-        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
+        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,jakarta.faces-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
     </JarScanner>
 </Context>
 

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/dao/grading/AssessmentGradingData.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/dao/grading/AssessmentGradingData.java
@@ -45,6 +45,9 @@ public class AssessmentGradingData implements java.io.Serializable
 	// private PublishedAssessmentIfc publishedAssessment;
 	private Date submittedDate;
 	private Boolean isLate;
+	// SAK-52267 grader chose to waive the assessment's automatic late penalty
+	// for this submission; null/false means the penalty applies
+	private Boolean ignoreLatePenalty;
 	private Boolean forGrade;
 	private Double totalAutoScore;
 	private Double totalOverrideScore;
@@ -234,6 +237,14 @@ public class AssessmentGradingData implements java.io.Serializable
 
 	public void setIsLate(Boolean isLate) {
 		this.isLate = isLate;
+	}
+
+	public Boolean getIgnoreLatePenalty() {
+		return ignoreLatePenalty;
+	}
+
+	public void setIgnoreLatePenalty(Boolean ignoreLatePenalty) {
+		this.ignoreLatePenalty = ignoreLatePenalty;
 	}
 
 	public Boolean getForGrade() {
@@ -487,6 +498,7 @@ public class AssessmentGradingData implements java.io.Serializable
         builder.append(gradedBy);
         builder.append(gradedDate);
         builder.append(gradedDate);
+        builder.append(ignoreLatePenalty);
         builder.append(isAutoSubmitted);
         builder.append(isLate);
         builder.append(isRecorded);
@@ -523,6 +535,7 @@ public class AssessmentGradingData implements java.io.Serializable
 	    builder.append(forGrade,other.forGrade);
 	    builder.append(gradedBy,other.gradedBy);
 	    builder.append(gradedDate,other.gradedDate);
+	    builder.append(ignoreLatePenalty,other.ignoreLatePenalty);
 	    builder.append(isAutoSubmitted,other.isAutoSubmitted);
 	    builder.append(isLate,other.isLate);
 	    builder.append(isRecorded,other.isRecorded);

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/AssessmentMetaDataIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/AssessmentMetaDataIfc.java
@@ -48,6 +48,8 @@ public interface AssessmentMetaDataIfc
    */
   public static final String LATE_PENALTY_TYPE = "ASSESSMENT_LATE_PENALTY_TYPE";
   public static final String LATE_PENALTY_VALUE = "ASSESSMENT_LATE_PENALTY_VALUE";
+  /** POINTS (default when absent) or PERCENT of the assessment's maximum score */
+  public static final String LATE_PENALTY_UNIT = "ASSESSMENT_LATE_PENALTY_UNIT";
 
   Long getId();
 

--- a/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/AssessmentMetaDataIfc.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/tool/assessment/data/ifc/assessment/AssessmentMetaDataIfc.java
@@ -40,6 +40,15 @@ public interface AssessmentMetaDataIfc
   public static final String TO_GRADEBOOK_ID = "TO_GRADEBOOK_ID";
   public static final String CATEGORY_LIST = "CATEGORY_LIST";
 
+  /**
+   * SAK-52267 automatic late penalty: mode is a
+   * {@code org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyType}
+   * name (FLAT or PER_DAY), absent/blank when no penalty is configured; value
+   * is the point deduction as an unsigned decimal string.
+   */
+  public static final String LATE_PENALTY_TYPE = "ASSESSMENT_LATE_PENALTY_TYPE";
+  public static final String LATE_PENALTY_VALUE = "ASSESSMENT_LATE_PENALTY_VALUE";
+
   Long getId();
 
   void setId(Long id);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -211,6 +211,7 @@ late_penalty_per_hour=Deduct per hour late
 late_penalty_per_day=Deduct per day late
 late_penalty_per_week=Deduct per week late
 late_penalty_points=Amount to deduct
+late_penalty_unit_label=Deduction unit
 late_penalty_unit_points=points
 late_penalty_unit_percent=% of total score
 late_penalty_error=Please specify a positive value for the late penalty.

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -203,6 +203,13 @@ gradebook_options_help=Send assessment score to Gradebook immediately on submiss
 gradebook_category_select=Select a Gradebook category (optional)
 gradebook_item_select=Select a Gradebook item
 gradebook_uncategorized=Uncategorized
+# SAK-52267 automatic late penalty
+late_penalty=Late Penalty
+late_penalty_none=No late penalty
+late_penalty_flat=Deduct points for late submissions
+late_penalty_per_day=Deduct points per day for late submissions
+late_penalty_points=Points to deduct
+late_penalty_error=Please specify a positive point value for the late penalty.
 grading_options_disabled_info=The option(s) below are disabled due to the selection of "Anyone with the link (Anonymous survey)" in the "Availability and Submissions" settings. Changing that option will unselect 'Anonymous Grading'.
 
 grading_scoring_title=Scoring and Grading

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -206,10 +206,15 @@ gradebook_uncategorized=Uncategorized
 # SAK-52267 automatic late penalty
 late_penalty=Late Penalty
 late_penalty_none=No late penalty
-late_penalty_flat=Deduct points for late submissions
-late_penalty_per_day=Deduct points per day for late submissions
-late_penalty_points=Points to deduct
-late_penalty_error=Please specify a positive point value for the late penalty.
+late_penalty_flat=Deduct once for late submissions
+late_penalty_per_hour=Deduct per hour late
+late_penalty_per_day=Deduct per day late
+late_penalty_per_week=Deduct per week late
+late_penalty_points=Amount to deduct
+late_penalty_unit_points=points
+late_penalty_unit_percent=% of total score
+late_penalty_error=Please specify a positive value for the late penalty.
+late_penalty_percent_error=A percentage late penalty cannot be more than 100.
 grading_options_disabled_info=The option(s) below are disabled due to the selection of "Anyone with the link (Anonymous survey)" in the "Availability and Submissions" settings. Changing that option will unselect 'Anonymous Grading'.
 
 grading_scoring_title=Scoring and Grading

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EvaluationMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EvaluationMessages.properties
@@ -7,6 +7,9 @@ par_anon=(anonymous)
 par_byuser=(by username)
 adj=Adj
 adjustment=Adjustment
+# SAK-52267 automatic late penalty
+late_penalty=Late Penalty
+ignore_late_penalty=Ignore late penalty
 all_late=All <br />Graded <br />LATE
 all_sub=All Submissions
 average_sub=Average Submission

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -146,7 +146,10 @@ public class AssessmentSettingsBean extends SpringBeanAutowiringSupport implemen
   private String rubrics;
   private String authors;
   @Getter @Setter private Boolean trackQuestions;
-  
+  // SAK-52267 automatic late penalty: type is "" (none), FLAT or PER_DAY
+  @Getter @Setter private String latePenaltyType;
+  @Getter @Setter private String latePenaltyValue;
+
   // these are properties in AssessmentAccessControl
   private Date startDate;
   private Date dueDate;
@@ -367,6 +370,8 @@ public class AssessmentSettingsBean extends SpringBeanAutowiringSupport implemen
       this.bgImage = assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.
           BGIMAGE);
       this.trackQuestions = Boolean.valueOf(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.TRACK_QUESTIONS));
+      this.latePenaltyType = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
+      this.latePenaltyValue = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
       if((assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.
 						    BGIMAGE)!=null )&&(!assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.
 																										BGIMAGE).equals(""))){

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/AssessmentSettingsBean.java
@@ -149,6 +149,8 @@ public class AssessmentSettingsBean extends SpringBeanAutowiringSupport implemen
   // SAK-52267 automatic late penalty: type is "" (none), FLAT or PER_DAY
   @Getter @Setter private String latePenaltyType;
   @Getter @Setter private String latePenaltyValue;
+  // POINTS (default) or PERCENT of the assessment's maximum score
+  @Getter @Setter private String latePenaltyUnit;
 
   // these are properties in AssessmentAccessControl
   private Date startDate;
@@ -372,6 +374,7 @@ public class AssessmentSettingsBean extends SpringBeanAutowiringSupport implemen
       this.trackQuestions = Boolean.valueOf(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.TRACK_QUESTIONS));
       this.latePenaltyType = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
       this.latePenaltyValue = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+      this.latePenaltyUnit = StringUtils.defaultIfBlank(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_UNIT), "POINTS");
       if((assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.
 						    BGIMAGE)!=null )&&(!assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.
 																										BGIMAGE).equals(""))){

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -144,6 +144,8 @@ public class PublishedAssessmentSettingsBean extends SpringBeanAutowiringSupport
   // SAK-52267 automatic late penalty: type is "" (none), FLAT or PER_DAY
   @Getter @Setter private String latePenaltyType;
   @Getter @Setter private String latePenaltyValue;
+  // POINTS (default) or PERCENT of the assessment's maximum score
+  @Getter @Setter private String latePenaltyUnit;
 
   // these are properties in PublishedAccessControl
   private Date startDate;
@@ -340,6 +342,7 @@ public class PublishedAssessmentSettingsBean extends SpringBeanAutowiringSupport
       this.trackQuestions = Boolean.valueOf(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.TRACK_QUESTIONS));
       this.latePenaltyType = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
       this.latePenaltyValue = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+      this.latePenaltyUnit = StringUtils.defaultIfBlank(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_UNIT), "POINTS");
 
       if((assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.BGIMAGE)!=null )
     		  && (!assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.BGIMAGE).equals(""))){

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/author/PublishedAssessmentSettingsBean.java
@@ -141,6 +141,9 @@ public class PublishedAssessmentSettingsBean extends SpringBeanAutowiringSupport
   private String rubrics;
   private String authors;
   @Getter @Setter private Boolean trackQuestions;
+  // SAK-52267 automatic late penalty: type is "" (none), FLAT or PER_DAY
+  @Getter @Setter private String latePenaltyType;
+  @Getter @Setter private String latePenaltyValue;
 
   // these are properties in PublishedAccessControl
   private Date startDate;
@@ -335,6 +338,8 @@ public class PublishedAssessmentSettingsBean extends SpringBeanAutowiringSupport
       this.bgImage = assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.
           BGIMAGE);
       this.trackQuestions = Boolean.valueOf(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.TRACK_QUESTIONS));
+      this.latePenaltyType = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
+      this.latePenaltyValue = StringUtils.defaultString(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
 
       if((assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.BGIMAGE)!=null )
     		  && (!assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.BGIMAGE).equals(""))){

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
@@ -76,6 +76,9 @@ public class AgentResults
   private Date submittedDate;
   private Date attemptDate;
   private Boolean isLate;
+  // SAK-52267 automatic late penalty: display amount and per-submission waiver
+  private String latePenalty;
+  private Boolean ignoreLatePenalty;
   private Boolean forGrade;
   private String totalAutoScore;
   private String totalOverrideScore;
@@ -232,6 +235,19 @@ public class AgentResults
   }
   public void setIsLate(Boolean isLate) {
     this.isLate = isLate;
+  }
+  // SAK-52267 the penalty display amount for the Total Scores column, e.g. "-5"
+  public String getLatePenalty() {
+    return Validator.check(latePenalty, "0");
+  }
+  public void setLatePenalty(String latePenalty) {
+    this.latePenalty = latePenalty;
+  }
+  public Boolean getIgnoreLatePenalty() {
+    return Validator.bcheck(ignoreLatePenalty, false);
+  }
+  public void setIgnoreLatePenalty(Boolean ignoreLatePenalty) {
+    this.ignoreLatePenalty = ignoreLatePenalty;
   }
   public Boolean getForGrade() {
     return Validator.bcheck(forGrade, true);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
@@ -69,6 +69,7 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
@@ -1103,6 +1104,12 @@ public class TotalScoresBean implements Serializable, PhaseAware {
 
   public PublishedAssessmentData getPublishedAssessment(){
     return publishedAssessment;
+  }
+
+  /** SAK-52267 whether this assessment has an automatic late penalty configured */
+  public boolean getLatePenaltyEnabled(){
+    return publishedAssessment != null
+        && StringUtils.isNotBlank(publishedAssessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
   }
 
   public void setPublishedAssessment(PublishedAssessmentData publishedAssessment){

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -356,6 +356,8 @@ public class SaveAssessmentSettings
         latePenaltyEnabled ? assessmentSettings.getLatePenaltyType() : "");
     assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_VALUE,
         latePenaltyEnabled ? StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()).replace(",", ".") : "");
+    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_UNIT,
+        latePenaltyEnabled && "PERCENT".equals(assessmentSettings.getLatePenaltyUnit()) ? "PERCENT" : "");
 
     // jj. save assessment first, then deal with ip
     assessmentService.saveAssessment(assessment);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettings.java
@@ -350,6 +350,13 @@ public class SaveAssessmentSettings
     assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.RUBRICS, TextFormat.convertPlaintextToFormattedTextNoHighUnicode(assessmentSettings.getRubrics()));
     assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.TRACK_QUESTIONS, Boolean.toString(assessmentSettings.getTrackQuestions()));
 
+    // SAK-52267 automatic late penalty; blank type = no penalty, value stored dot-normalized
+    boolean latePenaltyEnabled = StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType());
+    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_TYPE,
+        latePenaltyEnabled ? assessmentSettings.getLatePenaltyType() : "");
+    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_VALUE,
+        latePenaltyEnabled ? StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()).replace(",", ".") : "");
+
     // jj. save assessment first, then deal with ip
     assessmentService.saveAssessment(assessment);
     assessmentService.deleteAllSecuredIP(assessment);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
@@ -342,6 +342,24 @@ public class SaveAssessmentSettingsListener
 		}
     }
 
+    // SAK-52267 when a late penalty is selected its point value must be a positive number
+    if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())) {
+        boolean latePenaltyError = false;
+        String submittedPenalty = StringUtils.replace(StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()), ",", ".");
+        try {
+            if (Double.parseDouble(submittedPenalty) <= 0) {
+                latePenaltyError = true;
+            }
+        } catch (NumberFormatException ex) {
+            latePenaltyError = true;
+        }
+        if (latePenaltyError) {
+            error = true;
+            String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
+            context.addMessage(null, new FacesMessage(str_err));
+        }
+    }
+
     List<SelectItem> existingGradebook = assessmentSettings.getExistingGradebook();
     ToolSession currentToolSession = SessionManager.getCurrentToolSession();
     for (SelectItem item : existingGradebook) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
@@ -343,13 +343,20 @@ public class SaveAssessmentSettingsListener
 		}
     }
 
-    // SAK-52267 when a late penalty is selected its point value must be a positive
-    // number; the same parser runs at scoring time so validation cannot drift
-    if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())
-            && LatePenaltyCalculator.parsePenaltyValue(assessmentSettings.getLatePenaltyValue()) == null) {
-        error = true;
-        String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
-        context.addMessage(null, new FacesMessage(str_err));
+    // SAK-52267 when a late penalty is selected its value must be a positive number
+    // (and at most 100 for percentages); the same parser runs at scoring time so
+    // validation cannot drift
+    if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())) {
+        Double latePenaltyValue = LatePenaltyCalculator.parsePenaltyValue(assessmentSettings.getLatePenaltyValue());
+        if (latePenaltyValue == null) {
+            error = true;
+            String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
+            context.addMessage(null, new FacesMessage(str_err));
+        } else if ("PERCENT".equals(assessmentSettings.getLatePenaltyUnit()) && latePenaltyValue > 100d) {
+            error = true;
+            String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_percent_error");
+            context.addMessage(null, new FacesMessage(str_err));
+        }
     }
 
     List<SelectItem> existingGradebook = assessmentSettings.getExistingGradebook();

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SaveAssessmentSettingsListener.java
@@ -51,6 +51,7 @@ import org.sakaiproject.tool.assessment.ui.bean.author.AssessmentSettingsBean;
 import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -342,22 +343,13 @@ public class SaveAssessmentSettingsListener
 		}
     }
 
-    // SAK-52267 when a late penalty is selected its point value must be a positive number
-    if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())) {
-        boolean latePenaltyError = false;
-        String submittedPenalty = StringUtils.replace(StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()), ",", ".");
-        try {
-            if (Double.parseDouble(submittedPenalty) <= 0) {
-                latePenaltyError = true;
-            }
-        } catch (NumberFormatException ex) {
-            latePenaltyError = true;
-        }
-        if (latePenaltyError) {
-            error = true;
-            String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
-            context.addMessage(null, new FacesMessage(str_err));
-        }
+    // SAK-52267 when a late penalty is selected its point value must be a positive
+    // number; the same parser runs at scoring time so validation cannot drift
+    if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())
+            && LatePenaltyCalculator.parsePenaltyValue(assessmentSettings.getLatePenaltyValue()) == null) {
+        error = true;
+        String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
+        context.addMessage(null, new FacesMessage(str_err));
     }
 
     List<SelectItem> existingGradebook = assessmentSettings.getExistingGradebook();

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -102,6 +102,7 @@ import org.sakaiproject.tool.assessment.ui.bean.author.PublishRepublishNotificat
 import org.sakaiproject.tool.assessment.ui.bean.author.PublishedAssessmentSettingsBean;
 import org.sakaiproject.tool.assessment.ui.bean.authz.AuthorizationBean;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator;
 import org.sakaiproject.tool.assessment.util.TextFormat;
 import org.sakaiproject.tool.assessment.util.TimeLimitValidator;
 import org.sakaiproject.tool.cover.SessionManager;
@@ -209,6 +210,18 @@ implements ActionListener
 
 		// jj. save assessment first, then deal with ip
 	    assessmentService.saveAssessment(assessment);
+
+	    // SAK-52267 a late penalty configuration change re-scores existing graded
+	    // submissions immediately (and renotifies the gradebook), so stored final
+	    // scores never disagree with the current settings
+	    String oldPenaltyType = StringUtils.trimToEmpty(originalAssessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
+	    String oldPenaltyValue = StringUtils.trimToEmpty(originalAssessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+	    String newPenaltyType = StringUtils.trimToEmpty(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
+	    String newPenaltyValue = StringUtils.trimToEmpty(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+	    if (!StringUtils.equals(oldPenaltyType, newPenaltyType) || !StringUtils.equals(oldPenaltyValue, newPenaltyValue)) {
+	        new GradingService().applyLatePenaltiesToSubmissions(assessment);
+	    }
+
 	    assessmentService.deleteAllSecuredIP(assessment);
 	    // k. set ipAddresses
 	    Set ipSet = new HashSet();
@@ -586,22 +599,13 @@ implements ActionListener
 			}
 		}
 
-		// SAK-52267 when a late penalty is selected its point value must be a positive number
-		if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())) {
-			boolean latePenaltyError = false;
-			String submittedPenalty = StringUtils.replace(StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()), ",", ".");
-			try {
-				if (Double.parseDouble(submittedPenalty) <= 0) {
-					latePenaltyError = true;
-				}
-			} catch (NumberFormatException ex) {
-				latePenaltyError = true;
-			}
-			if (latePenaltyError) {
-				error = true;
-				String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
-				context.addMessage(null, new FacesMessage(str_err));
-			}
+		// SAK-52267 when a late penalty is selected its point value must be a positive
+		// number; the same parser runs at scoring time so validation cannot drift
+		if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())
+				&& LatePenaltyCalculator.parsePenaltyValue(assessmentSettings.getLatePenaltyValue()) == null) {
+			error = true;
+			String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
+			context.addMessage(null, new FacesMessage(str_err));
 		}
 
 		org.sakaiproject.grading.api.GradingService gradingService =

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -586,6 +586,24 @@ implements ActionListener
 			}
 		}
 
+		// SAK-52267 when a late penalty is selected its point value must be a positive number
+		if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())) {
+			boolean latePenaltyError = false;
+			String submittedPenalty = StringUtils.replace(StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()), ",", ".");
+			try {
+				if (Double.parseDouble(submittedPenalty) <= 0) {
+					latePenaltyError = true;
+				}
+			} catch (NumberFormatException ex) {
+				latePenaltyError = true;
+			}
+			if (latePenaltyError) {
+				error = true;
+				String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
+				context.addMessage(null, new FacesMessage(str_err));
+			}
+		}
+
 		org.sakaiproject.grading.api.GradingService gradingService =
 			(org.sakaiproject.grading.api.GradingService) ComponentManager.get("org.sakaiproject.grading.api.GradingService");
 
@@ -928,6 +946,13 @@ implements ActionListener
 	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.OBJECTIVES, TextFormat.convertPlaintextToFormattedTextNoHighUnicode(assessmentSettings.getObjectives()));
 	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.RUBRICS, TextFormat.convertPlaintextToFormattedTextNoHighUnicode(assessmentSettings.getRubrics()));
 	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.TRACK_QUESTIONS, Boolean.toString(assessmentSettings.getTrackQuestions()));
+
+	    // SAK-52267 automatic late penalty; blank type = no penalty, value stored dot-normalized
+	    boolean latePenaltyEnabled = StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType());
+	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_TYPE,
+	        latePenaltyEnabled ? assessmentSettings.getLatePenaltyType() : "");
+	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_VALUE,
+	        latePenaltyEnabled ? StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()).replace(",", ".") : "");
 	}
 
 	public boolean checkScore(PublishedAssessmentSettingsBean assessmentSettings, PublishedAssessmentFacade assessment, FacesContext context) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -216,9 +216,12 @@ implements ActionListener
 	    // scores never disagree with the current settings
 	    String oldPenaltyType = StringUtils.trimToEmpty(originalAssessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
 	    String oldPenaltyValue = StringUtils.trimToEmpty(originalAssessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+	    String oldPenaltyUnit = StringUtils.trimToEmpty(originalAssessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_UNIT));
 	    String newPenaltyType = StringUtils.trimToEmpty(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
 	    String newPenaltyValue = StringUtils.trimToEmpty(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
-	    if (!StringUtils.equals(oldPenaltyType, newPenaltyType) || !StringUtils.equals(oldPenaltyValue, newPenaltyValue)) {
+	    String newPenaltyUnit = StringUtils.trimToEmpty(assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_UNIT));
+	    if (!StringUtils.equals(oldPenaltyType, newPenaltyType) || !StringUtils.equals(oldPenaltyValue, newPenaltyValue)
+	            || !StringUtils.equals(oldPenaltyUnit, newPenaltyUnit)) {
 	        new GradingService().applyLatePenaltiesToSubmissions(assessment);
 	    }
 
@@ -599,13 +602,20 @@ implements ActionListener
 			}
 		}
 
-		// SAK-52267 when a late penalty is selected its point value must be a positive
-		// number; the same parser runs at scoring time so validation cannot drift
-		if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())
-				&& LatePenaltyCalculator.parsePenaltyValue(assessmentSettings.getLatePenaltyValue()) == null) {
-			error = true;
-			String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
-			context.addMessage(null, new FacesMessage(str_err));
+		// SAK-52267 when a late penalty is selected its value must be a positive number
+		// (and at most 100 for percentages); the same parser runs at scoring time so
+		// validation cannot drift
+		if (StringUtils.isNotBlank(assessmentSettings.getLatePenaltyType())) {
+			Double latePenaltyValue = LatePenaltyCalculator.parsePenaltyValue(assessmentSettings.getLatePenaltyValue());
+			if (latePenaltyValue == null) {
+				error = true;
+				String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_error");
+				context.addMessage(null, new FacesMessage(str_err));
+			} else if ("PERCENT".equals(assessmentSettings.getLatePenaltyUnit()) && latePenaltyValue > 100d) {
+				error = true;
+				String str_err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "late_penalty_percent_error");
+				context.addMessage(null, new FacesMessage(str_err));
+			}
 		}
 
 		org.sakaiproject.grading.api.GradingService gradingService =
@@ -957,6 +967,8 @@ implements ActionListener
 	        latePenaltyEnabled ? assessmentSettings.getLatePenaltyType() : "");
 	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_VALUE,
 	        latePenaltyEnabled ? StringUtils.trimToEmpty(assessmentSettings.getLatePenaltyValue()).replace(",", ".") : "");
+	    assessment.updateAssessmentMetaData(AssessmentMetaDataIfc.LATE_PENALTY_UNIT,
+	        latePenaltyEnabled && "PERCENT".equals(assessmentSettings.getLatePenaltyUnit()) ? "PERCENT" : "");
 	}
 
 	public boolean checkScore(PublishedAssessmentSettingsBean assessmentSettings, PublishedAssessmentFacade assessment, FacesContext context) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
@@ -568,9 +568,10 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
 
   /* Dump the grading and agent information into AgentResults */
   public void prepareAgentResult(PublishedAssessmentData p, Iterator iter, List agents, Map userRoles){
-	
+
 	TotalScoresBean bean = (TotalScoresBean) ContextUtil.lookupBean("totalScores");
 	Map agentResultsByAssessmentGradingIdMap = new HashMap();
+	GradingService gradingService = new GradingService();
 
     SecureDeliveryServiceAPI secureDelivery = SamigoApiFactory.getInstance().getSecureDeliveryServiceAPI();
     String moduleId = null;
@@ -635,9 +636,17 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
         results.setTimeElapsed(Integer.valueOf(0));      
       
       results.setComments(ComponentManager.get(FormattedText.class).convertFormattedTextToPlaintext(gdata.getComments()));
-      
+
       results.setIsLate(gdata.getIsLate());
-      
+
+      // SAK-52267 the penalty amount this submission attracts (shown even while
+      // waived, next to the Ignore late penalty checkbox)
+      results.setIgnoreLatePenalty(gdata.getIgnoreLatePenalty());
+      double latePenalty = gradingService.getLatePenalty(gdata, p);
+      results.setLatePenalty(latePenalty > 0
+          ? "-" + (latePenalty == Math.floor(latePenalty) ? String.valueOf((long) latePenalty) : String.valueOf(latePenalty))
+          : "0");
+
       Date dueDate = null;
       PublishedAccessControl ac = (PublishedAccessControl) p.getAssessmentAccessControl();
       if (ac!=null)

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreListener.java
@@ -23,6 +23,7 @@
 
 package org.sakaiproject.tool.assessment.ui.listener.evaluation;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -640,12 +641,17 @@ log.debug("totallistener: firstItem = " + bean.getFirstItem());
       results.setIsLate(gdata.getIsLate());
 
       // SAK-52267 the penalty amount this submission attracts (shown even while
-      // waived, next to the Ignore late penalty checkbox)
+      // waived, next to the Ignore late penalty checkbox), in the user's locale
       results.setIgnoreLatePenalty(gdata.getIgnoreLatePenalty());
       double latePenalty = gradingService.getLatePenalty(gdata, p);
-      results.setLatePenalty(latePenalty > 0
-          ? "-" + (latePenalty == Math.floor(latePenalty) ? String.valueOf((long) latePenalty) : String.valueOf(latePenalty))
-          : "0");
+      if (latePenalty > 0) {
+        NumberFormat penaltyFormat = NumberFormat.getInstance(localeService.getLocaleForCurrentSiteAndUser());
+        penaltyFormat.setGroupingUsed(false);
+        penaltyFormat.setMaximumFractionDigits(2);
+        results.setLatePenalty("-" + penaltyFormat.format(latePenalty));
+      } else {
+        results.setLatePenalty("0");
+      }
 
       Date dueDate = null;
       PublishedAccessControl ac = (PublishedAccessControl) p.getAssessmentAccessControl();

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreUpdateListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/TotalScoreUpdateListener.java
@@ -213,6 +213,8 @@ public class TotalScoreUpdateListener
         			data.setTotalOverrideScore(Double.valueOf(agentResults.getTotalOverrideScore()));
         			data.setFinalScore(Double.valueOf(agentResults.getFinalScore()));
         			data.setIsLate(agentResults.getIsLate());
+        			// SAK-52267 persist the grader's late penalty waiver
+        			data.setIgnoreLatePenalty(agentResults.getIgnoreLatePenalty());
         			data.setComments(agentResults.getComments());
         			data.setGradedBy(AgentFacade.getAgentString());
         			data.setGradedDate(new Date());
@@ -443,14 +445,22 @@ public class TotalScoreUpdateListener
         	}
         }
 
-      double newScore = totalAutoScore + totalOverrideScore;
+      // SAK-52267 the stored finalScore is penalized, so the recomputed score must be
+      // too, or every Update click on a late row would erase the deduction
+      GradingService gradingService = new GradingService();
+      double latePenalty = gradingService.getLatePenalty(old, bean.getPublishedAssessment());
+      double newScore = gradingService.computeFinalScore(totalAutoScore, totalOverrideScore,
+          latePenalty, agentResults.getIgnoreLatePenalty());
       newScoreString.append(Double.valueOf(newScore));
 	  double oldScore = 0;
       if (old.getFinalScore()!=null){
         oldScore = old.getFinalScore().doubleValue();
       }
       Boolean oldIsLate=old.getIsLate();
-      
+      // a waiver toggle must persist even when a compensating adjustment keeps the score equal
+      boolean ignoreLatePenaltyUnchanged = Boolean.TRUE.equals(agentResults.getIgnoreLatePenalty())
+          == Boolean.TRUE.equals(old.getIgnoreLatePenalty());
+
       String oldComments = old.getComments();
       log.debug("***oldScore = " + oldScore);
       log.debug("***newScore = " + newScore);
@@ -458,13 +468,13 @@ public class TotalScoreUpdateListener
       log.debug("***newIsLate = " + newIsLate);
       log.debug("***oldComments = " + oldComments);
       log.debug("***newComments = " + newComments);
-      if (Precision.equalsIncludingNaN(oldScore, newScore, 0.0001) && newIsLate.equals(oldIsLate) && 
-    		  ((newComments!=null && newComments.equals(oldComments)) 
+      if (Precision.equalsIncludingNaN(oldScore, newScore, 0.0001) && newIsLate.equals(oldIsLate) && ignoreLatePenaltyUnchanged &&
+    		  ((newComments!=null && newComments.equals(oldComments))
         		   || (newComments==null && oldComments==null)
         		   // following condition will happen when there is no comments (null) and user clicks on SubmissionId.
         		   // getComments() in AgentResults calls Validator.check(comments, "") so the null comment gets set to ""
         		   // there is nothing updated. update flag should be false
-        		   || ((newComments!=null && newComments.equals("")) && oldComments==null)) 
+        		   || ((newComments!=null && newComments.equals("")) && oldComments==null))
         		   ) {
         update = false;
       }

--- a/samigo/samigo-app/src/webapp/js/authoring.js
+++ b/samigo/samigo-app/src/webapp/js/authoring.js
@@ -705,6 +705,17 @@ function checkUserOrGroupRadio() {
 	}
 }
 
+// SAK-52267 show the late penalty points input only while a penalty type is selected
+function toggleLatePenaltyValue() {
+    const radios = document.getElementById('assessmentSettingsAction:latePenaltyType');
+    const valueBlock = document.getElementById('assessmentSettingsAction:latePenaltyValueBlock');
+    if (!radios || !valueBlock) {
+        return;
+    }
+    const checked = radios.querySelector('input:checked');
+    valueBlock.style.display = checked?.value ? 'block' : 'none';
+}
+
 function enableDisableToGradebook() {
     // Handle the display of the gradebook select dropdown
     const checkedInput = document.querySelector('#assessmentSettingsAction\\:toDefaultGradebook input:checked');

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -802,6 +802,7 @@
           style="#{empty assessmentSettings.latePenaltyType ? 'display:none;' : 'display:block;'}">
         <h:outputLabel for="latePenaltyValue" value="#{assessmentSettingsMessages.late_penalty_points}"/>
         <h:inputText id="latePenaltyValue" value="#{assessmentSettings.latePenaltyValue}" size="4" maxlength="8"/>
+        <h:outputLabel for="latePenaltyUnit" styleClass="sr-only" value="#{assessmentSettingsMessages.late_penalty_unit_label}"/>
         <h:selectOneMenu id="latePenaltyUnit" value="#{assessmentSettings.latePenaltyUnit}">
           <f:selectItem itemValue="POINTS" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_points}"/>
           <f:selectItem itemValue="PERCENT" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_percent}"/>

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -793,13 +793,19 @@
             onclick="toggleLatePenaltyValue();">
           <f:selectItem itemValue="" itemLabel="#{assessmentSettingsMessages.late_penalty_none}"/>
           <f:selectItem itemValue="FLAT" itemLabel="#{assessmentSettingsMessages.late_penalty_flat}"/>
+          <f:selectItem itemValue="PER_HOUR" itemLabel="#{assessmentSettingsMessages.late_penalty_per_hour}"/>
           <f:selectItem itemValue="PER_DAY" itemLabel="#{assessmentSettingsMessages.late_penalty_per_day}"/>
+          <f:selectItem itemValue="PER_WEEK" itemLabel="#{assessmentSettingsMessages.late_penalty_per_week}"/>
         </h:selectOneRadio>
       </div>
       <h:panelGroup layout="block" id="latePenaltyValueBlock" styleClass="col-md-10 col-md-offset-2"
           style="#{empty assessmentSettings.latePenaltyType ? 'display:none;' : 'display:block;'}">
         <h:outputLabel for="latePenaltyValue" value="#{assessmentSettingsMessages.late_penalty_points}"/>
         <h:inputText id="latePenaltyValue" value="#{assessmentSettings.latePenaltyValue}" size="4" maxlength="8"/>
+        <h:selectOneMenu id="latePenaltyUnit" value="#{assessmentSettings.latePenaltyUnit}">
+          <f:selectItem itemValue="POINTS" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_points}"/>
+          <f:selectItem itemValue="PERCENT" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_percent}"/>
+        </h:selectOneMenu>
       </h:panelGroup>
     </h:panelGroup>
 

--- a/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/authorSettings.jsp
@@ -785,6 +785,24 @@
       </h:panelGroup>
     </h:panelGroup>
 
+    <!-- LATE PENALTY (SAK-52267) -->
+    <h:panelGroup styleClass="row" layout="block">
+      <h:outputLabel for="latePenaltyType" styleClass="col-md-10 form-label mt-3" value="#{assessmentSettingsMessages.late_penalty}"/>
+      <div class="col-md-10">
+        <h:selectOneRadio id="latePenaltyType" value="#{assessmentSettings.latePenaltyType}" layout="pageDirection"
+            onclick="toggleLatePenaltyValue();">
+          <f:selectItem itemValue="" itemLabel="#{assessmentSettingsMessages.late_penalty_none}"/>
+          <f:selectItem itemValue="FLAT" itemLabel="#{assessmentSettingsMessages.late_penalty_flat}"/>
+          <f:selectItem itemValue="PER_DAY" itemLabel="#{assessmentSettingsMessages.late_penalty_per_day}"/>
+        </h:selectOneRadio>
+      </div>
+      <h:panelGroup layout="block" id="latePenaltyValueBlock" styleClass="col-md-10 col-md-offset-2"
+          style="#{empty assessmentSettings.latePenaltyType ? 'display:none;' : 'display:block;'}">
+        <h:outputLabel for="latePenaltyValue" value="#{assessmentSettingsMessages.late_penalty_points}"/>
+        <h:inputText id="latePenaltyValue" value="#{assessmentSettings.latePenaltyValue}" size="4" maxlength="8"/>
+      </h:panelGroup>
+    </h:panelGroup>
+
     <!-- *** FEEDBACK *** -->
     <h:panelGroup rendered="#{assessmentSettings.valueMap.feedbackAuthoring_isInstructorEditable==true or assessmentSettings.valueMap.feedbackType_isInstructorEditable==true or assessmentSettings.valueMap.feedbackComponents_isInstructorEditable==true}" >
     <div class="samigo-subheading mt-4">

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -799,6 +799,7 @@
           style="#{empty publishedSettings.latePenaltyType ? 'display:none;' : 'display:block;'}">
         <h:outputLabel for="latePenaltyValue" value="#{assessmentSettingsMessages.late_penalty_points}"/>
         <h:inputText id="latePenaltyValue" value="#{publishedSettings.latePenaltyValue}" size="4" maxlength="8"/>
+        <h:outputLabel for="latePenaltyUnit" styleClass="sr-only" value="#{assessmentSettingsMessages.late_penalty_unit_label}"/>
         <h:selectOneMenu id="latePenaltyUnit" value="#{publishedSettings.latePenaltyUnit}">
           <f:selectItem itemValue="POINTS" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_points}"/>
           <f:selectItem itemValue="PERCENT" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_percent}"/>

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -782,6 +782,24 @@
       </h:panelGroup>
     </h:panelGroup>
 
+    <!-- LATE PENALTY (SAK-52267) -->
+    <h:panelGroup styleClass="row" layout="block">
+      <h:outputLabel for="latePenaltyType" styleClass="col-md-10 form-label mt-3" value="#{assessmentSettingsMessages.late_penalty}"/>
+      <div class="col-md-10">
+        <h:selectOneRadio id="latePenaltyType" value="#{publishedSettings.latePenaltyType}" layout="pageDirection"
+            onclick="toggleLatePenaltyValue();">
+          <f:selectItem itemValue="" itemLabel="#{assessmentSettingsMessages.late_penalty_none}"/>
+          <f:selectItem itemValue="FLAT" itemLabel="#{assessmentSettingsMessages.late_penalty_flat}"/>
+          <f:selectItem itemValue="PER_DAY" itemLabel="#{assessmentSettingsMessages.late_penalty_per_day}"/>
+        </h:selectOneRadio>
+      </div>
+      <h:panelGroup layout="block" id="latePenaltyValueBlock" styleClass="col-md-10 col-md-offset-2"
+          style="#{empty publishedSettings.latePenaltyType ? 'display:none;' : 'display:block;'}">
+        <h:outputLabel for="latePenaltyValue" value="#{assessmentSettingsMessages.late_penalty_points}"/>
+        <h:inputText id="latePenaltyValue" value="#{publishedSettings.latePenaltyValue}" size="4" maxlength="8"/>
+      </h:panelGroup>
+    </h:panelGroup>
+
     <!-- *** FEEDBACK *** -->
     <h:panelGroup rendered="#{publishedSettings.valueMap.feedbackAuthoring_isInstructorEditable==true or publishedSettings.valueMap.feedbackType_isInstructorEditable==true or publishedSettings.valueMap.feedbackComponents_isInstructorEditable==true}" >
     <div class="samigo-subheading mt-4">

--- a/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/author/publishedSettings.jsp
@@ -790,13 +790,19 @@
             onclick="toggleLatePenaltyValue();">
           <f:selectItem itemValue="" itemLabel="#{assessmentSettingsMessages.late_penalty_none}"/>
           <f:selectItem itemValue="FLAT" itemLabel="#{assessmentSettingsMessages.late_penalty_flat}"/>
+          <f:selectItem itemValue="PER_HOUR" itemLabel="#{assessmentSettingsMessages.late_penalty_per_hour}"/>
           <f:selectItem itemValue="PER_DAY" itemLabel="#{assessmentSettingsMessages.late_penalty_per_day}"/>
+          <f:selectItem itemValue="PER_WEEK" itemLabel="#{assessmentSettingsMessages.late_penalty_per_week}"/>
         </h:selectOneRadio>
       </div>
       <h:panelGroup layout="block" id="latePenaltyValueBlock" styleClass="col-md-10 col-md-offset-2"
           style="#{empty publishedSettings.latePenaltyType ? 'display:none;' : 'display:block;'}">
         <h:outputLabel for="latePenaltyValue" value="#{assessmentSettingsMessages.late_penalty_points}"/>
         <h:inputText id="latePenaltyValue" value="#{publishedSettings.latePenaltyValue}" size="4" maxlength="8"/>
+        <h:selectOneMenu id="latePenaltyUnit" value="#{publishedSettings.latePenaltyUnit}">
+          <f:selectItem itemValue="POINTS" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_points}"/>
+          <f:selectItem itemValue="PERCENT" itemLabel="#{assessmentSettingsMessages.late_penalty_unit_percent}"/>
+        </h:selectOneMenu>
       </h:panelGroup>
     </h:panelGroup>
 

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -794,6 +794,18 @@ function showLoadingMessage() {
       <h:outputText value="#{description.roundedTotalAutoScore}" />
     </h:column>
     
+    <!-- LATE PENALTY (SAK-52267) -->
+    <h:column rendered="#{totalScores.latePenaltyEnabled && totalScores.allSubmissions!='4'}">
+      <f:facet name="header">
+        <h:outputText value="#{evaluationMessages.late_penalty}" />
+      </f:facet>
+      <h:outputText value="#{description.latePenalty}" />
+      <h:panelGroup layout="block" rendered="#{description.isLate=='true'}">
+        <h:selectBooleanCheckbox id="ignoreLatePenalty" value="#{description.ignoreLatePenalty}" />
+        <h:outputLabel for="ignoreLatePenalty" value="#{evaluationMessages.ignore_late_penalty}" />
+      </h:panelGroup>
+    </h:column>
+
     <!-- ADJUSTMENT -->
     <h:column rendered="#{totalScores.sortType!='totalOverrideScore' && totalScores.allSubmissions!='4'}">
       <f:facet name="header">

--- a/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/grading/GradingData.hbm.xml
+++ b/samigo/samigo-hibernate/src/java/org/sakaiproject/tool/assessment/data/dao/grading/GradingData.hbm.xml
@@ -45,6 +45,7 @@
     <property name="agentId" type="string" length="99" column="AGENTID" not-null="true" />
     <property name="submittedDate" type="timestamp" column="SUBMITTEDDATE" not-null="false" />
     <property name="isLate" type="boolean" column="ISLATE" not-null="true" />
+    <property name="ignoreLatePenalty" type="boolean" column="IGNORELATEPENALTY" not-null="false" />
     <property name="forGrade" type="boolean" column="FORGRADE" not-null="true" />
     <property name="totalAutoScore" type="double" column="TOTALAUTOSCORE" not-null="false" />
     <property name="totalOverrideScore" type="double" column="TOTALOVERRIDESCORE" not-null="false" />

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AutoSubmitFacadeQueries.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/facade/AutoSubmitFacadeQueries.java
@@ -109,6 +109,14 @@ public class AutoSubmitFacadeQueries extends HibernateDaoSupport implements Auto
 				}
 
 				agfq.completeItemGradingData(adata, sectionSetMap);
+
+				// SAK-52267 this path saves directly without storeGrades, so deduct any
+				// configured late penalty here; dueDate above is already extended-time aware
+				GradingService gradingService = new GradingService();
+				double totalAutoScore = adata.getTotalAutoScore() != null ? adata.getTotalAutoScore() : 0d;
+				double totalOverrideScore = adata.getTotalOverrideScore() != null ? adata.getTotalOverrideScore() : 0d;
+				adata.setFinalScore(gradingService.computeFinalScore(totalAutoScore, totalOverrideScore,
+						gradingService.getLatePenalty(adata, assessment, dueDate), adata.getIgnoreLatePenalty()));
 			}
 		}
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -77,6 +77,7 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentAccessControlIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.EvaluationModelIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemMetaDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
@@ -94,6 +95,8 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceH
 import org.sakaiproject.tool.assessment.services.assessment.EventLogService;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.tool.assessment.util.ExtendedTimeDeliveryService;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyType;
 import org.sakaiproject.tool.assessment.util.SamigoExpressionError;
 import org.sakaiproject.tool.assessment.util.SamigoExpressionParser;
 import org.sakaiproject.tool.assessment.util.comparator.ImageMapGradingItemComparator;
@@ -1323,6 +1326,71 @@ public class GradingService
         }
     }
     return totalAutoScore.doubleValue();
+  }
+
+  /**
+   * SAK-52267 the single formula behind every finalScore write:
+   * max(0, totalAutoScore + totalOverrideScore) minus the late penalty
+   * (still floored at zero), with the penalty waived when the submission's
+   * ignoreLatePenalty flag is set.
+   */
+  public double computeFinalScore(double totalAutoScore, double totalOverrideScore, double latePenalty, Boolean ignoreLatePenalty) {
+    double raw = totalAutoScore + totalOverrideScore;
+    if (raw < 0d) raw = 0d;
+    return LatePenaltyCalculator.applyPenalty(raw, latePenalty, ignoreLatePenalty);
+  }
+
+  /**
+   * SAK-52267 the late penalty in points that the assessment's settings assign
+   * to this submission, or 0 when none applies (no penalty configured, or the
+   * submission is not late). Does not consider the per-submission
+   * ignoreLatePenalty waiver so the amount can still be displayed alongside
+   * the waiver control. Resolves the student's effective due date itself; use
+   * {@link #getLatePenalty(AssessmentGradingData, PublishedAssessmentIfc, Date)}
+   * when the caller already has it.
+   */
+  public double getLatePenalty(AssessmentGradingData data, PublishedAssessmentIfc pub) {
+    if (data == null || pub == null || !Boolean.TRUE.equals(data.getIsLate())) return 0d;
+
+    LatePenaltyType type = LatePenaltyType.fromString(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
+    if (type == null) return 0d;
+
+    Date effectiveDueDate = null;
+    if (type == LatePenaltyType.PER_DAY) {
+      // only the per-day mode needs the (extended-time aware) due date
+      effectiveDueDate = pub.getAssessmentAccessControl().getDueDate();
+      ExtendedTimeDeliveryService assessmentExtended = new ExtendedTimeDeliveryService((PublishedAssessmentFacade) pub, data.getAgentId());
+      if (assessmentExtended.hasExtendedTime() && assessmentExtended.getDueDate() != null) {
+        effectiveDueDate = assessmentExtended.getDueDate();
+      }
+    }
+
+    return getLatePenalty(data, pub, effectiveDueDate);
+  }
+
+  /**
+   * Variant of {@link #getLatePenalty(AssessmentGradingData, PublishedAssessmentIfc)}
+   * for callers that have already resolved the student's effective due date
+   * (e.g. the autosubmit job).
+   */
+  public double getLatePenalty(AssessmentGradingData data, PublishedAssessmentIfc pub, Date effectiveDueDate) {
+    if (data == null || pub == null || !Boolean.TRUE.equals(data.getIsLate())) return 0d;
+
+    LatePenaltyType type = LatePenaltyType.fromString(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
+    if (type == null) return 0d;
+
+    Double value = parseLatePenaltyValue(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+    return LatePenaltyCalculator.penaltyPoints(type, value, data.getIsLate(), effectiveDueDate, data.getSubmittedDate());
+  }
+
+  private Double parseLatePenaltyValue(String raw) {
+    if (StringUtils.isBlank(raw)) return null;
+    try {
+      return Double.valueOf(raw.trim().replace(",", "."));
+    } catch (NumberFormatException e) {
+      log.debug("Ignoring malformed late penalty value [{}], {}", raw, e.toString());
+      return null;
+    }
   }
 
   private boolean isAnswered(ItemGradingData data, Long type) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -97,6 +97,7 @@ import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentS
 import org.sakaiproject.tool.assessment.util.ExtendedTimeDeliveryService;
 import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator;
 import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyType;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyUnit;
 import org.sakaiproject.tool.assessment.util.SamigoExpressionError;
 import org.sakaiproject.tool.assessment.util.SamigoExpressionParser;
 import org.sakaiproject.tool.assessment.util.comparator.ImageMapGradingItemComparator;
@@ -1382,7 +1383,17 @@ public class GradingService
     if (type == null) return 0d;
 
     Double value = LatePenaltyCalculator.parsePenaltyValue(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
-    return LatePenaltyCalculator.penaltyPoints(type, value, data.getIsLate(), effectiveDueDate, data.getSubmittedDate());
+    LatePenaltyUnit unit = LatePenaltyUnit.fromString(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_UNIT));
+    Double maxPoints = null;
+    if (unit == LatePenaltyUnit.PERCENT) {
+      try {
+        maxPoints = pub.getTotalScore();
+      } catch (Exception e) {
+        log.debug("Could not resolve total score for percent late penalty on assessment {}, applying nothing: {}",
+            pub.getPublishedAssessmentId(), e.toString());
+      }
+    }
+    return LatePenaltyCalculator.penaltyPoints(type, unit, value, maxPoints, data.getIsLate(), effectiveDueDate, data.getSubmittedDate());
   }
 
   /**

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -1405,6 +1405,10 @@ public class GradingService
   public void applyLatePenaltiesToSubmissions(PublishedAssessmentIfc pub) {
     if (pub == null) return;
     List<AssessmentGradingData> submissions = getAllSubmissions(pub.getPublishedAssessmentId().toString());
+    if (submissions == null) {
+      log.warn("Could not load submissions of published assessment {} to re-apply late penalties", pub.getPublishedAssessmentId());
+      return;
+    }
     int updated = 0;
     for (AssessmentGradingData data : submissions) {
       double totalAutoScore = data.getTotalAutoScore() != null ? data.getTotalAutoScore() : 0d;

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -1381,17 +1381,34 @@ public class GradingService
     LatePenaltyType type = LatePenaltyType.fromString(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_TYPE));
     if (type == null) return 0d;
 
-    Double value = parseLatePenaltyValue(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
+    Double value = LatePenaltyCalculator.parsePenaltyValue(pub.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.LATE_PENALTY_VALUE));
     return LatePenaltyCalculator.penaltyPoints(type, value, data.getIsLate(), effectiveDueDate, data.getSubmittedDate());
   }
 
-  private Double parseLatePenaltyValue(String raw) {
-    if (StringUtils.isBlank(raw)) return null;
-    try {
-      return Double.valueOf(raw.trim().replace(",", "."));
-    } catch (NumberFormatException e) {
-      log.debug("Ignoring malformed late penalty value [{}], {}", raw, e.toString());
-      return null;
+  /**
+   * SAK-52267 re-applies the current late penalty configuration to every
+   * stored graded submission of a published assessment, so a settings change
+   * takes effect immediately rather than on the next per-submission recompute.
+   * Rows whose finalScore changes are saved and renotified to the gradebook.
+   */
+  public void applyLatePenaltiesToSubmissions(PublishedAssessmentIfc pub) {
+    if (pub == null) return;
+    List<AssessmentGradingData> submissions = getAllSubmissions(pub.getPublishedAssessmentId().toString());
+    int updated = 0;
+    for (AssessmentGradingData data : submissions) {
+      double totalAutoScore = data.getTotalAutoScore() != null ? data.getTotalAutoScore() : 0d;
+      double totalOverrideScore = data.getTotalOverrideScore() != null ? data.getTotalOverrideScore() : 0d;
+      double newFinalScore = computeFinalScore(totalAutoScore, totalOverrideScore,
+          getLatePenalty(data, pub), data.getIgnoreLatePenalty());
+      if (data.getFinalScore() == null || Math.abs(data.getFinalScore() - newFinalScore) > 0.0001d) {
+        data.setFinalScore(newFinalScore);
+        saveOrUpdateAssessmentGrading(data);
+        notifyGradebookByScoringType(data, pub);
+        updated++;
+      }
+    }
+    if (updated > 0) {
+      log.info("Late penalty settings change re-scored {} submission(s) of published assessment {}", updated, pub.getPublishedAssessmentId());
     }
   }
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -845,11 +845,9 @@ public class GradingService
       }
       
       adata.setTotalAutoScore(totalAutoScore);
-      if (Double.compare((totalAutoScore+totalOverrideScore),Double.valueOf("0"))<0){
-    	  adata.setFinalScore(Double.valueOf("0"));
-      }else{
-    	  adata.setFinalScore(totalAutoScore+totalOverrideScore);
-      }
+      // SAK-52267 keep any late penalty applied when recomputing from item scores
+      adata.setFinalScore(computeFinalScore(totalAutoScore, totalOverrideScore,
+          getLatePenalty(adata, pub), adata.getIgnoreLatePenalty()));
       saveOrUpdateAssessmentGrading(adata);
       if (scoreDifference != 0){
         notifyGradebookByScoringType(adata, pub);
@@ -1278,12 +1276,11 @@ public class GradingService
       Set fullItemGradingSet = getItemGradingSet(data.getAssessmentGradingId().toString());
       double totalAutoScore = getTotalAutoScore(fullItemGradingSet);
       data.setTotalAutoScore(totalAutoScore);
-     
-      if (Double.compare((totalAutoScore + data.getTotalOverrideScore()), new Double("0"))<0){
-    	  data.setFinalScore( Double.valueOf("0"));
-      }else{
-    	  data.setFinalScore(totalAutoScore + data.getTotalOverrideScore());
-      }
+
+      // SAK-52267 deduct any configured late penalty (isLate was set above for new
+      // submissions; regrades reuse the stored flag and current settings)
+      data.setFinalScore(computeFinalScore(totalAutoScore, data.getTotalOverrideScore(),
+          getLatePenalty(data, pub), data.getIgnoreLatePenalty()));
       log.debug("****x6. "+(new Date()).getTime());
     } catch (GradebookServiceException ge) {
       log.error(ge.getMessage(), ge);
@@ -1357,9 +1354,14 @@ public class GradingService
 
     Date effectiveDueDate = null;
     if (type == LatePenaltyType.PER_DAY) {
-      // only the per-day mode needs the (extended-time aware) due date
+      // only the per-day mode needs the (extended-time aware) due date; callers pass
+      // facades or bare data objects, and ExtendedTimeDeliveryService re-fetches from
+      // a minimal facade when needed
       effectiveDueDate = pub.getAssessmentAccessControl().getDueDate();
-      ExtendedTimeDeliveryService assessmentExtended = new ExtendedTimeDeliveryService((PublishedAssessmentFacade) pub, data.getAgentId());
+      PublishedAssessmentFacade facade = pub instanceof PublishedAssessmentFacade
+          ? (PublishedAssessmentFacade) pub
+          : new PublishedAssessmentFacade(pub.getPublishedAssessmentId(), pub.getTitle(), pub.getAssessmentAccessControl());
+      ExtendedTimeDeliveryService assessmentExtended = new ExtendedTimeDeliveryService(facade, data.getAgentId());
       if (assessmentExtended.hasExtendedTime() && assessmentExtended.getDueDate() != null) {
         effectiveDueDate = assessmentExtended.getDueDate();
       }
@@ -2514,11 +2516,9 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
         double oldAutoScore = adata.getTotalAutoScore();
         double scoreDifference = totalAutoScore - oldAutoScore;
         adata.setTotalAutoScore(totalAutoScore);
-        if (Double.compare((totalAutoScore+totalOverrideScore),Double.valueOf("0"))<0){
-        	adata.setFinalScore(Double.valueOf("0"));
-        }else{
-        	adata.setFinalScore(totalAutoScore+totalOverrideScore);
-        }
+        // SAK-52267 keep any late penalty applied when recomputing from item scores
+        adata.setFinalScore(computeFinalScore(totalAutoScore, totalOverrideScore,
+            getLatePenalty(adata, pub), adata.getIgnoreLatePenalty()));
         saveOrUpdateAssessmentGrading(adata);
         if (scoreDifference != 0 || !newComment.equals(oldComment)){
           notifyGradebookByScoringType(adata, pub);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/LatePenaltyCalculator.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/LatePenaltyCalculator.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.util;
+
+import java.util.Date;
+
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SAK-52267 computes the automatic late penalty for Tests & Quizzes
+ * submissions. The semantics intentionally mirror the Assignments calculator
+ * ({@code org.sakaiproject.assignment.api.LatePenaltyCalculator}, SAK-15574) —
+ * keep the two in sync: a flat deduction or a per-day deduction where any part
+ * of a day late counts as a full day, the result floors at zero, and a
+ * per-submission ignore flag waives the deduction.
+ *
+ * Samigo differences: scores are double point values, lateness is gated on the
+ * submission's stored isLate flag (which already honors extended-time
+ * exceptions at submit time, SAM-3319), and days late are measured from the
+ * student's effective due date. When isLate is set but the recorded
+ * submittedDate is not after the due date (an autosubmitted attempt keeps the
+ * student's last-save time, SAM-1088), a minimum of one day is charged.
+ */
+@Slf4j
+public final class LatePenaltyCalculator {
+
+    private static final long DAY_MILLIS = 24L * 3600L * 1000L;
+
+    public enum LatePenaltyType {
+        FLAT,
+        PER_DAY;
+
+        /** @return the type for a stored metadata value, or null when absent/unrecognized */
+        public static LatePenaltyType fromString(String value) {
+            if (StringUtils.isBlank(value)) return null;
+            try {
+                return valueOf(value.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                log.debug("Unrecognized late penalty type [{}], treating as no penalty", value);
+                return null;
+            }
+        }
+    }
+
+    private LatePenaltyCalculator() {
+    }
+
+    /**
+     * Days late as whole 24-hour chunks with any remainder counting as a full
+     * day, so one minute late is 1 day and 24h+1s is 2 days. 0 when the
+     * submission is not after the due date or either date is missing.
+     */
+    public static long daysLate(Date effectiveDueDate, Date submittedDate) {
+        if (effectiveDueDate == null || submittedDate == null || !submittedDate.after(effectiveDueDate)) return 0;
+        long lateMillis = submittedDate.getTime() - effectiveDueDate.getTime();
+        return (lateMillis + DAY_MILLIS - 1) / DAY_MILLIS;
+    }
+
+    /**
+     * The penalty in points for a submission, or 0 when none applies. Gated on
+     * the stored isLate flag; a late submission is charged a minimum of one
+     * day in PER_DAY mode even when the recorded dates disagree (autosubmit).
+     *
+     * @param type         penalty mode from assessment metadata, null = none
+     * @param value        penalty points per application, null/NaN/&le;0 = none
+     * @param isLate       the submission's stored late flag
+     * @param effectiveDueDate the student's effective due date (extended time aware)
+     * @param submittedDate    when the submission was made
+     */
+    public static double penaltyPoints(LatePenaltyType type, Double value, Boolean isLate,
+            Date effectiveDueDate, Date submittedDate) {
+
+        if (!Boolean.TRUE.equals(isLate) || type == null) return 0d;
+        if (value == null || value.isNaN() || value <= 0d) {
+            if (value != null && !value.isNaN() && value < 0d) {
+                log.debug("Ignoring negative late penalty value [{}]", value);
+            }
+            return 0d;
+        }
+        if (type == LatePenaltyType.FLAT) return value;
+
+        long days = Math.max(1, daysLate(effectiveDueDate, submittedDate));
+        return value * days;
+    }
+
+    /**
+     * Applies a penalty to a raw final score, flooring at zero; the score is
+     * returned unchanged when the per-submission ignore flag is set or no
+     * penalty applies.
+     */
+    public static double applyPenalty(double rawFinalScore, double penalty, Boolean ignoreLatePenalty) {
+        if (Boolean.TRUE.equals(ignoreLatePenalty) || penalty <= 0d) return rawFinalScore;
+        return Math.max(0d, rawFinalScore - penalty);
+    }
+}

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/LatePenaltyCalculator.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/LatePenaltyCalculator.java
@@ -61,6 +61,29 @@ public final class LatePenaltyCalculator {
     }
 
     /**
+     * Parses a penalty point value as entered in settings or stored in
+     * metadata, accepting either decimal separator. Both the settings
+     * validation and scoring-time parsing use this, so they cannot drift.
+     *
+     * @return the positive point value, or null when blank, malformed, NaN,
+     *         zero or negative
+     */
+    public static Double parsePenaltyValue(String raw) {
+        if (StringUtils.isBlank(raw)) return null;
+        try {
+            double value = Double.parseDouble(raw.trim().replace(",", "."));
+            if (Double.isNaN(value) || value <= 0d) {
+                log.debug("Rejecting non-positive late penalty value [{}]", raw);
+                return null;
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            log.debug("Rejecting malformed late penalty value [{}], {}", raw, e.toString());
+            return null;
+        }
+    }
+
+    /**
      * Days late as whole 24-hour chunks with any remainder counting as a full
      * day, so one minute late is 1 day and 24h+1s is 2 days. 0 when the
      * submission is not after the due date or either date is missing.

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/LatePenaltyCalculator.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/LatePenaltyCalculator.java
@@ -25,25 +25,40 @@ import lombok.extern.slf4j.Slf4j;
  * SAK-52267 computes the automatic late penalty for Tests & Quizzes
  * submissions. The semantics intentionally mirror the Assignments calculator
  * ({@code org.sakaiproject.assignment.api.LatePenaltyCalculator}, SAK-15574) —
- * keep the two in sync: a flat deduction or a per-day deduction where any part
- * of a day late counts as a full day, the result floors at zero, and a
+ * keep the two in sync: a deduction in fixed points or a percentage of the
+ * maximum score, applied once (flat) or per hour/day/week late where any part
+ * of a period counts as a full period, the result floors at zero, and a
  * per-submission ignore flag waives the deduction.
  *
  * Samigo differences: scores are double point values, lateness is gated on the
  * submission's stored isLate flag (which already honors extended-time
- * exceptions at submit time, SAM-3319), and days late are measured from the
+ * exceptions at submit time, SAM-3319), and periods late are measured from the
  * student's effective due date. When isLate is set but the recorded
  * submittedDate is not after the due date (an autosubmitted attempt keeps the
- * student's last-save time, SAM-1088), a minimum of one day is charged.
+ * student's last-save time, SAM-1088), a minimum of one period is charged.
  */
 @Slf4j
 public final class LatePenaltyCalculator {
 
-    private static final long DAY_MILLIS = 24L * 3600L * 1000L;
+    private static final long HOUR_MILLIS = 3600L * 1000L;
+    private static final long DAY_MILLIS = 24L * HOUR_MILLIS;
+    private static final long WEEK_MILLIS = 7L * DAY_MILLIS;
 
     public enum LatePenaltyType {
-        FLAT,
-        PER_DAY;
+        FLAT(0L),
+        PER_HOUR(HOUR_MILLIS),
+        PER_DAY(DAY_MILLIS),
+        PER_WEEK(WEEK_MILLIS);
+
+        private final long periodMillis;
+
+        LatePenaltyType(long periodMillis) {
+            this.periodMillis = periodMillis;
+        }
+
+        public long getPeriodMillis() {
+            return periodMillis;
+        }
 
         /** @return the type for a stored metadata value, or null when absent/unrecognized */
         public static LatePenaltyType fromString(String value) {
@@ -57,16 +72,40 @@ public final class LatePenaltyCalculator {
         }
     }
 
+    /**
+     * What the penalty value means: fixed points, or a percentage of the
+     * assessment's maximum score per application.
+     */
+    public enum LatePenaltyUnit {
+        POINTS,
+        PERCENT;
+
+        /**
+         * @return the unit for a stored metadata value; absent or unrecognized
+         *         means POINTS so settings saved before units existed keep
+         *         their behavior
+         */
+        public static LatePenaltyUnit fromString(String value) {
+            if (StringUtils.isBlank(value)) return POINTS;
+            try {
+                return valueOf(value.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                log.debug("Unrecognized late penalty unit [{}], treating as POINTS", value);
+                return POINTS;
+            }
+        }
+    }
+
     private LatePenaltyCalculator() {
     }
 
     /**
-     * Parses a penalty point value as entered in settings or stored in
-     * metadata, accepting either decimal separator. Both the settings
-     * validation and scoring-time parsing use this, so they cannot drift.
+     * Parses a penalty value as entered in settings or stored in metadata,
+     * accepting either decimal separator. Both the settings validation and
+     * scoring-time parsing use this, so they cannot drift.
      *
-     * @return the positive point value, or null when blank, malformed, NaN,
-     *         zero or negative
+     * @return the positive value, or null when blank, malformed, NaN, zero or
+     *         negative
      */
     public static Double parsePenaltyValue(String raw) {
         if (StringUtils.isBlank(raw)) return null;
@@ -84,29 +123,35 @@ public final class LatePenaltyCalculator {
     }
 
     /**
-     * Days late as whole 24-hour chunks with any remainder counting as a full
-     * day, so one minute late is 1 day and 24h+1s is 2 days. 0 when the
-     * submission is not after the due date or either date is missing.
+     * Whole periods late with any remainder counting as a full period, so one
+     * minute late is 1 hour/day/week and exactly one period plus a second is
+     * 2. 0 when the submission is not after the due date or either date is
+     * missing.
      */
-    public static long daysLate(Date effectiveDueDate, Date submittedDate) {
-        if (effectiveDueDate == null || submittedDate == null || !submittedDate.after(effectiveDueDate)) return 0;
+    public static long periodsLate(Date effectiveDueDate, Date submittedDate, long periodMillis) {
+        if (effectiveDueDate == null || submittedDate == null || periodMillis <= 0
+                || !submittedDate.after(effectiveDueDate)) return 0;
         long lateMillis = submittedDate.getTime() - effectiveDueDate.getTime();
-        return (lateMillis + DAY_MILLIS - 1) / DAY_MILLIS;
+        return (lateMillis + periodMillis - 1) / periodMillis;
     }
 
     /**
      * The penalty in points for a submission, or 0 when none applies. Gated on
      * the stored isLate flag; a late submission is charged a minimum of one
-     * day in PER_DAY mode even when the recorded dates disagree (autosubmit).
+     * period in the interval modes even when the recorded dates disagree
+     * (autosubmit).
      *
-     * @param type         penalty mode from assessment metadata, null = none
-     * @param value        penalty points per application, null/NaN/&le;0 = none
-     * @param isLate       the submission's stored late flag
+     * @param type          penalty mode from assessment metadata, null = none
+     * @param unit          POINTS or PERCENT of maxPoints; null = POINTS
+     * @param value         points or percent per application, null/NaN/&le;0 = none
+     * @param maxPoints     the assessment's maximum score, needed for PERCENT;
+     *                      a missing/non-positive maximum yields no penalty
+     * @param isLate        the submission's stored late flag
      * @param effectiveDueDate the student's effective due date (extended time aware)
      * @param submittedDate    when the submission was made
      */
-    public static double penaltyPoints(LatePenaltyType type, Double value, Boolean isLate,
-            Date effectiveDueDate, Date submittedDate) {
+    public static double penaltyPoints(LatePenaltyType type, LatePenaltyUnit unit, Double value,
+            Double maxPoints, Boolean isLate, Date effectiveDueDate, Date submittedDate) {
 
         if (!Boolean.TRUE.equals(isLate) || type == null) return 0d;
         if (value == null || value.isNaN() || value <= 0d) {
@@ -115,10 +160,22 @@ public final class LatePenaltyCalculator {
             }
             return 0d;
         }
-        if (type == LatePenaltyType.FLAT) return value;
 
-        long days = Math.max(1, daysLate(effectiveDueDate, submittedDate));
-        return value * days;
+        double base;
+        if (unit == LatePenaltyUnit.PERCENT) {
+            if (maxPoints == null || maxPoints.isNaN() || maxPoints <= 0d) {
+                log.debug("Percent late penalty with no usable maximum score [{}], applying nothing", maxPoints);
+                return 0d;
+            }
+            base = value / 100d * maxPoints;
+        } else {
+            base = value;
+        }
+
+        if (type == LatePenaltyType.FLAT) return base;
+
+        long periods = Math.max(1, periodsLate(effectiveDueDate, submittedDate, type.getPeriodMillis()));
+        return base * periods;
     }
 
     /**

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueriesTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/facade/AssessmentGradingFacadeQueriesTest.java
@@ -115,7 +115,35 @@ public class AssessmentGradingFacadeQueriesTest extends AbstractTransactionalJUn
 			Assert.fail();
 		}
 	}
-	
+
+	// SAK-52267 the grader's per-submission late penalty waiver round-trips
+	@Test
+	public void testIgnoreLatePenaltyRoundTrip() {
+		AssessmentGradingData data = new AssessmentGradingData();
+		data.setPublishedAssessmentId(Long.valueOf(1));
+		data.setAgentId("agent");
+		data.setIsLate(true);
+		data.setForGrade(true);
+		data.setStatus(Integer.valueOf(1));
+		data.setIgnoreLatePenalty(Boolean.TRUE);
+		queries.saveOrUpdateAssessmentGrading(data);
+		Assert.assertNotNull(data.getAssessmentGradingId());
+
+		AssessmentGradingData loaded = queries.load(data.getAssessmentGradingId());
+		Assert.assertEquals(Boolean.TRUE, loaded.getIgnoreLatePenalty());
+
+		// absent by default so existing rows read as "penalty applies"
+		AssessmentGradingData plain = new AssessmentGradingData();
+		plain.setPublishedAssessmentId(Long.valueOf(1));
+		plain.setAgentId("agent2");
+		plain.setIsLate(true);
+		plain.setForGrade(true);
+		plain.setStatus(Integer.valueOf(1));
+		queries.saveOrUpdateAssessmentGrading(plain);
+		AssessmentGradingData loadedPlain = queries.load(plain.getAssessmentGradingId());
+		Assert.assertNotEquals(Boolean.TRUE, loadedPlain.getIgnoreLatePenalty());
+	}
+
 	@Test
 	public void testLoad() {
 		loadData();

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceFinalScoreTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceFinalScoreTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.services;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * SAK-52267 the single formula behind every finalScore write:
+ * finalScore = max(0, totalAutoScore + totalOverrideScore - latePenalty),
+ * with the penalty waived when ignoreLatePenalty is TRUE. Replaces the
+ * inline (auto + override) &lt; 0 ? 0 : auto + override computations.
+ */
+public class GradingServiceFinalScoreTest {
+
+    private static final double DELTA = 0.0001;
+
+    private GradingService gradingService;
+
+    @Before
+    public void setUp() {
+        gradingService = new GradingService();
+    }
+
+    @Test
+    public void noPenaltyKeepsLegacyBehavior() {
+        assertEquals(10.0, gradingService.computeFinalScore(8.0, 2.0, 0.0, null), DELTA);
+        // negative adjustments still floor at zero, as before
+        assertEquals(4.0, gradingService.computeFinalScore(8.0, -4.0, 0.0, null), DELTA);
+        assertEquals(0.0, gradingService.computeFinalScore(2.0, -4.0, 0.0, null), DELTA);
+    }
+
+    @Test
+    public void penaltyReducesFinalScore() {
+        assertEquals(5.0, gradingService.computeFinalScore(8.0, 2.0, 5.0, null), DELTA);
+        assertEquals(5.0, gradingService.computeFinalScore(8.0, 2.0, 5.0, Boolean.FALSE), DELTA);
+    }
+
+    @Test
+    public void penaltyFloorsAtZero() {
+        assertEquals(0.0, gradingService.computeFinalScore(3.0, 0.0, 50.0, null), DELTA);
+    }
+
+    @Test
+    public void ignoreWaivesPenalty() {
+        assertEquals(10.0, gradingService.computeFinalScore(8.0, 2.0, 5.0, Boolean.TRUE), DELTA);
+    }
+}

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/util/LatePenaltyCalculatorTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/util/LatePenaltyCalculatorTest.java
@@ -53,6 +53,25 @@ public class LatePenaltyCalculatorTest {
         assertNull(LatePenaltyType.fromString("bogus"));
     }
 
+    // shared parser behind both settings validation and scoring-time reads
+    @Test
+    public void parsePenaltyValueAcceptsPositiveNumbersEitherSeparator() {
+        assertEquals(Double.valueOf(5.0), LatePenaltyCalculator.parsePenaltyValue("5"));
+        assertEquals(Double.valueOf(2.5), LatePenaltyCalculator.parsePenaltyValue("2.5"));
+        assertEquals(Double.valueOf(2.5), LatePenaltyCalculator.parsePenaltyValue("2,5"));
+        assertEquals(Double.valueOf(1.0), LatePenaltyCalculator.parsePenaltyValue(" 1 "));
+    }
+
+    @Test
+    public void parsePenaltyValueRejectsInvalidInput() {
+        assertNull(LatePenaltyCalculator.parsePenaltyValue(null));
+        assertNull(LatePenaltyCalculator.parsePenaltyValue(""));
+        assertNull(LatePenaltyCalculator.parsePenaltyValue("abc"));
+        assertNull(LatePenaltyCalculator.parsePenaltyValue("0"));
+        assertNull(LatePenaltyCalculator.parsePenaltyValue("-2"));
+        assertNull(LatePenaltyCalculator.parsePenaltyValue("NaN"));
+    }
+
     // days late: ceiling of 24h chunks, 0 when on time
     @Test
     public void daysLateComputation() {

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/util/LatePenaltyCalculatorTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/util/LatePenaltyCalculatorTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyType;
+
+/**
+ * SAK-52267 late penalty computation for Tests & Quizzes. Mirrors the
+ * semantics of the Assignments calculator
+ * (org.sakaiproject.assignment.api.LatePenaltyCalculator, SAK-15574):
+ * any part of a day late counts as a full day, results floor at zero, and a
+ * per-submission ignore flag waives the deduction. Samigo operates on double
+ * point values and java.util.Date, and gates the penalty on the stored isLate
+ * flag, which already respects extended-time exceptions at submit time.
+ */
+public class LatePenaltyCalculatorTest {
+
+    private static final double DELTA = 0.0001;
+    private static final long HOUR = 3600 * 1000L;
+    private static final Date DUE = new Date(1767625200000L); // fixed instant
+
+    private static Date lateBy(long millis) {
+        return new Date(DUE.getTime() + millis);
+    }
+
+    // type parsing from stored metadata
+    @Test
+    public void fromStringParsesTypes() {
+        assertEquals(LatePenaltyType.FLAT, LatePenaltyType.fromString("FLAT"));
+        assertEquals(LatePenaltyType.PER_DAY, LatePenaltyType.fromString("PER_DAY"));
+        assertEquals(LatePenaltyType.FLAT, LatePenaltyType.fromString(" flat "));
+        assertNull(LatePenaltyType.fromString(null));
+        assertNull(LatePenaltyType.fromString(""));
+        assertNull(LatePenaltyType.fromString("bogus"));
+    }
+
+    // days late: ceiling of 24h chunks, 0 when on time
+    @Test
+    public void daysLateComputation() {
+        assertEquals(0, LatePenaltyCalculator.daysLate(DUE, new Date(DUE.getTime() - HOUR)));
+        assertEquals(0, LatePenaltyCalculator.daysLate(DUE, DUE)); // exactly at due = not late
+        assertEquals(1, LatePenaltyCalculator.daysLate(DUE, lateBy(60 * 1000L))); // 1 minute
+        assertEquals(1, LatePenaltyCalculator.daysLate(DUE, lateBy(24 * HOUR))); // exactly 24h
+        assertEquals(2, LatePenaltyCalculator.daysLate(DUE, lateBy(24 * HOUR + 1000L))); // 24h + 1s
+        assertEquals(4, LatePenaltyCalculator.daysLate(DUE, lateBy(84 * HOUR))); // 3.5 days -> 4
+        assertEquals(0, LatePenaltyCalculator.daysLate(null, lateBy(HOUR)));
+        assertEquals(0, LatePenaltyCalculator.daysLate(DUE, null));
+    }
+
+    // flat penalty applies once, however late
+    @Test
+    public void flatPenalty() {
+        assertEquals(5.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, 5.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(5.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, 5.0, Boolean.TRUE, DUE, lateBy(90 * HOUR)), DELTA);
+    }
+
+    // per-day penalty multiplies by whole days, partial day counts as full
+    @Test
+    public void perDayPenalty() {
+        assertEquals(2.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(4.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(30 * HOUR)), DELTA);
+        assertEquals(8.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(84 * HOUR)), DELTA);
+    }
+
+    // autosubmit edge (SAM-1088): isLate TRUE but the recorded submittedDate is
+    // the student's last save, which can be at or before the due date -> minimum one day
+    @Test
+    public void perDayPenaltyLateFlagWithOnTimeDatesChargesOneDay() {
+        assertEquals(2.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, new Date(DUE.getTime() - HOUR)), DELTA);
+        assertEquals(2.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, null), DELTA);
+    }
+
+    // the stored isLate flag gates everything: no penalty for on-time work
+    @Test
+    public void notLateNoPenaltyRegardlessOfDates() {
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, 5.0, Boolean.FALSE, DUE, lateBy(30 * HOUR)), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, 5.0, null, DUE, lateBy(30 * HOUR)), DELTA);
+    }
+
+    // defensive: missing or invalid configuration yields no penalty
+    @Test
+    public void invalidConfigurationNoPenalty() {
+        Date submitted = lateBy(HOUR);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(null, 5.0, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, null, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, 0.0, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, -2.0, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, Double.NaN, Boolean.TRUE, DUE, submitted), DELTA);
+    }
+
+    // decimal penalty values are honored
+    @Test
+    public void decimalPenaltyValue() {
+        assertEquals(2.5, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, 2.5, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+    }
+
+    // applying the penalty floors at zero and honors the ignore waiver
+    @Test
+    public void applyPenaltyFloorsAndHonorsIgnore() {
+        assertEquals(85.0, LatePenaltyCalculator.applyPenalty(90.0, 5.0, null), DELTA);
+        assertEquals(85.0, LatePenaltyCalculator.applyPenalty(90.0, 5.0, Boolean.FALSE), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.applyPenalty(3.0, 50.0, null), DELTA);
+        assertEquals(90.0, LatePenaltyCalculator.applyPenalty(90.0, 5.0, Boolean.TRUE), DELTA);
+        assertEquals(90.0, LatePenaltyCalculator.applyPenalty(90.0, 0.0, null), DELTA);
+    }
+}

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/util/LatePenaltyCalculatorTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/util/LatePenaltyCalculatorTest.java
@@ -22,35 +22,57 @@ import java.util.Date;
 
 import org.junit.Test;
 import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyType;
+import org.sakaiproject.tool.assessment.util.LatePenaltyCalculator.LatePenaltyUnit;
 
 /**
  * SAK-52267 late penalty computation for Tests & Quizzes. Mirrors the
  * semantics of the Assignments calculator
  * (org.sakaiproject.assignment.api.LatePenaltyCalculator, SAK-15574):
- * any part of a day late counts as a full day, results floor at zero, and a
- * per-submission ignore flag waives the deduction. Samigo operates on double
- * point values and java.util.Date, and gates the penalty on the stored isLate
- * flag, which already respects extended-time exceptions at submit time.
+ * a deduction in points or percent of the maximum score, applied once (flat)
+ * or per hour/day/week late with any partial period counting as a full one,
+ * results floored at zero, gated on the stored isLate flag, with a
+ * per-submission ignore flag that waives the deduction.
  */
 public class LatePenaltyCalculatorTest {
 
     private static final double DELTA = 0.0001;
+    private static final long MINUTE = 60 * 1000L;
     private static final long HOUR = 3600 * 1000L;
+    private static final long DAY = 24 * HOUR;
+    private static final long WEEK = 7 * DAY;
     private static final Date DUE = new Date(1767625200000L); // fixed instant
+    private static final Double MAX = 50.0;
 
     private static Date lateBy(long millis) {
         return new Date(DUE.getTime() + millis);
     }
 
-    // type parsing from stored metadata
+    private static double points(LatePenaltyType type, Double value, Boolean isLate, Date due, Date submitted) {
+        return LatePenaltyCalculator.penaltyPoints(type, LatePenaltyUnit.POINTS, value, null, isLate, due, submitted);
+    }
+
+    // type/unit parsing from stored metadata
     @Test
     public void fromStringParsesTypes() {
         assertEquals(LatePenaltyType.FLAT, LatePenaltyType.fromString("FLAT"));
+        assertEquals(LatePenaltyType.PER_HOUR, LatePenaltyType.fromString("PER_HOUR"));
         assertEquals(LatePenaltyType.PER_DAY, LatePenaltyType.fromString("PER_DAY"));
+        assertEquals(LatePenaltyType.PER_WEEK, LatePenaltyType.fromString("PER_WEEK"));
         assertEquals(LatePenaltyType.FLAT, LatePenaltyType.fromString(" flat "));
         assertNull(LatePenaltyType.fromString(null));
         assertNull(LatePenaltyType.fromString(""));
         assertNull(LatePenaltyType.fromString("bogus"));
+    }
+
+    @Test
+    public void unitFromStringDefaultsToPoints() {
+        assertEquals(LatePenaltyUnit.POINTS, LatePenaltyUnit.fromString("POINTS"));
+        assertEquals(LatePenaltyUnit.PERCENT, LatePenaltyUnit.fromString("PERCENT"));
+        assertEquals(LatePenaltyUnit.PERCENT, LatePenaltyUnit.fromString(" percent "));
+        // absent or unrecognized means POINTS so pre-existing settings keep working
+        assertEquals(LatePenaltyUnit.POINTS, LatePenaltyUnit.fromString(null));
+        assertEquals(LatePenaltyUnit.POINTS, LatePenaltyUnit.fromString(""));
+        assertEquals(LatePenaltyUnit.POINTS, LatePenaltyUnit.fromString("bogus"));
     }
 
     // shared parser behind both settings validation and scoring-time reads
@@ -72,74 +94,131 @@ public class LatePenaltyCalculatorTest {
         assertNull(LatePenaltyCalculator.parsePenaltyValue("NaN"));
     }
 
-    // days late: ceiling of 24h chunks, 0 when on time
+    // periods late: ceiling of whole periods, 0 when on time, boundary counts as that period
     @Test
-    public void daysLateComputation() {
-        assertEquals(0, LatePenaltyCalculator.daysLate(DUE, new Date(DUE.getTime() - HOUR)));
-        assertEquals(0, LatePenaltyCalculator.daysLate(DUE, DUE)); // exactly at due = not late
-        assertEquals(1, LatePenaltyCalculator.daysLate(DUE, lateBy(60 * 1000L))); // 1 minute
-        assertEquals(1, LatePenaltyCalculator.daysLate(DUE, lateBy(24 * HOUR))); // exactly 24h
-        assertEquals(2, LatePenaltyCalculator.daysLate(DUE, lateBy(24 * HOUR + 1000L))); // 24h + 1s
-        assertEquals(4, LatePenaltyCalculator.daysLate(DUE, lateBy(84 * HOUR))); // 3.5 days -> 4
-        assertEquals(0, LatePenaltyCalculator.daysLate(null, lateBy(HOUR)));
-        assertEquals(0, LatePenaltyCalculator.daysLate(DUE, null));
+    public void periodsLateComputation() {
+        assertEquals(0, LatePenaltyCalculator.periodsLate(DUE, new Date(DUE.getTime() - HOUR), DAY));
+        assertEquals(0, LatePenaltyCalculator.periodsLate(DUE, DUE, DAY)); // exactly at due = not late
+        assertEquals(1, LatePenaltyCalculator.periodsLate(DUE, lateBy(MINUTE), DAY));
+        assertEquals(1, LatePenaltyCalculator.periodsLate(DUE, lateBy(DAY), DAY)); // exactly 24h = 1 day
+        assertEquals(2, LatePenaltyCalculator.periodsLate(DUE, lateBy(DAY + 1000L), DAY));
+        assertEquals(4, LatePenaltyCalculator.periodsLate(DUE, lateBy(84 * HOUR), DAY)); // 3.5 days -> 4
+        // hours
+        assertEquals(1, LatePenaltyCalculator.periodsLate(DUE, lateBy(MINUTE), HOUR));
+        assertEquals(1, LatePenaltyCalculator.periodsLate(DUE, lateBy(HOUR), HOUR)); // exactly 60m = 1
+        assertEquals(2, LatePenaltyCalculator.periodsLate(DUE, lateBy(HOUR + 1000L), HOUR));
+        assertEquals(25, LatePenaltyCalculator.periodsLate(DUE, lateBy(DAY + HOUR), HOUR));
+        // weeks
+        assertEquals(1, LatePenaltyCalculator.periodsLate(DUE, lateBy(HOUR), WEEK));
+        assertEquals(1, LatePenaltyCalculator.periodsLate(DUE, lateBy(WEEK), WEEK)); // exactly 7d = 1
+        assertEquals(2, LatePenaltyCalculator.periodsLate(DUE, lateBy(WEEK + 1000L), WEEK));
+        // nulls
+        assertEquals(0, LatePenaltyCalculator.periodsLate(null, lateBy(HOUR), DAY));
+        assertEquals(0, LatePenaltyCalculator.periodsLate(DUE, null, DAY));
     }
 
     // flat penalty applies once, however late
     @Test
     public void flatPenalty() {
-        assertEquals(5.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.FLAT, 5.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
-        assertEquals(5.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.FLAT, 5.0, Boolean.TRUE, DUE, lateBy(90 * HOUR)), DELTA);
+        assertEquals(5.0, points(LatePenaltyType.FLAT, 5.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(5.0, points(LatePenaltyType.FLAT, 5.0, Boolean.TRUE, DUE, lateBy(90 * HOUR)), DELTA);
     }
 
-    // per-day penalty multiplies by whole days, partial day counts as full
+    // per-interval penalties multiply by whole periods, partial counts as full
+    @Test
+    public void perHourPenalty() {
+        assertEquals(1.5, points(LatePenaltyType.PER_HOUR, 1.5, Boolean.TRUE, DUE, lateBy(MINUTE)), DELTA);
+        assertEquals(1.5, points(LatePenaltyType.PER_HOUR, 1.5, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(3.0, points(LatePenaltyType.PER_HOUR, 1.5, Boolean.TRUE, DUE, lateBy(HOUR + 1000L)), DELTA);
+    }
+
     @Test
     public void perDayPenalty() {
-        assertEquals(2.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
-        assertEquals(4.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(30 * HOUR)), DELTA);
-        assertEquals(8.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(84 * HOUR)), DELTA);
+        assertEquals(2.0, points(LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(4.0, points(LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(30 * HOUR)), DELTA);
+        assertEquals(8.0, points(LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, lateBy(84 * HOUR)), DELTA);
+    }
+
+    @Test
+    public void perWeekPenalty() {
+        assertEquals(3.0, points(LatePenaltyType.PER_WEEK, 3.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(3.0, points(LatePenaltyType.PER_WEEK, 3.0, Boolean.TRUE, DUE, lateBy(WEEK)), DELTA);
+        assertEquals(6.0, points(LatePenaltyType.PER_WEEK, 3.0, Boolean.TRUE, DUE, lateBy(WEEK + DAY)), DELTA);
+    }
+
+    // percent deducts a share of the maximum score per application (Canvas model)
+    @Test
+    public void percentOfMaxFlat() {
+        assertEquals(5.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, LatePenaltyUnit.PERCENT, 10.0, MAX, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        // decimals: 2.5% of 40
+        assertEquals(1.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, LatePenaltyUnit.PERCENT, 2.5, 40.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+    }
+
+    @Test
+    public void percentOfMaxPerInterval() {
+        // 10% of 50 per day, 30h late = 2 days -> 10 points
+        assertEquals(10.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_DAY, LatePenaltyUnit.PERCENT, 10.0, MAX, Boolean.TRUE, DUE, lateBy(30 * HOUR)), DELTA);
+        // 1% of 50 per hour, 25h late = 25 hours -> 12.5 points
+        assertEquals(12.5, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_HOUR, LatePenaltyUnit.PERCENT, 1.0, MAX, Boolean.TRUE, DUE, lateBy(DAY + HOUR)), DELTA);
+        // 20% of 50 per week, 8 days late = 2 weeks -> 20 points
+        assertEquals(20.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.PER_WEEK, LatePenaltyUnit.PERCENT, 20.0, MAX, Boolean.TRUE, DUE, lateBy(8 * DAY)), DELTA);
+    }
+
+    // percent without a usable maximum yields no penalty rather than a guess
+    @Test
+    public void percentWithMissingMaxNoPenalty() {
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, LatePenaltyUnit.PERCENT, 10.0, null, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, LatePenaltyUnit.PERCENT, 10.0, 0.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, LatePenaltyUnit.PERCENT, 10.0, -5.0, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+    }
+
+    // a null unit behaves as POINTS (pre-existing stored settings)
+    @Test
+    public void nullUnitBehavesAsPoints() {
+        assertEquals(5.0, LatePenaltyCalculator.penaltyPoints(
+                LatePenaltyType.FLAT, null, 5.0, MAX, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
     }
 
     // autosubmit edge (SAM-1088): isLate TRUE but the recorded submittedDate is
-    // the student's last save, which can be at or before the due date -> minimum one day
+    // the student's last save, which can be at or before the due date -> minimum one period
     @Test
-    public void perDayPenaltyLateFlagWithOnTimeDatesChargesOneDay() {
-        assertEquals(2.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, new Date(DUE.getTime() - HOUR)), DELTA);
-        assertEquals(2.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, null), DELTA);
+    public void intervalPenaltyLateFlagWithOnTimeDatesChargesOnePeriod() {
+        assertEquals(2.0, points(LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, new Date(DUE.getTime() - HOUR)), DELTA);
+        assertEquals(2.0, points(LatePenaltyType.PER_DAY, 2.0, Boolean.TRUE, DUE, null), DELTA);
+        assertEquals(1.5, points(LatePenaltyType.PER_HOUR, 1.5, Boolean.TRUE, DUE, null), DELTA);
+        assertEquals(3.0, points(LatePenaltyType.PER_WEEK, 3.0, Boolean.TRUE, DUE, null), DELTA);
     }
 
     // the stored isLate flag gates everything: no penalty for on-time work
     @Test
     public void notLateNoPenaltyRegardlessOfDates() {
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.FLAT, 5.0, Boolean.FALSE, DUE, lateBy(30 * HOUR)), DELTA);
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.FLAT, 5.0, null, DUE, lateBy(30 * HOUR)), DELTA);
+        assertEquals(0.0, points(LatePenaltyType.FLAT, 5.0, Boolean.FALSE, DUE, lateBy(30 * HOUR)), DELTA);
+        assertEquals(0.0, points(LatePenaltyType.FLAT, 5.0, null, DUE, lateBy(30 * HOUR)), DELTA);
     }
 
     // defensive: missing or invalid configuration yields no penalty
     @Test
     public void invalidConfigurationNoPenalty() {
         Date submitted = lateBy(HOUR);
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(null, 5.0, Boolean.TRUE, DUE, submitted), DELTA);
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, null, Boolean.TRUE, DUE, submitted), DELTA);
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, 0.0, Boolean.TRUE, DUE, submitted), DELTA);
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, -2.0, Boolean.TRUE, DUE, submitted), DELTA);
-        assertEquals(0.0, LatePenaltyCalculator.penaltyPoints(LatePenaltyType.FLAT, Double.NaN, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, points(null, 5.0, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, points(LatePenaltyType.FLAT, null, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, points(LatePenaltyType.FLAT, 0.0, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, points(LatePenaltyType.FLAT, -2.0, Boolean.TRUE, DUE, submitted), DELTA);
+        assertEquals(0.0, points(LatePenaltyType.FLAT, Double.NaN, Boolean.TRUE, DUE, submitted), DELTA);
     }
 
     // decimal penalty values are honored
     @Test
     public void decimalPenaltyValue() {
-        assertEquals(2.5, LatePenaltyCalculator.penaltyPoints(
-                LatePenaltyType.FLAT, 2.5, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
+        assertEquals(2.5, points(LatePenaltyType.FLAT, 2.5, Boolean.TRUE, DUE, lateBy(HOUR)), DELTA);
     }
 
     // applying the penalty floors at zero and honors the ignore waiver


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52267

> **First pass**, mirroring the Assignments implementation (SAK-15574, #14737) with identical semantics so the two tools behave consistently. It implements the January 2026 T&L/UX mockups with working backend logic so the feature can be played with; details to be revisited based on testing and feedback ([ticket comment](https://sakaiproject.atlassian.net/browse/SAK-52267?focusedCommentId=255420) has the open questions, including the extended-time decision below).

## Problem

Instructors who apply a late policy to assessments have to hand-adjust every late submission's score. The T&L/UX group filed this as the Tests & Quizzes counterpart to SAK-15574, noting it may be even more useful here since assessments are usually auto-graded — with no instructor in the loop, a late penalty currently requires manually adjusting scores the tool already computed.

## Feature

**Settings.** The Grading and Feedback section gains a "Late Penalty" radio group — no penalty (default), deduct N points for late submissions, or deduct N points per day late — with the point value validated as a positive number. Stored as assessment metadata (`ASSESSMENT_LATE_PENALTY_TYPE` / `..._VALUE`), which publishing already copies; editable on both draft and published settings. Placed below "Add Grades to Gradebook" (the mockup sketches it above Anonymous Grading; moved so the scoring-related options read top-down into the penalty).

**Semantics** (same as Assignments): any part of a day late counts as a full day; the effective score floors at zero; the penalty is gated on the submission's stored `isLate` flag. Per-day lateness is measured against the student's **effective due date** — their "Exceptions to Availability Dates and Time Limit" entry when one exists — so accommodated students are not penalized incorrectly (the submit-time `isLate` flag already honors extensions per SAM-3319). An autosubmitted attempt whose recorded submission time is the student's last save before the due date (SAM-1088) is charged a minimum of one day.

**Scoring.** Samigo's `finalScore` is already a stored derived column (`max(0, totalAutoScore + totalOverrideScore)`) that the gradebook push, student views, statistics, and highest/last/average scoring all read — so the penalty is applied wherever `finalScore` is recomputed, while `totalAutoScore`/`totalOverrideScore` stay raw. A new pure `LatePenaltyCalculator` plus `GradingService.computeFinalScore`/`getLatePenalty` centralize the formula, and every write site uses it: submission and regrade (`storeGrades`), question-score edits (`updateItemScore`, `updateAssessmentGradingScore`), the autosubmit job (which saves without `storeGrades` and already resolves the extended-time due date locally), and the Total Scores save listener. That last one matters: its change detection compared the stored (penalized) final score against a freshly computed unpenalized sum, so without it every Update click on a late row would have silently erased the deduction.

**Total Scores.** A "Late Penalty" column between Score and Adjustment shows the deduction ("0" or "−5") and, on late rows, an **Ignore late penalty** checkbox per the mockup. The waiver persists as a new nullable `IGNORELATEPENALTY` column on `SAM_ASSESSMENTGRADING_T` (null = penalty applies, so existing rows are unaffected), and toggling it recomputes the final score and renotifies the gradebook through the existing save flow — including when a compensating adjustment keeps the displayed score equal.

## Update (post-review): intervals and percentages

The penalty model is generalized: deduct **once, per hour, per day, or per week** late (any partial period counts as a full period), in **fixed points or a percentage of the assessment's total score** per application (the Canvas model). Absent unit metadata means points, so nothing saved earlier changes behavior; percentages are validated to at most 100, and unit changes trigger the same re-score of stored submissions as other penalty settings changes. Covered by the expanded calculator matrix (18 tests).

## Schema change

One nullable Boolean column: `SAM_ASSESSMENTGRADING_T.IGNORELATEPENALTY` (hbm-mapped, so `auto.ddl` handles dev). A companion conversion-script PR to sakai-reference is needed:
```sql
ALTER TABLE SAM_ASSESSMENTGRADING_T ADD IGNORELATEPENALTY BIT;      -- mysql
ALTER TABLE SAM_ASSESSMENTGRADING_T ADD IGNORELATEPENALTY NUMBER(1,0); -- oracle
```

Note: the branch also carries the one-line docker `context.xml` commit from #14738 (required for JSF tools to run in the docker dev environment); it will fall out on rebase once #14738 merges.

## Known limitations (intentional for a first pass)

- ~~Changing penalty settings does not retro-touch stored final scores~~ Addressed after review: changing the late penalty configuration on a published assessment now re-scores existing graded submissions immediately and renotifies the gradebook.
- The waiver is only exposed on Total Scores (not Submission Status).
- Statistics and histograms distribute the stored (penalized) final scores while per-item scores stay raw.
- The per-day amount is bounded by the late-acceptance window; a long "accept until" with per-day penalties can floor scores at 0, matching Assignments.
- The Tests & Quizzes equivalent of the Assignments grader annotation in student feedback views is not added; students see the penalized score wherever scores are already shown.

## Testing

- `LatePenaltyCalculatorTest` (9 tests): flat and per-day math, partial-day ceiling, exactly-24h boundary, minimum one day for autosubmit's late-flag-with-on-time-dates edge, isLate gating, null/negative/NaN config inert, decimals, floor at zero, waiver passthrough.
- `GradingServiceFinalScoreTest` (4): the centralized formula preserves legacy behavior with no penalty (including negative-adjustment flooring) and applies/waives the penalty.
- `AssessmentGradingFacadeQueriesTest` (+1): the new column round-trips through Hibernate, and absent means "penalty applies".
- Review follow-ups: penalty value parsing/validation lives in `LatePenaltyCalculator.parsePenaltyValue` shared by both settings listeners and the scoring-time read; the Total Scores penalty column formats with the Sakai-resolved locale.
- Manually verified end to end on a local instance driving the real UI: published a 10-point assessment with a 5/day penalty; a student submitting ~90 seconds late scored `totalAutoScore` 10 / `finalScore` 5, gradebook 5; Total Scores rendered Score 10, Late Penalty −5 with checkbox, Adjustment 0.0, Final Score 5 with the red LATE marker; checking Ignore late penalty + Update restored 10 everywhere with the flag persisted; unchecking reapplied the penalty; editing the question score to 8 on Question Scores kept the penalty (final 3, gradebook 3) — the regression the centralization exists to prevent. Settings round-trip on draft and published assessments; assessments without penalty metadata behave exactly as before (all 150 samigo module tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic late-penalty options for assessments, including configurable timing, amount, and unit choices.
  * Added a new reviewer control to ignore late penalties for individual submissions.
  * Late penalties can now be shown in total score views and reflected in published/authoring settings.

* **Bug Fixes**
  * Late-penalty values now validate correctly and prevent invalid percentage settings.
  * Updated score calculations so late penalties are applied consistently and waived when selected.
  * Existing submissions can be recalculated when late-penalty settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->