### PR TITLE
SAK-45285 DateManager: editing an item's open date shifts its other dates by the same delta

### DIFF
--- a/docker/tomcat/conf/context.xml
+++ b/docker/tomcat/conf/context.xml
@@ -1,7 +1,7 @@
 <Context>
     <JarScanner>
         <!-- This is to speedup startup so that tomcat doesn't scan as much -->
-        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
+        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,jakarta.faces-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
     </JarScanner>
 </Context>
 

--- a/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
+++ b/site-manage/datemanager/tool/src/main/java/org/sakaiproject/datemanager/tool/MainController.java
@@ -106,6 +106,10 @@ public class MainController {
         model.addAttribute("userLanguage", loc.getLanguage());
         model.addAttribute("userLocale", loc.toString());
         model.addAttribute("userTimeZone", userTimeService.getLocalTimeZone().getID());
+        // SAK-45285 version the tool's static assets so browsers refetch them on
+        // upgrade; same convention as PortalUtils.getCDNQuery()
+        model.addAttribute("cdnVersion", serverConfigurationService.getString("portal.cdn.version",
+                serverConfigurationService.getString("version.service", "0")));
 
         return model;
     }

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -218,6 +218,14 @@ DTMN.setDatePickerValue = function(datepicker, date, useTime)
   datepicker.classList.add("border-warning");
 };
 
+// SAK-45285 drop a trailing timezone designator so hidden values parse in the
+// strict local formats; the datepicker writes "-06:00"-style suffixes in
+// negative-offset zones, which a bare split on "+" misses
+DTMN.stripOffset = function(value)
+{
+  return value.replace(/(Z|[+-]\d{2}:?\d{2})$/, "");
+};
+
 // SAK-45285 shift a date by the wall-clock difference between two anchor
 // values: whole calendar days first (so time-of-day never drifts, including
 // across DST) plus any change in the anchor's time of day
@@ -249,8 +257,8 @@ DTMN.syncRowDates = function(hiddenField)
 
   const tool = hiddenField.dataset.tool;
   const useTime = tool !== "gradebookItems";
-  const oldAnchor = DTMN.parseDatePickerInputValue(previous.split("+")[0], useTime);
-  const newAnchor = DTMN.parseDatePickerInputValue(hiddenField.value.split("+")[0], useTime);
+  const oldAnchor = DTMN.parseDatePickerInputValue(DTMN.stripOffset(previous), useTime);
+  const newAnchor = DTMN.parseDatePickerInputValue(DTMN.stripOffset(hiddenField.value), useTime);
   if (!oldAnchor.isValid() || !newAnchor.isValid() || oldAnchor.isSame(newAnchor)) {
     return;
   }
@@ -271,7 +279,7 @@ DTMN.syncRowDates = function(hiddenField)
     }
 
     const siblingUseTime = sibling.dataset.tool !== "gradebookItems";
-    const current = DTMN.parseDatePickerInputValue(sibling.value.split("+")[0], siblingUseTime);
+    const current = DTMN.parseDatePickerInputValue(DTMN.stripOffset(sibling.value), siblingUseTime);
     if (!current.isValid()) {
       return;
     }

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -5,6 +5,10 @@ DTMN.collapseElements = [ ];
 DTMN.bulkFields = DTMN.bulkFields || [];
 DTMN.nextIndex = -1;
 
