### PR TITLE
SAK-52720 Announcements: read receipts — see which students have viewed an announcement

### DIFF
--- a/announcement/announcement-api/api/pom.xml
+++ b/announcement/announcement-api/api/pom.xml
@@ -31,6 +31,10 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+        </dependency>
     </dependencies>
     
     <build>

--- a/announcement/announcement-api/api/src/bundle/announcement.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement.properties
@@ -372,3 +372,19 @@ announcement.edit.selectonerole = You must select at least one role
 announcement.edit.allselectedroles = All roles selected
 announcement.edit.rolesselected = roles selected
 announcement.edit.searchrole = Search role
+
+# Read receipts
+receipts.link = View read receipts
+receipts.title = Read receipts
+receipts.viewed = Viewed
+receipts.notviewed = Not yet viewed
+receipts.name = Name
+receipts.time = First viewed
+receipts.emailenabled = Email notifications enabled
+receipts.yes = Yes
+receipts.no = No
+receipts.none = No one has viewed this announcement yet.
+receipts.disclaimer = Read receipts reflect in-Sakai views only. Recipients who read this announcement solely through the email notification are not counted here.
+receipts.emailnuance = Shows each person's standing announcement notification preference. Whether an email was actually sent for this specific post also depends on the notification level chosen when it was posted.
+receipts.close = Close
+receipts.highlight = Highlight rows

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
@@ -21,8 +21,10 @@
 
 package org.sakaiproject.announcement.api;
 
+import java.time.Instant;
 import java.util.List;
 
+import org.sakaiproject.announcement.api.model.AnnouncementReadReceipt;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.exception.IdInvalidException;
@@ -243,4 +245,22 @@ public interface AnnouncementService extends MessageService
 	 * @return list of visible MOTD announcements.
 	 */
 	public List<AnnouncementMessage> getVisibleMessagesOfTheDay(Time afterDate, int numberOfAnnouncements, boolean ascending);
+
+	/**
+	 * Record that a user has read (opened) an announcement message inside Sakai. The earliest view
+	 * time is retained; subsequent reads of the same message by the same user are ignored.
+	 *
+	 * @param messageRef the message reference (as returned by {@link org.sakaiproject.message.api.Message#getReference()})
+	 * @param userId     the id of the user who read the announcement
+	 * @param when       the time the announcement was read
+	 */
+	public void recordRead(String messageRef, String userId, Instant when);
+
+	/**
+	 * Return the read receipts recorded for the given announcement message reference.
+	 *
+	 * @param messageRef the message reference
+	 * @return the list of read receipts, one per user who has read the message; never null
+	 */
+	public List<AnnouncementReadReceipt> getReadReceipts(String messageRef);
 }

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/model/AnnouncementReadReceipt.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/model/AnnouncementReadReceipt.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.announcement.api.model;
+
+import java.time.Instant;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import org.sakaiproject.springframework.data.PersistableEntity;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Records that a user opened (read) a specific announcement message inside Sakai. One row is kept
+ * per message reference and user, holding the earliest time the announcement was viewed.
+ */
+@Entity
+@Table(name = "ANNC_READ_RECEIPT",
+    uniqueConstraints = { @UniqueConstraint(name = "UniqueAnncReadReceipt", columnNames = { "MESSAGE_REF", "USER_ID" }) },
+    indexes = { @Index(name = "annc_read_receipt_message_ref_idx", columnList = "MESSAGE_REF") })
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class AnnouncementReadReceipt implements PersistableEntity<Long> {
+
+    @Id
+    @Column(name = "ID")
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "annc_read_receipt_id_sequence")
+    @SequenceGenerator(name = "annc_read_receipt_id_sequence", sequenceName = "ANNC_READ_RECEIPT_S")
+    private Long id;
+
+    @EqualsAndHashCode.Include
+    @Column(name = "MESSAGE_REF", length = 255, nullable = false)
+    private String messageRef;
+
+    @EqualsAndHashCode.Include
+    @Column(name = "USER_ID", length = 99, nullable = false)
+    private String userId;
+
+    @Column(name = "FIRST_VIEWED", nullable = false)
+    private Instant firstViewed;
+
+    public AnnouncementReadReceipt(String messageRef, String userId, Instant firstViewed) {
+        this.messageRef = messageRef;
+        this.userId = userId;
+        this.firstViewed = firstViewed;
+    }
+}

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/repository/AnnouncementReadReceiptRepository.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/repository/AnnouncementReadReceiptRepository.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.announcement.api.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.sakaiproject.announcement.api.model.AnnouncementReadReceipt;
+import org.sakaiproject.springframework.data.SpringCrudRepository;
+
+public interface AnnouncementReadReceiptRepository extends SpringCrudRepository<AnnouncementReadReceipt, Long> {
+
+    Optional<AnnouncementReadReceipt> findByMessageRefAndUserId(String messageRef, String userId);
+
+    List<AnnouncementReadReceipt> findByMessageRef(String messageRef);
+}

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/cover/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/cover/AnnouncementService.java
@@ -564,5 +564,21 @@ public class AnnouncementService
 
 		return service.getVisibleMessagesOfTheDay(afterDate, numberOfAnnouncements, ascending);
 	}
