### PR TITLE
SAK-52703: Block specific users from logging through the Sakai SSO

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -5811,3 +5811,14 @@
 # Configure the thread pool size for the scheduling service.
 # DEFAULT: 8
 # schedulingservice.poolsize=4
+
+# Comma-separated list of identifier patterns that are not allowed to authenticate
+# using Sakai local authentication. Matching is case-insensitive.
+#
+# Supported patterns:
+#   admin              Exact match
+#   test*              Identifiers starting with "test"
+#   *@example.com      Identifiers ending with "@example.com"
+#
+# login.local.blocked.identifiers=admin,test*,*@example.com
+# DEFAULT: none

--- a/login/login-api/api/src/java/org/sakaiproject/login/api/Login.java
+++ b/login/login-api/api/src/java/org/sakaiproject/login/api/Login.java
@@ -32,4 +32,5 @@ public interface Login {
 	
 	public static final String EXCEPTION_DISABLED = "Account Disabled: The user's authentication has been disabled";
 	
+	public static final String EXCEPTION_SSO_REQUIRED = "sso-required-login";
 }

--- a/login/login-impl/impl/src/java/org/sakaiproject/login/impl/LoginServiceComponent.java
+++ b/login/login-impl/impl/src/java/org/sakaiproject/login/impl/LoginServiceComponent.java
@@ -198,6 +198,10 @@ public abstract class LoginServiceComponent implements LoginService {
 	}
 
 	private boolean matchesPattern(String identifier, String pattern) {
+		if ("*".equals(pattern)) {
+        	return false;
+		}
+
 		if (pattern.startsWith("*") && pattern.endsWith("*") && pattern.length() > 2) {
 			return identifier.contains(pattern.substring(1, pattern.length() - 1));
 		}

--- a/login/login-impl/impl/src/java/org/sakaiproject/login/impl/LoginServiceComponent.java
+++ b/login/login-impl/impl/src/java/org/sakaiproject/login/impl/LoginServiceComponent.java
@@ -214,7 +214,6 @@ public abstract class LoginServiceComponent implements LoginService {
 			return identifier.startsWith(pattern.substring(0, pattern.length() - 1));
 		}
 
-		// exacto
 		return identifier.equals(pattern);
 	}
 