+// SAK-45285 the row column that, when edited by hand, drags the row's other
+// dates along by the same delta so an item's original spacing is preserved
+DTMN.rowAnchorFields = [ "open_date", "signup_begins" ];
+
 DTMN.initDatePicker = function(updates, notModified) {
 
   // use an event listener to populate the date pickers on demand instead of populating everything on page load
@@ -203,12 +207,78 @@ DTMN.setDatePickerValue = function(datepicker, date, useTime)
   const hiddenField = td ? td.querySelector("input[type=hidden]") : null;
   if (hiddenField) {
     hiddenField.value = DTMN.getHiddenDateValue(date, useTime);
+    // programmatic write (shift/bulk/row-sync): the row-sync listener must not
+    // treat it as a hand edit, or bulk shifts would compound per row
+    hiddenField.dataset.dtmnProgrammatic = "true";
     hiddenField.dispatchEvent(new Event("change", {bubbles: true}));
   } else {
     datepicker.dispatchEvent(new Event("change", {bubbles: true}));
   }
 
   datepicker.classList.add("border-warning");
+};
+
+// SAK-45285 shift a date by the wall-clock difference between two anchor
+// values: whole calendar days first (so time-of-day never drifts, including
+// across DST) plus any change in the anchor's time of day
+DTMN.shiftPreservingWallClock = function(date, oldAnchor, newAnchor)
+{
+  const dayDelta = newAnchor.clone().startOf("day").diff(oldAnchor.clone().startOf("day"), "days");
+  const timeDelta = newAnchor.diff(newAnchor.clone().startOf("day"))
+      - oldAnchor.diff(oldAnchor.clone().startOf("day"));
+  return date.clone().add(dayDelta, "days").add(timeDelta, "milliseconds");
+};
+
+// SAK-45285 when a row's anchor date is edited by hand, move the row's other
+// populated dates by the same delta; empty cells stay empty and every field
+// remains editable afterward
+DTMN.syncRowDates = function(hiddenField)
+{
+  const previous = hiddenField.dataset.dtmnPrevValue || "";
+  hiddenField.dataset.dtmnPrevValue = hiddenField.value;
+
+  if (hiddenField.dataset.dtmnProgrammatic === "true") {
+    delete hiddenField.dataset.dtmnProgrammatic;
+    return;
+  }
+
+  const field = hiddenField.dataset.field;
+  if (!DTMN.rowAnchorFields.includes(field) || previous === "" || hiddenField.value === "") {
+    return;
+  }
+
+  const tool = hiddenField.dataset.tool;
+  const useTime = tool !== "gradebookItems";
+  const oldAnchor = DTMN.parseDatePickerInputValue(previous.split("+")[0], useTime);
+  const newAnchor = DTMN.parseDatePickerInputValue(hiddenField.value.split("+")[0], useTime);
+  if (!oldAnchor.isValid() || !newAnchor.isValid() || oldAnchor.isSame(newAnchor)) {
+    return;
+  }
+
+  const idx = hiddenField.dataset.idx;
+  const siblings = document.querySelectorAll(
+      'input[type=hidden][data-tool="' + tool + '"][data-idx="' + idx + '"]');
+
+  siblings.forEach(function(sibling) {
+    if (sibling === hiddenField || sibling.value === "" || DTMN.rowAnchorFields.includes(sibling.dataset.field)) {
+      return;
+    }
+
+    const td = sibling.closest("td");
+    const datepicker = td ? td.querySelector("input.datepicker") : null;
+    if (!datepicker || datepicker.disabled) {
+      return;
+    }
+
+    const siblingUseTime = sibling.dataset.tool !== "gradebookItems";
+    const current = DTMN.parseDatePickerInputValue(sibling.value.split("+")[0], siblingUseTime);
+    if (!current.isValid()) {
+      return;
+    }
+
+    DTMN.setDatePickerValue(datepicker,
+        DTMN.shiftPreservingWallClock(current, oldAnchor, newAnchor), siblingUseTime);
+  });
 };
 
 DTMN.attachDatePicker = function (selector, updates, notModified) {
@@ -283,6 +353,12 @@ DTMN.attachDatePicker = function (selector, updates, notModified) {
       }
       notModified.push(tool + idx + field);
     });
+
+    // SAK-45285 a hand edit of the row's anchor date drags the row's other
+    // dates along by the same delta; registered after the bookkeeping handler
+    // above so the anchor's own update is recorded first
+    $hidden.attr('data-dtmn-prev-value', $hidden.val());
+    $hidden.on('change', function () { DTMN.syncRowDates(this); });
 
     $hidden.attr('id', 'hidden_datepicker_' + DTMN.nextIndex);
     var dateFormat = 'YYYY-MM-DDTHH:mm:ss';

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/confirm_import.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/confirm_import.html
@@ -8,7 +8,7 @@
 		<link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
 		<script src="/library/js/headscripts.js" type="text/javascript"></script>
 		<script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>
