### PR TITLE
SAK-52717 CKEditor: theme the toolbar collapser in dark mode

### DIFF
--- a/library/src/webapp-filtered/editor/ckeditor.launch.js
+++ b/library/src/webapp-filtered/editor/ckeditor.launch.js
@@ -635,6 +635,19 @@ sakai.editor.editors.ckeditor.launch = function(targetId, config, w, h) {
                 ] 
                 {id} .cke_button_arrow [
                     border--top-color: {toolbarElementsBorder};
+                ]
+                {id} a.cke_toolbox_collapser [
+                    background-color:{defaultBackground};
+                    border-color:{defaultBorder};
+                ]
+                {id} a.cke_toolbox_collapser:hover [
+                    background-color:{darkBackground};
+                ]
+                {id}.cke_chrome a.cke_toolbox_collapser:not(.cke_toolbox_collapser_min) .cke_arrow [
+                    border-top-color:{defaultTextColor};
+                ]
+                {id}.cke_chrome a.cke_toolbox_collapser_min .cke_arrow [
+                    border-left-color:{defaultTextColor};
                 ]` +
                 // Combo buttons.
                 `{id} a.cke_combo_button:hover,


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-52717

Follow-up to #14748 / SAK-52714 (same dark-mode CKEditor concern, distinct visible symptom).

## Problem
The Lessons inline **Question Text** editor starts with a collapsed toolbar, so its collapse/expand control is prominent. In dark mode that control rendered wrong:
- a **white background** box on the dark toolbar, and
- an arrow that **disappeared** (dark `#333` on dark) once the toolbar was expanded.

## Cause
The collapser is styled by the Sakai skin (`tool.css`) for light mode only — white background, `#333` arrow. The dark-theme `chameleon` skin override in `ckeditor.launch.js` themes the toolbar, buttons, combos, elements-path and dialogs, but never touched `.cke_toolbox_collapser`, so it kept its light-mode colors.

## Fix
Extend the chameleon override to theme the collapser:
- background → `--sakai-background-color-2`, border → `--sakai-border-color`, hover → `--sakai-background-color-3`
- arrow → `--sakai-text-color-1`, recoloring the **existing** border edge per state so `tool.css`'s geometry is preserved: **right** when collapsed ("more options") and **down** when expanded. `:not(.cke_toolbox_collapser_min)` keeps the two states from bleeding into each other.

One file: `library/src/webapp-filtered/editor/ckeditor.launch.js`.

## Testing
Verified in a dark-mode profile by opening Lessons → Add Question and toggling the toolbar collapser: background now matches the toolbar, and the arrow is light/visible in both states — right (▶) collapsed, down (▼) expanded. Light mode unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the editor toolbar toolbox collapse button to look more polished, including improved default background and border.
  * Enhanced the hover state for clearer interactivity.
  * Updated the collapse/expand arrow colors in both minimized and non-minimized states for better contrast, including in darker themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->