### PR TITLE
SAK-52714 CKEditor: keep the dark theme on recreated editor documents

### DIFF
--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -87,38 +87,20 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
       }
     }
 
-    function addClassOnLoad(){
+    function addThemeClassToEditorDocument(editor){
         try {
-            if (typeof this.instances !== 'undefined'){
-                //Run on all ckeditor instances on the page
-                for (const instance in this.instances) {
-                    //check for the instance to be an object not a function
-                    if (Object.hasOwnProperty.call(this.instances, instance)) {
-                        const instanceDoc = this.instances[instance];
-                        //Add sakai-dark-theme class to ckeditor iframe
-                        instanceDoc.document.$.documentElement.classList.add('sakaiUserTheme-dark');
-                    }
-                }
-            }
+            //Add sakai-dark-theme class to ckeditor iframe
+            editor.document.$.documentElement.classList.add('sakaiUserTheme-dark');
         } catch (error) {
             console.error(error);
         }
     }
 
-    function addClassOnModeChange(){
-        try {
-            //Only run when switching out of source mode into mysiwyg mode
-            if (this.mode === 'wysiwyg') {
-                //Check for the editor to be an object not a function
-                if (Object.prototype.hasOwnProperty.call(this, 'document')) {
-                    const instanceDoc = this.document.$;
-                    //Add sakai-dark-theme class to ckeditor iframe
-                    instanceDoc.documentElement.classList.add('sakaiUserTheme-dark');
-                }
-            }
-        } catch (error) {
-            console.error(error);
-        }
+    function addClassOnInstanceReady(evt){
+        addThemeClassToEditorDocument(evt.editor);
+        //contentDom fires whenever the editable document is recreated —
+        //mode switches, setData, and dialogs that reopen the same instance
+        evt.editor.on('contentDom', () => addThemeClassToEditorDocument(evt.editor));
     }
 
     // Prune the GET parameters and '?' off the URL
@@ -527,15 +509,13 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         }
 
         //CKEditor doesn't have a method to add classes to the HTML element
-        //so we manually add the class on load
+        //so we manually add the class as each instance becomes ready. This must
+        //apply to EVERY instance, not once per page: tools like Lessons destroy
+        //and recreate editors (e.g. reopening the question dialog), and a
+        //once-handler leaves every later instance with a white background.
         //should be refactored when ckeditor5 is implemented
         if (document.firstElementChild.classList.contains('sakaiUserTheme-dark')){
-  
-            CKEDITOR.once('instanceReady', addClassOnLoad);
-            // //and we watch for switching out or source mode
-            CKEDITOR.once('instanceReady', function(editor){
-                editor.editor.on('mode', addClassOnModeChange);
-            });
+            CKEDITOR.on('instanceReady', addClassOnInstanceReady);
         }
 
         //Enable ckeditor to reflect themeswitcher changes. Overrides:

--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -56,6 +56,27 @@ function objectMerge(obj/*, ...*/) {
     return obj;
 }
 
+// Applies the dark-theme class to an editor's editable document. Kept at module
+// scope (not nested in launch()) so the CKEDITOR.on('instanceReady', ...) below
+// is registered with a stable function reference: CKEditor 4 dedups listeners by
+// reference identity, so a page that creates/recreates many editors ends up with
+// a single global handler instead of one leaked per launch() call.
+function addThemeClassToEditorDocument(editor){
+    try {
+        //Add sakai-dark-theme class to ckeditor iframe
+        editor.document.$.documentElement.classList.add('sakaiUserTheme-dark');
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+function addClassOnInstanceReady(evt){
+    addThemeClassToEditorDocument(evt.editor);
+    //contentDom fires whenever the editable document is recreated —
+    //mode switches, setData, and dialogs that reopen the same instance
+    evt.editor.on('contentDom', () => addThemeClassToEditorDocument(evt.editor));
+}
+
 // Please note that no more parameters should be added to this signature.
 // The config object allows for name-based config options to be passed.
 // The w and h parameters should be removed as soon as their uses can be migrated.
@@ -85,22 +106,6 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
       if (document.body) {
         return document.body.clientWidth;
       }
-    }
-
-    function addThemeClassToEditorDocument(editor){
-        try {
-            //Add sakai-dark-theme class to ckeditor iframe
-            editor.document.$.documentElement.classList.add('sakaiUserTheme-dark');
-        } catch (error) {
-            console.error(error);
-        }
-    }
-
-    function addClassOnInstanceReady(evt){
-        addThemeClassToEditorDocument(evt.editor);
-        //contentDom fires whenever the editable document is recreated —
-        //mode switches, setData, and dialogs that reopen the same instance
-        evt.editor.on('contentDom', () => addThemeClassToEditorDocument(evt.editor));
     }
 
     // Prune the GET parameters and '?' off the URL
@@ -509,10 +514,12 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
         }
 
         //CKEditor doesn't have a method to add classes to the HTML element
-        //so we manually add the class as each instance becomes ready. This must
-        //apply to EVERY instance, not once per page: tools like Lessons destroy
-        //and recreate editors (e.g. reopening the question dialog), and a
-        //once-handler leaves every later instance with a white background.
+        //so we manually add the class as each instance becomes ready. instanceReady
+        //fires per instance, so this correctly applies to EVERY editor — including
+        //ones tools like Lessons destroy and recreate (e.g. reopening the question
+        //dialog). addClassOnInstanceReady is defined at module scope so repeat
+        //launch() calls re-register the same reference, which CKEditor 4 dedups to
+        //a single global handler rather than leaking one listener per call.
         //should be refactored when ckeditor5 is implemented
         if (document.firstElementChild.classList.contains('sakaiUserTheme-dark')){
             CKEDITOR.on('instanceReady', addClassOnInstanceReady);


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-52714

## Problem
In dark mode a CKEditor edit area can render white on a dark page. Reproducible by editing a Lessons inline Question item (the Question Text box is white), in a clean profile, and on production.

## Cause
The dark-theme class was added via `CKEDITOR.once('instanceReady', ...)`, so only the first editor on the page was themed — and even that instance lost the class whenever CKEditor rebuilt the editable document (mode switch, `setData`, a dialog reopening a reused instance).

## Fix
Theme every instance on `instanceReady` and re-apply on `contentDom`, which fires each time the editable document is (re)created. One file: `library/src/webapp-filtered/editor/ckeditor.launch.js`. Relates to SAK-44562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode support for CKEditor by making theme styling apply more reliably inside editor windows.
  * Fixed cases where the editor could lose its dark styling when content reloads, dialogs open, or the editor switches modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->