-		<script th:src="@{/js/initDatePicker.js}"></script>
+		<script th:src="@{/js/initDatePicker.js(v=${cdnVersion})}"></script>
 		<script th:inline="javascript">
 		  /*<![CDATA[*/
 			var sakai = sakai || {}; sakai.editor = sakai.editor || {};

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/import_page.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/import_page.html
@@ -8,7 +8,7 @@
 		<link media="all" href="/library/skin/tool_base.css" rel="stylesheet" type="text/css" />
 		<script src="/library/js/headscripts.js" type="text/javascript"></script>
 		<script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js"></script>
-		<script th:src="@{/js/initDatePicker.js}"></script>
+		<script th:src="@{/js/initDatePicker.js(v=${cdnVersion})}"></script>
 		<script th:inline="javascript">
 		  /*<![CDATA[*/
 			var sakai = sakai || {}; sakai.editor = sakai.editor || {};

--- a/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
+++ b/site-manage/datemanager/tool/src/main/webapp/WEB-INF/templates/index.html
@@ -21,7 +21,7 @@
       /*]]>*/
     </script>
     <script src="/library/js/lang-datepicker/lang-datepicker.js"></script>
-    <script th:src="@{/js/initDatePicker.js}"></script>
+    <script th:src="@{/js/initDatePicker.js(v=${cdnVersion})}"></script>
     <meta http-equiv="Content-Style-Type" content="text/css" />
 
     <div class="page-header border-bottom">

--- a/site-manage/datemanager/tool/src/test/js/loadDtmn.js
+++ b/site-manage/datemanager/tool/src/test/js/loadDtmn.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Test-only helper: load the browser script initDatePicker.js into Node so its pure date functions
+// can be unit tested. The script is a plain browser global (it does `var DTMN = ...` and attaches
+// functions, with no module.exports) and only touches document/$/moment INSIDE function bodies, so it
+// loads cleanly in a vm context as long as we provide `moment`. The date logic is deliberately
+// timezone-agnostic (wall-clock only - Sakai resolves the zone server-side), so plain `moment` is all
+// that's needed; run the suite under TZ=UTC (see package.json) for deterministic wall-clock math.
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const moment = require("moment");
+
+const SCRIPT_PATH = path.resolve(
+  __dirname,
+  "../../main/resources/static/js/initDatePicker.js"
+);
+
+/**
+ * Load a fresh DTMN object.
+ *
+ * @returns {{DTMN: object, moment: import("moment")}} the populated DTMN plus the same moment instance
+ *          the script uses, so tests build inputs from the identical library.
+ */
+function loadDtmn() {
+  const source = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+  const sandbox = { moment, console };
+  // In a vm context globalThis is the sandbox itself; provide a minimal sakai stub so any incidental
+  // sakai.locale lookups elsewhere in the script can't throw.
+  sandbox.globalThis = sandbox;
+  sandbox.sakai = { locale: {} };
+
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: SCRIPT_PATH });
+
+  if (!sandbox.DTMN) {
+    throw new Error("initDatePicker.js did not define DTMN when loaded");
+  }
+  return { DTMN: sandbox.DTMN, moment };
+}
+
+module.exports = { loadDtmn };

--- a/site-manage/datemanager/tool/src/test/js/package-lock.json
+++ b/site-manage/datemanager/tool/src/test/js/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "datemanager-js-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datemanager-js-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "moment": "2.30.1"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    }
+  }
+}

--- a/site-manage/datemanager/tool/src/test/js/package-lock.json
+++ b/site-manage/datemanager/tool/src/test/js/package-lock.json
@@ -8,7 +8,8 @@
       "name": "datemanager-js-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "moment": "2.30.1"