-	
+
+	public static void recordRead(String messageRef, String userId, java.time.Instant when)
+	{
+		org.sakaiproject.announcement.api.AnnouncementService service = getInstance();
+		if (service == null) return;
+
+		service.recordRead(messageRef, userId, when);
+	}
+
+	public static java.util.List<org.sakaiproject.announcement.api.model.AnnouncementReadReceipt> getReadReceipts(String messageRef)
+	{
+		org.sakaiproject.announcement.api.AnnouncementService service = getInstance();
+		if (service == null) return null;
+
+		return service.getReadReceipts(messageRef);
+	}
+
 }

--- a/announcement/announcement-impl/impl/pom.xml
+++ b/announcement/announcement-impl/impl/pom.xml
@@ -62,6 +62,10 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
       <dependency>

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/AnnouncementObserver.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/AnnouncementObserver.java
@@ -36,6 +36,8 @@ public class AnnouncementObserver implements Observer {
     private EventTrackingService eventTrackingService;
     @Setter
     private MemoryService memoryService;
+    @Setter
+    private AnnouncementService announcementService;
     private Cache<String, List<Message>> messagesCache;
 
     public void init() {
@@ -65,6 +67,15 @@ public class AnnouncementObserver implements Observer {
                     String channelName = getChannel(event);
                     log.debug("Announcement event: {}", eventType);
                     messagesCache.remove(channelName);
+                    break;
+                case AnnouncementService.SECURE_ANNC_READ:
+                    // Persist a read receipt for this view. Never let a receipt failure disrupt
+                    // event processing, and do NOT clear the channel cache (a read changes nothing).
+                    try {
+                        announcementService.recordRead(event.getResource(), event.getUserId(), event.getEventTime().toInstant());
+                    } catch (Exception e) {
+                        log.warn("Failed to record announcement read receipt for {}: {}", event.getResource(), e.toString());
+                    }
                     break;
                 default:
                     break;

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -67,6 +67,8 @@ import org.sakaiproject.announcement.api.AnnouncementMessageHeader;
 import org.sakaiproject.announcement.api.AnnouncementMessageHeaderEdit;
 import org.sakaiproject.announcement.api.AnnouncementService;
 import org.sakaiproject.announcement.api.ViewableFilter;
+import org.sakaiproject.announcement.api.model.AnnouncementReadReceipt;
+import org.sakaiproject.announcement.api.repository.AnnouncementReadReceiptRepository;
 import org.sakaiproject.authz.api.FunctionManager;
 import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityAdvisor;
@@ -141,6 +143,7 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 	@Setter private AliasService aliasService;
 	@Setter private ToolManager toolManager;
 	@Setter private PreferencesService preferencesService;
+	@Setter private AnnouncementReadReceiptRepository announcementReadReceiptRepository;
 	@Resource(name="org.sakaiproject.util.api.LinkMigrationHelper")
 	private LinkMigrationHelper linkMigrationHelper;
 
@@ -2632,5 +2635,37 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 		} catch (PermissionException e) {
 			log.error("The current user does not have permission to remove announcementChannel aliases for context: {}", siteId, e);
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void recordRead(String messageRef, String userId, Instant when) {
+		if (StringUtils.isBlank(messageRef) || StringUtils.isBlank(userId) || when == null) {
+			return;
+		}
+
+		// Keep the earliest view time; ignore re-reads. A unique constraint on (MESSAGE_REF, USER_ID)
+		// guards against the rare race where two events for the same user arrive concurrently.
+		if (announcementReadReceiptRepository.findByMessageRefAndUserId(messageRef, userId).isPresent()) {
+			return;
+		}
+
+		try {
+			announcementReadReceiptRepository.save(new AnnouncementReadReceipt(messageRef, userId, when));
+		} catch (Exception e) {
+			// Most likely a concurrent insert tripping the unique constraint; the row already exists.
+			log.debug("Could not record announcement read receipt for message {} and user {}: {}", messageRef, userId, e.toString());
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public List<AnnouncementReadReceipt> getReadReceipts(String messageRef) {
+		if (StringUtils.isBlank(messageRef)) {
+			return new ArrayList<>();
+		}
+		return announcementReadReceiptRepository.findByMessageRef(messageRef);
 	}
 }

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/repository/AnnouncementReadReceiptRepositoryImpl.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/repository/AnnouncementReadReceiptRepositoryImpl.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.announcement.impl.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.Session;
+
+import org.sakaiproject.announcement.api.model.AnnouncementReadReceipt;
+import org.sakaiproject.announcement.api.repository.AnnouncementReadReceiptRepository;
+import org.sakaiproject.springframework.data.SpringCrudRepositoryImpl;
+
+import org.springframework.transaction.annotation.Transactional;
+
+public class AnnouncementReadReceiptRepositoryImpl extends SpringCrudRepositoryImpl<AnnouncementReadReceipt, Long> implements AnnouncementReadReceiptRepository {
+
+    @Transactional(readOnly = true)
+    public Optional<AnnouncementReadReceipt> findByMessageRefAndUserId(String messageRef, String userId) {
+
+        Session session = sessionFactory.getCurrentSession();
+
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<AnnouncementReadReceipt> query = cb.createQuery(AnnouncementReadReceipt.class);
+        Root<AnnouncementReadReceipt> receipt = query.from(AnnouncementReadReceipt.class);
+        query.where(cb.and(cb.equal(receipt.get("messageRef"), messageRef),
+                            cb.equal(receipt.get("userId"), userId)));
+
+        return session.createQuery(query).uniqueResultOptional();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AnnouncementReadReceipt> findByMessageRef(String messageRef) {
+
+        Session session = sessionFactory.getCurrentSession();
+
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<AnnouncementReadReceipt> query = cb.createQuery(AnnouncementReadReceipt.class);
+        Root<AnnouncementReadReceipt> receipt = query.from(AnnouncementReadReceipt.class);
+        query.where(cb.equal(receipt.get("messageRef"), messageRef));
+
+        return session.createQuery(query).list();
+    }
+}

--- a/announcement/announcement-impl/impl/src/webapp/WEB-INF/components.xml
+++ b/announcement/announcement-impl/impl/src/webapp/WEB-INF/components.xml
@@ -1,7 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    xmlns:tx="http://www.springframework.org/schema/tx"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+	<tx:annotation-driven transaction-manager="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
+
+	<bean id="announcementHibernateMappings"
+		  class="org.sakaiproject.springframework.orm.hibernate.impl.AdditionalHibernateMappingsImpl">
+		<property name="annotatedClasses">
+			<list>
+				<value>org.sakaiproject.announcement.api.model.AnnouncementReadReceipt</value>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="org.sakaiproject.announcement.api.repository.AnnouncementReadReceiptRepository"
+		  class="org.sakaiproject.announcement.impl.repository.AnnouncementReadReceiptRepositoryImpl">
+		<property name="sessionFactory" ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+	</bean>
 
 	<bean id="org.sakaiproject.announcement.impl.AnnouncementObserver"
 		  class="org.sakaiproject.announcement.impl.AnnouncementObserver"
@@ -11,6 +29,9 @@
 		</property>
 		<property name="eventTrackingService">
 			<ref bean="org.sakaiproject.event.api.EventTrackingService" />
+		</property>
+		<property name="announcementService">
+			<ref bean="org.sakaiproject.announcement.api.AnnouncementService" />
 		</property>
 	</bean>
 
@@ -40,6 +61,7 @@
 		<property name="linkMigrationHelper" ref="org.sakaiproject.util.api.LinkMigrationHelper"/>
  		<property name="toolManager"><ref bean="org.sakaiproject.tool.api.ToolManager"/></property>
 		<property name="siteEmailNotificationAnnc"><ref bean="org.sakaiproject.announcement.impl.SiteEmailNotificationAnnc"/></property>
+		<property name="announcementReadReceiptRepository"><ref bean="org.sakaiproject.announcement.api.repository.AnnouncementReadReceiptRepository"/></property>
  		<property name="containerTableName"><value>ANNOUNCEMENT_CHANNEL</value></property>
  		<property name="resourceTableName"><value>ANNOUNCEMENT_MESSAGE</value></property>
  		<property name="locksInDb"><value>false</value></property>

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -21,16 +21,21 @@
 
 package org.sakaiproject.announcement.entityprovider;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,6 +50,7 @@ import org.sakaiproject.announcement.api.AnnouncementMessage;
 import org.sakaiproject.announcement.api.AnnouncementMessageHeader;
 import org.sakaiproject.announcement.api.AnnouncementService;
 import org.sakaiproject.announcement.api.ViewableFilter;
+import org.sakaiproject.announcement.api.model.AnnouncementReadReceipt;
 import org.sakaiproject.announcement.tool.AnnouncementAction;
 import org.sakaiproject.announcement.tool.AnnouncementWrapper;
 import org.sakaiproject.announcement.tool.AnnouncementWrapperComparator;
@@ -70,6 +76,8 @@ import org.sakaiproject.entitybroker.entityprovider.extension.Formats;
 import org.sakaiproject.entitybroker.exception.EntityException;
 import org.sakaiproject.entitybroker.exception.EntityNotFoundException;
 import org.sakaiproject.entitybroker.util.AbstractEntityProvider;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.message.api.Message;
@@ -80,6 +88,9 @@ import org.sakaiproject.time.api.Time;
 import org.sakaiproject.time.api.TimeService;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.ToolManager;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
+import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.MergedList;
 import org.sakaiproject.util.ResourceLoader;
@@ -689,7 +700,134 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 		String announcementId = view.getPathSegment(4);
 		return getAnnouncement(siteId, channelId, announcementId);
 	}
-	
+
+	/**
+	 * Read receipts for a single announcement, for managers only.
+	 *
+	 * Route: /direct/announcement/readReceipts/{siteId}/{channelId}/{messageId}.json
+	 *
+	 * Returns {@code {viewed:[...], notViewed:[...], viewedCount, totalCount}} where each row carries
+	 * userId, displayName, sortName, emailEnabled and (for viewed rows) firstViewed.
+	 */
+	@EntityCustomAction(action="readReceipts", viewKey=EntityView.VIEW_LIST)
+	public Map<String, Object> getReadReceipts(EntityView view, Map<String, Object> params) {
+
+		String siteId = view.getPathSegment(2);
+		String channelId = view.getPathSegment(3);
+		String announcementId = view.getPathSegment(4);
+
+		if (StringUtils.isBlank(siteId) || StringUtils.isBlank(channelId) || StringUtils.isBlank(announcementId)) {
+			throw new IllegalArgumentException("You must supply siteId, channelId and messageId");
+		}
+
+		String channelRef = announcementService.channelReference(siteId, channelId);
+		AnnouncementChannel channel;
+		AnnouncementMessage message;
+		try {
+			channel = announcementService.getAnnouncementChannel(channelRef);
+			message = channel.getAnnouncementMessage(announcementId);
+		} catch (IdUnusedException e) {
+			throw new EntityNotFoundException("Couldn't find: " + e.getId(), e.getId());
+		} catch (PermissionException e) {
+			throw new EntityException("You don't have permissions to access this channel.", e.getResource(), 403);
+		}
+
+		// Permission-gate to managers: only those who can edit messages in this channel may see receipts.
+		if (!channel.allowEditMessage(announcementId)) {
+			throw new EntityException("You don't have permission to view read receipts for this announcement.", channelRef, 403);
+		}
+
+		// The stored MESSAGE_REF equals message.getReference() (what the read event carries).
+		String messageRef = message.getReference();
+
+		Site site;
+		try {
+			site = siteService.getSite(siteId);
+		} catch (IdUnusedException e) {
+			throw new EntityNotFoundException("Invalid siteId: " + siteId, siteId);
+		}
+
+		// Map of userId -> firstViewed for everyone who has read the announcement.
+		Map<String, Instant> viewedTimes = new HashMap<>();
+		for (AnnouncementReadReceipt receipt : announcementService.getReadReceipts(messageRef)) {
+			viewedTimes.put(receipt.getUserId(), receipt.getFirstViewed());
+		}
+
+		// Focus the receipts on students: everyone allowed to read the announcement, minus
+		// those who can post announcements (instructors/TAs/managers).
+		Set<String> allowedUserIds = site.getUsersIsAllowed(AnnouncementService.SECURE_ANNC_READ);
+		Set<String> managerUserIds = site.getUsersIsAllowed(AnnouncementService.SECURE_ANNC_ADD);
+		Set<String> studentUserIds = allowedUserIds.stream()
+				.filter(id -> !managerUserIds.contains(id))
+				.collect(Collectors.toSet());
+
+		Set<String> viewedUserIds = studentUserIds.stream()
+				.filter(viewedTimes::containsKey)
+				.collect(Collectors.toSet());
+		Set<String> notViewedUserIds = studentUserIds.stream()
+				.filter(id -> !viewedTimes.containsKey(id))
+				.collect(Collectors.toSet());
+
+		List<Map<String, Object>> viewed = new ArrayList<>();
+		for (User user : userDirectoryService.getUsers(viewedUserIds)) {
+			Map<String, Object> row = buildUserRow(user);
+			Instant firstViewed = viewedTimes.get(user.getId());
+			row.put("firstViewed", formatInstant(firstViewed));
+			row.put("firstViewedSort", firstViewed != null ? firstViewed.toEpochMilli() : 0L);
+			viewed.add(row);
+		}
+
+		List<Map<String, Object>> notViewed = new ArrayList<>();
+		for (User user : userDirectoryService.getUsers(notViewedUserIds)) {
+			notViewed.add(buildUserRow(user));
+		}
+
+		Comparator<Map<String, Object>> bySortName =
+				Comparator.comparing(r -> StringUtils.defaultString((String) r.get("sortName")), String.CASE_INSENSITIVE_ORDER);
+		viewed.sort(bySortName);
+		notViewed.sort(bySortName);
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("viewed", viewed);
+		result.put("notViewed", notViewed);
+		result.put("viewedCount", viewed.size());
+		result.put("totalCount", viewed.size() + notViewed.size());
+		return result;
+	}
+
+	private Map<String, Object> buildUserRow(User user) {
+		Map<String, Object> row = new LinkedHashMap<>();
+		row.put("userId", user.getId());
+		row.put("displayName", user.getDisplayName());
+		row.put("sortName", user.getSortName());
+		row.put("emailEnabled", isAnnouncementEmailEnabled(user.getId()));
+		return row;
+	}
+
+	/**
+	 * Resolve a user's standing announcement email-notification preference. Mirrors the kernel
+	 * resolution in EmailNotification: a missing preference (or any read failure) defaults to
+	 * enabled (NOTI_OPTIONAL); only an explicit NOTI_NONE disables it.
+	 */
+	boolean isAnnouncementEmailEnabled(String userId) {
+		try {
+			Preferences prefs = preferencesService.getPreferences(userId);
+			ResourceProperties props = prefs.getProperties(NotificationService.PREFS_TYPE + AnnouncementService.APPLICATION_ID);
+			int level = (int) props.getLongProperty(Integer.toString(NotificationService.NOTI_OPTIONAL));
+			return level != NotificationService.NOTI_NONE;
+		} catch (Exception e) {
+			// Missing preference or unparseable value: default to the standing OPTIONAL (enabled) level.
+			return true;
+		}
+	}
+
+	private String formatInstant(Instant instant) {
+		if (instant == null) {
+			return "";
+		}
+		return timeService.newTime(instant.toEpochMilli()).toStringLocalFull();
+	}
+
 	/**
 	* message/siteId/EntityID
 	*/
@@ -740,6 +878,10 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 		try {
 			AnnouncementChannel channel = announcementService.getAnnouncementChannel(ref);
 			AnnouncementMessage message = channel.getAnnouncementMessage(announcementId);
+			// This is a full-body read of a single announcement over REST, which otherwise fires no
+			// read event. Post it so the read receipt is captured like any in-tool view. List
+			// endpoints (getAnnouncements / createDecoratedAnnouncement) intentionally do NOT post.
+			eventTrackingService.post(eventTrackingService.newEvent(AnnouncementService.SECURE_ANNC_READ, message.getReference(), false));
 			return createDecoratedAnnouncement(message, null);
 		} catch (IdUnusedException e) {
 			throw new EntityNotFoundException("Couldn't find: "+ e.getId(), e.getId());
@@ -869,6 +1011,12 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 
 	@Setter
 	private LocaleService localeService;
+
+	@Setter
+	private EventTrackingService eventTrackingService;
+
+	@Setter
+	private PreferencesService preferencesService;
 
 	private Locale getLocale() {
 		return localeService.getLocaleForCurrentSiteAndUser();

--- a/announcement/announcement-tool/tool/src/test/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderReadReceiptsTest.java
+++ b/announcement/announcement-tool/tool/src/test/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderReadReceiptsTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.announcement.entityprovider;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.user.api.Preferences;
+import org.sakaiproject.user.api.PreferencesService;
+
+/**
+ * Covers the per-student "email notifications enabled" resolution that drives the Yes/No
+ * column (and the light-red highlighting) in the read-receipts overlay: only an explicit
+ * "None" announcement notification preference counts as disabled; every other value — and a
+ * missing preference — is treated as enabled.
+ */
+public class AnnouncementEntityProviderReadReceiptsTest {
+
+	private static final String USER = "user-1";
+
+	@Mock private PreferencesService preferencesService;
+	@Mock private Preferences preferences;
+	@Mock private ResourceProperties properties;
+
+	private AnnouncementEntityProviderImpl provider;
+	private AutoCloseable mocks;
+
+	@Before
+	public void setUp() throws Exception {
+		mocks = MockitoAnnotations.openMocks(this);
+		provider = new AnnouncementEntityProviderImpl();
+		provider.setPreferencesService(preferencesService);
+		when(preferencesService.getPreferences(USER)).thenReturn(preferences);
+		when(preferences.getProperties(anyString())).thenReturn(properties);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		mocks.close();
+	}
+
+	@Test
+	public void emailDisabledWhenPreferenceIsNone() throws Exception {
+		when(properties.getLongProperty(anyString())).thenReturn(0L); // NOTI_NONE
+		assertFalse(provider.isAnnouncementEmailEnabled(USER));
+	}
+
+	@Test
+	public void emailEnabledWhenPreferenceIsEachEmail() throws Exception {
+		when(properties.getLongProperty(anyString())).thenReturn(1L); // NOTI_REQUIRED
+		assertTrue(provider.isAnnouncementEmailEnabled(USER));
+	}
+
+	@Test
+	public void emailEnabledWhenPreferenceIsDigest() throws Exception {
+		when(properties.getLongProperty(anyString())).thenReturn(2L); // NOTI_OPTIONAL
+		assertTrue(provider.isAnnouncementEmailEnabled(USER));
+	}
+
+	@Test
+	public void emailEnabledByDefaultWhenPreferenceMissing() throws Exception {
+		// A missing/unparseable preference throws; the resolver defaults to enabled.
+		when(properties.getLongProperty(anyString())).thenThrow(new RuntimeException("no such property"));
+		assertTrue(provider.isAnnouncementEmailEnabled(USER));
+	}
+}

--- a/announcement/announcement-tool/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/announcement/announcement-tool/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -16,6 +16,8 @@
 		<property name="entityManager"><ref bean="org.sakaiproject.entity.api.EntityManager"/></property>
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService"/>
 		<property name="localeService" ref="org.sakaiproject.util.api.LocaleService"/>
+		<property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
+		<property name="preferencesService" ref="org.sakaiproject.user.api.PreferencesService"/>
 	</bean>
 	
 </beans>

--- a/announcement/announcement-tool/tool/src/webapp/js/announcements.js
+++ b/announcement/announcement-tool/tool/src/webapp/js/announcements.js
@@ -21,3 +21,133 @@ document.querySelectorAll(".announcement-select-checkbox").forEach(cb => {
 document.getElementById("announcement-reset-button")?.addEventListener("click", () => {
   sakai.announcements.toggleBulkButtons(true);
 });
+
+// Read receipts modal — one combined, sortable, colour-coded table.
+(() => {
+
+  const modal = document.getElementById("anncReceiptsModal");
+  if (!modal) return;
+
+  const table = document.getElementById("anncReceiptsTable");
+  const yesLabel = modal.dataset.yes || "Yes";
+  const noLabel = modal.dataset.no || "No";
+
+  // Highlight toggle (in the modal body, above the table). The tint CSS is gated on the
+  // .annc-highlight-on class, so toggling it just adds/removes that class.
+  const highlightToggle = document.getElementById("anncReceiptsHighlightToggle");
+  let highlightOn = highlightToggle ? highlightToggle.checked : false;
+  if (highlightToggle) {
+    highlightToggle.addEventListener("change", () => {
+      highlightOn = highlightToggle.checked;
+      render();
+    });
+  }
+
+  const escapeHtml = value => {
+    const div = document.createElement("div");
+    div.textContent = value == null ? "" : value;
+    return div.innerHTML;
+  };
+
+  let data = [];
+  let sortKey = "status"; // default order: red (unseen, no email), yellow (unseen, email), green (viewed)
+  let sortAsc = true;
+
+  // red = not viewed & email off, yellow = not viewed & email on, green = viewed.
+  const rowClass = row => row.viewed ? "annc-row-viewed" : (row.emailEnabled ? "annc-row-emailed" : "annc-row-noemail");
+  const statusRank = row => row.viewed ? 2 : (row.emailEnabled ? 1 : 0);
+
+  const sortValue = (row, key) => {
+    if (key === "firstViewedSort") return row.firstViewedSort || 0;
+    if (key === "emailEnabled") return row.emailEnabled ? 1 : 0;
+    if (key === "status") return statusRank(row);
+    return (row.sortName || row.displayName || "").toLowerCase();
+  };
+
+  const render = () => {
+    const tbody = table.querySelector("tbody");
+    const rows = data.slice().sort((a, b) => {
+      const av = sortValue(a, sortKey), bv = sortValue(b, sortKey);
+      let cmp = av < bv ? -1 : (av > bv ? 1 : 0);
+      if (cmp === 0) { // stable secondary sort by name
+        const an = sortValue(a, "sortName"), bn = sortValue(b, "sortName");
+        cmp = an < bn ? -1 : (an > bn ? 1 : 0);
+      }
+      return sortAsc ? cmp : -cmp;
+    });
+    tbody.innerHTML = "";
+    rows.forEach(row => {
+      const tr = document.createElement("tr");
+      if (highlightOn) tr.classList.add(rowClass(row));
+      const viewedCell = row.viewed ? escapeHtml(row.firstViewed) : "";
+      tr.innerHTML =
+        `<td>${escapeHtml(row.displayName)}</td>` +
+        `<td>${viewedCell}</td>` +
+        `<td>${row.emailEnabled ? escapeHtml(yesLabel) : escapeHtml(noLabel)}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.querySelectorAll("thead th[data-sort-key]").forEach(th => {
+      const icon = th.querySelector(".annc-sort-icon");
+      if (!icon) return;
+      icon.className = "annc-sort-icon fa " +
+        (th.dataset.sortKey === sortKey ? (sortAsc ? "fa-sort-up" : "fa-sort-down") : "fa-sort");
+    });
+  };
+
+  table.querySelectorAll("thead th[data-sort-key]").forEach(th => {
+    th.addEventListener("click", () => {
+      const clicked = th.dataset.sortKey;
+      if (sortKey === clicked) { sortAsc = !sortAsc; } else { sortKey = clicked; sortAsc = true; }
+      render();
+    });
+  });
+
+  modal.addEventListener("show.bs.modal", event => {
+
+    const ref = event.relatedTarget?.dataset.anncRef;
+    const errorEl = document.getElementById("anncReceiptsError");
+    const noneEl = document.getElementById("anncReceiptsNone");
+
+    // Reset (keep the default status sort).
+    errorEl.classList.add("d-none");
+    errorEl.textContent = "";
+    noneEl.classList.add("d-none");
+    data = [];
+    sortKey = "status";
+    sortAsc = true;
+    render();
+    document.getElementById("anncReceiptsViewedCount").textContent = "0";
+    document.getElementById("anncReceiptsTotalCount").textContent = "0";
+
+    // Reference is /announcement/msg/{site}/{channel}/{msg}
+    const parts = (ref || "").split("/");
+    if (parts.length < 6) {
+      errorEl.textContent = "Could not resolve this announcement.";
+      errorEl.classList.remove("d-none");
+      return;
+    }
+    const [ , , , site, channel, msg ] = parts;
+    const url = `/direct/announcement/readReceipts/${site}/${channel}/${msg}.json`;
+
+    fetch(url, { credentials: "same-origin", headers: { "Accept": "application/json" } })
+      .then(response => {
+        if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+        return response.json();
+      })
+      .then(payload => {
+        // EntityBroker wraps the returned map in a {"data": {...}} envelope
+        const d = payload && payload.data ? payload.data : (payload || {});
+        const viewed = (d.viewed || []).map(r => ({ ...r, viewed: true }));
+        const notViewed = (d.notViewed || []).map(r => ({ ...r, viewed: false, firstViewed: "", firstViewedSort: 0 }));
+        data = viewed.concat(notViewed);
+        render();
+        document.getElementById("anncReceiptsViewedCount").textContent = viewed.length;
+        document.getElementById("anncReceiptsTotalCount").textContent = data.length;
+        if (data.length === 0) noneEl.classList.remove("d-none");
+      })
+      .catch(error => {
+        errorEl.textContent = error.message;
+        errorEl.classList.remove("d-none");
+      });
+  });
+})();

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements.vm
@@ -582,7 +582,8 @@
 											$formattedText.escapeHtml($ann_item.Header.subject) <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a>
 										#end
 										#if ($channel.allowEditMessage($ann_item.Id))
-											<div class="itemAction"><a href="#toolLinkParam("AnnouncementAction" "doReviseannouncement" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.editann.subject', $formattedText.escapeHtml($ann_item.Header.subject))"><i class="fa fa-lg fa-pencil-square-o"></i> $tlang.getString("gen.revise") <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a></div>
+											<div class="itemAction"><a href="#toolLinkParam("AnnouncementAction" "doReviseannouncement" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage('gen.editann.subject', $formattedText.escapeHtml($ann_item.Header.subject))"><i class="fa fa-lg fa-pencil-square-o"></i> $tlang.getString("gen.revise") <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a>
+											<a href="#" class="annc-receipts-link ms-3" data-bs-toggle="modal" data-bs-target="#anncReceiptsModal" data-annc-ref="$formattedText.escapeHtml($ann_item.reference)" title="$tlang.getString('receipts.link')"><i class="fa fa-eye" aria-hidden="true"></i> $tlang.getString("receipts.link") <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a></div>
 										#end
 									</td>
 									<td headers="author" class="d-none d-sm-table-cell">
@@ -813,6 +814,7 @@
 										#end
 											#if ($channel.allowEditMessage($ann_item.Id))
 												<span class="itemAction"><a href="#toolLinkParam("AnnouncementAction" "doReviseannouncement" "itemReference=$formattedText.escapeUrl($ann_item.reference)")" title="$tlang.getFormattedMessage("gen.editann.subject", $formattedText.escapeHtml($ann_item.Header.subject))"><i class="fa fa-lg fa-pencil-square-o"></i> $tlang.getString("gen.revise") <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a>
+												<a href="#" class="annc-receipts-link ms-3" data-bs-toggle="modal" data-bs-target="#anncReceiptsModal" data-annc-ref="$formattedText.escapeHtml($ann_item.reference)" title="$tlang.getString('receipts.link')"><i class="fa fa-eye" aria-hidden="true"></i> $tlang.getString("receipts.link") <span class="skip">$formattedText.escapeHtml($ann_item.Header.subject)</span></a>
 											#end
 											$separator 
 											#set ($ref = $entityManager.newReference($ann_item.Reference))
@@ -845,6 +847,57 @@
 				#end
 			#end
 		#end
-	#end	
+	#end
 </div>
+
+## Shared read-receipts modal (populated by announcements.js on show.bs.modal)
+<style>
+	/* Status row colours from Bootstrap colour tokens (Sakai themes "success" purple, so green uses
+	   --sakai-color-green). Light mode: light tint + dark text. Dark mode: darker tint + white text. */
+	.annc-receipts-table > tbody > tr.annc-row-noemail { --bs-table-bg: color-mix(in srgb, var(--bs-danger) 26%, var(--bs-white, #fff)); --bs-table-color: var(--bs-black, #000); }
+	.annc-receipts-table > tbody > tr.annc-row-emailed { --bs-table-bg: color-mix(in srgb, var(--bs-warning) 20%, var(--bs-white, #fff)); --bs-table-color: var(--bs-black, #000); }
+	.annc-receipts-table > tbody > tr.annc-row-viewed  { --bs-table-bg: color-mix(in srgb, var(--sakai-color-green) 20%, var(--bs-white, #fff)); --bs-table-color: var(--bs-black, #000); }
+	.sakaiUserTheme-dark .annc-receipts-table > tbody > tr.annc-row-noemail { --bs-table-bg: color-mix(in srgb, var(--bs-danger) 68%, #000); --bs-table-color: #fff; }
+	.sakaiUserTheme-dark .annc-receipts-table > tbody > tr.annc-row-emailed { --bs-table-bg: color-mix(in srgb, var(--bs-warning) 45%, #000); --bs-table-color: #fff; }
+	.sakaiUserTheme-dark .annc-receipts-table > tbody > tr.annc-row-viewed  { --bs-table-bg: color-mix(in srgb, var(--sakai-color-green) 45%, #000); --bs-table-color: #fff; }
+</style>
+<div class="modal fade" id="anncReceiptsModal" tabindex="-1" role="dialog" aria-labelledby="anncReceiptsModalLabel" aria-hidden="true"
+	data-yes="$tlang.getString('receipts.yes')" data-no="$tlang.getString('receipts.no')">
+	<div class="modal-dialog modal-lg modal-dialog-scrollable" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="anncReceiptsModalLabel">$tlang.getString("receipts.title")</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="$tlang.getString('receipts.close')"></button>
+			</div>
+				<div class="modal-body">
+					<div id="anncReceiptsError" class="alert alert-danger d-none" role="alert"></div>
+					<div class="d-flex justify-content-between align-items-center mb-2">
+						<span class="small">$tlang.getString("receipts.viewed") <span id="anncReceiptsViewedCount">0</span> / <span id="anncReceiptsTotalCount">0</span></span>
+						<div class="form-check form-switch mb-0">
+							<input class="form-check-input" type="checkbox" role="switch" id="anncReceiptsHighlightToggle" checked>
+							<label class="form-check-label" for="anncReceiptsHighlightToggle">$tlang.getString("receipts.highlight")</label>
+						</div>
+					</div>
+					<div id="anncReceiptsTableWrap" class="annc-highlight-on">
+						<table class="table table-sm table-hover annc-receipts-table" id="anncReceiptsTable">
+							<thead>
+								<tr>
+									<th scope="col" class="annc-sortable" data-sort-key="sortName" role="button">$tlang.getString("receipts.name") <i class="annc-sort-icon fa fa-sort" aria-hidden="true"></i></th>
+									<th scope="col" class="annc-sortable" data-sort-key="firstViewedSort" role="button">$tlang.getString("receipts.time") <i class="annc-sort-icon fa fa-sort" aria-hidden="true"></i></th>
+									<th scope="col" class="annc-sortable" data-sort-key="emailEnabled" role="button">$tlang.getString("receipts.emailenabled") <i class="fa fa-info-circle" title="$tlang.getString('receipts.emailnuance')" aria-hidden="true"></i> <i class="annc-sort-icon fa fa-sort" aria-hidden="true"></i></th>
+								</tr>
+							</thead>
+							<tbody></tbody>
+						</table>
+					</div>
+					<div id="anncReceiptsNone" class="alert alert-info d-none mt-2" role="alert">$tlang.getString("receipts.none")</div>
+				</div>
+			<div class="modal-footer">
+				<small class="me-auto">$tlang.getString("receipts.disclaimer")</small>
+				<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">$tlang.getString("receipts.close")</button>
+			</div>
+		</div>
+	</div>
+</div>
+
 <script src="/sakai-announcement-tool/js/announcements.js$!{portalCdnQuery}"></script>


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-52720

## What this adds

A **"View read receipts"** link next to the Revise action on each announcement (visible to those who can manage announcements). It opens a Bootstrap modal with a single, sortable table of the site's students showing, per student:

- whether they have **viewed** the announcement in Sakai, and the **first-viewed** time;
- whether they have **email notifications enabled** for announcements.

Rows are colour-coded (a "Highlight rows" switch, on by default, toggles it):

- **green** — viewed (always, regardless of email);
- **yellow** — not viewed but email on (may have seen it via the email notification);
- **red** — not viewed and email off (likely has not seen it at all).

The red group sorts first so at-risk students surface. A disclaimer notes that receipts reflect **in-Sakai views only** — a recipient who read the announcement solely through the email notification is not counted.

## Why inline in the tool rather than the Statistics tool

To be clear up front: I know this information is already available via the Statistics (SiteStats) tool — the `annc.read` event is registered and reportable there. This isn't about the data not existing; it's about convenience and workflow. The goal is to surface it **inline in Announcements, right next to each announcement**, so an instructor can see who has read a given announcement in a single click — without leaving the tool, switching to Statistics, and figuring out how to construct the right event/reference report to get exactly the information they want. It also works out of the box (SiteStats detailed-event collection is off by default) and adds the "who likely hasn't seen it at all" colour-coding that a raw event report doesn't give.

## Implementation

Reuses the already-firing `annc.read` event instead of adding new tracking:

- **`AnnouncementReadReceipt`** JPA entity + `SpringCrudRepository` attached to the shared kernel session factory (table `ANNC_READ_RECEIPT`; auto-DDL like Conversations).
- **`AnnouncementObserver`** records the read on `annc.read` (find-or-insert, keeps the earliest view, ignores re-reads).
- **`AnnouncementService.recordRead` / `getReadReceipts`** on the API.
- **`readReceipts`** EntityProvider action (manager-gated) returns viewed / not-viewed, filtered to students (readers minus those who can post announcements), each with an email-enabled flag resolved from the `sakai:announcement` notification preference.
- Posts `annc.read` from the REST `getAnnouncement` single-item path so full-body REST reads are tracked too (the tool, synoptic widget, and dashboard already post it).
- Bootstrap-5 modal + vanilla JS; colours built from Bootstrap tokens (`--bs-danger`/`--bs-warning` + `--bs-table-bg`/`--bs-table-color`) and the `--sakai-color-green` token (Sakai themes `--bs-success` purple), theme-aware and WCAG-AA in light and dark mode.
- Unit test for the email-enabled resolution.

## Testing

Verified end-to-end on a dev stack:
- A student opening an announcement records a row; re-opening does not duplicate it or change the first-viewed time.
- The overlay lists students with correct viewed/first-viewed/email values; a student with the announcement preference set to "None" shows email = No and is highlighted red.
- Colours and text are legible and distinct in both light and dark themes; the endpoint returns 403 to non-managers.

## Notes / limitations

- Only reads after deploy are captured (no backfill).
- For a group-restricted announcement the "not yet viewed" list is site-wide rather than intersected with the message's groups (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
