### PR TITLE
SAK-52708 T&Q: email students that grading/comments were updated (single + bulk), with Update & Notify

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
@@ -305,7 +305,13 @@
 			min-width: 70px;
 		}
 	}
-	
+
+	// let the per-row "Email last sent" note wrap over a few lines so the
+	// Total Scores Notify column stays slim
+	.sam-notify-last-sent {
+		max-width: 8em;
+	}
+
 	.navIntraTool {
 		margin: 0px !important;
 	}

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/SamigoETSProvider.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/SamigoETSProvider.java
@@ -18,6 +18,7 @@ package org.sakaiproject.samigo.api;
 import org.sakaiproject.event.api.Event;
 
 
+import java.util.List;
 import java.util.Map;
 
 public interface SamigoETSProvider {
@@ -32,4 +33,25 @@ public interface SamigoETSProvider {
      * @param count the number of errors
      */
     void notifyAutoSubmitFailures(int count);
+
+    /**
+     * emails students that their instructor has added comments or
+     * updated the grading on an assessment, with a link into the site's
+     * Tests &amp; Quizzes tool. Delivery honors each student's Tests &amp;
+     * Quizzes notification preference (immediate or digest; ignore is
+     * skipped), and students without an email address are skipped.
+     *
+     * @param studentUserIds  the user ids to notify
+     * @param siteId          the site holding the assessment
+     * @param assessmentTitle the assessment title for the message
+     * @return how many notifications were actually delivered
+     */
+    /**
+     * Emails the given students that grading/comments changed on an assessment.
+     *
+     * @return the userIds that were actually delivered to (sent or digested);
+     *         callers must not treat skipped users (no email, unknown, opted
+     *         out) as notified.
+     */
+    List<String> notifyGradingUpdated(List<String> studentUserIds, String siteId, String assessmentTitle);
 }

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/SamigoETSProvider.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/SamigoETSProvider.java
@@ -44,11 +44,6 @@ public interface SamigoETSProvider {
      * @param studentUserIds  the user ids to notify
      * @param siteId          the site holding the assessment
      * @param assessmentTitle the assessment title for the message
-     * @return how many notifications were actually delivered
-     */
-    /**
-     * Emails the given students that grading/comments changed on an assessment.
-     *
      * @return the userIds that were actually delivered to (sent or digested);
      *         callers must not treat skipped users (no email, unknown, opted
      *         out) as notified.

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -39,6 +39,8 @@ public final class SamigoConstants {
     public static final     String      EMAIL_TEMPLATE_AUTO_SUBMIT_ERRORS_FILE_NAME         = "template-assessmentAutoSubmitErrors.xml";
     public static final     String      EMAIL_TEMPLATE_ASSESSMENT_AVAILABLE_REMINDER        = "sam.assessmentAvailableReminder";
     public static final     String      EMAIL_TEMPLATE_ASSESSMENT_AVAILABLE_FILE_NAME       = "template-assessmentAvailableReminder.xml";
+    public static final     String      EMAIL_TEMPLATE_GRADING_UPDATED                      = "sam.gradingUpdated";
+    public static final     String      EMAIL_TEMPLATE_GRADING_UPDATED_FILE_NAME            = "template-gradingUpdated.xml";
 
     /*
      * Events
@@ -58,6 +60,8 @@ public final class SamigoConstants {
 
     //Assessment scoring events
     public static final     String      EVENT_ASSESSMENT_TOTAL_SCORE_UPDATE                 = "sam.total.score.update";
+    /** instructor manually emailed a student that grading/comments changed */
+    public static final     String      EVENT_GRADING_UPDATED_NOTIFY                        = "sam.grading.updated.notify";
     public static final     String      EVENT_ASSESSMENT_STUDENT_SCORE_UPDATE               = "sam.student.score.update";
     public static final     String      EVENT_ASSESSMENT_AUTO_GRADED                        = "sam.assessment.graded.auto";
     public static final     String      EVENT_ASSESSMENT_QUESTION_SCORE_UPDATE              = "sam.question.score.update";

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EvaluationMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/EvaluationMessages.properties
@@ -412,3 +412,14 @@ timeStatsVariation_title=Variation
 questionVariation_title=Variation of students who have obtained more than a {0} in the score ({1} submitted)
 rubrics_button_download=Download all rubrics
 rubrics=rubrics
+
+# email student that grading/comments were updated
+notify_grading_updated=Email student: grading updated
+notify_grading_updated_save=Update & Notify
+notify_grading_updated_column=Notify
+notify_grading_updated_tooltip=Send an automated email that comments or grading were updated on this submission
+notify_grading_updated_sent=Sent
+notify_grading_updated_cooldown=Just sent; you can send another update shortly
+notify_grading_updated_last_sent=Email last sent: {0}
+notify_grading_updated_result=Grading-update email sent to {0} student(s).
+notify_grading_updated_result_with_skipped=Grading-update email sent to {0} student(s); {1} skipped (notified moments ago).

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/AgentResults.java
@@ -233,6 +233,11 @@ public class AgentResults
   public void setIsLate(Boolean isLate) {
     this.isLate = isLate;
   }
+  /** string form for EL map lookups on the notify column */
+  public String getAssessmentGradingIdString() {
+    return assessmentGradingId == null ? "" : assessmentGradingId.toString();
+  }
+
   public Boolean getForGrade() {
     return Validator.bcheck(forGrade, true);
   }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
@@ -22,7 +22,9 @@
 package org.sakaiproject.tool.assessment.ui.bean.evaluation;
 
 import java.io.Serializable;
-import java.text.DateFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -405,8 +407,8 @@ public class TotalScoresBean implements Serializable, PhaseAware {
 	
   // "email student: grading updated" — session-side cooldown and
   // last-sent display; resets with the session (no schema change)
-  private static final long NOTIFY_COOLDOWN_MILLIS = 60L * 1000L;
-  private final Map<String, Date> gradingNotifiedDates = new HashMap<>();
+  private static final Duration NOTIFY_COOLDOWN = Duration.ofMinutes(1);
+  private final Map<String, Instant> gradingNotifiedDates = new HashMap<>();
 
   /** true when the assessment's feedback settings let students see grading now */
   public boolean getGradingNotifyAvailable() {
@@ -427,12 +429,12 @@ public class TotalScoresBean implements Serializable, PhaseAware {
   }
 
   public void markGradingNotified(String assessmentGradingId) {
-    gradingNotifiedDates.put(assessmentGradingId, new Date());
+    gradingNotifiedDates.put(assessmentGradingId, Instant.now());
   }
 
   public boolean isNotifyCoolingDown(String assessmentGradingId) {
-    Date sent = gradingNotifiedDates.get(assessmentGradingId);
-    return sent != null && System.currentTimeMillis() - sent.getTime() < NOTIFY_COOLDOWN_MILLIS;
+    Instant sent = gradingNotifiedDates.get(assessmentGradingId);
+    return sent != null && Instant.now().isBefore(sent.plus(NOTIFY_COOLDOWN));
   }
 
   /** per-row cooldown state for the JSP, keyed by assessmentGradingId string */
@@ -448,8 +450,10 @@ public class TotalScoresBean implements Serializable, PhaseAware {
     if (gradingNotifiedDates.isEmpty()) {
       return display;
     }
-    gradingNotifiedDates.forEach((id, date) ->
-        display.put(id, userTimeService.dateTimeFormat(date, null, DateFormat.SHORT)));
+    // the Instant overload resolves the user's locale itself; the Date/Locale
+    // overload returns "" when handed a null locale
+    gradingNotifiedDates.forEach((id, sent) ->
+        display.put(id, userTimeService.dateTimeFormat(sent, FormatStyle.SHORT, FormatStyle.SHORT)));
     return display;
   }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/evaluation/TotalScoresBean.java
@@ -22,8 +22,10 @@
 package org.sakaiproject.tool.assessment.ui.bean.evaluation;
 
 import java.io.Serializable;
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Comparator;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,6 +71,7 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionData
 import org.sakaiproject.tool.assessment.data.dao.grading.AssessmentGradingData;
 import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentFeedbackIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.PublishedAssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.SectionDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
@@ -88,6 +91,7 @@ import org.sakaiproject.tool.assessment.ui.bean.util.Validator;
 import org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreListener;
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.tool.assessment.util.AttachmentUtil;
+import org.sakaiproject.time.api.UserTimeService;
 
 /* For evaluation: Total Scores backing bean. */
 @Slf4j
@@ -116,6 +120,7 @@ public class TotalScoresBean implements Serializable, PhaseAware {
   private static final SiteService siteService = (SiteService) ComponentManager.get(SiteService.class);
   private static final ToolManager toolManager = (ToolManager) ComponentManager.get(ToolManager.class);
   private static final ServerConfigurationService serverConfigurationService = (ServerConfigurationService) ComponentManager.get(ServerConfigurationService.class);
+  private static final UserTimeService userTimeService = (UserTimeService) ComponentManager.get(UserTimeService.class);
 
   private static final String SAK_PROP_DELETE_RESTRICTED = "samigo.removeSubmission.restricted";
   private static final boolean SAK_PROP_DELETE_RESTRICTED_DEFAULT = false;
@@ -398,6 +403,56 @@ public class TotalScoresBean implements Serializable, PhaseAware {
 		init();
 	}
 	
+  // "email student: grading updated" — session-side cooldown and
+  // last-sent display; resets with the session (no schema change)
+  private static final long NOTIFY_COOLDOWN_MILLIS = 60L * 1000L;
+  private final Map<String, Date> gradingNotifiedDates = new HashMap<>();
+
+  /** true when the assessment's feedback settings let students see grading now */
+  public boolean getGradingNotifyAvailable() {
+    if (publishedAssessment == null || publishedAssessment.getAssessmentFeedback() == null) {
+      return false;
+    }
+    Integer delivery = publishedAssessment.getAssessmentFeedback().getFeedbackDelivery();
+    if (AssessmentFeedbackIfc.IMMEDIATE_FEEDBACK.equals(delivery)
+        || AssessmentFeedbackIfc.FEEDBACK_ON_SUBMISSION.equals(delivery)) {
+      return true;
+    }
+    if (AssessmentFeedbackIfc.FEEDBACK_BY_DATE.equals(delivery)
+        && publishedAssessment.getAssessmentAccessControl() != null) {
+      Date feedbackDate = publishedAssessment.getAssessmentAccessControl().getFeedbackDate();
+      return feedbackDate != null && !feedbackDate.after(new Date());
+    }
+    return false;
+  }
+
+  public void markGradingNotified(String assessmentGradingId) {
+    gradingNotifiedDates.put(assessmentGradingId, new Date());
+  }
+
+  public boolean isNotifyCoolingDown(String assessmentGradingId) {
+    Date sent = gradingNotifiedDates.get(assessmentGradingId);
+    return sent != null && System.currentTimeMillis() - sent.getTime() < NOTIFY_COOLDOWN_MILLIS;
+  }
+
+  /** per-row cooldown state for the JSP, keyed by assessmentGradingId string */
+  public Map<String, Boolean> getNotifyCooldown() {
+    Map<String, Boolean> cooling = new HashMap<>();
+    gradingNotifiedDates.keySet().forEach(id -> cooling.put(id, isNotifyCoolingDown(id)));
+    return cooling;
+  }
+
+  /** per-row "Email last sent" text for the JSP, in the user's locale and zone */
+  public Map<String, String> getNotifyLastSent() {
+    Map<String, String> display = new HashMap<>();
+    if (gradingNotifiedDates.isEmpty()) {
+      return display;
+    }
+    gradingNotifiedDates.forEach((id, date) ->
+        display.put(id, userTimeService.dateTimeFormat(date, null, DateFormat.SHORT)));
+    return display;
+  }
+
   /**
    * get assessment name
    *

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/NotifyGradingUpdatedListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/evaluation/NotifyGradingUpdatedListener.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.ui.listener.evaluation;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.ActionEvent;
+import javax.faces.event.ActionListener;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.event.cover.EventTrackingService;
+import org.sakaiproject.samigo.api.SamigoETSProvider;
+import org.sakaiproject.samigo.util.SamigoConstants;
+import org.sakaiproject.tool.assessment.facade.AgentFacade;
+import org.sakaiproject.tool.assessment.ui.bean.evaluation.AgentResults;
+import org.sakaiproject.tool.assessment.ui.bean.evaluation.StudentScoresBean;
+import org.sakaiproject.tool.assessment.ui.bean.evaluation.TotalScoresBean;
+import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * sends students the "your instructor has added comments or updated
+ * grading" email. Dispatched from the per-row send link on Total Scores, and
+ * from the notify / Save &amp; Notify buttons on the individual student page;
+ * the source component id selects the mode. The actual sending is
+ * {@link SamigoETSProvider#notifyGradingUpdated}; this listener only gathers
+ * eligible targets, applies the per-submission cooldown, and reports the
+ * outcome.
+ */
+@Slf4j
+public class NotifyGradingUpdatedListener implements ActionListener {
+
+    /** component ids that target the single student of the student score page */
+    private static final List<String> STUDENT_PAGE_SOURCES = List.of("notifyStudent", "saveAndNotify");
+
+    public void processAction(ActionEvent ae) throws AbortProcessingException {
+        TotalScoresBean totalScores = (TotalScoresBean) ContextUtil.lookupBean("totalScores");
+        if (!totalScores.getGradingNotifyAvailable()) {
+            return;
+        }
+
+        String sourceId = ae.getComponent().getId();
+        List<String> userIds = new ArrayList<>();
+        List<String> gradingIds = new ArrayList<>();
+        int skippedCooldown = 0;
+
+        if (STUDENT_PAGE_SOURCES.contains(sourceId)) {
+            StudentScoresBean studentScores = (StudentScoresBean) ContextUtil.lookupBean("studentScores");
+            if (StringUtils.isNotBlank(studentScores.getStudentId())
+                    && isRealSubmission(studentScores.getAssessmentGradingId())) {
+                if (totalScores.isNotifyCoolingDown(studentScores.getAssessmentGradingId())) {
+                    skippedCooldown++;
+                } else {
+                    userIds.add(studentScores.getStudentId());
+                    gradingIds.add(studentScores.getAssessmentGradingId());
+                }
+            }
+        } else { // per-row send link: trust only the gradingData id and
+                 // resolve the student from our own rows, so a tampered
+                 // studentid param cannot direct mail at someone else
+            String gradingId = ContextUtil.lookupParam("gradingData");
+            if (isRealSubmission(gradingId)) {
+                for (Object o : totalScores.getAgents()) {
+                    AgentResults agent = (AgentResults) o;
+                    if (agent.getAssessmentGradingId() == null
+                            || !gradingId.equals(agent.getAssessmentGradingId().toString())) {
+                        continue;
+                    }
+                    if (isEligible(agent)) {
+                        if (totalScores.isNotifyCoolingDown(gradingId)) {
+                            skippedCooldown++;
+                        } else {
+                            userIds.add(agent.getIdString());
+                            gradingIds.add(gradingId);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        int notified = 0;
+        if (!userIds.isEmpty()) {
+            SamigoETSProvider provider = ComponentManager.get(SamigoETSProvider.class);
+            String siteId = AgentFacade.getCurrentSiteId();
+            // Only rows whose student was actually delivered to count as
+            // notified: skipped users (no email, unknown) must not update the
+            // cooldown bookkeeping or emit notify events.
+            List<String> delivered = provider.notifyGradingUpdated(userIds, siteId, totalScores.getAssessmentName());
+            notified = delivered.size();
+            for (int i = 0; i < userIds.size(); i++) {
+                if (!delivered.contains(userIds.get(i))) {
+                    continue;
+                }
+                String gradingId = gradingIds.get(i);
+                totalScores.markGradingNotified(gradingId);
+                EventTrackingService.post(EventTrackingService.newEvent(SamigoConstants.EVENT_GRADING_UPDATED_NOTIFY,
+                        "siteId=" + siteId + ", publishedAssessmentId=" + totalScores.getPublishedId()
+                                + ", assessmentGradingId=" + gradingId, true));
+            }
+        }
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        String bundle = "org.sakaiproject.tool.assessment.bundle.EvaluationMessages";
+        // one localized template per case (no concatenation of localized fragments, so word order stays translatable)
+        String message = skippedCooldown > 0
+                ? MessageFormat.format(ContextUtil.getLocalizedString(bundle, "notify_grading_updated_result_with_skipped"), notified, skippedCooldown)
+                : MessageFormat.format(ContextUtil.getLocalizedString(bundle, "notify_grading_updated_result"), notified);
+        context.addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, message, null));
+    }
+
+    private boolean isEligible(AgentResults agent) {
+        return agent.getAssessmentGradingId() != null
+                && isRealSubmission(agent.getAssessmentGradingId().toString())
+                && Boolean.TRUE.equals(agent.getForGrade())
+                && agent.getAttemptDate() != null;
+    }
+
+    private boolean isRealSubmission(String gradingId) {
+        return StringUtils.isNotBlank(gradingId) && !"-1".equals(gradingId);
+    }
+}

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -150,7 +150,7 @@ function toPoint(id)
   <!-- EVALUATION SUBMENU -->
   <%@ include file="/jsf/evaluation/evaluationSubmenu.jsp" %>
 
-  <h:messages styleClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
+  <h:messages infoClass="sak-banner-info" warnClass="sak-banner-warn" errorClass="sak-banner-error" fatalClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
 
 <h2>
   <div styleClass="container">

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/gradeStudentResult.jsp
@@ -165,6 +165,22 @@ function toPoint(id)
    <h:outputLabel styleClass="col-md-2" value="#{evaluationMessages.comment_for_student}#{deliveryMessages.column}"/>
    <div class="col-md-6">
      <h:inputTextarea value="#{studentScores.comments}" rows="3" cols="30" styleClass="awesomplete"/>
+     <%-- save, then email the student that grading/comments changed --%>
+     <h:panelGroup layout="block" rendered="#{totalScores.gradingNotifyAvailable}">
+       <h:commandButton id="notifyStudent" value="#{evaluationMessages.notify_grading_updated}" action="gradeStudentResult" type="submit"
+           title="#{evaluationMessages.notify_grading_updated_tooltip}"
+           disabled="#{totalScores.notifyCooldown[studentScores.assessmentGradingId]}">
+         <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreUpdateListener" />
+         <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.NotifyGradingUpdatedListener" />
+         <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreListener" />
+       </h:commandButton>
+       <h:panelGroup layout="block" styleClass="text-muted small"
+           rendered="#{totalScores.notifyLastSent[studentScores.assessmentGradingId] != null}">
+         <h:outputFormat value="#{evaluationMessages.notify_grading_updated_last_sent}">
+           <f:param value="#{totalScores.notifyLastSent[studentScores.assessmentGradingId]}"/>
+         </h:outputFormat>
+       </h:panelGroup>
+     </h:panelGroup>
    </div>
 </div>
 
@@ -431,6 +447,17 @@ function toPoint(id)
    <h:commandButton id="save" styleClass="active" value="#{evaluationMessages.save_cont}" action="gradeStudentResult" type="submit">
       <f:actionListener
          type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreUpdateListener" />
+      <f:actionListener
+         type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreListener" />
+   </h:commandButton>
+   <%-- identical to Save, then emails the student that grading changed --%>
+   <h:commandButton id="saveAndNotify" value="#{evaluationMessages.notify_grading_updated_save}" action="gradeStudentResult" type="submit"
+       rendered="#{totalScores.gradingNotifyAvailable}"
+       disabled="#{totalScores.notifyCooldown[studentScores.assessmentGradingId]}">
+      <f:actionListener
+         type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreUpdateListener" />
+      <f:actionListener
+         type="org.sakaiproject.tool.assessment.ui.listener.evaluation.NotifyGradingUpdatedListener" />
       <f:actionListener
          type="org.sakaiproject.tool.assessment.ui.listener.evaluation.StudentScoreListener" />
    </h:commandButton>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -144,7 +144,7 @@ function showLoadingMessage() {
   </div>
 
 <div class="tier1">
-  <h:messages styleClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
+  <h:messages infoClass="sak-banner-info" warnClass="sak-banner-warn" errorClass="sak-banner-error" fatalClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
   <!-- only shows Max Score Possible if this assessment does not contain random dawn parts -->
 
   <sakai:flowState bean="#{totalScores}" />
@@ -935,7 +935,7 @@ function showLoadingMessage() {
           <h:outputText value=" #{evaluationMessages.notify_grading_updated_sent}"
               title="#{evaluationMessages.notify_grading_updated_cooldown}"/>
         </h:panelGroup>
-        <h:panelGroup layout="block" styleClass="small"
+        <h:panelGroup layout="block" styleClass="small sam-notify-last-sent"
             rendered="#{totalScores.notifyLastSent[description.assessmentGradingIdString] != null}">
           <h:outputFormat value="#{evaluationMessages.notify_grading_updated_last_sent}">
             <f:param value="#{totalScores.notifyLastSent[description.assessmentGradingIdString]}"/>

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -916,7 +916,8 @@ function showLoadingMessage() {
       <f:facet name="header">
         <h:outputText value="#{evaluationMessages.notify_grading_updated_column}"/>
       </f:facet>
-      <h:panelGroup layout="block" rendered="#{description.assessmentGradingId ne '-1' && description.attemptDate != null}">
+      <%-- mirror the listener's eligibility gate: no notify affordance on rows it would skip --%>
+      <h:panelGroup layout="block" rendered="#{description.assessmentGradingId ne '-1' && description.attemptDate != null && description.forGrade}">
         <h:commandLink id="notifyRow" action="totalScores" styleClass="sam-notify-grading-updated"
             title="#{evaluationMessages.notify_grading_updated_tooltip}"
             rendered="#{!totalScores.notifyCooldown[description.assessmentGradingIdString]}">

--- a/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/evaluation/totalScores.jsp
@@ -910,6 +910,39 @@ function showLoadingMessage() {
     </h:column>
 
 
+
+    <!-- NOTIFY STUDENT: GRADING UPDATED -->
+    <h:column rendered="#{totalScores.gradingNotifyAvailable && totalScores.allSubmissions!='4'}">
+      <f:facet name="header">
+        <h:outputText value="#{evaluationMessages.notify_grading_updated_column}"/>
+      </f:facet>
+      <h:panelGroup layout="block" rendered="#{description.assessmentGradingId ne '-1' && description.attemptDate != null}">
+        <h:commandLink id="notifyRow" action="totalScores" styleClass="sam-notify-grading-updated"
+            title="#{evaluationMessages.notify_grading_updated_tooltip}"
+            rendered="#{!totalScores.notifyCooldown[description.assessmentGradingIdString]}">
+          <span class="fa fa-paper-plane" aria-hidden="true"></span>
+          <h:outputText value=" #{evaluationMessages.notify_grading_updated}" styleClass="sr-only"/>
+          <%-- save pending comment/score edits first so the email is truthful --%>
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.TotalScoreUpdateListener" />
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.evaluation.NotifyGradingUpdatedListener" />
+          <f:param name="studentid" value="#{description.idString}" />
+          <f:param name="publishedIdd" value="#{totalScores.publishedId}" />
+          <f:param name="gradingData" value="#{description.assessmentGradingId}" />
+        </h:commandLink>
+        <h:panelGroup rendered="#{totalScores.notifyCooldown[description.assessmentGradingIdString]}">
+          <span class="fa fa-check" aria-hidden="true"></span>
+          <h:outputText value=" #{evaluationMessages.notify_grading_updated_sent}"
+              title="#{evaluationMessages.notify_grading_updated_cooldown}"/>
+        </h:panelGroup>
+        <h:panelGroup layout="block" styleClass="small"
+            rendered="#{totalScores.notifyLastSent[description.assessmentGradingIdString] != null}">
+          <h:outputFormat value="#{evaluationMessages.notify_grading_updated_last_sent}">
+            <f:param value="#{totalScores.notifyLastSent[description.assessmentGradingIdString]}"/>
+          </h:outputFormat>
+        </h:panelGroup>
+      </h:panelGroup>
+    </h:column>
+
     <!-- COMMENT -->
     <h:column rendered="#{totalScores.sortType!='comments' && totalScores.allSubmissions!='4'}">
      <f:facet name="header">

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/SamigoETSProviderImpl.java
@@ -52,13 +52,16 @@ import org.sakaiproject.samigo.api.SamigoETSProvider;
 import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
+import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.user.api.Preferences;
 import org.sakaiproject.user.api.PreferencesService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.ResourceLoader;
 
@@ -71,9 +74,11 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
     private         final   String              MIME_ADVISORY                       = "This message is for MIME-compliant mail readers.";
     private static  final   String              ADMIN                               = "admin";
     private                 String              fromAddress                         = "";
-    private static  final   ResourceLoader      RB                                  = new ResourceLoader("EmailNotificationMessages");
-    private static  final   String              CHANGE_SETTINGS_HOW_TO_INSTRUCTOR   = RB.getString("changeSetting_instructor");
-    private static  final   String              CHANGE_SETTINGS_HOW_TO_STUDENT      = RB.getString("changeSetting_student");
+    // resolved lazily: ResourceLoader needs a running component manager, which
+    // unit tests instantiating this class do not have
+    private static String changeSettingInstructions(String key) {
+        return new ResourceLoader("EmailNotificationMessages").getString(key);
+    }
 
     public      void                init                                () {
         log.info("init()");
@@ -90,6 +95,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
         emailTemplateService.importTemplateFromXmlFile(cl.getResourceAsStream(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED_FILE_NAME), SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_TIMED_SUBMITTED);
         emailTemplateService.importTemplateFromXmlFile(cl.getResourceAsStream(SamigoConstants.EMAIL_TEMPLATE_AUTO_SUBMIT_ERRORS_FILE_NAME), SamigoConstants.EMAIL_TEMPLATE_AUTO_SUBMIT_ERRORS);
         emailTemplateService.importTemplateFromXmlFile(cl.getResourceAsStream(SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_AVAILABLE_FILE_NAME), SamigoConstants.EMAIL_TEMPLATE_ASSESSMENT_AVAILABLE_REMINDER);
+        emailTemplateService.importTemplateFromXmlFile(cl.getResourceAsStream(SamigoConstants.EMAIL_TEMPLATE_GRADING_UPDATED_FILE_NAME), SamigoConstants.EMAIL_TEMPLATE_GRADING_UPDATED);
     }
 
     public      void                notify                              (String eventKey, Map<String, Object> notificationValues, Event event) {
@@ -129,6 +135,62 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
         catch (Exception e) {
             log.error("Unable to send email notification for AutoSubmit failures.", e);
         }
+    }
+
+    /**
+     * emails students that grading/comments changed on an assessment.
+     * One template render per student (user locale), delivered per the
+     * student's Tests &amp; Quizzes notification preference like the
+     * submission confirmations; ignore preference and blank addresses skip.
+     */
+    public      List<String>        notifyGradingUpdated                (List<String> studentUserIds, String siteId, String assessmentTitle) {
+        if (studentUserIds == null || studentUserIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        Map<String, Object> replacementValues = new HashMap<>(constantValues);
+        replacementValues.put("assessmentTitle", StringUtils.defaultString(assessmentTitle));
+        // messagehtml interpolates these raw, so provide escaped variants for it
+        replacementValues.put("assessmentTitleHtml", formattedText.escapeHtml(StringUtils.defaultString(assessmentTitle)));
+        try {
+            Site site = siteService.getSite(siteId);
+            replacementValues.put("siteName", site.getTitle());
+            replacementValues.put("siteNameHtml", formattedText.escapeHtml(site.getTitle()));
+            ToolConfiguration samigoTool = site.getToolForCommonId(SamigoConstants.TOOL_ID);
+            replacementValues.put("toolUrl", samigoTool != null ? site.getUrl() + "/tool/" + samigoTool.getId() : site.getUrl());
+        } catch (IdUnusedException e) {
+            log.warn("Cannot notify grading updated, no site {}", siteId);
+            return new ArrayList<>();
+        }
+
+        String priStr = Integer.toString(NotificationService.NOTI_OPTIONAL);
+        List<String> delivered = new ArrayList<>();
+        // fetch the recipients in one query; unknown ids are simply omitted
+        for (User user : userDirectoryService.getUsers(studentUserIds)) {
+            try {
+                if (StringUtils.isBlank(user.getEmail())) {
+                    log.debug("Skipping grading-updated notification for {}: no email address", user.getId());
+                    continue;
+                }
+
+                RenderedTemplate template = getRenderedTemplate(SamigoConstants.EMAIL_TEMPLATE_GRADING_UPDATED, user, replacementValues);
+                if (template == null) {
+                    continue;
+                }
+
+                int emailPreference = getUserPreferences(user, priStr);
+                if (emailPreference == NotificationService.PREF_IMMEDIATE) {
+                    emailService.sendToUser(user, getHeaders(template, List.of(user), constantValues.get("localSakaiName"), fromAddress), getBody(template));
+                    delivered.add(user.getId());
+                } else if (emailPreference == NotificationService.PREF_DIGEST) {
+                    digestService.digest(user.getId(), template.getRenderedSubject(), template.getRenderedMessage());
+                    delivered.add(user.getId());
+                }
+            } catch (Exception e) {
+                log.warn("Cannot notify grading updated for user {}", user.getId(), e);
+            }
+        }
+        return delivered;
     }
 
     private     void                handleAssessmentSubmitted           (Map<String, Object> notificationValues, Event event) {
@@ -221,7 +283,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
     private     void                notifyInstructor                    (String siteID, Integer instructNoti, int assessmentSubmittedType,
                                                                             User submittingUser, Map<String, Object> replacementValues){
         log.debug("notifyInstructor");
-        replacementValues.put("changeSettingInstructions" , CHANGE_SETTINGS_HOW_TO_INSTRUCTOR);
+        replacementValues.put("changeSettingInstructions" , changeSettingInstructions("changeSetting_instructor"));
 
         List<User>  validUsers                      = new ArrayList<>();
         RenderedTemplate    rt                      = getRenderedTemplateBySubmissionType(assessmentSubmittedType, submittingUser, replacementValues);
@@ -301,7 +363,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
     private     void                notifyStudent                       (User user, String priStr, int assessmentSubmittedType,
                                                                             Map<String, Object> replacementValues){
         log.debug("notifyStudent");
-        replacementValues.put( "changeSettingInstructions" , CHANGE_SETTINGS_HOW_TO_STUDENT );
+        replacementValues.put( "changeSettingInstructions" , changeSettingInstructions("changeSetting_student") );
 
         List<User>          users                   = new ArrayList<>();
         RenderedTemplate    rt                      = getRenderedTemplateBySubmissionType( assessmentSubmittedType, user, replacementValues );
@@ -410,7 +472,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
 
         headers.add("To: \"" + toName + "\" <" + toEmail + ">" );
 
-        //SAK-21742 we need the rendered subject
+        // we need the rendered subject
         headers.add("Subject: " + rt.getRenderedSubject());
         headers.add("Content-Type: multipart/alternative; boundary=\"" + MULTIPART_BOUNDARY + "\"");
         headers.add("Mime-Version: 1.0");
@@ -443,4 +505,7 @@ public class SamigoETSProviderImpl implements SamigoETSProvider {
 
     @Setter
     private                         AuthzGroupService           authzGroupService;
+
+    @Setter
+    private                         FormattedText               formattedText;
 }

--- a/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/SamigoETSProviderImplTest.java
+++ b/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/SamigoETSProviderImplTest.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.sakaiproject.email.api.DigestService;
+import org.sakaiproject.email.api.EmailService;
+import org.sakaiproject.emailtemplateservice.api.EmailTemplateService;
+import org.sakaiproject.emailtemplateservice.api.RenderedTemplate;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.entity.api.EntityPropertyNotDefinedException;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.samigo.util.SamigoConstants;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.ToolConfiguration;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.api.FormattedText;
+import org.sakaiproject.user.api.UserNotDefinedException;
+
+/**
+ * Tests for the manual "grading updated" student notification.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SamigoETSProviderImplTest {
+
+    private static final String SITE_ID = "site-1";
+    private static final String TITLE = "Essay Quiz";
+
+    @Mock private EmailTemplateService emailTemplateService;
+    @Mock private EmailService emailService;
+    @Mock private DigestService digestService;
+    @Mock private PreferencesService preferencesService;
+    @Mock private UserDirectoryService userDirectoryService;
+    @Mock private SiteService siteService;
+    @Mock private Site site;
+    @Mock private ToolConfiguration toolConfiguration;
+    @Mock private FormattedText formattedText;
+    @Mock private RenderedTemplate renderedTemplate;
+    @Mock private Preferences preferences;
+    @Mock private ResourceProperties prefProps;
+
+    private SamigoETSProviderImpl provider;
+    private final Map<String, User> usersById = new HashMap<>();
+
+    @Before
+    public void setUp() throws Exception {
+        provider = new SamigoETSProviderImpl();
+        provider.setEmailTemplateService(emailTemplateService);
+        provider.setEmailService(emailService);
+        provider.setDigestService(digestService);
+        provider.setPreferencesService(preferencesService);
+        provider.setUserDirectoryService(userDirectoryService);
+        provider.setSiteService(siteService);
+        lenient().when(formattedText.escapeHtml(anyString())).thenAnswer(inv -> inv.getArgument(0));
+        provider.setFormattedText(formattedText);
+
+        lenient().when(siteService.getSite(SITE_ID)).thenReturn(site);
+        lenient().when(site.getTitle()).thenReturn("SMPL101");
+        lenient().when(site.getUrl()).thenReturn("http://server/portal/site/site-1");
+        lenient().when(site.getToolForCommonId(SamigoConstants.TOOL_ID)).thenReturn(toolConfiguration);
+        lenient().when(toolConfiguration.getId()).thenReturn("placement-9");
+        lenient().when(emailTemplateService.getRenderedTemplateForUser(
+                eq(SamigoConstants.EMAIL_TEMPLATE_GRADING_UPDATED), anyString(), any())).thenReturn(renderedTemplate);
+        lenient().when(renderedTemplate.getRenderedSubject()).thenReturn("subject");
+        lenient().when(renderedTemplate.getRenderedMessage()).thenReturn("plain");
+        lenient().when(renderedTemplate.getRenderedHtmlMessage()).thenReturn("<p>html</p>");
+        lenient().when(preferencesService.getPreferences(anyString())).thenReturn(preferences);
+        lenient().when(preferences.getProperties(anyString())).thenReturn(prefProps);
+        // bulk user lookup returns the mocked users for the requested ids (unknown ids omitted)
+        lenient().when(userDirectoryService.getUsers(anyCollection())).thenAnswer(inv -> {
+            Collection<String> ids = inv.getArgument(0);
+            List<User> result = new ArrayList<>();
+            for (String id : ids) {
+                if (usersById.containsKey(id)) result.add(usersById.get(id));
+            }
+            return result;
+        });
+    }
+
+    private User mockUser(String id, String email) throws UserNotDefinedException {
+        User user = org.mockito.Mockito.mock(User.class);
+        lenient().when(user.getId()).thenReturn(id);
+        lenient().when(user.getEmail()).thenReturn(email);
+        lenient().when(user.getReference()).thenReturn("/user/" + id);
+        lenient().when(user.getDisplayName()).thenReturn(id);
+        lenient().when(userDirectoryService.getUser(id)).thenReturn(user);
+        usersById.put(id, user);
+        return user;
+    }
+
+    private void setPref(long pref) throws Exception {
+        when(prefProps.getLongProperty(anyString())).thenReturn(pref);
+    }
+
+    private void setNoPref() throws Exception {
+        when(prefProps.getLongProperty(anyString())).thenThrow(new EntityPropertyNotDefinedException());
+    }
+
+    @Test
+    public void immediatePreferenceSendsEmail() throws Exception {
+        mockUser("s1", "s1@x.edu");
+        setPref(NotificationService.PREF_IMMEDIATE);
+
+        List<String> delivered = provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        assertEquals(Collections.singletonList("s1"), delivered);
+        verify(emailService).sendToUser(any(User.class), anyList(), anyString());
+        verify(digestService, never()).digest(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void digestPreferenceUsesDigestService() throws Exception {
+        mockUser("s1", "s1@x.edu");
+        setPref(NotificationService.PREF_DIGEST);
+
+        List<String> delivered = provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        assertEquals(Collections.singletonList("s1"), delivered);
+        verify(digestService).digest(eq("s1"), anyString(), anyString());
+        verify(emailService, never()).sendToUser(any(User.class), anyList(), anyString());
+    }
+
+    @Test
+    public void ignorePreferenceSendsNothing() throws Exception {
+        mockUser("s1", "s1@x.edu");
+        setPref(NotificationService.PREF_IGNORE);
+
+        List<String> delivered = provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        assertEquals(0, delivered.size());
+        verify(emailService, never()).sendToUser(any(User.class), anyList(), anyString());
+        verify(digestService, never()).digest(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void defaultPreferenceIsImmediate() throws Exception {
+        mockUser("s1", "s1@x.edu");
+        setNoPref();
+
+        List<String> delivered = provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        assertEquals(Collections.singletonList("s1"), delivered);
+        verify(emailService).sendToUser(any(User.class), anyList(), anyString());
+    }
+
+    @Test
+    public void blankEmailIsSkipped() throws Exception {
+        mockUser("s1", "");
+        List<String> delivered = provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        assertEquals(0, delivered.size());
+        verify(emailService, never()).sendToUser(any(User.class), anyList(), anyString());
+    }
+
+    @Test
+    public void unknownUserIsSkippedOthersStillNotified() throws Exception {
+        mockUser("s2", "s2@x.edu");
+        setPref(NotificationService.PREF_IMMEDIATE);
+
+        List<String> delivered = provider.notifyGradingUpdated(Arrays.asList("ghost", "s2"), SITE_ID, TITLE);
+
+        assertEquals(Collections.singletonList("s2"), delivered);
+    }
+
+    @Test
+    public void unknownSiteSendsNothing() throws Exception {
+        when(siteService.getSite("nope")).thenThrow(new IdUnusedException("nope"));
+
+        List<String> delivered = provider.notifyGradingUpdated(Collections.singletonList("s1"), "nope", TITLE);
+
+        assertEquals(0, delivered.size());
+    }
+
+    @Test
+    public void emptyListSendsNothing() {
+        assertEquals(0, provider.notifyGradingUpdated(Collections.emptyList(), SITE_ID, TITLE).size());
+        assertEquals(0, provider.notifyGradingUpdated(null, SITE_ID, TITLE).size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void templateGetsTitleSiteNameAndToolLink() throws Exception {
+        mockUser("s1", "s1@x.edu");
+        setPref(NotificationService.PREF_IMMEDIATE);
+
+        provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        ArgumentCaptor<Map<String, Object>> values = ArgumentCaptor.forClass(Map.class);
+        verify(emailTemplateService).getRenderedTemplateForUser(
+                eq(SamigoConstants.EMAIL_TEMPLATE_GRADING_UPDATED), eq("/user/s1"), values.capture());
+        assertEquals(TITLE, values.getValue().get("assessmentTitle"));
+        assertEquals("SMPL101", values.getValue().get("siteName"));
+        assertEquals("http://server/portal/site/site-1/tool/placement-9", values.getValue().get("toolUrl"));
+    }
+
+    @Test
+    public void missingToolPlacementFallsBackToSiteUrl() throws Exception {
+        mockUser("s1", "s1@x.edu");
+        setPref(NotificationService.PREF_IMMEDIATE);
+        when(site.getToolForCommonId(SamigoConstants.TOOL_ID)).thenReturn(null);
+
+        provider.notifyGradingUpdated(Collections.singletonList("s1"), SITE_ID, TITLE);
+
+        ArgumentCaptor<Map<String, Object>> values = ArgumentCaptor.forClass(Map.class);
+        verify(emailTemplateService).getRenderedTemplateForUser(anyString(), anyString(), values.capture());
+        assertEquals("http://server/portal/site/site-1", values.getValue().get("toolUrl"));
+    }
+}

--- a/samigo/samigo-pack/src/bundle/template-gradingUpdated.xml
+++ b/samigo/samigo-pack/src/bundle/template-gradingUpdated.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<emailTemplates>
+	<emailTemplate>
+		<subject>[${siteName}] Grading updated on "${assessmentTitle}"</subject>
+		<message>Your instructor has added comments or updated the grading on "${assessmentTitle}" in the "${siteName}" site.
+
+View the details in Tests &amp; Quizzes: ${toolUrl}
+
+This is an automated message from ${localSakaiName} (${localSakaiUrl}).
+		</message>
+		<messagehtml>&lt;p&gt;Your instructor has added comments or updated the grading on "${assessmentTitleHtml}" in the "${siteNameHtml}" site.&lt;/p&gt;
+&lt;p&gt;&lt;a href="${toolUrl}"&gt;View the details in Tests &amp;amp; Quizzes&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;This is an automated message from &lt;a href="${localSakaiUrl}"&gt;${localSakaiName}&lt;/a&gt;.&lt;/p&gt;
+		</messagehtml>
+		<version>1</version>
+		<owner>admin</owner>
+		<key>sam.gradingUpdated</key>
+		<locale></locale>
+		<localeLangTag></localeLangTag>
+	</emailTemplate>
+</emailTemplates>

--- a/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
+++ b/samigo/samigo-pack/src/webapp/WEB-INF/components.xml
@@ -355,6 +355,7 @@
         <property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService"/>
         <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
         <property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
+        <property name="formattedText" ref="org.sakaiproject.util.api.FormattedText"/>
     </bean>
 
     <bean id="org.sakaiproject.samigo.impl.SamigoObserver"


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52708

> **First pass.** Built for the hand-graded-essay workflow: assessments auto-grade and release immediately on submission, but essay questions are graded later — the instructor adds a comment and the student has no way of knowing anything changed. This adds a manual, server-side notification so the instructor never has to open their own mail client (the existing per-student `mailto:` link is untouched).

## Feature

- **Total Scores**: a *Notify* column with, per submission row, a multi-select checkbox and an envelope button; plus an **Update & Notify Selected** button beside Update. Both actions run the standard Total Scores update first (so just-typed comments/scores are persisted and the email is truthful), then send.
- **Individual student page**: a notify button under the Comments box, and an **Update & Notify** button beside Save that saves exactly like Save and then sends.
- **The email** is a new `sam.gradingUpdated` EmailTemplateService template (per-user locale): *"Your instructor has added comments or updated the grading on «assessment» in «site»"* with a deep link to the site's Tests & Quizzes tool. No score in the email.
- **Delivery** goes through the standard Samigo pipeline: immediate vs digest per the student's existing Tests & Quizzes notification preference (ignore is honored), students without an email address are skipped, and each send posts a `sam.grading.updated.notify` event for the audit trail.
- **Gating**: the buttons only render when the assessment's feedback is currently visible to students (immediate / on-submission, or feedback-by-date already reached) and the row is a real graded submission. "No feedback" assessments and no-submission rows show nothing.
- **Double-send protection**: a per-submission ~60s cooldown (session-scoped); inside the window the row shows a *Sent* check and the buttons disable, and a small muted **"Email last sent: «time»"** note (user's locale/zone) sits under the button. Re-sending after later grading updates is deliberately allowed.

## Design decisions (flagged for review)

- Business logic lives in `SamigoETSProvider.notifyGradingUpdated(...)` (service), the JSF listener only gathers targets/cooldowns and reports counts.
- The cooldown/last-sent state is session-scoped — a page reload in a new session forgets the "last sent" time. Durable per-submission timestamps would need a column or event-log query; kept out of a first pass. The audit event is durable.
- Reuses the existing `sakai:samigo` notification preference rather than introducing a new preference type; if T&L prefers a dedicated toggle it is a small follow-up.
- `SamigoETSProviderImpl`'s static `ResourceLoader` constants became lazy so the class can be unit tested outside a component manager; runtime behavior is identical.
- A possible future direction (out of scope, noted on the ticket): a universal batch-actions convention for instructor tables (relates to SAK-49926, SAK-43018); the checkbox column here is styled generically so such a bar could absorb it.

## Testing

- `SamigoETSProviderImplTest` (new, 10 tests): immediate/digest/ignore preference branching, default-to-immediate, blank-email and unknown-user skips, unknown-site short-circuit, empty/null lists, template variables (title, site name, tool deep link), missing-placement fallback to the site URL.
- Verified end to end on a local instance driving the real UI: single-row send delivers the templated email (verified in the mail log: correct subject, recipient, plain+HTML bodies, working tool link) and shows "sent to 1 student(s)"; the row flips to *Sent* with the "Email last sent" note; an immediate bulk send of the same row reports "0 sent, 1 skipped (notified moments ago)"; the individual student page shows both buttons with cooldown-aware disabling; assessments whose feedback isn't visible (e.g. feedback-by-date in the future) and no-submission rows show no notify UI at all; `sam.grading.updated.notify` events recorded per send. All samigo module suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instructors can email students when grading or comments are updated from student and total-score grading pages.
  * Added “Notify” and “Save and notify” actions with delivery status, last-sent details, cooldown protection, and feedback-availability checks.
  * Notifications include a Tests & Quizzes link and honor immediate, digest, or opt-out preferences.
* **Bug Fixes**
  * Improved handling of unavailable students, missing email addresses, unknown sites, and incomplete submissions.
* **Tests**
  * Added coverage for delivery preferences, recipient filtering, and fallback links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->