+        "moment": "2.30.1",
+        "moment-timezone": "0.5.45"
       }
     },
     "node_modules/moment": {
@@ -17,6 +18,19 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "engines": {
         "node": "*"
       }

--- a/site-manage/datemanager/tool/src/test/js/package.json
+++ b/site-manage/datemanager/tool/src/test/js/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "datemanager-js-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Standalone unit tests for the DateManager client-side date logic (initDatePicker.js). Not part of the Maven build.",
+  "scripts": {
+    "test": "TZ=UTC node --test"
+  },
+  "devDependencies": {
+    "moment": "2.30.1"
+  }
+}

--- a/site-manage/datemanager/tool/src/test/js/package.json
+++ b/site-manage/datemanager/tool/src/test/js/package.json
@@ -7,6 +7,7 @@
     "test": "TZ=UTC node --test"
   },
   "devDependencies": {
-    "moment": "2.30.1"
+    "moment": "2.30.1",
+    "moment-timezone": "0.5.45"
   }
 }

--- a/site-manage/datemanager/tool/src/test/js/rowOffsetSync.test.js
+++ b/site-manage/datemanager/tool/src/test/js/rowOffsetSync.test.js
@@ -85,6 +85,22 @@ test("a shift is a no-op when the anchor did not move", () => {
     "2026-08-20T23:59:00");
 });
 
