### PR TITLE
SAK-52710 T&Q recover typed but unsaved answers from a local draft

### DIFF
--- a/docker/tomcat/conf/context.xml
+++ b/docker/tomcat/conf/context.xml
@@ -1,7 +1,7 @@
 <Context>
     <JarScanner>
         <!-- This is to speedup startup so that tomcat doesn't scan as much -->
-        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
+        <JarScanFilter defaultPluggabilityScan="false" defaultTldScan="false" tldScan="jsf2-widgets-*.jar,jakarta.faces-*.jar,javax.faces-*.jar,jsf-impl-*.jar,jsf-widgets-*.jar,myfaces-impl-*.jar,pluto-taglib-*.jar,sakai-sections-app-util-*.jar,spring-webmvc-*.jar,standard-*.jar,tomahawk*.jar,tomahawk-*.jar"/>
     </JarScanner>
 </Context>
 

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoMultiTabTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoMultiTabTest.java
@@ -1,0 +1,709 @@
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microsoft.playwright.ElementHandle;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.LocatorAssertions;
+import com.microsoft.playwright.options.LoadState;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+/**
+ * Acceptance tests for SAK-44349: opening the same assessment in multiple
+ * browser tabs must never lose or corrupt saved answers.
+ *
+ * Against an unfixed build the stale-tab scenarios fail (that is the repro);
+ * with the delivery state guard deployed the whole suite must be green. The
+ * single-tab scenarios are regression canaries that must pass either way.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SamigoMultiTabTest extends SakaiUiTestBase {
+
+    /**
+     * Deep assertions verify answer rows directly in the database. They run
+     * only when SAKAI_E2E_DB_CMD (env var or system property) holds a command
+     * prefix that accepts "-N -B -e <sql>", e.g. for the docker dev stack:
+     * export SAKAI_E2E_DB_CMD="docker exec sakai-mariadb mysql -uroot -psakairoot sakai"
+     * Without it, UI-level assertions still run; scenarios that cannot even be
+     * staged without DB access (retakes, time limits) are skipped via assumptions.
+     */
+    private static final String DB_CMD = System.getProperty("SAKAI_E2E_DB_CMD",
+        System.getenv().getOrDefault("SAKAI_E2E_DB_CMD", ""));
+
+    private static boolean dbChecksEnabled() {
+        return DB_CMD != null && !DB_CMD.isBlank();
+    }
+
+    private static void assumeDb() {
+        org.junit.jupiter.api.Assumptions.assumeTrue(dbChecksEnabled(),
+            "scenario requires SAKAI_E2E_DB_CMD for staging/verification");
+    }
+
+    private static final String RUN_ID = Long.toString(System.currentTimeMillis());
+    private static final String QUIZ_NAV = "MultiTab Nav " + RUN_ID;
+    private static final String QUIZ_RACE = "MultiTab Race " + RUN_ID;
+    private static final String QUIZ_TIMED = "MultiTab Timed " + RUN_ID;
+    private static final String ESSAY_ANSWER = "The mitochondria is the powerhouse of the cell " + RUN_ID;
+    private static final String STUDENT = "student0011";
+
+    private static String courseUrl;
+
+    private String ensureCourseUrl() {
+        if (courseUrl != null && !courseUrl.isBlank()) {
+            return courseUrl;
+        }
+        sakai.login("instructor1");
+        courseUrl = sakai.createCourse("instructor1", List.of("sakai\\.samigo"));
+        return courseUrl;
+    }
+
+    @Test
+    @Order(1)
+    void setupPublishesMultiTabQuizzes() {
+        ensureCourseUrl();
+        sakai.login("instructor1");
+
+        for (String title : List.of(QUIZ_NAV, QUIZ_RACE, QUIZ_TIMED)) {
+            createAndPublishTwoQuestionQuiz(title);
+        }
+
+        if (dbChecksEnabled()) {
+            // Unlimited submissions lets scenarios retake without republishing.
+            for (String title : List.of(QUIZ_NAV, QUIZ_RACE, QUIZ_TIMED)) {
+                long id = publishedAssessmentId(title);
+                db("UPDATE SAM_PUBLISHEDACCESSCONTROL_T SET UNLIMITEDSUBMISSIONS=1, SUBMISSIONSALLOWED=NULL WHERE ASSESSMENTID=" + id);
+            }
+            // 2-minute time limit for the expiry scenario; set via DB so the UI flow stays simple.
+            db("UPDATE SAM_PUBLISHEDACCESSCONTROL_T SET TIMELIMIT=120 WHERE ASSESSMENTID=" + publishedAssessmentId(QUIZ_TIMED));
+
+            assertEquals("1", dbScalar("SELECT CAST(UNLIMITEDSUBMISSIONS AS UNSIGNED) FROM SAM_PUBLISHEDACCESSCONTROL_T WHERE ASSESSMENTID="
+                + publishedAssessmentId(QUIZ_NAV)));
+        }
+    }
+
+    @Test
+    @Order(2)
+    void singleTabTakeSaveSubmitStillWorks() {
+        ensureCourseUrl();
+
+        sakai.login(STUDENT);
+        enterQuiz(page, QUIZ_NAV);
+
+        selectMcOption(page, 1);
+        clickDelivery(page, "next");
+        fillEssay(page, ESSAY_ANSWER);
+        clickDelivery(page, "save");
+
+        if (dbChecksEnabled()) {
+            long quizId = publishedAssessmentId(QUIZ_NAV);
+            List<String[]> rows = gradingRows(quizId);
+            assertEquals(2, rows.size(), "expected one MC row and one essay row, got: " + describe(rows));
+            assertTrue(rows.stream().anyMatch(r -> !"NULL".equals(r[2])), "MC answer missing: " + describe(rows));
+            assertTrue(rows.stream().anyMatch(r -> r[3].contains("powerhouse")), "essay text missing: " + describe(rows));
+        }
+
+        clickDelivery(page, "submitForGrade");
+        // Confirmation page repeats the submit button id.
+        if (page.locator("#takeAssessmentForm\\:submitForGrade").count() > 0) {
+            clickDelivery(page, "submitForGrade");
+        }
+        assertThat(page.locator("body")).containsText(Pattern.compile("submi", Pattern.CASE_INSENSITIVE));
+        if (dbChecksEnabled()) {
+            assertEquals("1", dbScalar("SELECT CAST(FORGRADE AS UNSIGNED) FROM SAM_ASSESSMENTGRADING_T WHERE PUBLISHEDASSESSMENTID="
+                + publishedAssessmentId(QUIZ_NAV)
+                + " ORDER BY ASSESSMENTGRADINGID DESC LIMIT 1"), "attempt should be submitted for grade");
+        }
+    }
+
+    @Test
+    @Order(3)
+    void staleTabPostMustNotDestroyDataAndMustRecover() {
+        assumeDb();
+        ensureCourseUrl();
+        long quizId = publishedAssessmentId(QUIZ_NAV);
+
+        sakai.login(STUDENT);
+        String toolUrl = enterTestsTool(page);
+        Page tabA = page;
+        beginQuiz(tabA, QUIZ_NAV);
+
+        // Second tab: same session, re-enters the in-progress attempt.
+        Page tabB = context.newPage();
+        tabB.navigate(toolUrl);
+        beginQuiz(tabB, QUIZ_NAV);
+
+        // Tab B becomes the live tab: answers MC with option 2 and advances.
+        selectMcOption(tabB, 2);
+        clickDelivery(tabB, "next");
+        String liveAnswerId = latestMcAnswerId(quizId);
+        assertFalse("NULL".equals(liveAnswerId), "tab B's answer should be persisted");
+
+        // Tab A is now stale. It posts option 1 from an outdated page.
+        selectMcOption(tabA, 1);
+        clickDelivery(tabA, "next");
+
+        // INVARIANT: the persisted answer survives no matter what the UI shows.
+        assertEquals(liveAnswerId, latestMcAnswerId(quizId),
+            "stale tab post must not overwrite the live tab's saved answer");
+
+        // Post-fix UX: friendly resync instead of the fatal Data Discrepancy dead end.
+        String bodyText = tabA.locator("body").textContent();
+        assertFalse(bodyText.contains("Data Discrepancy"),
+            "stale tab should get the friendly resync page, not the fatal discrepancy error");
+        assertThat(tabA.locator("#samigo-stale-tab-marker")).hasCount(1);
+
+        // One-click recovery back into the live attempt.
+        clickFirstVisible(tabA, "input[type=\"submit\"][value*=\"Continue\"], button:has-text(\"Continue\"), a:has-text(\"Continue\")");
+        assertThat(tabA.locator("#takeAssessmentForm")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+
+        tabB.close();
+    }
+
+    @Test
+    @Order(4)
+    void concurrentSavesFromTwoTabsNeverCorruptRows() {
+        ensureCourseUrl();
+
+        sakai.login(STUDENT);
+        String toolUrl = enterTestsTool(page);
+        Page tabA = page;
+        beginQuiz(tabA, QUIZ_RACE);
+
+        Page tabB = context.newPage();
+        tabB.navigate(toolUrl);
+        beginQuiz(tabB, QUIZ_RACE);
+
+        for (int round = 1; round <= 3; round++) {
+            ensureOnDeliveryPage(tabA, toolUrl, QUIZ_RACE);
+            ensureOnDeliveryPage(tabB, toolUrl, QUIZ_RACE);
+            selectMcOption(tabA, 1);
+            selectMcOption(tabB, 2);
+
+            // Fire both saves as close to simultaneously as possible.
+            CompletableFuture<Void> a = CompletableFuture.runAsync(() ->
+                tabA.evaluate("() => document.getElementById('takeAssessmentForm:save').click()"));
+            CompletableFuture<Void> b = CompletableFuture.runAsync(() ->
+                tabB.evaluate("() => document.getElementById('takeAssessmentForm:save').click()"));
+            CompletableFuture.allOf(a, b).join();
+            tabA.waitForLoadState(LoadState.DOMCONTENTLOADED);
+            tabB.waitForLoadState(LoadState.DOMCONTENTLOADED);
+            tabA.waitForTimeout(1_500);
+
+            if (!dbChecksEnabled()) {
+                continue;
+            }
+            long quizId = publishedAssessmentId(QUIZ_RACE);
+            // INVARIANTS, every round: at most one row per published item, never a
+            // blank/deleted MC answer once one was saved, no constraint violations.
+            List<String[]> rows = gradingRows(quizId);
+            long mcRows = rows.stream().filter(r -> !"NULL".equals(r[2])).count();
+            assertEquals(1, mcRows, "round " + round + ": exactly one MC answer row expected: " + describe(rows));
+            // Group by item only: two rows with DIFFERENT answer ids on a
+            // single-select item are exactly the duplicate artifact to catch.
+            String dupes = dbScalar("SELECT COUNT(*) FROM SAM_ITEMGRADING_T ig JOIN SAM_ASSESSMENTGRADING_T ag"
+                + " ON ig.ASSESSMENTGRADINGID = ag.ASSESSMENTGRADINGID"
+                + " WHERE ag.PUBLISHEDASSESSMENTID=" + quizId
+                + " GROUP BY ig.ASSESSMENTGRADINGID, ig.PUBLISHEDITEMID HAVING COUNT(*) > 1 LIMIT 1");
+            assertTrue(dupes == null || dupes.isBlank(), "round " + round + ": duplicate item grading rows detected");
+        }
+
+        tabB.close();
+    }
+
+    @Test
+    @Order(5)
+    void timedExpiryFromStaleBlankTabMustNotBlankSavedAnswers() {
+        assumeDb();
+        ensureCourseUrl();
+        long quizId = publishedAssessmentId(QUIZ_TIMED);
+
+        sakai.login(STUDENT);
+        String toolUrl = enterTestsTool(page);
+
+        // Tab B first: navigate it to the essay page, where it will hold the
+        // stale BLANK rendering. (Position is shared session state, so tab A
+        // will resume on the same page.)
+        Page tabB = context.newPage();
+        tabB.navigate(toolUrl);
+        beginQuiz(tabB, QUIZ_TIMED);
+        clickDelivery(tabB, "next");
+        assertThat(tabB.locator("#takeAssessmentForm textarea, #takeAssessmentForm .cke")).not().hasCount(0);
+
+        // Tab A: resumes the same attempt. Re-entry resets to Q1 in random
+        // access mode, so navigate to the essay page (tab A becomes the live
+        // tab there), then type the essay and save it.
+        Page tabA = page;
+        tabA.navigate(toolUrl);
+        beginQuiz(tabA, QUIZ_TIMED);
+        if (tabA.locator("#takeAssessmentForm textarea:visible").count() == 0) {
+            clickDelivery(tabA, "next");
+        }
+        fillEssay(tabA, ESSAY_ANSWER);
+        clickDelivery(tabA, "save");
+
+        List<String[]> saved = gradingRows(quizId);
+        assertTrue(saved.stream().anyMatch(r -> r[3].contains("powerhouse")),
+            "essay should be saved before the forced submit: " + describe(saved));
+
+        // Fire the forced timeout submit from the stale blank tab: this is the
+        // exact button (submitNoCheck -> delivery.submitFromTimeoutPopup) the
+        // timer popup clicks when time expires, and it bypasses all checks.
+        // Its blank essay field binds into the shared page contents; without
+        // the backstop this blanks the saved essay (SAK-43421's scenario).
+        tabB.evaluate("() => document.getElementById('takeAssessmentForm:submitNoCheck').click()");
+        tabB.waitForLoadState(LoadState.DOMCONTENTLOADED);
+        waitForSubmission(quizId, tabA, tabB, 60_000);
+
+        List<String[]> after = gradingRows(quizId);
+        assertTrue(after.stream().anyMatch(r -> r[3].contains("powerhouse")),
+            "essay answer was blanked by the stale tab's forced submit: " + describe(after));
+
+        tabB.close();
+    }
+
+    @Test
+    @Order(6)
+    void currentTabTimeoutSubmitKeepsFullAuthority() {
+        // The forced timeout submit from the CURRENT tab must keep today's
+        // semantics: the student's last (unsaved) change wins, with exactly one
+        // row per single-select item - no duplicate rows, no constraint abort.
+        ensureCourseUrl();
+        long quizId = publishedAssessmentId(QUIZ_TIMED);
+
+        sakai.login(STUDENT);
+        enterQuiz(page, QUIZ_TIMED);
+        selectMcOption(page, 1);
+        clickDelivery(page, "save");
+        String firstAnswer = latestMcAnswerId(quizId);
+        assertFalse("NULL".equals(firstAnswer), "first MC answer should be saved");
+
+        // Change the answer but do NOT save, then let the "timer" force-submit.
+        selectMcOption(page, 2);
+        page.evaluate("() => document.getElementById('takeAssessmentForm:submitNoCheck').click()");
+        page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+        waitForSubmission(quizId, page, page, 60_000);
+
+        List<String[]> rows = gradingRows(quizId);
+        long mcRows = rows.stream().filter(r -> !"NULL".equals(r[2])).count();
+        assertEquals(1, mcRows, "exactly one MC row after a current-tab timeout submit: " + describe(rows));
+        assertFalse(firstAnswer.equals(latestMcAnswerId(quizId)),
+            "the changed answer must win on a current-tab timeout submit (no over-freeze)");
+    }
+
+    @Test
+    @Order(7)
+    void autosaveKeepsTheActiveTabValid() {
+        // Accepted autosaves verify WITHOUT rotating the guard token, so the
+        // active tab must remain valid across autosave cycles regardless of
+        // whether the response scrape in saveForm.js finds anything. This also
+        // covers the lost-response case: since the response's content plays no
+        // part in the tab's validity (nothing rotates), an autosave whose
+        // response is eaten by the network leaves the tab exactly as valid as
+        // this test proves it to be after a processed one.
+        // Requires samigo.autoSave.repeat.milliseconds=15000.
+        ensureCourseUrl();
+
+        sakai.login(STUDENT);
+        enterQuiz(page, QUIZ_RACE);
+        selectMcOption(page, 1);
+
+        // Wait past one autosave cycle (15s interval + request time).
+        page.waitForTimeout(25_000);
+        assertTrue(page.locator("#stale-tab-warning").isHidden(),
+            "the active tab's own autosave must never trip the stale-tab warning");
+
+        // The manual save after an autosave is the regression: it must be
+        // accepted, not bounced to the resync page.
+        clickDelivery(page, "next");
+        String body = page.locator("body").textContent();
+        assertFalse(body.contains("This page is out of date"),
+            "active tab was invalidated by its own autosave (token scrape broken)");
+        if (dbChecksEnabled()) {
+            assertTrue(gradingRows(publishedAssessmentId(QUIZ_RACE)).stream().anyMatch(r -> !"NULL".equals(r[2])),
+                "answer should be saved after autosave + next");
+        }
+    }
+
+    @Test
+    @Order(8)
+    void tableOfContentsNavigationStaysSafe() {
+        assumeDb();
+        ensureCourseUrl();
+        long quizId = publishedAssessmentId(QUIZ_NAV);
+
+        sakai.login(STUDENT);
+        enterQuiz(page, QUIZ_NAV);
+        selectMcOption(page, 1);
+        clickDelivery(page, "next");
+        String savedAnswer = latestMcAnswerId(quizId);
+        assertFalse("NULL".equals(savedAnswer), "MC answer should persist before TOC nav");
+
+        // Table of Contents round trip back to Q1.
+        clickFirstVisible(page, "a[id$='showTOC']");
+        assertThat(page.locator("#tableOfContentsForm")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+        Locator questionLink = page.locator("#tableOfContentsForm a").filter(
+            new Locator.FilterOptions().setHasText("Pick an option")).first();
+        questionLink.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+        assertThat(page.locator("#takeAssessmentForm")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+
+        assertEquals(savedAnswer, latestMcAnswerId(quizId), "TOC navigation must not disturb saved answers");
+        String body = page.locator("body").textContent();
+        assertFalse(body.contains("This page is out of date"),
+            "single-tab TOC navigation must not trip the stale-tab guard");
+        assertFalse(body.contains("Discrepancy in Data"),
+            "single-tab TOC navigation must not trip the discrepancy page");
+    }
+
+    @Test
+    @Order(10)
+    void duplicatedTabCannotSilentlyOverwrite() {
+        // Duplicating a tab is a plain GET re-render of the delivery view; it
+        // must rotate the guard token so the two copies cannot share one valid
+        // token and autosave/post over each other (the classic silent loss).
+        assumeDb();
+        ensureCourseUrl();
+        long quizId = publishedAssessmentId(QUIZ_RACE);
+
+        sakai.login(STUDENT);
+        enterQuiz(page, QUIZ_RACE);
+        selectMcOption(page, 1);
+        clickDelivery(page, "save");
+        String saved = latestMcAnswerId(quizId);
+        assertFalse("NULL".equals(saved), "answer should be saved before duplication");
+
+        Page dup = context.newPage();
+        dup.navigate(page.url());
+        dup.locator("#takeAssessmentForm").waitFor(
+            new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(20_000));
+
+        // The original tab is now the stale copy: its post must resync, never
+        // silently apply.
+        selectMcOption(page, 2);
+        clickDelivery(page, "next");
+        assertThat(page.locator("#samigo-stale-tab-marker")).hasCount(1);
+        assertEquals(saved, latestMcAnswerId(quizId),
+            "a duplicated tab's sibling must not overwrite saved answers");
+
+        dup.close();
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private void createAndPublishTwoQuestionQuiz(String title) {
+        page.navigate(courseUrl);
+        sakai.toolClick("Tests");
+
+        Locator addLink = page.locator("#authorIndexForm a").filter(
+            new Locator.FilterOptions().setHasText(Pattern.compile("^Add$", Pattern.CASE_INSENSITIVE))).first();
+        assertThat(addLink).isVisible();
+        addLink.click(new Locator.ClickOptions().setForce(true));
+        assertThat(page.locator("#authorIndexForm\\:title")).isVisible();
+        page.locator("#authorIndexForm\\:title").fill(title);
+        page.locator("#authorIndexForm\\:createnew").click(new Locator.ClickOptions().setForce(true));
+
+        // Q1: multiple choice, correct = second option.
+        selectQuestionType(Pattern.compile("multiple\\s*choice", Pattern.CASE_INSENSITIVE));
+        page.locator("#itemForm\\:answerptr").fill("10.00");
+        page.locator("#itemForm textarea").first().fill("Pick an option (multi-tab repro)");
+        page.locator("#itemForm\\:mcchoices textarea").nth(0).fill("Option one");
+        page.locator("#itemForm\\:mcchoices textarea").nth(1).fill("Option two");
+        page.locator("#itemForm\\:mcchoices textarea").nth(2).fill("Option three");
+        page.locator("#itemForm\\:mcchoices input[type=\"radio\"]").nth(1).check(new Locator.CheckOptions().setForce(true));
+        clickSubmit(page, "Save");
+        assertThat(page.locator("#assessmentForm\\:parts")).isVisible();
+
+        // Q2: short answer / essay.
+        selectQuestionType(Pattern.compile("short\\s*answer|essay", Pattern.CASE_INSENSITIVE));
+        page.locator("#itemForm\\:answerptr").fill("10.00");
+        page.locator("#itemForm\\:questionItemText_textinput").first().fill("Explain something (multi-tab repro)");
+        clickSubmit(page, "Save");
+        assertThat(page.locator("#assessmentForm\\:parts")).isVisible();
+
+        // Settings: open availability window, then publish.
+        page.getByRole(com.microsoft.playwright.options.AriaRole.LINK,
+            new Page.GetByRoleOptions().setName("Settings")).first().click(new Locator.ClickOptions().setForce(true));
+
+        DateTimeFormatter dateTime12h = DateTimeFormatter.ofPattern("MM/dd/yyyy h:mm a", Locale.US);
+        sakai.selectDate("#assessmentSettingsAction\\:startDate",
+            LocalDateTime.now().minusDays(1).format(dateTime12h).toLowerCase(Locale.US));
+        sakai.selectDate("#assessmentSettingsAction\\:endDate",
+            LocalDateTime.now().plusYears(2).format(dateTime12h).toLowerCase(Locale.US));
+
+        clickFirstVisible(page,
+            "button:has-text(\"Save Settings and Publish\"), input[type=\"submit\"][value*=\"Save Settings and Publish\"], input[type=\"submit\"][value*=\"Publish\"], button:has-text(\"Publish\")");
+        clickFirstVisibleIfPresent(page,
+            "input[type=\"submit\"][value*=\"Publish\"], button:has-text(\"Publish\")");
+        page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+    }
+
+    private void selectQuestionType(Pattern labelPattern) {
+        Locator select = page.locator("select[id$=\":changeQType\"]").first();
+        if (!isVisible(select, 5_000)) {
+            select = page.locator("#content form select:visible").first();
+        }
+        assertThat(select).isVisible();
+        String matchedValue = null;
+        for (ElementHandle option : select.locator("option").elementHandles()) {
+            String label = option.textContent();
+            if (label != null && labelPattern.matcher(label).find()) {
+                matchedValue = option.getAttribute("value");
+                break;
+            }
+        }
+        if (matchedValue == null || matchedValue.isBlank()) {
+            throw new IllegalStateException("No question type option matches " + labelPattern);
+        }
+        select.selectOption(matchedValue);
+    }
+
+    private String enterTestsTool(Page target) {
+        target.navigate(sakaiAbsolute(courseUrl));
+        if (target == page) {
+            sakai.toolClick("Tests");
+        } else {
+            Locator tool = target.locator("a.btn-nav").filter(
+                new Locator.FilterOptions().setHasText(Pattern.compile("Tests", Pattern.CASE_INSENSITIVE))).first();
+            tool.click(new Locator.ClickOptions().setForce(true));
+            target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+        }
+        return target.url();
+    }
+
+    private void enterQuiz(Page target, String title) {
+        enterTestsTool(target);
+        beginQuiz(target, title);
+    }
+
+    private void beginQuiz(Page target, String title) {
+        Locator link = target.locator("#selectIndexForm\\:selectTable a[id$=':takeAssessment']").filter(
+            new Locator.FilterOptions().setHasText(title)).first();
+        link.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(20_000));
+        link.click(new Locator.ClickOptions().setForce(true));
+        target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+
+        Locator begin = target.locator(
+            "input[type=\"submit\"][value*=\"Begin\"], input[type=\"submit\"][value*=\"Continue\"], button:has-text(\"Begin\"), button:has-text(\"Continue\")").first();
+        if (isVisible(begin, 10_000)) {
+            // The begin page may require the Honor Pledge checkbox before starting.
+            Locator pledge = target.locator("#takeAssessmentForm input[type=\"checkbox\"]:visible");
+            if (pledge.count() > 0) {
+                pledge.first().check(new Locator.CheckOptions().setForce(true));
+            }
+            begin.click(new Locator.ClickOptions().setForce(true));
+            target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+            // A timed assessment interposes one more confirmation.
+            Locator confirm = target.locator(
+                "input[type=\"submit\"][value*=\"Begin\"], button:has-text(\"Begin\")").first();
+            if (target.locator("#takeAssessmentForm input[type=\"radio\"]").count() == 0 && isVisible(confirm, 3_000)) {
+                confirm.click(new Locator.ClickOptions().setForce(true));
+                target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+            }
+        }
+        // The begin page and the delivery page share the same form id, so wait
+        // for actual question content, not just the form.
+        target.locator("#takeAssessmentForm input[type=\"radio\"], #takeAssessmentForm textarea").first().waitFor(
+            new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(20_000));
+    }
+
+    private void ensureOnDeliveryPage(Page target, String toolUrl, String title) {
+        if (target.locator("#takeAssessmentForm input[type=\"radio\"]").count() > 0) {
+            return;
+        }
+        target.navigate(toolUrl);
+        beginQuiz(target, title);
+    }
+
+    private void selectMcOption(Page target, int oneBasedOption) {
+        Locator radios = target.locator("#takeAssessmentForm input[type=\"radio\"]");
+        radios.first().waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(20_000));
+        radios.nth(oneBasedOption - 1).check(new Locator.CheckOptions().setForce(true));
+    }
+
+    private void fillEssay(Page target, String text) {
+        Locator textarea = target.locator("#takeAssessmentForm textarea:visible").first();
+        if (isVisible(textarea, 5_000)) {
+            textarea.fill(text);
+            return;
+        }
+        // Rich-text delivery: write through CKEditor's backing textarea.
+        Boolean done = (Boolean) target.evaluate(
+            "(text) => { const inst = window.CKEDITOR && Object.values(window.CKEDITOR.instances)[0];"
+            + "if (!inst) return false; inst.setData(text); inst.updateElement(); return true; }", text);
+        if (!Boolean.TRUE.equals(done)) {
+            throw new IllegalStateException("No essay input found in delivery page");
+        }
+    }
+
+    private void clickDelivery(Page target, String buttonId) {
+        Locator button = target.locator("#takeAssessmentForm\\:" + buttonId).first();
+        button.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(20_000));
+        button.click(new Locator.ClickOptions().setForce(true));
+        target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+        target.waitForTimeout(500);
+    }
+
+    private void waitForSubmission(long quizId, Page tabA, Page tabB, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            String forGrade = dbScalar("SELECT CAST(FORGRADE AS UNSIGNED) FROM SAM_ASSESSMENTGRADING_T WHERE PUBLISHEDASSESSMENTID="
+                + quizId + " ORDER BY ASSESSMENTGRADINGID DESC LIMIT 1");
+            if ("1".equals(forGrade)) {
+                return;
+            }
+            tabA.waitForTimeout(5_000);
+        }
+        throw new AssertionError("Timed attempt was never auto-submitted within " + timeoutMs + "ms");
+    }
+
+    private static final java.util.Map<String, Long> ASSESSMENT_IDS = new java.util.concurrent.ConcurrentHashMap<>();
+
+    private long publishedAssessmentId(String title) {
+        return ASSESSMENT_IDS.computeIfAbsent(title, t -> {
+            String id = dbScalar("SELECT ID FROM SAM_PUBLISHEDASSESSMENT_T WHERE TITLE='" + t + "'");
+            if (id == null || id.isBlank()) {
+                throw new IllegalStateException("Published assessment not found: " + t);
+            }
+            return Long.parseLong(id.trim());
+        });
+    }
+
+    /** Latest attempt's item rows: ITEMGRADINGID, PUBLISHEDITEMID, PUBLISHEDANSWERID, ANSWERTEXT. */
+    private List<String[]> gradingRows(long quizId) {
+        String out = db("SELECT ig.ITEMGRADINGID, ig.PUBLISHEDITEMID, IFNULL(ig.PUBLISHEDANSWERID,'NULL'),"
+            + " IFNULL(ig.ANSWERTEXT,'NULL') FROM SAM_ITEMGRADING_T ig WHERE ig.ASSESSMENTGRADINGID ="
+            + " (SELECT MAX(ASSESSMENTGRADINGID) FROM SAM_ASSESSMENTGRADING_T WHERE PUBLISHEDASSESSMENTID=" + quizId + ")");
+        List<String[]> rows = new ArrayList<>();
+        for (String line : out.split("\n")) {
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] cols = line.split("\t", -1);
+            if (cols.length >= 4) {
+                rows.add(cols);
+            }
+        }
+        return rows;
+    }
+
+    private String latestMcAnswerId(long quizId) {
+        return gradingRows(quizId).stream()
+            .map(r -> r[2])
+            .filter(v -> !"NULL".equals(v))
+            .findFirst()
+            .orElse("NULL");
+    }
+
+    private String describe(List<String[]> rows) {
+        StringBuilder sb = new StringBuilder();
+        for (String[] row : rows) {
+            sb.append(String.join("|", row)).append(" ; ");
+        }
+        return sb.toString();
+    }
+
+    private String dbScalar(String sql) {
+        String out = db(sql);
+        return out == null ? null : out.strip();
+    }
+
+    private String db(String sql) {
+        try {
+            java.util.List<String> command = new ArrayList<>(java.util.Arrays.asList(DB_CMD.trim().split("\\s+")));
+            command.addAll(java.util.Arrays.asList("-N", "-B", "-e", sql));
+            Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+            StringBuilder output = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("Warning:")) {
+                        continue;
+                    }
+                    output.append(line).append('\n');
+                }
+            }
+            int exit = process.waitFor();
+            if (exit != 0) {
+                throw new IllegalStateException("mysql exited " + exit + " for: " + sql + "\n" + output);
+            }
+            return output.toString();
+        } catch (java.io.IOException | InterruptedException e) {
+            throw new IllegalStateException("db query failed: " + sql, e);
+        }
+    }
+
+    private String sakaiAbsolute(String pathOrUrl) {
+        if (pathOrUrl.startsWith("http")) {
+            return pathOrUrl;
+        }
+        return org.sakaiproject.e2e.support.SakaiEnvironment.baseUrl() + pathOrUrl;
+    }
+
+    private void clickSubmit(Page target, String label) {
+        Locator submit = target.locator(
+            "input[type=\"submit\"][value*=\"" + label + "\"], button:has-text(\"" + label + "\")");
+        int count = (int) submit.count();
+        for (int index = 0; index < count; index++) {
+            Locator candidate = submit.nth(index);
+            if (isVisible(candidate, 5_000)) {
+                candidate.click(new Locator.ClickOptions().setForce(true));
+                target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+                return;
+            }
+        }
+        throw new AssertionError("No visible submit for label: " + label);
+    }
+
+    private void clickFirstVisible(Page target, String selector) {
+        Locator locator = target.locator(selector).first();
+        assertThat(locator).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(15_000));
+        locator.click(new Locator.ClickOptions().setForce(true));
+        target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+    }
+
+    private boolean clickFirstVisibleIfPresent(Page target, String selector) {
+        Locator locator = target.locator(selector);
+        int count = (int) locator.count();
+        for (int index = 0; index < count; index++) {
+            Locator candidate = locator.nth(index);
+            if (isVisible(candidate, 5_000)) {
+                candidate.click(new Locator.ClickOptions().setForce(true));
+                target.waitForLoadState(LoadState.DOMCONTENTLOADED);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isVisible(Locator locator, double timeoutMs) {
+        try {
+            locator.waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.VISIBLE).setTimeout(timeoutMs));
+            return true;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+}

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoMultiTabTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoMultiTabTest.java
@@ -19,7 +19,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -198,15 +197,14 @@ class SamigoMultiTabTest extends SakaiUiTestBase {
             selectMcOption(tabA, 1);
             selectMcOption(tabB, 2);
 
-            // Fire both saves as close to simultaneously as possible.
-            CompletableFuture<Void> a = CompletableFuture.runAsync(() ->
-                tabA.evaluate("() => document.getElementById('takeAssessmentForm:save').click()"));
-            CompletableFuture<Void> b = CompletableFuture.runAsync(() ->
-                tabB.evaluate("() => document.getElementById('takeAssessmentForm:save').click()"));
-            CompletableFuture.allOf(a, b).join();
+            // Fire both saves as close to simultaneously as possible. Playwright
+            // Java is not thread-safe, so instead of Java threads each page arms
+            // a JS timer and the clicks fire concurrently browser-side.
+            tabA.evaluate("() => setTimeout(() => document.getElementById('takeAssessmentForm:save').click(), 100)");
+            tabB.evaluate("() => setTimeout(() => document.getElementById('takeAssessmentForm:save').click(), 100)");
             tabA.waitForLoadState(LoadState.DOMCONTENTLOADED);
             tabB.waitForLoadState(LoadState.DOMCONTENTLOADED);
-            tabA.waitForTimeout(1_500);
+            tabA.waitForTimeout(2_000);
 
             if (!dbChecksEnabled()) {
                 continue;
@@ -286,6 +284,7 @@ class SamigoMultiTabTest extends SakaiUiTestBase {
         // The forced timeout submit from the CURRENT tab must keep today's
         // semantics: the student's last (unsaved) change wins, with exactly one
         // row per single-select item - no duplicate rows, no constraint abort.
+        assumeDb();
         ensureCourseUrl();
         long quizId = publishedAssessmentId(QUIZ_TIMED);
 

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoMultiTabTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoMultiTabTest.java
@@ -406,6 +406,53 @@ class SamigoMultiTabTest extends SakaiUiTestBase {
         dup.close();
     }
 
+    @Test
+    @Order(11)
+    void typedEssayDraftSurvivesTabLossWithoutSaving() {
+        // SAK-44349 draft layer: text typed but never saved must be recoverable
+        // on this device after the tab/browser is lost (the 23.x essay-loss
+        // report). Simulated by navigating away without any form submit.
+        assumeDb();
+        ensureCourseUrl();
+        long quizId = publishedAssessmentId(QUIZ_NAV);
+
+        sakai.login(STUDENT);
+        String toolUrl = enterTestsTool(page);
+        beginQuiz(page, QUIZ_NAV);
+
+        // Get to the essay page (Q1 MC unanswered is fine) and type WITHOUT saving.
+        if (page.locator("#takeAssessmentForm textarea:visible").count() == 0) {
+            clickDelivery(page, "next");
+        }
+        String draftText = "draft only, never saved " + RUN_ID;
+        fillEssay(page, draftText);
+        // Let the 2s draft debounce fire.
+        page.waitForTimeout(3_500);
+
+        // Abandon the page without submitting anything (tab close / crash).
+        page.navigate(toolUrl);
+
+        // Server never saw the text.
+        assertFalse(gradingRows(quizId).stream().anyMatch(r -> r[3].contains("draft only")),
+            "draft text must not be on the server yet");
+
+        // Re-enter the attempt: the empty essay field must be restored from
+        // the local draft, with a visible notice.
+        beginQuiz(page, QUIZ_NAV);
+        if (page.locator("#takeAssessmentForm textarea:visible").count() == 0) {
+            clickDelivery(page, "next");
+        }
+        assertThat(page.locator("#draft-restored-info")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(10_000));
+        String restored = page.locator("#takeAssessmentForm textarea:visible").first().inputValue();
+        assertTrue(restored.contains("draft only, never saved"),
+            "restored textarea should contain the draft, got: " + restored);
+
+        // And saving the restored draft persists it.
+        clickDelivery(page, "save");
+        assertTrue(gradingRows(quizId).stream().anyMatch(r -> r[3].contains("draft only")),
+            "restored draft should persist on save");
+    }
+
     // ---------------------------------------------------------------- helpers
 
     private void createAndPublishTwoQuestionQuiz(String title) {

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/util/SamigoConstants.java
@@ -158,6 +158,7 @@ public final class SamigoConstants {
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_ENABLED     = "samigo.email.autoSubmit.errorNotification.enabled";
     public static final     String      SAK_PROP_AUTO_SUBMIT_ERROR_NOTIFICATION_TO_ADDRESS  = "samigo.email.autoSubmit.errorNotification.toAddress";
     public static final     String      SAK_PROP_SUPPORT_EMAIL_ADDRESS                      = "mail.support";
+    public static final     String      SAK_PROP_DELIVERY_STALE_TAB_GUARD                   = "samigo.delivery.staleTabGuard";
     public static final     String      SAK_PROP_EVENTLOG_IPADDRESS_ENABLED                 = "samigo.eventlog.ipaddress.enabled";
 
     /*

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -465,6 +465,7 @@ stale_tab_title=This page is out of date
 stale_tab_1=This or another assessment was updated in a different browser tab or window, so the answers on this page could not be applied. All of your previously saved answers are safe.
 stale_tab_2=Click Continue Assessment to pick up where you left off. To avoid this message, keep the assessment open in only one tab or window, and use the assessment's own navigation buttons rather than your browser's Back and Forward buttons.
 stale_tab_continue=Continue Assessment
+draft_restored=Unsaved work from a previous session on this device was recovered and is shown below. Review it, then click Save.
 stale_tab_autosave_warning=This assessment is open in another browser tab or window. Automatic saving is paused here; continue working in the most recent tab.
 
 text_or=or

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/DeliveryMessages.properties
@@ -460,6 +460,13 @@ data_discrepancy_5_url=Click <strong>Return to assessment</strong> below to retu
 data_discrepancy_button=Return to assessment list
 data_discrepancy_link=Return to assessment
 
+# SAK-44349 stale-tab guard
+stale_tab_title=This page is out of date
+stale_tab_1=This or another assessment was updated in a different browser tab or window, so the answers on this page could not be applied. All of your previously saved answers are safe.
+stale_tab_2=Click Continue Assessment to pick up where you left off. To avoid this message, keep the assessment open in only one tab or window, and use the assessment's own navigation buttons rather than your browser's Back and Forward buttons.
+stale_tab_continue=Continue Assessment
+stale_tab_autosave_warning=This assessment is open in another browser tab or window. Automatic saving is paused here; continue working in the most recent tab.
+
 text_or=or
 text_period=.
 text_out_of=out of

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/delivery/DeliveryBean.java
@@ -98,6 +98,7 @@ import org.sakaiproject.tool.assessment.ui.bean.shared.PersonBean;
 import org.sakaiproject.tool.assessment.ui.bean.util.Validator;
 import org.sakaiproject.tool.assessment.ui.listener.delivery.BeginDeliveryActionListener;
 import org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryActionListener;
+import org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryStateGuard;
 import org.sakaiproject.tool.assessment.ui.listener.delivery.LinearAccessDeliveryActionListener;
 import org.sakaiproject.tool.assessment.ui.listener.delivery.SubmitToGradingActionListener;
 import org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener;
@@ -132,6 +133,11 @@ public class DeliveryBean implements Serializable {
   private static final String MATHJAX_SRC_PATH = ServerConfigurationService.getString(MATHJAX_SRC_PATH_SAKAI_PROP);
   
   public static final String LINEAR_ACCESS = "1";
+
+  // SAK-44349: per-render state token; a stale tab's POST fails its check
+  // before JSF can bind that tab's inputs into this shared session-scoped bean
+  @Getter
+  private final DeliveryStateGuard stateGuard = new DeliveryStateGuard();
 
   @Getter @Setter
   private String assessmentId;
@@ -2105,10 +2111,34 @@ public class DeliveryBean implements Serializable {
     }
     
     log.debug("check 4");
-    // check 4: check for multiple window & browser trick 
+    // check 4: check for multiple window & browser trick
+    // SAK-44349: for a token-verified post the browser-echoed timestamp can
+    // only false-positive (e.g. an autosave whose response was lost to the
+    // network still advanced submittedDate), but the token is session-scoped
+    // and proves nothing about OTHER sessions (a second browser or device on
+    // the same attempt). So verified posts compare the session bean's
+    // submittedDate against the DB - in sync for this session's own writes,
+    // divergent when another session moved the attempt - and land on the
+    // recoverable resync page instead of the fatal error. Unverified posts
+    // keep the legacy check unchanged.
     boolean discrepancyInData = false;
-    if (assessmentGrading!=null && !checkDataIntegrity(assessmentGrading)){
-      discrepancyInData = true;
+    if (assessmentGrading != null) {
+      if (isTokenVerifiedRequest()) {
+        // Another session (a second browser or device on the same attempt)
+        // advanced the DB submittedDate strictly beyond what this session last
+        // saw. Use after(), not equals(): the DB truncates to whole seconds
+        // while the session bean may hold a millisecond-precision Date from its
+        // own last write, so equals() would false-positive on this session's
+        // own saves.
+        Date sessionDate = adata != null ? adata.getSubmittedDate() : null;
+        Date dbDate = assessmentGrading.getSubmittedDate();
+        if (dbDate != null && (sessionDate == null || dbDate.after(sessionDate))) {
+          log.info("SAK-44349 attempt {} advanced by another session; sending resync", assessmentGrading.getAssessmentGradingId());
+          return "staleTabResync";
+        }
+      } else if (!checkDataIntegrity(assessmentGrading)) {
+        discrepancyInData = true;
+      }
     }
 
     log.debug("check 5");
@@ -2353,6 +2383,11 @@ public class DeliveryBean implements Serializable {
 	  return status.equals(AssessmentGradingData.ASSESSMENT_UPDATED_NEED_RESUBMIT);
   }
   
+  /** SAK-44349: was this request accepted by the delivery state guard? */
+  private boolean isTokenVerifiedRequest() {
+    return DeliveryStateGuard.isVerified(FacesContext.getCurrentInstance());
+  }
+
   private boolean checkDataIntegrity(AssessmentGradingData assessmentGrading){
     // get assessmentGrading from DB, this is to avoid same assessment being
     // opened in the differnt browser

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryActionListener.java
@@ -571,6 +571,7 @@ public class DeliveryActionListener
     	  delivery.setPageContents(getPageContents(publishedAssessment, delivery, itemGradingHash, publishedAnswerHash));
         }
       }
+
     } catch (RuntimeException e) {
     	DeliveryBean delivery = (DeliveryBean) ContextUtil.lookupBean("delivery");
     	String id = getPublishedAssessmentId(delivery);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryStateGuard.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryStateGuard.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.ui.listener.delivery;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.faces.context.FacesContext;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.samigo.util.SamigoConstants;
+
+/**
+ * SAK-44349: state token for the delivery stale-tab guard.
+ *
+ * Every render of a guarded delivery view carries the token currently held by
+ * the session-scoped DeliveryBean; rendering rotates it, so every previously
+ * rendered form (other tabs, duplicated tabs, back/forward cache pages) is
+ * invalidated. A POST must return the current token to be processed; on
+ * acceptance the token rotates atomically, so a duplicate or concurrent
+ * submit of the same form loses cleanly. Autosave posts verify without
+ * rotating and autosave re-renders do not rotate, so a current tab's autosave
+ * can never invalidate that tab - even when its response is lost in transit.
+ */
+public class DeliveryStateGuard implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Request parameter carrying the token back from the browser. */
+    public static final String TOKEN_PARAM = "dlvrStateToken";
+    /** Request parameter identifying an autosave post of the delivery form. */
+    public static final String AUTOSAVE_PARAM = "takeAssessmentForm:autoSave";
+    /** Request parameter of the forced time-expiry submit button. */
+    public static final String TIMEOUT_SUBMIT_PARAM = "takeAssessmentForm:submitNoCheck";
+    /** Request attribute marking a request that passed the token check. */
+    public static final String REQUEST_ATTR_VERIFIED = "samigo.delivery.tokenVerified";
+
+    public enum Decision {
+        /** Token matches: process the request. */
+        ACCEPT,
+        /** Stale interactive POST: reject and show the resync page. */
+        REJECT_RESYNC,
+        /** Stale autosave POST: reject; the client handles it quietly. */
+        REJECT_SILENT,
+        /** Guard does not apply to this request. */
+        BYPASS
+    }
+
+    private String token = newToken();
+
+    public synchronized String getToken() {
+        return token;
+    }
+
+    /** Rotate the token, invalidating every previously rendered form. */
+    public synchronized String regenerate() {
+        token = newToken();
+        return token;
+    }
+
+    /** Non-rotating comparison, for posts that must not advance the sequence. */
+    public synchronized boolean matches(String postedToken) {
+        return StringUtils.isNotEmpty(postedToken) && postedToken.equals(token);
+    }
+
+    /**
+     * Atomically accept-and-rotate: succeeds for exactly one caller per issued
+     * token, so concurrent duplicate posts cannot both pass.
+     */
+    public synchronized boolean compareAndRotate(String postedToken) {
+        if (matches(postedToken)) {
+            token = newToken();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Decide what to do with a delivery-form POST.
+     *
+     * Autosave posts verify WITHOUT rotating (like Moodle's negative-sequence
+     * autosave steps). The forced time-expiry submit is tried against the
+     * token first - in the normal single-tab case it matches and gets full
+     * authority - but a stale one is never blocked (BYPASS): the persistence
+     * backstop in SubmitToGradingActionListener protects saved answers there.
+     */
+    public static Decision evaluate(DeliveryStateGuard guard, String postedToken,
+            boolean guardEnabled, boolean timeoutSubmit, boolean autoSavePost) {
+        if (!guardEnabled || guard == null) {
+            return Decision.BYPASS;
+        }
+        if (autoSavePost) {
+            return guard.matches(postedToken) ? Decision.ACCEPT : Decision.REJECT_SILENT;
+        }
+        if (timeoutSubmit) {
+            return guard.compareAndRotate(postedToken) ? Decision.ACCEPT : Decision.BYPASS;
+        }
+        return guard.compareAndRotate(postedToken) ? Decision.ACCEPT : Decision.REJECT_RESYNC;
+    }
+
+    /** Is the stale-tab guard enabled by configuration? Default true. */
+    public static boolean isGuardEnabled() {
+        return ServerConfigurationService.getBoolean(SamigoConstants.SAK_PROP_DELIVERY_STALE_TAB_GUARD, true);
+    }
+
+    /** Was this request's token verified by the guard? */
+    public static boolean isVerified(FacesContext context) {
+        return context != null && Boolean.TRUE.equals(context.getExternalContext()
+                .getRequestMap().get(REQUEST_ATTR_VERIFIED));
+    }
+
+    /** Is this request an autosave post from the delivery form? */
+    public static boolean isAutoSavePost(Map<String, String> requestParams) {
+        return requestParams != null && requestParams.containsKey(AUTOSAVE_PARAM);
+    }
+
+    /** Is this request the forced time-expiry submit? */
+    public static boolean isTimeoutSubmit(Map<String, String> requestParams) {
+        return requestParams != null && requestParams.containsKey(TIMEOUT_SUBMIT_PARAM);
+    }
+
+    private static String newToken() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryStateGuardPhaseListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryStateGuardPhaseListener.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.ui.listener.delivery;
+
+import java.util.Map;
+
+import javax.faces.component.UIViewRoot;
+import javax.faces.context.FacesContext;
+import javax.faces.event.PhaseEvent;
+import javax.faces.event.PhaseId;
+import javax.faces.event.PhaseListener;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.sakaiproject.tool.assessment.ui.bean.delivery.DeliveryBean;
+import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
+
+/**
+ * SAK-44349: the two halves of the delivery stale-tab guard.
+ *
+ * GATE (after RESTORE_VIEW): a POST to a guarded delivery view must carry the
+ * current state token; a stale post is short-circuited to the non-fatal
+ * resync view before JSF's Update Model Values can bind its inputs into the
+ * shared session-scoped DeliveryBean. Acceptance rotates the token atomically,
+ * so duplicate/concurrent posts of the same form lose cleanly.
+ *
+ * ROTATION (before RENDER_RESPONSE): every render of a guarded view - POST
+ * response, plain GET, duplicated tab, back/forward revalidation - issues a
+ * fresh token, so every previously rendered form is invalid by construction.
+ * Autosave responses are the one exception: autosaves must not advance the
+ * sequence, or a lost autosave response would invalidate its own tab.
+ *
+ * Scoped to student take modes; review and preview posts fall through to the
+ * legacy checks untouched.
+ */
+@Slf4j
+public class DeliveryStateGuardPhaseListener implements PhaseListener {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String DELIVERY_VIEW = "/jsf/delivery/deliverAssessment.jsp";
+    private static final String TOC_VIEW = "/jsf/delivery/tableOfContents.jsp";
+    private static final String CONFIRM_SUBMIT_VIEW = "/jsf/delivery/confirmSubmit.jsp";
+    private static final String DELIVERY_FORM = "takeAssessmentForm";
+    private static final String TOC_FORM = "tableOfContentsForm";
+    private static final String RESYNC_OUTCOME = "staleTabResync";
+
+    @Override
+    public PhaseId getPhaseId() {
+        return PhaseId.ANY_PHASE;
+    }
+
+    @Override
+    public void beforePhase(PhaseEvent event) {
+        if (event.getPhaseId() != PhaseId.RENDER_RESPONSE) {
+            return;
+        }
+        FacesContext context = event.getFacesContext();
+        DeliveryBean delivery = guardedDelivery(context);
+        if (delivery == null || !DeliveryStateGuard.isGuardEnabled()) {
+            return;
+        }
+        Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+        if (DeliveryStateGuard.isAutoSavePost(params)) {
+            return;
+        }
+        delivery.getStateGuard().regenerate();
+    }
+
+    @Override
+    public void afterPhase(PhaseEvent event) {
+        if (event.getPhaseId() != PhaseId.RESTORE_VIEW) {
+            return;
+        }
+        FacesContext context = event.getFacesContext();
+        if (!context.isPostback() || context.getResponseComplete()) {
+            return;
+        }
+        DeliveryBean delivery = guardedDelivery(context);
+        if (delivery == null) {
+            return;
+        }
+        Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+        String viewId = context.getViewRoot().getViewId();
+        boolean deliveryForm = params.containsKey(DELIVERY_FORM);
+        if (!(TOC_VIEW.equals(viewId) ? params.containsKey(TOC_FORM) : deliveryForm)) {
+            return;
+        }
+
+        DeliveryStateGuard.Decision decision = DeliveryStateGuard.evaluate(
+            delivery.getStateGuard(),
+            params.get(DeliveryStateGuard.TOKEN_PARAM),
+            DeliveryStateGuard.isGuardEnabled(),
+            DeliveryStateGuard.isTimeoutSubmit(params),
+            DeliveryStateGuard.isAutoSavePost(params));
+
+        switch (decision) {
+            case ACCEPT:
+                // Only a genuine token match earns this attribute: it lifts the
+                // persistence backstop and the cross-window submittedDate check
+                // switches to its session-aware form (DeliveryBean check 4).
+                context.getExternalContext().getRequestMap()
+                    .put(DeliveryStateGuard.REQUEST_ATTR_VERIFIED, Boolean.TRUE);
+                break;
+            case REJECT_SILENT:
+            case REJECT_RESYNC:
+                log.info("SAK-44349 stale {} post rejected; view={}, gradingId={}",
+                    decision == DeliveryStateGuard.Decision.REJECT_SILENT ? "autosave" : "interactive",
+                    viewId, delivery.getAssessmentGradingId());
+                context.renderResponse();
+                context.getApplication().getNavigationHandler()
+                    .handleNavigation(context, null, RESYNC_OUTCOME);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * The session DeliveryBean when this request targets a guarded view in a
+     * student take mode; null otherwise.
+     */
+    private DeliveryBean guardedDelivery(FacesContext context) {
+        UIViewRoot viewRoot = context.getViewRoot();
+        if (viewRoot == null) {
+            return null;
+        }
+        String viewId = viewRoot.getViewId();
+        if (!DELIVERY_VIEW.equals(viewId) && !TOC_VIEW.equals(viewId) && !CONFIRM_SUBMIT_VIEW.equals(viewId)) {
+            return null;
+        }
+        DeliveryBean delivery = (DeliveryBean) ContextUtil.lookupBean("delivery");
+        if (delivery == null) {
+            return null;
+        }
+        String actionString = delivery.getActionString();
+        if (!"takeAssessment".equals(actionString) && !"takeAssessmentViaUrl".equals(actionString)) {
+            return null;
+        }
+        return delivery;
+    }
+}

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingActionListener.java
@@ -102,6 +102,85 @@ public class SubmitToGradingActionListener implements ActionListener {
 	private final PublishedAssessmentService publishedAssesmentService = new PublishedAssessmentService();
 
 	private final PreferencesService preferencesService = ComponentManager.get( PreferencesService.class );
+
+	/**
+	 * SAK-44349: does the persistence backstop apply to this request? Only the
+	 * forced time-expiry submit can bypass the token gate while carrying answer
+	 * inputs, so the backstop is scoped to exactly that: a STALE timeout submit
+	 * (guard on, timeout param present, token not verified) may add first-time
+	 * answers but never blank or delete existing ones. Everything else - normal
+	 * verified posts, guard-disabled deployments, non-JSF invocations, the
+	 * final submit from the confirmation page - keeps full legacy authority.
+	 */
+	private boolean isBackstopRequired() {
+		if (!DeliveryStateGuard.isGuardEnabled()) {
+			return false;
+		}
+		FacesContext context = FacesContext.getCurrentInstance();
+		if (context == null) {
+			return false;
+		}
+		return DeliveryStateGuard.isTimeoutSubmit(context.getExternalContext().getRequestParameterMap())
+				&& !DeliveryStateGuard.isVerified(context);
+	}
+
+	/**
+	 * SAK-44349: does this row hold an actual student answer? Rationale-only
+	 * and media-only (file upload/audio) rows are deliberately not counted -
+	 * those types never generate removals, so the freeze below is moot for
+	 * them and counting them would only over-freeze.
+	 */
+	static boolean hasAnswerContent(ItemGradingData item) {
+		return item != null && (item.getPublishedAnswerId() != null
+				|| StringUtils.isNotBlank(item.getAnswerText()));
+	}
+
+	/**
+	 * SAK-44349: an unverified post must not overwrite a persisted answer
+	 * with a blank one (e.g. the time-expiry submit firing from a stale,
+	 * never-touched tab while another tab holds the real answers).
+	 */
+	static boolean shouldPreserveExistingAnswer(boolean tokenVerified, ItemGradingData oldItem, ItemGradingData newItem) {
+		return !tokenVerified && hasAnswerContent(oldItem) && !hasAnswerContent(newItem);
+	}
+
+	/**
+	 * SAK-44349: for an unverified post, an item that already holds a saved
+	 * answer is frozen - its removals are blocked AND its incoming rows are
+	 * dropped. Blocking only the removal while letting the replacement row
+	 * through would create duplicate rows on single-select items (or violate
+	 * the uniqueStudentResponse constraint and abort the forced submit).
+	 * Items with no saved content may still receive first-time answers.
+	 *
+	 * Freezing is deliberately per-ITEM, not per-blank: on a multi-blank FIB
+	 * where one blank is saved, a stale timeout post cannot add the other
+	 * blank either. Conservative by design - an unverified post never
+	 * modifies an item that holds any saved answer.
+	 *
+	 * @return how many rows were dropped from the set
+	 */
+	static int dropRowsForFrozenItems(Set<ItemGradingData> rows, Set<Long> frozenItemIds) {
+		if (rows == null || rows.isEmpty() || frozenItemIds.isEmpty()) {
+			return 0;
+		}
+		int before = rows.size();
+		rows.removeIf(row -> row != null && row.getPublishedItemId() != null
+				&& frozenItemIds.contains(row.getPublishedItemId()));
+		return before - rows.size();
+	}
+
+	/** SAK-44349: published item ids that already hold a saved answer. */
+	static Set<Long> answeredItemIds(Collection<ItemGradingData> persistedRows) {
+		Set<Long> answered = new HashSet<>();
+		if (persistedRows != null) {
+			for (ItemGradingData row : persistedRows) {
+				if (hasAnswerContent(row) && row.getPublishedItemId() != null) {
+					answered.add(row.getPublishedItemId());
+				}
+			}
+		}
+		return answered;
+	}
 	private final UserDirectoryService userDirectoryService = ComponentManager.get( UserDirectoryService.class );
         private final TaskService taskService = ComponentManager.get( TaskService.class );
 
@@ -438,6 +517,21 @@ public class SubmitToGradingActionListener implements ActionListener {
 			log.debug("*** 2a. before removal & addition {}", (new Date()));
 			if (itemGradingSet != null) {
 				log.debug("*** 2aa. removing old itemGrading {}", (new Date()));
+				// SAK-44349: a stale timeout submit must not touch items that
+				// already hold a saved answer - neither deleting their rows nor
+				// inserting replacements. Freeze them wholesale; first-time
+				// answers to other items still land.
+				if (isBackstopRequired() && adata.getAssessmentGradingId() != null) {
+					Set<ItemGradingData> persistedRows =
+							service.getItemGradingSet(adata.getAssessmentGradingId().toString());
+					Set<Long> frozenItemIds = answeredItemIds(persistedRows);
+					int blockedRemoves = dropRowsForFrozenItems(removes, frozenItemIds);
+					int blockedAdds = dropRowsForFrozenItems(adds, frozenItemIds);
+					if (blockedRemoves + blockedAdds > 0) {
+						log.warn("SAK-44349 backstop: froze {} removal(s) and {} add(s) for already-answered items on a stale timeout submit, gradingId={}",
+								blockedRemoves, blockedAdds, adata.getAssessmentGradingId());
+					}
+				}
 				itemGradingSet.removeAll(removes);
 				service.deleteAll(removes);
 				// refresh itemGradingSet & assessmentGrading after removal
@@ -540,13 +634,21 @@ public class SubmitToGradingActionListener implements ActionListener {
 			map.put(item.getItemGradingId(), item);
 		}
 
+		// SAK-44349: a stale timeout submit may add answers but never blank existing ones
+		boolean tokenVerified = !isBackstopRequired();
+
 		// go through new itemGrading
 		Iterator<ItemGradingData> iter1 = newItemGradingSet.iterator();
 		while (iter1.hasNext()) {
 			ItemGradingData newItem = iter1.next();
 			ItemGradingData oldItem = map.get(newItem.getItemGradingId());
 			if (oldItem != null) {
-			    if (!oldItem.equals(newItem) || 
+			    if (shouldPreserveExistingAnswer(tokenVerified, oldItem, newItem)) {
+			        log.warn("SAK-44349 backstop: kept existing answer for itemGrading {} over a blank from a stale timeout submit, gradingId={}",
+			                oldItem.getItemGradingId(), adata.getAssessmentGradingId());
+			        continue;
+			    }
+			    if (!oldItem.equals(newItem) ||
 			    // Check for presence of old data in the EMI, calcQuestion and imagQuestion maps.
 			    // FIB, NR, and MCMR maps are not checked; checking them for previous data can cause updates when only the date has changed.
 			    // The above check (!oldItem.equals(newItem) suffices for checking new data against these question types. See SAK-39928 for more details.

--- a/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryStateGuardTest.java
+++ b/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/listener/delivery/DeliveryStateGuardTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.ui.listener.delivery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryStateGuard.Decision;
+
+/**
+ * SAK-44349: decision logic of the delivery stale-tab guard.
+ */
+public class DeliveryStateGuardTest {
+
+    @Test
+    public void acceptedTokenRotatesSoTheSameFormCannotPostTwice() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        String issued = guard.getToken();
+
+        assertTrue(guard.compareAndRotate(issued));
+        assertNotEquals(issued, guard.getToken());
+        assertFalse("second post of the same form must lose", guard.compareAndRotate(issued));
+    }
+
+    @Test
+    public void missingOrForeignTokensAreRejected() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        assertFalse(guard.compareAndRotate(null));
+        assertFalse(guard.compareAndRotate(""));
+        assertFalse(guard.compareAndRotate("not-the-token"));
+        // and rejection must not rotate: the real token still works
+        assertTrue(guard.compareAndRotate(guard.getToken()));
+    }
+
+    @Test
+    public void regenerateInvalidatesOutstandingForms() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        String issued = guard.getToken();
+        guard.regenerate();
+        assertFalse("a re-render must invalidate previously issued forms", guard.compareAndRotate(issued));
+    }
+
+    @Test
+    public void concurrentDuplicatePostsAcceptExactlyOne() throws Exception {
+        int threads = 8;
+        for (int round = 0; round < 25; round++) {
+            DeliveryStateGuard guard = new DeliveryStateGuard();
+            String issued = guard.getToken();
+            CountDownLatch start = new CountDownLatch(1);
+            ExecutorService pool = Executors.newFixedThreadPool(threads);
+            List<Future<Boolean>> results = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                results.add(pool.submit((Callable<Boolean>) () -> {
+                    start.await();
+                    return guard.compareAndRotate(issued);
+                }));
+            }
+            start.countDown();
+            int accepted = 0;
+            for (Future<Boolean> result : results) {
+                if (result.get()) {
+                    accepted++;
+                }
+            }
+            pool.shutdown();
+            assertEquals("exactly one of the concurrent duplicate posts may win", 1, accepted);
+        }
+    }
+
+    @Test
+    public void evaluateBypassesWhenDisabledOrNoGuard() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        String issued = guard.getToken();
+
+        assertEquals(Decision.BYPASS, DeliveryStateGuard.evaluate(guard, "junk", false, false, false));
+        assertEquals(Decision.BYPASS, DeliveryStateGuard.evaluate(null, "junk", true, false, false));
+        // bypass must not consume the token
+        assertEquals(issued, guard.getToken());
+    }
+
+    @Test
+    public void evaluateAcceptsCurrentTokenAndRotates() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        String issued = guard.getToken();
+
+        assertEquals(Decision.ACCEPT, DeliveryStateGuard.evaluate(guard, issued, true, false, false));
+        assertEquals(Decision.REJECT_RESYNC, DeliveryStateGuard.evaluate(guard, issued, true, false, false));
+    }
+
+    @Test
+    public void timeoutSubmitGetsFullAuthorityWhenCurrentButIsNeverBlocked() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        String issued = guard.getToken();
+
+        // single-tab case: the timeout submit carries the current token and
+        // must be verified (full authority), consuming the token
+        assertEquals(Decision.ACCEPT, DeliveryStateGuard.evaluate(guard, issued, true, true, false));
+        // stale timeout submit: never blocked, but unverified (backstop applies)
+        assertEquals(Decision.BYPASS, DeliveryStateGuard.evaluate(guard, issued, true, true, false));
+        assertEquals(Decision.BYPASS, DeliveryStateGuard.evaluate(guard, null, true, true, false));
+    }
+
+    @Test
+    public void autosaveVerifiesWithoutRotatingSoTheTabStaysValid() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+        String issued = guard.getToken();
+
+        // accepted autosave must NOT advance the sequence (Moodle-style):
+        // the same tab's next post still carries a valid token
+        assertEquals(Decision.ACCEPT, DeliveryStateGuard.evaluate(guard, issued, true, false, true));
+        assertEquals(issued, guard.getToken());
+        assertEquals(Decision.ACCEPT, DeliveryStateGuard.evaluate(guard, issued, true, false, true));
+        assertEquals(Decision.ACCEPT, DeliveryStateGuard.evaluate(guard, issued, true, false, false));
+    }
+
+    @Test
+    public void staleAutosaveIsRejectedSilentlyStaleInteractiveGetsResync() {
+        DeliveryStateGuard guard = new DeliveryStateGuard();
+
+        assertEquals(Decision.REJECT_SILENT, DeliveryStateGuard.evaluate(guard, "stale", true, false, true));
+        assertEquals(Decision.REJECT_RESYNC, DeliveryStateGuard.evaluate(guard, "stale", true, false, false));
+        assertEquals(Decision.REJECT_RESYNC, DeliveryStateGuard.evaluate(guard, null, true, false, false));
+    }
+}

--- a/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingBackstopTest.java
+++ b/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/listener/delivery/SubmitToGradingBackstopTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.ui.listener.delivery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.sakaiproject.tool.assessment.ui.listener.delivery.SubmitToGradingActionListener.answeredItemIds;
+import static org.sakaiproject.tool.assessment.ui.listener.delivery.SubmitToGradingActionListener.dropRowsForFrozenItems;
+import static org.sakaiproject.tool.assessment.ui.listener.delivery.SubmitToGradingActionListener.hasAnswerContent;
+import static org.sakaiproject.tool.assessment.ui.listener.delivery.SubmitToGradingActionListener.shouldPreserveExistingAnswer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
+
+/**
+ * SAK-44349: persistence backstop rules. Posts that were not verified by the
+ * stale-tab guard (forced time-expiry submit, token-less paths) may add or
+ * change answers but must never blank or delete existing ones.
+ */
+public class SubmitToGradingBackstopTest {
+
+    private ItemGradingData item(Long gradingId, Long publishedAnswerId, String answerText) {
+        return item(gradingId, 100L, publishedAnswerId, answerText);
+    }
+
+    private ItemGradingData item(Long gradingId, Long publishedItemId, Long publishedAnswerId, String answerText) {
+        ItemGradingData item = new ItemGradingData();
+        item.setItemGradingId(gradingId);
+        item.setPublishedItemId(publishedItemId);
+        item.setPublishedAnswerId(publishedAnswerId);
+        item.setAnswerText(answerText);
+        return item;
+    }
+
+    @Test
+    public void answerContentRecognizesSelectionsAndText() {
+        assertFalse(hasAnswerContent(null));
+        assertFalse(hasAnswerContent(item(1L, null, null)));
+        assertFalse(hasAnswerContent(item(1L, null, "   ")));
+        assertTrue(hasAnswerContent(item(1L, 42L, null)));
+        assertTrue(hasAnswerContent(item(1L, null, "an essay")));
+    }
+
+    @Test
+    public void verifiedPostsKeepFullAuthorityIncludingIntentionalClears() {
+        ItemGradingData saved = item(1L, 42L, "saved answer");
+        ItemGradingData blank = item(1L, null, "");
+        assertFalse(shouldPreserveExistingAnswer(true, saved, blank));
+    }
+
+    @Test
+    public void unverifiedPostsCannotBlankASavedAnswer() {
+        ItemGradingData saved = item(1L, 42L, null);
+        ItemGradingData blank = item(1L, null, " ");
+        assertTrue(shouldPreserveExistingAnswer(false, saved, blank));
+
+        ItemGradingData savedText = item(2L, null, "essay text");
+        assertTrue(shouldPreserveExistingAnswer(false, savedText, item(2L, null, null)));
+    }
+
+    @Test
+    public void unverifiedPostsMayStillAddOrImproveAnswers() {
+        // nothing saved yet: writing a first answer is fine
+        assertFalse(shouldPreserveExistingAnswer(false, item(1L, null, null), item(1L, 42L, null)));
+        // At THIS row-level layer a non-blank replacement passes; in practice
+        // the item-level freeze (dropRowsForFrozenItems, applied first) drops
+        // replacements for answered items, so this layer only sees them when
+        // the freeze was skipped. It must then still block blanking only.
+        assertFalse(shouldPreserveExistingAnswer(false, item(1L, 42L, null), item(1L, 43L, null)));
+        assertFalse(shouldPreserveExistingAnswer(false, item(1L, null, "old"), item(1L, null, "new")));
+    }
+
+    @Test
+    public void answeredItemsAreDetectedFromPersistedRows() {
+        Set<Long> answered = answeredItemIds(Arrays.asList(
+            item(1L, 100L, 42L, null),      // MC answered
+            item(2L, 200L, null, "essay"),  // essay answered
+            item(3L, 300L, null, "  "),     // blank row: not answered
+            item(4L, null, 42L, null)));    // no item id: ignored
+        assertEquals(new HashSet<>(Arrays.asList(100L, 200L)), answered);
+        assertTrue(answeredItemIds(null).isEmpty());
+    }
+
+    @Test
+    public void frozenItemsRejectBothRemovalsAndReplacementRows() {
+        // The changed-MC-answer-then-stale-timeout case: old row for item 100
+        // in removes, replacement row (different answer) in adds. Both must be
+        // dropped or a single-select item ends up with two rows (or a
+        // uniqueStudentResponse constraint violation).
+        Set<Long> frozen = new HashSet<>(Arrays.asList(100L));
+        Set<ItemGradingData> removes = new HashSet<>(Arrays.asList(item(1L, 100L, 42L, null)));
+        Set<ItemGradingData> adds = new HashSet<>(Arrays.asList(
+            item(null, 100L, 43L, null),   // replacement for frozen item: drop
+            item(null, 200L, null, "new essay text")));  // first-time answer: keep
+
+        assertEquals(1, dropRowsForFrozenItems(removes, frozen));
+        assertEquals(1, dropRowsForFrozenItems(adds, frozen));
+        assertTrue(removes.isEmpty());
+        assertEquals(1, adds.size());
+        assertEquals(Long.valueOf(200L), adds.iterator().next().getPublishedItemId());
+    }
+
+    @Test
+    public void nothingIsFrozenWhenNothingWasAnswered() {
+        Set<ItemGradingData> adds = new HashSet<>(Arrays.asList(item(null, 100L, 43L, null)));
+        assertEquals(0, dropRowsForFrozenItems(adds, answeredItemIds(Arrays.asList(item(1L, 100L, null, " ")))));
+        assertEquals(1, adds.size());
+    }
+}

--- a/samigo/samigo-app/src/webapp/WEB-INF/faces-config.xml
+++ b/samigo/samigo-app/src/webapp/WEB-INF/faces-config.xml
@@ -309,6 +309,11 @@
       <to-view-id>/jsf/delivery/discrepancyInData.jsp</to-view-id>
     </navigation-case>
     <navigation-case>
+      <!-- SAK-44349 stale-tab guard rejection -->
+      <from-outcome>staleTabResync</from-outcome>
+      <to-view-id>/jsf/delivery/staleTabResync.jsp</to-view-id>
+    </navigation-case>
+    <navigation-case>
       <from-outcome>assessmentNotAvailable</from-outcome>
       <to-view-id>/jsf/delivery/assessmentNotAvailable.jsp</to-view-id>
     </navigation-case>
@@ -999,5 +1004,10 @@
     </navigation-case>
     <!-- Add other navigation cases based on possible return values from validate() -->
   </navigation-rule>
+
+  <lifecycle>
+    <!-- SAK-44349: reject stale multi-tab delivery posts before model update -->
+    <phase-listener>org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryStateGuardPhaseListener</phase-listener>
+  </lifecycle>
 
 </faces-config>

--- a/samigo/samigo-app/src/webapp/js/samigoDraft.js
+++ b/samigo/samigo-app/src/webapp/js/samigoDraft.js
@@ -11,47 +11,59 @@
  * a field the server rendered EMPTY, with a visible notice. Everything is
  * best-effort: storage failures are silent.
  */
-var samigoDraft = (function () {
+const samigoDraft = (() => {
     "use strict";
 
-    var PREFIX = "samigoDraft_";
-    var LAST_PURGE_KEY = "samigoDraftLastPurge";
-    var MAX_FIELD_LENGTH = 262144; // 256 KB per field
-    var TTL_MS = 7 * 24 * 60 * 60 * 1000;
-    var PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000;
-    var DEBOUNCE_MS = 2000;
+    const PREFIX = "samigoDraft_";
+    const LAST_PURGE_KEY = "samigoDraftLastPurge";
+    const MAX_FIELD_LENGTH = 262144; // 256 KB per field
+    const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+    const PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+    const DEBOUNCE_MS = 2000;
 
-    var attemptKey = null;
-    var pageKey = "";
-    var timers = {};
+    let attemptKey = null;
+    let pageKey = "";
+    const timers = {};
+    // Pending debounced writes by field name, so a Save/Next submit or a
+    // page hide can commit them before the debounce timer would have fired.
+    const pendingWrites = {};
     // Fields we restored a draft into this render: their content is NOT
     // server-confirmed, so the confirmed-content cleanup must skip them.
-    var restoredFields = {};
+    const restoredFields = {};
 
-    function username() {
+    const username = () => {
         try {
             if (typeof portal !== "undefined" && portal.user && typeof portal.user.eid === "string") {
                 return portal.user.eid;
             }
         } catch (e) { }
         return "";
-    }
+    };
 
-    function hiddenValue(name) {
+    const assessmentForm = () => document.getElementById("takeAssessmentForm");
+
+    const hiddenValue = (name) => {
         try {
-            var field = document.forms[0].elements["takeAssessmentForm:" + name];
+            const field = assessmentForm().elements[`takeAssessmentForm:${name}`];
             return field && field.value ? field.value : "";
         } catch (e) { return ""; }
-    }
+    };
 
-    function fieldKey(name) {
+    const fieldKey = (name) => {
         // JSF client ids are positional and repeat across pages in
         // question-per-page and part-per-page layouts, so the page position
         // must be part of the key or drafts leak between questions.
-        return PREFIX + attemptKey + "_" + pageKey + "_" + name + "_" + username();
-    }
+        return `${PREFIX}${attemptKey}_${pageKey}_${name}_${username()}`;
+    };
 
-    function store(name, value) {
+    const isBlank = (html) => {
+        if (!html) { return true; }
+        // Embedded media/structure is content even when there is no text.
+        if (/<\s*(img|iframe|audio|video|object|embed|svg|math|canvas|table|hr)\b/i.test(html)) { return false; }
+        return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/gi, " ").replace(/\s+/g, "") === "";
+    };
+
+    const store = (name, value) => {
         try {
             if (isBlank(value) || value.length > MAX_FIELD_LENGTH) {
                 // A cleared field must not resurrect later - including one an
@@ -62,65 +74,76 @@ var samigoDraft = (function () {
             }
             localStorage.setItem(fieldKey(name), JSON.stringify({ t: Date.now(), v: value }));
         } catch (e) { /* quota exceeded or private mode */ }
-    }
+    };
 
-    function read(name) {
+    const read = (name) => {
         try {
-            var raw = localStorage.getItem(fieldKey(name));
+            const raw = localStorage.getItem(fieldKey(name));
             if (!raw) { return null; }
-            var parsed = JSON.parse(raw);
+            const parsed = JSON.parse(raw);
             return parsed && parsed.v ? parsed.v : null;
         } catch (e) { return null; }
-    }
+    };
 
-    function remove(name) {
+    const remove = (name) => {
         try { localStorage.removeItem(fieldKey(name)); } catch (e) { }
-    }
+    };
 
-    function purgeExpired() {
+    const purgeExpired = () => {
         try {
-            var now = Date.now();
-            var last = parseInt(localStorage.getItem(LAST_PURGE_KEY), 10);
+            const now = Date.now();
+            const last = parseInt(localStorage.getItem(LAST_PURGE_KEY), 10);
             if (!isNaN(last) && (now - last) < PURGE_INTERVAL_MS) {
                 return;
             }
             localStorage.setItem(LAST_PURGE_KEY, String(now));
-            for (var i = localStorage.length - 1; i >= 0; i--) {
-                var k = localStorage.key(i);
-                if (k && k.indexOf(PREFIX) === 0) {
-                    var drop = true;
+            for (let i = localStorage.length - 1; i >= 0; i--) {
+                const key = localStorage.key(i);
+                if (key && key.indexOf(PREFIX) === 0) {
+                    let drop = true;
                     try {
-                        var parsed = JSON.parse(localStorage.getItem(k));
+                        const parsed = JSON.parse(localStorage.getItem(key));
                         drop = !parsed || !parsed.t || (now - parsed.t) > TTL_MS;
                     } catch (e) { /* unparseable: drop */ }
-                    if (drop) { localStorage.removeItem(k); }
+                    if (drop) { localStorage.removeItem(key); }
                 }
             }
         } catch (e) { }
-    }
+    };
 
-    function debounced(name, fn) {
+    const debounced = (name, fn) => {
         if (timers[name]) { clearTimeout(timers[name]); }
-        timers[name] = setTimeout(fn, DEBOUNCE_MS);
-    }
+        pendingWrites[name] = fn;
+        timers[name] = setTimeout(() => {
+            delete pendingWrites[name];
+            delete timers[name];
+            fn();
+        }, DEBOUNCE_MS);
+    };
 
-    function isBlank(html) {
-        if (!html) { return true; }
-        // Embedded media/structure is content even when there is no text.
-        if (/<\s*(img|iframe|audio|video|object|embed|svg|math|canvas|table|hr)\b/i.test(html)) { return false; }
-        return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/gi, " ").replace(/\s+/g, "") === "";
-    }
+    // A Save/Next click right after typing must not outrun the debounce: the
+    // whole point is surviving a POST that dies, so the snapshot has to be in
+    // localStorage BEFORE the request leaves.
+    const flushPending = () => {
+        Object.keys(pendingWrites).forEach((name) => {
+            clearTimeout(timers[name]);
+            const fn = pendingWrites[name];
+            delete pendingWrites[name];
+            delete timers[name];
+            fn();
+        });
+    };
 
-    function showRestoredNotice() {
-        var notice = document.getElementById("draft-restored-info");
+    const showRestoredNotice = () => {
+        const notice = document.getElementById("draft-restored-info");
         if (notice) { notice.style.display = "block"; }
-    }
+    };
 
-    function hookTextarea(area) {
+    const hookTextarea = (area) => {
         if (!area.name || area.samigoDraftHooked) { return; }
         area.samigoDraftHooked = true;
 
-        var draft = read(area.name);
+        const draft = read(area.name);
         if (draft && isBlank(area.value)) {
             area.value = draft;
             restoredFields[area.name] = true;
@@ -129,22 +152,17 @@ var samigoDraft = (function () {
             // Server-confirmed content: the local draft is obsolete.
             remove(area.name);
         }
-        var handler = function () {
-            debounced(area.name, function () { store(area.name, area.value); });
-        };
-        if (area.addEventListener) {
-            area.addEventListener("input", handler, false);
-        } else {
-            area.onkeyup = handler;
-        }
-    }
+        area.addEventListener("input", () => {
+            debounced(area.name, () => store(area.name, area.value));
+        });
+    };
 
-    function hookEditor(editor) {
+    const hookEditor = (editor) => {
         if (!editor || editor.samigoDraftHooked) { return; }
         editor.samigoDraftHooked = true;
 
         if (!restoredFields[editor.name]) {
-            var draft = read(editor.name);
+            const draft = read(editor.name);
             if (draft && isBlank(editor.getData())) {
                 editor.setData(draft);
                 restoredFields[editor.name] = true;
@@ -155,34 +173,38 @@ var samigoDraft = (function () {
                 remove(editor.name);
             }
         }
-        editor.on("change", function () {
-            debounced(editor.name, function () { store(editor.name, editor.getData()); });
+        editor.on("change", () => {
+            debounced(editor.name, () => store(editor.name, editor.getData()));
         });
-    }
+    };
 
-    function init(gradingId) {
+    const init = (gradingId) => {
         if (!gradingId || !window.localStorage) { return; }
         attemptKey = String(gradingId);
-        pageKey = "p" + hiddenValue("partIndex") + "q" + hiddenValue("questionIndex");
+        pageKey = `p${hiddenValue("partIndex")}q${hiddenValue("questionIndex")}`;
         purgeExpired();
 
-        var form = document.getElementById("takeAssessmentForm");
+        const form = assessmentForm();
         if (!form) { return; }
 
-        var areas = form.getElementsByTagName("textarea");
-        for (var i = 0; i < areas.length; i++) {
-            hookTextarea(areas[i]);
-        }
+        // Capture phase so the flush runs even if another submit handler
+        // stops propagation; pagehide/visibilitychange cover programmatic
+        // form.submit() calls and the tab being closed or backgrounded.
+        form.addEventListener("submit", flushPending, true);
+        window.addEventListener("pagehide", flushPending);
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "hidden") { flushPending(); }
+        });
+
+        Array.from(form.getElementsByTagName("textarea")).forEach(hookTextarea);
 
         if (window.CKEDITOR) {
-            CKEDITOR.on("instanceReady", function (evt) { hookEditor(evt.editor); });
-            for (var name in CKEDITOR.instances) {
-                if (CKEDITOR.instances.hasOwnProperty(name) && CKEDITOR.instances[name].status === "ready") {
-                    hookEditor(CKEDITOR.instances[name]);
-                }
-            }
+            CKEDITOR.on("instanceReady", (evt) => hookEditor(evt.editor));
+            Object.values(CKEDITOR.instances)
+                .filter((instance) => instance.status === "ready")
+                .forEach(hookEditor);
         }
-    }
+    };
 
-    return { init: init };
+    return { init };
 })();

--- a/samigo/samigo-app/src/webapp/js/samigoDraft.js
+++ b/samigo/samigo-app/src/webapp/js/samigoDraft.js
@@ -1,0 +1,187 @@
+/**
+ * SAK-52710: client-side draft persistence for text answers in delivery.
+ *
+ * Snapshots what the student types (plain textareas and CKEditor instances)
+ * into localStorage, keyed by attempt + page position + field + user. Unlike
+ * the CKEditor autosave plugin, drafts are NEVER deleted when a form button
+ * is clicked - a Next/Save click whose POST dies (network drop, stale-tab
+ * resync) must not take the draft down with it. Drafts are deleted when the
+ * student clears the field or the server renders it with confirmed content,
+ * expire after 7 days, and are capped in size. A draft is only restored into
+ * a field the server rendered EMPTY, with a visible notice. Everything is
+ * best-effort: storage failures are silent.
+ */
+var samigoDraft = (function () {
+    "use strict";
+
+    var PREFIX = "samigoDraft_";
+    var LAST_PURGE_KEY = "samigoDraftLastPurge";
+    var MAX_FIELD_LENGTH = 262144; // 256 KB per field
+    var TTL_MS = 7 * 24 * 60 * 60 * 1000;
+    var PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+    var DEBOUNCE_MS = 2000;
+
+    var attemptKey = null;
+    var pageKey = "";
+    var timers = {};
+    // Fields we restored a draft into this render: their content is NOT
+    // server-confirmed, so the confirmed-content cleanup must skip them.
+    var restoredFields = {};
+
+    function username() {
+        try {
+            if (typeof portal !== "undefined" && portal.user && typeof portal.user.eid === "string") {
+                return portal.user.eid;
+            }
+        } catch (e) { }
+        return "";
+    }
+
+    function hiddenValue(name) {
+        try {
+            var field = document.forms[0].elements["takeAssessmentForm:" + name];
+            return field && field.value ? field.value : "";
+        } catch (e) { return ""; }
+    }
+
+    function fieldKey(name) {
+        // JSF client ids are positional and repeat across pages in
+        // question-per-page and part-per-page layouts, so the page position
+        // must be part of the key or drafts leak between questions.
+        return PREFIX + attemptKey + "_" + pageKey + "_" + name + "_" + username();
+    }
+
+    function store(name, value) {
+        try {
+            if (!value || value.length === 0 || value.length > MAX_FIELD_LENGTH) {
+                // A cleared field must not resurrect later; an over-long field
+                // must not freeze at a misleading older snapshot.
+                localStorage.removeItem(fieldKey(name));
+                return;
+            }
+            localStorage.setItem(fieldKey(name), JSON.stringify({ t: Date.now(), v: value }));
+        } catch (e) { /* quota exceeded or private mode */ }
+    }
+
+    function read(name) {
+        try {
+            var raw = localStorage.getItem(fieldKey(name));
+            if (!raw) { return null; }
+            var parsed = JSON.parse(raw);
+            return parsed && parsed.v ? parsed.v : null;
+        } catch (e) { return null; }
+    }
+
+    function remove(name) {
+        try { localStorage.removeItem(fieldKey(name)); } catch (e) { }
+    }
+
+    function purgeExpired() {
+        try {
+            var now = Date.now();
+            var last = parseInt(localStorage.getItem(LAST_PURGE_KEY), 10);
+            if (!isNaN(last) && (now - last) < PURGE_INTERVAL_MS) {
+                return;
+            }
+            localStorage.setItem(LAST_PURGE_KEY, String(now));
+            for (var i = localStorage.length - 1; i >= 0; i--) {
+                var k = localStorage.key(i);
+                if (k && k.indexOf(PREFIX) === 0) {
+                    var drop = true;
+                    try {
+                        var parsed = JSON.parse(localStorage.getItem(k));
+                        drop = !parsed || !parsed.t || (now - parsed.t) > TTL_MS;
+                    } catch (e) { /* unparseable: drop */ }
+                    if (drop) { localStorage.removeItem(k); }
+                }
+            }
+        } catch (e) { }
+    }
+
+    function debounced(name, fn) {
+        if (timers[name]) { clearTimeout(timers[name]); }
+        timers[name] = setTimeout(fn, DEBOUNCE_MS);
+    }
+
+    function isBlank(html) {
+        if (!html) { return true; }
+        // Embedded media/structure is content even when there is no text.
+        if (/<\s*(img|iframe|audio|video|object|embed|svg|math|canvas|table|hr)\b/i.test(html)) { return false; }
+        return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/gi, " ").replace(/\s+/g, "") === "";
+    }
+
+    function showRestoredNotice() {
+        var notice = document.getElementById("draft-restored-info");
+        if (notice) { notice.style.display = "block"; }
+    }
+
+    function hookTextarea(area) {
+        if (!area.name || area.samigoDraftHooked) { return; }
+        area.samigoDraftHooked = true;
+
+        var draft = read(area.name);
+        if (draft && isBlank(area.value)) {
+            area.value = draft;
+            restoredFields[area.name] = true;
+            showRestoredNotice();
+        } else if (!isBlank(area.value)) {
+            // Server-confirmed content: the local draft is obsolete.
+            remove(area.name);
+        }
+        var handler = function () {
+            debounced(area.name, function () { store(area.name, area.value); });
+        };
+        if (area.addEventListener) {
+            area.addEventListener("input", handler, false);
+        } else {
+            area.onkeyup = handler;
+        }
+    }
+
+    function hookEditor(editor) {
+        if (!editor || editor.samigoDraftHooked) { return; }
+        editor.samigoDraftHooked = true;
+
+        if (!restoredFields[editor.name]) {
+            var draft = read(editor.name);
+            if (draft && isBlank(editor.getData())) {
+                editor.setData(draft);
+                restoredFields[editor.name] = true;
+                showRestoredNotice();
+            } else if (!isBlank(editor.getData())) {
+                // Confirmed by the server - but only when the content did not
+                // come from our own just-restored, still-unsaved draft.
+                remove(editor.name);
+            }
+        }
+        editor.on("change", function () {
+            debounced(editor.name, function () { store(editor.name, editor.getData()); });
+        });
+    }
+
+    function init(gradingId) {
+        if (!gradingId || !window.localStorage) { return; }
+        attemptKey = String(gradingId);
+        pageKey = "p" + hiddenValue("partIndex") + "q" + hiddenValue("questionIndex");
+        purgeExpired();
+
+        var form = document.getElementById("takeAssessmentForm");
+        if (!form) { return; }
+
+        var areas = form.getElementsByTagName("textarea");
+        for (var i = 0; i < areas.length; i++) {
+            hookTextarea(areas[i]);
+        }
+
+        if (window.CKEDITOR) {
+            CKEDITOR.on("instanceReady", function (evt) { hookEditor(evt.editor); });
+            for (var name in CKEDITOR.instances) {
+                if (CKEDITOR.instances.hasOwnProperty(name) && CKEDITOR.instances[name].status === "ready") {
+                    hookEditor(CKEDITOR.instances[name]);
+                }
+            }
+        }
+    }
+
+    return { init: init };
+})();

--- a/samigo/samigo-app/src/webapp/js/samigoDraft.js
+++ b/samigo/samigo-app/src/webapp/js/samigoDraft.js
@@ -161,17 +161,19 @@ const samigoDraft = (() => {
         if (!editor || editor.samigoDraftHooked) { return; }
         editor.samigoDraftHooked = true;
 
-        if (!restoredFields[editor.name]) {
-            const draft = read(editor.name);
-            if (draft && isBlank(editor.getData())) {
-                editor.setData(draft);
-                restoredFields[editor.name] = true;
-                showRestoredNotice();
-            } else if (!isBlank(editor.getData())) {
-                // Confirmed by the server - but only when the content did not
-                // come from our own just-restored, still-unsaved draft.
-                remove(editor.name);
-            }
+        const draft = read(editor.name);
+        if (draft && isBlank(editor.getData())) {
+            // Restore into the live editor even when hookTextarea already put
+            // the draft into the underlying textarea: an editor launched
+            // before init() was instantiated from the still-empty textarea,
+            // so the textarea restore never reached what the student sees.
+            editor.setData(draft);
+            restoredFields[editor.name] = true;
+            showRestoredNotice();
+        } else if (!restoredFields[editor.name] && !isBlank(editor.getData())) {
+            // Confirmed by the server - but only when the content did not
+            // come from our own just-restored, still-unsaved draft.
+            remove(editor.name);
         }
         editor.on("change", () => {
             debounced(editor.name, () => store(editor.name, editor.getData()));

--- a/samigo/samigo-app/src/webapp/js/samigoDraft.js
+++ b/samigo/samigo-app/src/webapp/js/samigoDraft.js
@@ -53,9 +53,10 @@ var samigoDraft = (function () {
 
     function store(name, value) {
         try {
-            if (!value || value.length === 0 || value.length > MAX_FIELD_LENGTH) {
-                // A cleared field must not resurrect later; an over-long field
-                // must not freeze at a misleading older snapshot.
+            if (isBlank(value) || value.length > MAX_FIELD_LENGTH) {
+                // A cleared field must not resurrect later - including one an
+                // editor "cleared" to blank markup like <p>&nbsp;</p> - and an
+                // over-long field must not freeze at a misleading older snapshot.
                 localStorage.removeItem(fieldKey(name));
                 return;
             }

--- a/samigo/samigo-app/src/webapp/js/saveForm.js
+++ b/samigo/samigo-app/src/webapp/js/saveForm.js
@@ -95,6 +95,37 @@ function SaveFormContentAsync(toUrl, formId, buttonName, updateVar, updateVar2, 
 	// So if we need anything from it we have to get it.
 	// Get new date from response and update the form variable
 
+	// SAK-44349: the server rejected this autosave because the assessment
+	// moved on in another tab. Nothing was saved (or lost); stop autosaving
+	// here and tell the student to continue in the newer tab.
+	if (text.indexOf("samigo-stale-tab-marker") >= 0) {
+	    document.getElementById("autosave-msg").style.display = "none";
+	    // Re-enable the buttons/links so the student can still click through
+	    // (any post from here lands on the recoverable resync page).
+	    for (var i=0; i<disabledButtons.length; i++) {
+		document.forms[formId].elements[disabledButtons[i]].disabled=false;
+	    }
+	    for (var i=0; i<disabledLinks.length; i++) {
+		var item = disabledLinks[i];
+		var link = document.getElementById(item[0]);
+		link.onmouseup = item[1];
+		link.onclick = item[2];
+	    }
+	    // The attempt was submitted in another tab/window: force a post so
+	    // this tab leaves its editable (but unsaveable) state.
+	    if (text.indexOf("samigo-attempt-submitted-marker") >= 0) {
+	        $("#autosave-timeexpired-warning").show();
+	        $("[id$=\\:save]")[0].click();
+	        return;
+	    }
+	    var staleWarning = document.getElementById("stale-tab-warning");
+	    if (staleWarning != null) {
+		staleWarning.style.display = "block";
+	    }
+	    window.status = "";
+	    return;
+	}
+
 	var saveok = true;
         var i = text.indexOf('"' + updateVar);
 	if (i < 0) {

--- a/samigo/samigo-app/src/webapp/jsf/delivery/confirmSubmit.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/confirmSubmit.jsp
@@ -61,6 +61,9 @@ remove the javascript onclick stuff.
 <!-- content... -->
 <h:form id="takeAssessmentForm" enctype="multipart/form-data"
    onsubmit="saveTime()">
+<%-- SAK-44349: raw input on purpose - the posted (possibly stale) token must
+     never be written back into the shared session bean by JSF --%>
+<input type="hidden" name="dlvrStateToken" value="<h:outputText value="#{delivery.stateGuard.token}"/>" />
 
 <!-- DONE BUTTON FOR PREVIEW -->
 <h:panelGroup rendered="#{delivery.actionString=='previewAssessment'}">

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -39,6 +39,7 @@
       <script src="/sakai-editor/editor.js"></script>
       <script src="/sakai-editor/editor-launch.js"></script>
       <script src="/samigo-app/js/saveForm.js"></script>
+      <script src="/samigo-app/js/samigoDraft.js"></script>
       <script src="/samigo-app/js/deliveryQuestionCancellation.js"></script>
       <script type="module" src="/webcomponents/bundles/rubric-association-requirements.js<h:outputText value="#{questionScores.CDNQuery}" />"></script>
 
@@ -282,6 +283,10 @@ document.links[newindex].onclick();
          reaches the first copy. --%>
     <div role="alert" class="sak-banner-warn" style="display: none" id="stale-tab-warning">
       <h:outputText value="#{deliveryMessages.stale_tab_autosave_warning}" escape="false" />
+    </div>
+    <%-- SAK-52710: shown when an unsaved local draft was restored --%>
+    <div role="alert" class="sak-banner-info" style="display: none" id="draft-restored-info">
+      <h:outputText value="#{deliveryMessages.draft_restored}" escape="false" />
     </div>
     <h:inputHidden id="assessmentID" value="#{delivery.assessmentId}"/>
     <h:inputHidden id="assessTitle" value="#{delivery.assessmentTitle}" />
@@ -705,6 +710,10 @@ document.links[newindex].onclick();
 	checkRadio();
 	fixImplicitLabeling();
 	SaveFormContentAsync('deliverAssessment.faces', 'takeAssessmentForm', 'takeAssessmentForm:autoSave', 'takeAssessmentForm:lastSubmittedDate1', 'takeAssessmentForm:lastSubmittedDate2',  <h:outputText value="#{delivery.autoSaveRepeatMilliseconds}"/>, <h:outputText value="#{delivery.actionString=='takeAssessment' or delivery.actionString=='takeAssessmentViaUrl'}"/>);
+	<%-- SAK-52710: local draft snapshots of typed answers (take modes only) --%>
+	<h:panelGroup rendered="#{(delivery.actionString=='takeAssessment' || delivery.actionString=='takeAssessmentViaUrl') && delivery.assessmentGrading != null}">
+	samigoDraft.init('<h:outputText value="#{delivery.assessmentGrading.assessmentGradingId}"/>');
+	</h:panelGroup>
 	setTimeout('setLocation2()',2);
 	questionProgress.transposeTOCTables();
 	questionProgress.access(<h:outputText value="#{delivery.navigation}"/>, <h:outputText value="#{delivery.questionLayout}"/>);

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -240,6 +240,9 @@ document.links[newindex].onclick();
    rendered ="#{delivery.assessmentGrading.submittedDate!=null}"/>
 <h:inputHidden id="lastSubmittedDate2" value="0"
    rendered ="#{delivery.assessmentGrading.submittedDate==null}"/>
+<%-- SAK-44349: raw input on purpose - the posted (possibly stale) token must
+     never be written back into the shared session bean by JSF --%>
+<input type="hidden" name="dlvrStateToken" value="<h:outputText value="#{delivery.stateGuard.token}"/>" />
 <h:inputHidden id="hasTimeLimit" value="#{delivery.hasTimeLimit}"/>   
 <h:inputHidden id="attemptDate" value="#{delivery.assessmentGrading.attemptDate.time}" rendered ="#{delivery.assessmentGrading.attemptDate!=null}"/>   
 <h:inputHidden id="showTimeWarning" value="#{delivery.showTimeWarning}"/>
@@ -508,6 +511,10 @@ document.links[newindex].onclick();
                <h:outputText value="#{deliveryMessages.autosaveFailedDetail}" escape="false" />
              </p>
            </div>
+           <%-- SAK-44349: shown when this tab's autosave was rejected as stale --%>
+           <div role="alert" class="sak-banner-warn" style="display: none" id="stale-tab-warning">
+             <h:outputText value="#{deliveryMessages.stale_tab_autosave_warning}" escape="false" />
+           </div>
            <div role="alert" class="sak-banner-error" style="display: none" id="multiple-tabs-warning">
              <h5><h:outputText value="#{deliveryMessages.multipleTabsWarning_heading}" escape="false" /></h5>
              <p>
@@ -694,7 +701,7 @@ document.links[newindex].onclick();
 	setLocation(); 
 	checkRadio();
 	fixImplicitLabeling();
-	SaveFormContentAsync('deliverAssessment.faces', 'takeAssessmentForm', 'takeAssessmentForm:autoSave', 'takeAssessmentForm:lastSubmittedDate1', 'takeAssessmentForm:lastSubmittedDate2',  <h:outputText value="#{delivery.autoSaveRepeatMilliseconds}"/>, <h:outputText value="#{delivery.actionString=='takeAssessment' or delivery.actionString=='takeAssessmentViaUrl'}"/>); 
+	SaveFormContentAsync('deliverAssessment.faces', 'takeAssessmentForm', 'takeAssessmentForm:autoSave', 'takeAssessmentForm:lastSubmittedDate1', 'takeAssessmentForm:lastSubmittedDate2',  <h:outputText value="#{delivery.autoSaveRepeatMilliseconds}"/>, <h:outputText value="#{delivery.actionString=='takeAssessment' or delivery.actionString=='takeAssessmentViaUrl'}"/>);
 	setTimeout('setLocation2()',2);
 	questionProgress.transposeTOCTables();
 	questionProgress.access(<h:outputText value="#{delivery.navigation}"/>, <h:outputText value="#{delivery.questionLayout}"/>);

--- a/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/deliverAssessment.jsp
@@ -276,6 +276,13 @@ document.links[newindex].onclick();
 
     <!-- FORM ... note, move these hiddens to whereever they are needed as fparams-->
     <h:messages styleClass="sak-banner-error" rendered="#{! empty facesContext.maximumSeverity}" layout="table"/>
+    <%-- SAK-44349: shown when this tab's autosave was rejected as stale. Kept
+         outside the part/question tables - ids inside them are duplicated per
+         question in part/assessment layouts, so getElementById only ever
+         reaches the first copy. --%>
+    <div role="alert" class="sak-banner-warn" style="display: none" id="stale-tab-warning">
+      <h:outputText value="#{deliveryMessages.stale_tab_autosave_warning}" escape="false" />
+    </div>
     <h:inputHidden id="assessmentID" value="#{delivery.assessmentId}"/>
     <h:inputHidden id="assessTitle" value="#{delivery.assessmentTitle}" />
 
@@ -510,10 +517,6 @@ document.links[newindex].onclick();
                <h:outputText value="#{deliveryMessages.autosaveFailed_reason}" escape="false" /><br />
                <h:outputText value="#{deliveryMessages.autosaveFailedDetail}" escape="false" />
              </p>
-           </div>
-           <%-- SAK-44349: shown when this tab's autosave was rejected as stale --%>
-           <div role="alert" class="sak-banner-warn" style="display: none" id="stale-tab-warning">
-             <h:outputText value="#{deliveryMessages.stale_tab_autosave_warning}" escape="false" />
            </div>
            <div role="alert" class="sak-banner-error" style="display: none" id="multiple-tabs-warning">
              <h5><h:outputText value="#{deliveryMessages.multipleTabsWarning_heading}" escape="false" /></h5>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/staleTabResync.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/staleTabResync.jsp
@@ -1,4 +1,3 @@
-<html>
 <%@ page contentType="text/html;charset=utf-8" pageEncoding="utf-8" language="java" %>
 <%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
 <%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
@@ -78,4 +77,3 @@
       </body>
     </html>
   </f:view>
-</html>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/staleTabResync.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/staleTabResync.jsp
@@ -1,0 +1,81 @@
+<html>
+<%@ page contentType="text/html;charset=utf-8" pageEncoding="utf-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsf/html" prefix="h" %>
+<%@ taglib uri="http://java.sun.com/jsf/core" prefix="f" %>
+<%@ taglib uri="http://www.sakaiproject.org/samigo" prefix="samigo" %>
+<!DOCTYPE html
+     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<!--
+<%--
+***********************************************************************************
+*
+* Copyright (c) 2026 The Apereo Foundation
+*
+* Licensed under the Educational Community License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://opensource.org/licenses/ecl2
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* SAK-44349: non-fatal landing page when a stale tab's post was rejected by
+* the delivery state guard. Saved answers are untouched; one click resumes
+* the attempt at its current position.
+**********************************************************************************/
+--%>
+-->
+  <f:view>
+    <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+      <head><%= request.getAttribute("html.head") %>
+      <title><h:outputText value="#{deliveryMessages.stale_tab_title}"/></title>
+      </head>
+      <body onload="<%= request.getAttribute("html.body.onload") %>">
+
+<div class="portletBody">
+  <!-- content... -->
+  <div id="samigo-stale-tab-marker" class="d-none">staleTabResync</div>
+  <h:panelGroup rendered="#{delivery.assessmentSubmitted}">
+    <f:verbatim><div id="samigo-attempt-submitted-marker" class="d-none">submitted</div></f:verbatim>
+  </h:panelGroup>
+  <h3><h:outputText value="#{deliveryMessages.stale_tab_title}"/></h3>
+  <div class="sak-banner-warn">
+    <h:outputText value="#{deliveryMessages.stale_tab_1}"/>
+    <br/><br/>
+    <h:outputText value="#{deliveryMessages.stale_tab_2}"/>
+  </div>
+
+ <h:form id="staleTabResync">
+ <p class="act">
+       <h:commandButton id="continueAssessment1" value="#{deliveryMessages.stale_tab_continue}"
+           action="#{delivery.validate}" type="submit" styleClass="active"
+           rendered="#{(delivery.actionString=='takeAssessment'
+                    || delivery.actionString=='takeAssessmentViaUrl')
+                    && delivery.navigation != 1}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryActionListener" />
+       </h:commandButton>
+       <h:commandButton id="continueAssessment2" value="#{deliveryMessages.stale_tab_continue}"
+           action="#{delivery.validate}" type="submit" styleClass="active"
+           rendered="#{(delivery.actionString=='takeAssessment'
+                    || delivery.actionString=='takeAssessmentViaUrl')
+                    && delivery.navigation == 1}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.delivery.LinearAccessDeliveryActionListener" />
+       </h:commandButton>
+       <h:commandButton value="#{deliveryMessages.data_discrepancy_button}" type="submit" action="select"
+           rendered="#{delivery.actionString!='takeAssessmentViaUrl'}">
+          <f:actionListener type="org.sakaiproject.tool.assessment.ui.listener.select.SelectActionListener" />
+       </h:commandButton>
+ </p>
+ </h:form>
+  <!-- end content -->
+</div>
+      </body>
+    </html>
+  </f:view>
+</html>

--- a/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
+++ b/samigo/samigo-app/src/webapp/jsf/delivery/tableOfContents.jsp
@@ -83,7 +83,10 @@ function saveTime()
 
 <h:form id="tableOfContentsForm">
 
-<h:inputHidden id="hasTimeLimit" value="#{delivery.hasTimeLimit}"/>   
+<%-- SAK-44349: raw input on purpose - the posted (possibly stale) token must
+     never be written back into the shared session bean by JSF --%>
+<input type="hidden" name="dlvrStateToken" value="<h:outputText value="#{delivery.stateGuard.token}"/>" />
+<h:inputHidden id="hasTimeLimit" value="#{delivery.hasTimeLimit}"/>
 <h:inputHidden id="showTimeWarning" value="#{delivery.showTimeWarning}"/>
 <h:inputHidden id="showTimer" value="#{delivery.showTimer}"/>
 


### PR DESCRIPTION
**Depends on #14743** (SAK-44349 stale-tab guard) — stacked on that branch; only the last commit is new here. Marked draft until the base PR lands.

Students lose typed essay/short-answer text when a tab is closed, a network drop eats a save, or a stale-tab post is rejected. The text existed only in the DOM and is unrecoverable — several of us have watched students lose essays this way on 23.x.

### Why the CKEditor autosave plugin doesn't cover this

* Its `saveDetectionSelectors` treat **any** form button click as a successful save and delete the stored draft — so a Next/Save click whose POST dies takes the draft down with it.
* Its storage key embeds the page URL and the positional editor id, which are not stable across delivery renders.
* Samigo essay answers render as **plain textareas** by default (the rich-text editor is behind a toggle), which the plugin never sees.

### What this adds

`samigoDraft.js`, delivery-only: snapshots typed answers (plain textareas and CKEditor instances) into localStorage, keyed by attempt + page position + field + user (page position matters — JSF client ids are positional and repeat across pages, so without it drafts would leak between questions). Debounced at 2s. Drafts are never deleted by button clicks; they are deleted when the student clears the field or the server renders it with confirmed content (so an intentionally cleared answer is not resurrected), expire after 7 days, and are dropped rather than frozen when a field outgrows the size cap. On render, a draft is restored only into a field the server delivered **empty**, with a visible notice asking the student to review and save; content restored this way is not treated as server-confirmed.

Covered by an e2e scenario in `SamigoMultiTabTest` (type an essay, abandon the tab without saving, re-enter, assert the draft is restored and persists on save), green on chromium and firefox.

### A note on this contribution

Same transparency as the base PR: built with an AI coding agent (Claude) against a real pain point. If the community prefers extending the CKEditor autosave plugin's config instead (e.g. clearing `saveDetectionSelectors` for delivery editors), happy to pivot to that — this PR is the version that also covers the plain-textarea default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “stale tab” protection for assessment delivery with a dedicated resync flow and user-facing recovery/warning messaging.
  * Added typed-answer draft restoration (including rich-text editor content) using local draft persistence, with improved autosave behavior.
* **Bug Fixes**
  * Prevented unverified/stale timeout submissions from blanking or replacing already-persisted answers.
  * Improved multi-tab submission integrity to avoid overwriting and to handle near-simultaneous saves safely.
* **Tests**
  * Added new e2e acceptance coverage plus unit tests for stale-tab guarding and submission backstop behavior.
* **Chores**
  * Updated runtime JAR scanning to also include `jakarta.faces-*.jar`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->