### PR TITLE
SAK-52672 Samigo PDF export "Infinite table loop" when an assessment contains question attachments - Fix

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/pdf/HTMLWorker.java
@@ -161,7 +161,9 @@ import lombok.extern.slf4j.Slf4j;
 				final String base64Data = src.substring(src.indexOf(",") + 1);
 				try {
 					img = Image.getInstance(Base64.getDecoder().decode(base64Data));
-					img.scaleToFit(400f, 350f);
+					if (img.getWidth() > 400f || img.getHeight() > 350f) {
+						img.scaleToFit(400f, 350f);
+					}
 				} catch (Exception e) {
 					log.warn("Failed retrieving image", e.toString());
 				}
@@ -211,7 +213,7 @@ import lombok.extern.slf4j.Slf4j;
 
 			Map<String, Image> imgDict = new java.util.HashMap<>();
 			imgDict.put(imgPath, imgPdf);
-			tempProps.put("image_dictionary", imgDict);
+			tempProps.put("img_static", imgDict);
 
 			this.setInterfaceProps(tempProps);
 			try {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/PDFAssessmentBean.java
@@ -40,8 +40,8 @@ import javax.faces.context.FacesContext;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAnswer;
 import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAssessmentAttachment;
@@ -51,6 +51,7 @@ import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedSectionAtta
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
+import org.sakaiproject.tool.assessment.jsf.convert.AnswerSurveyConverter;
 import org.sakaiproject.tool.assessment.pdf.HTMLWorker;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.DeliveryBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.ItemContentsBean;
@@ -61,9 +62,7 @@ import org.sakaiproject.tool.assessment.ui.listener.delivery.DeliveryActionListe
 import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.api.FormattedText;
-import org.sakaiproject.component.cover.ComponentManager;
 
-import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.Element;
 import com.lowagie.text.Font;
@@ -76,7 +75,8 @@ import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPRow;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
-import org.sakaiproject.tool.assessment.jsf.convert.AnswerSurveyConverter;
+
+import lombok.extern.slf4j.Slf4j;
 
 /* Print to PDF backing bean. */
 @Slf4j
@@ -268,7 +268,6 @@ public class PDFAssessmentBean implements Serializable {
 				while (assessmentAttachmentIter.hasNext()) {
 					assessmentIntros.append("<br />");
 					PublishedAssessmentAttachment assessmentAttachment = (PublishedAssessmentAttachment) assessmentAttachmentIter.next();
-					assessmentIntros.append("  ");
 					appendAttachmentHtml(assessmentIntros, assessmentAttachment.getFilename(), assessmentAttachment.getMimeType(), assessmentAttachment.getResourceId());
 				}
 			}
@@ -323,7 +322,6 @@ public class PDFAssessmentBean implements Serializable {
 					while (partAttachmentIter.hasNext()) {
 						partIntros.append("<br />");
 						PublishedSectionAttachment partAttachment = (PublishedSectionAttachment) partAttachmentIter.next();
-						partIntros.append("  ");
 						appendAttachmentHtml(partIntros, partAttachment.getFilename(), partAttachment.getMimeType(), partAttachment.getResourceId());
 					}
 				}
@@ -360,7 +358,6 @@ public class PDFAssessmentBean implements Serializable {
 					Iterator itemAttachmentIter = itemAttachmentList.iterator();
 					while (itemAttachmentIter.hasNext()) {
 						PublishedItemAttachment itemAttachment = (PublishedItemAttachment) itemAttachmentIter.next();
-						contentBuffer.append("  ");
 						appendAttachmentHtml(contentBuffer, itemAttachment.getFilename(), itemAttachment.getMimeType(), itemAttachment.getResourceId());
 					}
 				}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52672

minor fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling in exported PDFs so embedded images are only resized when they exceed the target dimensions, preserving better image quality for smaller images.
  * Adjusted PDF formatting around attachment sections to reduce extra spacing and produce cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->