--- a/login/login-impl/impl/src/java/org/sakaiproject/login/impl/LoginServiceComponent.java
+++ b/login/login-impl/impl/src/java/org/sakaiproject/login/impl/LoginServiceComponent.java
@@ -20,6 +20,9 @@
  **********************************************************************************/
 package org.sakaiproject.login.impl;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -70,6 +73,10 @@ public abstract class LoginServiceComponent implements LoginService {
 			
 			boolean isEidEmpty = (eid == null) || (eid.length() == 0);
 			boolean isPwEmpty = (pw == null) || (pw.length() == 0);
+
+			if (isBlockedIdentifier(eid)) {
+				throw new LoginException(Login.EXCEPTION_SSO_REQUIRED);
+			}
 			
 			if (isAdvisorEnabled) {
 				if (!loginAdvisor.checkCredentials(credentials)) {
@@ -172,5 +179,39 @@ public abstract class LoginServiceComponent implements LoginService {
 		
 		return loginAdvisor;
 	}
-	
+
+	private boolean isBlockedIdentifier(String identifier) {
+		if (identifier == null) {
+			return false;
+		}
+
+		String normalizedIdentifier = identifier.trim().toLowerCase(Locale.ROOT);
+
+		List<String> blockedIdentifiers = serverConfigurationService()
+				.getStringList("login.local.blocked.identifiers", Collections.emptyList());
+
+		return blockedIdentifiers.stream()
+				.map(String::trim)
+				.filter(s -> !s.isEmpty())
+				.map(s -> s.toLowerCase(Locale.ROOT))
+				.anyMatch(pattern -> matchesPattern(normalizedIdentifier, pattern));
+	}
+
+	private boolean matchesPattern(String identifier, String pattern) {
+		if (pattern.startsWith("*") && pattern.endsWith("*") && pattern.length() > 2) {
+			return identifier.contains(pattern.substring(1, pattern.length() - 1));
+		}
+
+		if (pattern.startsWith("*")) {
+			return identifier.endsWith(pattern.substring(1));
+		}
+
+		if (pattern.endsWith("*")) {
+			return identifier.startsWith(pattern.substring(0, pattern.length() - 1));
+		}
+
+		// exacto
+		return identifier.equals(pattern);
+	}
+
 }

--- a/login/login-tool/tool/src/bundle/auth.properties
+++ b/login/login-tool/tool/src/bundle/auth.properties
@@ -35,6 +35,7 @@ log.invalid.with.penalty = Login failed. To help us maintain security please typ
 log.invalid.credentials = One or more of your credentials were not correctly entered. Please ensure \
 	that your user id and password are correct, and type the distorted words or letters shown into \
 	the text box below.
+log.sso.required=This account cannot be used with the local login. Please sign in using your institution's login.
 log.disabled.user=Your account has been disabled.
 log.tryagain = Unable to process that login, please try again.
 log.password.reset = Forgot your password?

--- a/login/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
+++ b/login/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
@@ -26,6 +26,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import javax.security.auth.login.LoginException;
 import javax.servlet.ServletConfig;
@@ -347,6 +350,20 @@ public class SkinnableLogin extends HttpServlet implements Login {
 		{
 			LoginCredentials credentials = new LoginCredentials(req);
 			credentials.setSessionId(session.getId());
+
+			List<String> blockedIdentifiers = serverConfigurationService.getStringList("login.local.blocked.identifiers", Collections.<String>emptyList());
+
+			String username = Optional.ofNullable(credentials.getIdentifier())
+				.map(String::toLowerCase)
+				.orElse("");
+
+			if (blockedIdentifiers.stream()
+					.map(s -> s.trim().toLowerCase())
+					.anyMatch(username::contains)) {
+				rcontext.put(ATTR_MSG, rb.getString("log.sso.required"));
+				sendResponse(rcontext, res, "xlogin", null);
+				return;
+			}
 
 			try {
 				loginService.authenticate(credentials);

--- a/login/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
+++ b/login/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
@@ -351,20 +351,6 @@ public class SkinnableLogin extends HttpServlet implements Login {
 			LoginCredentials credentials = new LoginCredentials(req);
 			credentials.setSessionId(session.getId());
 
-			List<String> blockedIdentifiers = serverConfigurationService.getStringList("login.local.blocked.identifiers", Collections.<String>emptyList());
-
-			String username = Optional.ofNullable(credentials.getIdentifier())
-				.map(String::toLowerCase)
-				.orElse("");
-
-			if (blockedIdentifiers.stream()
-					.map(s -> s.trim().toLowerCase())
-					.anyMatch(username::contains)) {
-				rcontext.put(ATTR_MSG, rb.getString("log.sso.required"));
-				sendResponse(rcontext, res, "xlogin", null);
-				return;
-			}
-
 			try {
 				loginService.authenticate(credentials);
 				String returnUrl = (String) session.getAttribute(Tool.HELPER_DONE_URL);
@@ -396,6 +382,10 @@ public class SkinnableLogin extends HttpServlet implements Login {
 				} else if (message.equals(EXCEPTION_MISSING_CREDENTIALS)) {
 					rcontext.put(ATTR_MSG, rb.getString("log.tryagain"));
 					//Do we need to log this one? You can't really brute force with empty credentials...
+				} else if (message.equals(EXCEPTION_SSO_REQUIRED)) {
+					rcontext.put(ATTR_MSG, rb.getString("log.sso.required"));
+					sendResponse(rcontext, res, "xlogin", null);
+					return;
 				} else {
 					rcontext.put(ATTR_MSG, rb.getString("log.invalid"));
 					logFailedAttempt(credentials);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for blocking local sign-in for configured identifier patterns and directing users to sign in via their institution.
  * Introduced a dedicated on-screen message for single sign-on (SSO) required accounts instead of treating them like invalid credentials.
* **Configuration**
  * Added `login.local.blocked.identifiers` (disabled by default) to define a comma-separated, case-insensitive set of wildcard patterns (exact, prefix/suffix, or contains) that are prevented from authenticating locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->