+test("a shift across a DST boundary keeps wall-clock time (zone-aware moments)", () => {
+  // America/New_York springs forward 2026-03-08: the anchor moves Mar 6 -> Mar 13
+  // (7 calendar days across the transition) and the 23:00 due time stays 23:00,
+  // even though the interval is only 167 real hours
+  const tz = require("moment-timezone");
+  const oldAnchor = tz.tz("2026-03-06T08:00:00", "America/New_York");
+  const newAnchor = tz.tz("2026-03-13T08:00:00", "America/New_York");
+  const due = tz.tz("2026-03-06T23:00:00", "America/New_York");
+  const shiftedDue = DTMN.shiftPreservingWallClock(due, oldAnchor, newAnchor);
+  assert.equal(shiftedDue.format("YYYY-MM-DDTHH:mm:ss"), "2026-03-13T23:00:00");
+  assert.equal(newAnchor.diff(oldAnchor, "hours"), 167); // proves we really crossed DST
+  // and back again across the same boundary
+  const restored = DTMN.shiftPreservingWallClock(shiftedDue, newAnchor, oldAnchor);
+  assert.equal(restored.format("YYYY-MM-DDTHH:mm:ss"), "2026-03-06T23:00:00");
+});
+
 test("days are applied as calendar days so time-of-day never drifts", () => {
   // 90-day jump lands at the same wall-clock time
   assert.equal(

--- a/site-manage/datemanager/tool/src/test/js/rowOffsetSync.test.js
+++ b/site-manage/datemanager/tool/src/test/js/rowOffsetSync.test.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// SAK-45285 when a row's open date is edited, the row's later dates shift by
+// the same wall-clock delta, preserving the offsets the item already had.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { loadDtmn } = require("./loadDtmn");
+
+const { DTMN, moment } = loadDtmn();
+
+function m(value) {
+  return moment(value, "YYYY-MM-DDTHH:mm:ss", true);
+}
+
+function shifted(dateStr, oldAnchorStr, newAnchorStr) {
+  return DTMN.shiftPreservingWallClock(m(dateStr), m(oldAnchorStr), m(newAnchorStr))
+    .format("YYYY-MM-DDTHH:mm:ss");
+}
+
+test("anchor fields are the open date and the sign-up begins column", () => {
+  // copy out of the vm realm so deepEqual compares contents, not prototypes
+  assert.deepEqual(Array.from(DTMN.rowAnchorFields), ["open_date", "signup_begins"]);
+});
+
+test("moving the open date forward a week moves the due date the same week, wall clock preserved", () => {
+  assert.equal(
+    shifted("2026-08-20T23:59:00", "2026-08-13T08:00:00", "2026-08-20T08:00:00"),
+    "2026-08-27T23:59:00");
+});
+
+test("moving the open date backward shifts siblings backward", () => {
+  assert.equal(
+    shifted("2026-08-20T23:59:00", "2026-08-13T08:00:00", "2026-08-06T08:00:00"),
+    "2026-08-13T23:59:00");
+});
+
+test("a year rollover preserves the original open-to-due spread", () => {
+  // Aug 13 2025 -> Aug 12 2026 (364 days); due follows exactly
+  assert.equal(
+    shifted("2025-08-27T23:59:00", "2025-08-13T08:00:00", "2026-08-12T08:00:00"),
+    "2026-08-26T23:59:00");
+});
+
+test("changing only the open time shifts sibling times by the same amount", () => {
+  assert.equal(
+    shifted("2026-08-20T23:00:00", "2026-08-13T08:00:00", "2026-08-13T08:30:00"),
+    "2026-08-20T23:30:00");
+});
+
+test("changing date and time together applies both parts", () => {
+  assert.equal(
+    shifted("2026-08-20T22:00:00", "2026-08-13T08:00:00", "2026-08-14T09:15:00"),
+    "2026-08-21T23:15:00");
+});
+
+test("a shift is a no-op when the anchor did not move", () => {
+  assert.equal(
+    shifted("2026-08-20T23:59:00", "2026-08-13T08:00:00", "2026-08-13T08:00:00"),
+    "2026-08-20T23:59:00");
+});
+
+test("days are applied as calendar days so time-of-day never drifts", () => {
+  // 90-day jump lands at the same wall-clock time
+  assert.equal(
+    shifted("2026-01-10T17:45:00", "2026-01-05T09:00:00", "2026-04-05T09:00:00"),
+    "2026-04-10T17:45:00");
+});
+
+test("date-only values (gradebook style) shift by whole days", () => {
+  const result = DTMN.shiftPreservingWallClock(
+    moment("2026-08-20", "YYYY-MM-DD", true),
+    m("2026-08-13T08:00:00"),
+    m("2026-08-20T08:00:00"));
+  assert.equal(result.format("YYYY-MM-DD"), "2026-08-27");
+});

--- a/site-manage/datemanager/tool/src/test/js/rowOffsetSync.test.js
+++ b/site-manage/datemanager/tool/src/test/js/rowOffsetSync.test.js
@@ -32,6 +32,17 @@ function shifted(dateStr, oldAnchorStr, newAnchorStr) {
     .format("YYYY-MM-DDTHH:mm:ss");
 }
 
+test("offset suffixes are stripped whatever their sign (the Americas write negative offsets)", () => {
+  assert.equal(DTMN.stripOffset("2026-07-04T16:25:00-06:00"), "2026-07-04T16:25:00");
+  assert.equal(DTMN.stripOffset("2026-07-04T16:25:00+02:00"), "2026-07-04T16:25:00");
+  assert.equal(DTMN.stripOffset("2026-07-04T16:25:00+0000"), "2026-07-04T16:25:00");
+  assert.equal(DTMN.stripOffset("2026-07-04T16:25:00Z"), "2026-07-04T16:25:00");
+  // untouched when there is no offset: bare seconds are not an offset
+  assert.equal(DTMN.stripOffset("2026-07-04T16:25:00"), "2026-07-04T16:25:00");
+  assert.equal(DTMN.stripOffset("2026-07-04"), "2026-07-04");
+  assert.equal(DTMN.stripOffset(""), "");
+});
+
 test("anchor fields are the open date and the sign-up begins column", () => {
   // copy out of the vm realm so deepEqual compares contents, not prototypes
   assert.deepEqual(Array.from(DTMN.rowAnchorFields), ["open_date", "signup_begins"]);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-45285

Completes the ticket's remaining ask (suggestion I / Tiffany's refinement): when an instructor hand-edits a single item's **Open Date** (or **Sign-Up Begins**) in Date Manager, the row's other populated dates — Due, Accept Until, Feedback windows, Sign-Up Deadline — immediately shift by the same delta, preserving the spacing the item already had. All fields remain editable afterward.

The bulk halves of the ticket are covered elsewhere: SAK-52523 (merged, #14504) added the bulk date setters, and SAK-52598 (#14726, in review) adds per-column fills, Smart Shift, and the Bulk Term Date Matrix.

## Behavior details

- The delta is applied as **whole calendar days plus the change in time of day**, so a +7-day edit keeps every sibling at its original wall-clock time (no DST drift), and changing only the open *time* nudges sibling times by the same amount.
- **Empty cells stay empty** — no dates are invented; setting an anchor that was previously blank shifts nothing.
- Disabled columns (e.g. Accept Until when late submissions are off, feedback dates when feedback-by-date is off) are skipped.
- Programmatic writes from the existing Shift and Bulk tools are flagged and ignored by the row sync, so batch operations can never compound with it.
- Rows without an anchor column (e.g. gradebook items, which only have a due date) are unaffected.

## Design note: why the sync is unconditional (no opt-out checkbox)

There is a real minority case where an instructor wants to edit *only* the open date — most plausibly opening an item early while keeping its deadline ("see it Monday, still due Friday"). We considered a toggle and decided against complicating the UI, because:

- Date Manager is the bulk/rollover tool; one-off availability tweaks normally happen in each tool's own settings page, which this change does not touch.
- The ticket discussion explicitly specified this behavior ("when you update the open date, the others automatically update to match; then you can edit the other dates as needed").
- Every auto-shifted field is highlighted (`border-warning`) and nothing persists until Save.
- The sync is exactly self-inverting: re-entering the previous open date shifts every sibling back to precisely its original value, so an unwanted shift is undone with one edit — and the "open early, keep deadline" intent is achieved by fixing the due date back (edits to non-anchor fields never cascade).

If reviewers or T&L prefer an explicit opt-out, it's a small follow-up rather than a redesign.

## Also in this PR (found during live verification)

- **Negative-offset parse fix**: the hidden date values carry the user-zone offset, and stripping it with a bare split on `+` (the idiom used elsewhere in this file) fails for every zone west of UTC, silently disabling the sync. Any trailing `Z`/`±hh:mm` designator is now stripped, with unit coverage. Caught by hand-testing in a UTC-6 browser after every UTC-based automated pass came up green — the same latent idiom remains in the pre-existing change-tracking handler (`updates[tool][idx][field]`), which reviewers may want cleaned up here or separately.
- **Cache busting**: the tool served `initDatePicker.js` with no `Cache-Control` header and an unversioned URL, so browsers keep a heuristically-cached copy across Sakai upgrades (Firefox hard refresh doesn't reach iframe subresources). The script URL is now versioned from `portal.cdn.version` / `version.service`, matching `PortalUtils.getCDNQuery()`.

## Testing

- Extends the standalone Node test harness for the DateManager date logic with 10 tests covering offset-suffix stripping (±hh:mm and Z), forward/backward shifts, year rollover, time-only changes, combined date+time changes, no-op anchors, long jumps (time-of-day never drifts), and date-only (gradebook-format) values. `npm ci && npm test` in `site-manage/datemanager/tool/src/test/js`.
- Manually verified end to end against a local instance in both Chromium and Firefox, in UTC and UTC-6 browser timezones: editing an open date via the native datetime-local input shifts the row's due date with wall-clock preserved, highlights both fields, enables Save, and re-entering the old open date restores the row exactly.
- Note: the harness files (`loadDtmn.js`, `package.json`, lock file) are identical to the ones in #14726, so whichever PR merges second picks them up as an already-resolved add/add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date fields in the same row now synchronize when anchor dates are edited, automatically shifting related dates while preserving the original wall-clock time.
* **Bug Fixes**
  * Prevented row synchronization from triggering on programmatic date updates to avoid unintended compounding/drift.
  * Improved Tomcat scanning for Jakarta Faces JARs.
* **Tests**
  * Added Node-based unit tests (including DST boundary coverage) for row offset synchronization.
* **Chores**
  * Enabled cache-busting for the date picker by loading a versioned script across tool pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->