### PR TITLE
SAK-44528 Announcements: persist the Email Notification setting (+ a separate one-off "send now")

### DIFF
--- a/announcement/announcement-api/api/src/bundle/announcement.properties
+++ b/announcement/announcement-api/api/src/bundle/announcement.properties
@@ -263,6 +263,13 @@ revise.notify.ver.dated_future.date = Set to display on {0}
 #SAK-25955
 #revise.savedraft = Save Draft
 revise.savechanges = Save Changes
+revise.lastemailsent=Last email sent: {0}
+revise.notifynow=Send an email notification now
+revise.sendonrelease=Send email when posted
+revise.sendonrelease.locked=Return to draft to change
+revise.sendonrelease.tip=Saved with the announcement and kept when the site is copied.
+revise.notifynow.tip=A one-time send — not saved, and not kept when the site is copied.
+revise.notify.level=Email notification level
 revise.preview = Preview
 
 displayto.access = Access

--- a/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
+++ b/announcement/announcement-api/api/src/java/org/sakaiproject/announcement/api/AnnouncementService.java
@@ -68,6 +68,12 @@ public interface AnnouncementService extends MessageService
     /** The property name of the channel to use instead of the site channel */
     public final static String ANNOUNCEMENT_CHANNEL_PROPERTY = "channel";
 
+	/** Message property: the persisted email-notification choice for the announcement, pre-selected on edit and kept on site copy. */
+	public static final String NOTIFICATION_LEVEL = "notificationLevel";
+
+	/** Message property: when an email notification actually went out, for the "Last email sent" hint; not carried onto an imported copy. */
+	public static final String NOTIFICATION_SENT_TIME = "notificationSentTime";
+
 	/** The Reference type for an announcement rss feed */
 	public static final String REF_TYPE_ANNOUNCEMENT_RSS = "rss";
 	

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/BaseAnnouncementService.java
@@ -1710,6 +1710,9 @@ public abstract class BaseAnnouncementService extends BaseMessage implements Ann
 						ResourcePropertiesEdit p = nMessage.getPropertiesEdit();
 						p.clear();
 						p.addAll(oProperties);
+						// an imported copy has not been emailed in the destination site, so don't carry the
+						// source's "last email sent" marker over (the chosen notification level is kept)
+						p.removeProperty(AnnouncementService.NOTIFICATION_SENT_TIME);
 
 						// complete the edit
 						nChannel.commitMessage(nMessage, NotificationService.NOTI_IGNORE);

--- a/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/SiteEmailNotificationAnnc.java
+++ b/announcement/announcement-impl/impl/src/java/org/sakaiproject/announcement/impl/SiteEmailNotificationAnnc.java
@@ -484,7 +484,7 @@ public class SiteEmailNotificationAnnc extends SiteEmailNotification
 				final AnnouncementMessageHeader hdr = (AnnouncementMessageHeader) msg.getAnnouncementHeader();
 		
 				// read the notification options
-				final String notification = msg.getProperties().getProperty("notificationLevel");
+				final String notification = msg.getProperties().getProperty(AnnouncementService.NOTIFICATION_LEVEL);
 		
 				int noti = NotificationService.NOTI_OPTIONAL;
 				if ("r".equals(notification))

--- a/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1845,7 +1845,33 @@ public class AnnouncementAction extends PagedResourceActionII
 
 			context.put(SPECIFY_DATES, specify);
 			context.put(HIDDEN, edit.getHeader().getDraft());
-			// there is no chance to get the notification setting at this point
+			// pre-select the previously chosen notification level rather than resetting to None,
+			// so the author can see whether recipients will be notified when they re-open the item.
+			String editNotification = edit.getProperties().getProperty(AnnouncementService.NOTIFICATION_LEVEL);
+			if (editNotification == null) {
+				editNotification = serverConfigurationService.getString("announcement.default.notification", "n");
+			}
+			context.put("noti", editNotification);
+
+			// only offer an explicit "Save & Notify (Again)" when editing an already-released item.
+			boolean anncReleased = !edit.getHeader().getDraft() && releaseDate != null && !TimeService.newTime().before(releaseDate);
+			context.put("anncReleased", anncReleased);
+			boolean anncAlreadyNotified = anncReleased && ("r".equals(editNotification) || "o".equals(editNotification));
+			String lastEmailSent = null;
+			try {
+				lastEmailSent = edit.getProperties().getTimeProperty(AnnouncementService.NOTIFICATION_SENT_TIME).toStringLocalFull();
+			} catch (Exception e) {
+				// no recorded send time
+			}
+			if (lastEmailSent == null && anncAlreadyNotified) {
+				lastEmailSent = releaseDate.toStringLocalFull();
+			}
+			context.put("lastEmailSent", lastEmailSent);
+			// server-resolved "is this item visible right now", in the site/user timezone, so the one-off
+			// "Send now" control's initial state does not depend on the browser's clock
+			context.put("visibleNowAtLoad", !edit.getHeader().getDraft()
+					&& (releaseDate == null || !TimeService.newTime().before(releaseDate))
+					&& (retractDate == null || TimeService.newTime().before(retractDate)));
 		
 			//output notification history
 			if (state.getEdit()!= null){
@@ -2625,6 +2651,64 @@ public class AnnouncementAction extends PagedResourceActionII
 	} // doPost
 
 	/**
+	 * Sakai's existing "when to notify" behaviour for the persistent Email Notification level.
+	 * The level is now persisted and pre-selected on edit, so this keeps a plain re-save of a live
+	 * announcement from re-emailing: notify only for a brand-new post, a draft being released, or a
+	 * scheduled future release, and never while the item is saved hidden/draft. A deliberate one-off
+	 * send is handled separately by the "Send an email notification now" checkbox.
+	 */
+	static boolean shouldSendNotification(boolean isNew, boolean wasDraft, boolean nowHidden, Time releaseDate, Time now) {
+		return !nowHidden
+			&& (isNew
+				|| wasDraft
+				|| (releaseDate != null && now != null && now.before(releaseDate)));
+	}
+
+	/**
+	 * the notification level to actually send when saving. A ticked one-off "Send an email
+	 * notification now" wins and sends at its own chosen level; otherwise Sakai's existing first
+	 * notification (new post / publishing a draft / scheduled release) sends at the persistent level;
+	 * otherwise nothing is sent.
+	 */
+	static int resolveCommitLevel(boolean sendNow, int oneOffLevel, boolean firstNotification, int persistentLevel) {
+		if (sendNow) return oneOffLevel;
+		if (firstNotification) return persistentLevel;
+		return NotificationService.NOTI_NONE;
+	}
+
+	/**
+	 * Whether the one-off "Send an email notification now" may fire. Only when the user ticked it and
+	 * the item is actually visible right now -- not while saved hidden/draft, not before a future
+	 * release, and not once it has been retracted. Enforced server-side so a bypassed client control
+	 * cannot email an item recipients can no longer see.
+	 */
+	static boolean canSendNow(boolean notifyNowChecked, boolean nowHidden, Time releaseDate, Time retractDate, Time now) {
+		return notifyNowChecked
+			&& !nowHidden
+			&& (releaseDate == null || now == null || !now.before(releaseDate))
+			&& (retractDate == null || now == null || now.before(retractDate));
+	}
+
+	/** Maps a stored notification-level property value ("r"/"n"/other) to a NotificationService level. */
+	static int notiLevelFor(String level) {
+		if ("r".equals(level)) return NotificationService.NOTI_REQUIRED;
+		if ("n".equals(level)) return NotificationService.NOTI_NONE;
+		return NotificationService.NOTI_OPTIONAL;
+	}
+
+	/**
+	 * The email-notification level to persist. The level locks once the announcement has been released, so
+	 * a released item -- or a request that omits the disabled control -- keeps its stored value rather than
+	 * trusting the submitted parameter (which could otherwise overwrite it or default it to Optional).
+	 */
+	static String resolveNotificationLevel(String submitted, String stored, boolean locked) {
+		if ((locked || StringUtils.isBlank(submitted)) && StringUtils.isNotBlank(stored)) {
+			return stored;
+		}
+		return submitted;
+	}
+
+	/**
 	 * post or save draft of a message?
 	 */
 	protected void postOrSaveDraft(RunData rundata, Context context, boolean post)
@@ -2667,15 +2751,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			// read the notification options
 			String notification = (String) sstate.getAttribute(AnnouncementAction.SSTATE_NOTI_VALUE);
 
-			int noti = NotificationService.NOTI_OPTIONAL;
-			if ("r".equals(notification))
-			{
-				noti = NotificationService.NOTI_REQUIRED;
-			}
-			else if ("n".equals(notification))
-			{
-				noti = NotificationService.NOTI_NONE;
-			}
+			int noti = notiLevelFor(notification);
 
 			try
 			{
@@ -2755,7 +2831,10 @@ public class AnnouncementAction extends PagedResourceActionII
 				{
 					// in addition to setting release date property, also set Date to release date so properly sorted
 					msg.getPropertiesEdit().addProperty(AnnouncementService.RELEASE_DATE, tempReleaseDate.toString());
-					header.setDate(tempReleaseDate);					
+					header.setDate(tempReleaseDate);
+					// adopt the effective release so the notification decisions below (schedule vs send-now,
+					// sent-time record) see the future date instead of a null from this Preview path
+					releaseDate = tempReleaseDate;
 				}
 				else
 				{
@@ -2783,6 +2862,7 @@ public class AnnouncementAction extends PagedResourceActionII
 				else if (tempRetractDate != null)
 				{
 					msg.getPropertiesEdit().addProperty(AnnouncementService.RETRACT_DATE, tempRetractDate.toString());
+					retractDate = tempRetractDate;
 				}
 				else 
 				{
@@ -2895,22 +2975,50 @@ public class AnnouncementAction extends PagedResourceActionII
 
 				// save notification level if this is a future notification message
 				Time now = TimeService.newTime();
-				
+
+				// the persisted level locks once the announcement has been released: for a released item, or a
+				// request that omits the disabled control, keep the stored value so a crafted or missing notify
+				// parameter can't overwrite it or silently downgrade it to Optional
+				boolean levelLocked = !oDraft && releaseDate != null && !now.before(releaseDate);
+				notification = resolveNotificationLevel(notification,
+						msg.getProperties().getProperty(AnnouncementService.NOTIFICATION_LEVEL), levelLocked);
+				noti = notiLevelFor(notification);
+
 				int notiLevel=noti;
 				if (msg.getAnnouncementHeaderEdit().getDraft()){
 					notiLevel=3; //Set notilevel as 3 if it a hidden announcement, as no notification is sent regardless of the notification option
 				}
 				
+				// persist the chosen level on every save (not only future posts) so the dropdown can
+				// pre-select it on re-open, and so it survives import (import copies all message properties).
+				if (notification != null) {
+					msg.getPropertiesEdit().addProperty(AnnouncementService.NOTIFICATION_LEVEL, notification);
+				}
+
 				if (releaseDate != null && now.before(releaseDate))// && noti != NotificationService.NOTI_NONE)
 				{
-					msg.getPropertiesEdit().addProperty("notificationLevel", notification);
 					msg.getPropertiesEdit().addPropertyToList("noti_history", now.toStringLocalFull()+"_"+notiLevel+"_"+releaseDate.toStringLocalFull());
 				}
 				else {
 					msg.getPropertiesEdit().addPropertyToList("noti_history", now.toStringLocalFull()+"_"+notiLevel);
 				}
 				
-				channel.commitMessage(msg, noti, "org.sakaiproject.announcement.impl.SiteEmailNotificationAnnc");
+				// keep Sakai's existing "when to notify" behaviour for the persistent level -- send
+				// only for a new post, a draft being released, or a scheduled future release; a plain re-save of
+				// a live announcement never re-emails. The transient "Send an email notification now" checkbox
+				// can additionally send one email now at its own chosen level (not persisted, not copied).
+				boolean firstNotification = shouldSendNotification(state.getIsNewAnnouncement(), oDraft, Boolean.TRUE.equals(tempHidden), releaseDate, now);
+				// the one-off "Send now" only fires for an item that is visible right now -- enforced server-side
+				// so a bypassed/disabled client control can't email a future or hidden announcement
+				boolean sendNow = canSendNow("true".equals(params.getString("notifyNow")), Boolean.TRUE.equals(tempHidden), releaseDate, retractDate, now);
+				int oneOffLevel = "r".equals(params.getString("notifyNowLevel")) ? NotificationService.NOTI_REQUIRED : NotificationService.NOTI_OPTIONAL;
+				int commitNoti = resolveCommitLevel(sendNow, oneOffLevel, firstNotification, noti);
+				// remember when an email actually went out (immediate send/re-notify) so a later edit
+				// can show "Last email sent"; scheduled future sends are inferred from the release date instead.
+				if (commitNoti != NotificationService.NOTI_NONE && (releaseDate == null || !now.before(releaseDate))) {
+					msg.getPropertiesEdit().addProperty(AnnouncementService.NOTIFICATION_SENT_TIME, now.toString());
+				}
+				channel.commitMessage(msg, commitNoti, "org.sakaiproject.announcement.impl.SiteEmailNotificationAnnc");
 
 				setMotdAttachmentsPublic(header, channelId);
 

--- a/announcement/announcement-tool/tool/src/test/org/sakaiproject/announcement/tool/AnnouncementNotificationGuardTest.java
+++ b/announcement/announcement-tool/tool/src/test/org/sakaiproject/announcement/tool/AnnouncementNotificationGuardTest.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2003-2024 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.announcement.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.time.api.Time;
+
+/**
+ * the Email Notification level is persisted and pre-selected on edit, so this guard keeps
+ * Sakai's existing "when to notify" behaviour for that level: notify only for a new post, a draft being
+ * released, or a scheduled future release; a plain re-save of a live announcement must NOT re-email.
+ * (A deliberate one-off send is handled separately by the transient "Send an email notification now" box.)
+ * args: isNew, wasDraft, nowHidden, releaseDate, now
+ */
+public class AnnouncementNotificationGuardTest {
+
+	@Test
+	public void newImmediatePostNotifies() {
+		assertTrue(AnnouncementAction.shouldSendNotification(true, false, false, null, mock(Time.class)));
+	}
+
+	@Test
+	public void newDraftDoesNotNotify() {
+		assertFalse(AnnouncementAction.shouldSendNotification(true, false, true, null, mock(Time.class)));
+	}
+
+	@Test
+	public void editingLiveAnnouncementDoesNotResend() {
+		// The core fix: re-saving an already-released announcement must not re-notify.
+		assertFalse(AnnouncementAction.shouldSendNotification(false, false, false, null, mock(Time.class)));
+	}
+
+	@Test
+	public void draftBeingReleasedNotifies() {
+		assertTrue(AnnouncementAction.shouldSendNotification(false, true, false, null, mock(Time.class)));
+	}
+
+	@Test
+	public void draftStayingHiddenDoesNotNotify() {
+		assertFalse(AnnouncementAction.shouldSendNotification(false, true, true, null, mock(Time.class)));
+	}
+
+	@Test
+	public void scheduledFutureReleaseNotifies() {
+		Time now = mock(Time.class), release = mock(Time.class);
+		when(now.before(release)).thenReturn(true);
+		assertTrue(AnnouncementAction.shouldSendNotification(false, false, false, release, now));
+	}
+
+	@Test
+	public void editingAfterReleaseDoesNotResend() {
+		Time now = mock(Time.class), release = mock(Time.class);
+		when(now.before(release)).thenReturn(false);
+		assertFalse(AnnouncementAction.shouldSendNotification(false, false, false, release, now));
+	}
+
+	// resolveCommitLevel(sendNow, oneOffLevel, firstNotification, persistentLevel)
+	// NOTI_REQUIRED = High, NOTI_OPTIONAL = Low, NOTI_NONE = no email.
+
+	@Test
+	public void oneOffCheckboxSendsAtItsOwnLevel() {
+		// a ticked "send now" wins even when the persistent path would not send (a plain live edit)
+		assertEquals(NotificationService.NOTI_OPTIONAL,
+			AnnouncementAction.resolveCommitLevel(true, NotificationService.NOTI_OPTIONAL, false, NotificationService.NOTI_NONE));
+	}
+
+	@Test
+	public void firstNotificationSendsAtPersistentLevel() {
+		// no one-off: a genuine first notification sends at the persisted dropdown level
+		assertEquals(NotificationService.NOTI_REQUIRED,
+			AnnouncementAction.resolveCommitLevel(false, NotificationService.NOTI_OPTIONAL, true, NotificationService.NOTI_REQUIRED));
+	}
+
+	@Test
+	public void plainLiveEditSendsNothing() {
+		// no one-off and not a first notification (a plain re-save of a live item) => no email
+		assertEquals(NotificationService.NOTI_NONE,
+			AnnouncementAction.resolveCommitLevel(false, NotificationService.NOTI_REQUIRED, false, NotificationService.NOTI_REQUIRED));
+	}
+
+	// canSendNow(notifyNowChecked, nowHidden, releaseDate, retractDate, now) -- the one-off "Send now"
+	// gate, enforced server-side so a bypassed/disabled client control cannot email a hidden, unreleased,
+	// or retracted item.
+
+	@Test
+	public void sendNowRequiresTheBoxTicked() {
+		assertFalse(AnnouncementAction.canSendNow(false, false, null, null, mock(Time.class)));
+	}
+
+	@Test
+	public void sendNowBlockedWhileHidden() {
+		assertFalse(AnnouncementAction.canSendNow(true, true, null, null, mock(Time.class)));
+	}
+
+	@Test
+	public void sendNowAllowedForAVisibleItem() {
+		assertTrue(AnnouncementAction.canSendNow(true, false, null, null, mock(Time.class)));
+	}
+
+	@Test
+	public void sendNowBlockedForAFutureRelease() {
+		Time now = mock(Time.class), release = mock(Time.class);
+		when(now.before(release)).thenReturn(true);
+		assertFalse(AnnouncementAction.canSendNow(true, false, release, null, now));
+	}
+
+	@Test
+	public void sendNowAllowedOnceReleaseHasPassed() {
+		Time now = mock(Time.class), release = mock(Time.class);
+		when(now.before(release)).thenReturn(false);
+		assertTrue(AnnouncementAction.canSendNow(true, false, release, null, now));
+	}
+
+	@Test
+	public void sendNowBlockedAfterRetract() {
+		// once the retract date has passed the item is no longer visible, so "Send now" must not fire
+		Time now = mock(Time.class), retract = mock(Time.class);
+		when(now.before(retract)).thenReturn(false);
+		assertFalse(AnnouncementAction.canSendNow(true, false, null, retract, now));
+	}
+
+	@Test
+	public void sendNowAllowedBeforeRetract() {
+		Time now = mock(Time.class), retract = mock(Time.class);
+		when(now.before(retract)).thenReturn(true);
+		assertTrue(AnnouncementAction.canSendNow(true, false, null, retract, now));
+	}
+
+	// resolveNotificationLevel(submitted, stored, locked) -- the persisted level is server-authoritative
+	// once released, and falls back to the stored value when the disabled control is omitted.
+
+	@Test
+	public void lockedLevelKeepsTheStoredValue() {
+		// a released (locked) item ignores a crafted/changed submitted level
+		assertEquals("r", AnnouncementAction.resolveNotificationLevel("o", "r", true));
+	}
+
+	@Test
+	public void editableLevelTrustsTheSubmittedValue() {
+		assertEquals("o", AnnouncementAction.resolveNotificationLevel("o", "r", false));
+	}
+
+	@Test
+	public void absentLevelFallsBackToStored() {
+		// a disabled control isn't submitted -> don't default to Optional, keep the stored level
+		assertEquals("r", AnnouncementAction.resolveNotificationLevel(null, "r", false));
+		assertEquals("r", AnnouncementAction.resolveNotificationLevel("", "r", false));
+	}
+
+	// notiLevelFor maps a stored "r"/"n"/other value to a NotificationService level.
+
+	@Test
+	public void notiLevelForMapsStoredValues() {
+		assertEquals(NotificationService.NOTI_REQUIRED, AnnouncementAction.notiLevelFor("r"));
+		assertEquals(NotificationService.NOTI_NONE, AnnouncementAction.notiLevelFor("n"));
+		assertEquals(NotificationService.NOTI_OPTIONAL, AnnouncementAction.notiLevelFor("o"));
+		assertEquals(NotificationService.NOTI_OPTIONAL, AnnouncementAction.notiLevelFor(null));
+	}
+}

--- a/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
+++ b/announcement/announcement-tool/tool/src/webapp/vm/announcement/chef_announcements-revise.vm
@@ -50,6 +50,72 @@ function resizeFrame(){
 			}
 		});
 
+		// two email controls — persisted "Send on release" + transient one-off "Send now".
+		(function(){
+			var relBox=$('#sendOnRelease'), relLvl=$('#releaseLevel'), relLocked=$('#sendOnReleaseLocked'), notifyHidden=$('#notifyHidden');
+			var nowBox=$('#notifyNow'), nowLvl=$('#notifyNowLevel');
+			if (!relBox.length && !nowBox.length) return;
+			var anncReleasedAtLoad = #if($anncReleased)true#{else}false#end;
+			// server-resolved visibility at load, in the site/user timezone (not the browser's)
+			var visibleNowAtLoad = #if($visibleNowAtLoad)true#{else}false#end;
+			var releaseEdited = false, retractEdited = false;
+			var isDraft = function(){ return $('#hidden_true').is(':checked'); };
+			var releaseInPast = function() {
+				var g = function(n){ return document.querySelector('input[name="'+n+'"]'); };
+				var y=g('release_year'), mo=g('release_month'), d=g('release_day');
+				if (!y || !mo || !d || !y.value || !mo.value || !d.value) return false;
+				var h = parseInt((g('release_hour')||{}).value || '0', 10) || 0;
+				var mi = parseInt((g('release_minute')||{}).value || '0', 10) || 0;
+				var ap = (((g('release_ampm')||{}).value) || '').toString().toLowerCase();
+				if (ap.indexOf('pm') >= 0) { if (h < 12) h += 12; } else if (ap.indexOf('am') >= 0) { if (h === 12) h = 0; }
+				return new Date(parseInt(y.value,10), parseInt(mo.value,10)-1, parseInt(d.value,10), h, mi).getTime() <= Date.now();
+			};
+			var retractInPast = function() {
+				var g = function(n){ return document.querySelector('input[name="'+n+'"]'); };
+				var y=g('retract_year'), mo=g('retract_month'), d=g('retract_day');
+				if (!y || !mo || !d || !y.value || !mo.value || !d.value) return false;
+				var h = parseInt((g('retract_hour')||{}).value || '0', 10) || 0;
+				var mi = parseInt((g('retract_minute')||{}).value || '0', 10) || 0;
+				var ap = (((g('retract_ampm')||{}).value) || '').toString().toLowerCase();
+				if (ap.indexOf('pm') >= 0) { if (h < 12) h += 12; } else if (ap.indexOf('am') >= 0) { if (h === 12) h = 0; }
+				return new Date(parseInt(y.value,10), parseInt(mo.value,10)-1, parseInt(d.value,10), h, mi).getTime() <= Date.now();
+			};
+			var visibleNow = function() {
+				if (isDraft()) return false;
+				if (!$('#hidden_specify').is(':checked')) return true;
+				// trust the server's timezone-correct answer until the user edits a date
+				if (!releaseEdited && !retractEdited) return visibleNowAtLoad;
+				var afterRelease = !$('#use_start_date').is(':checked') || releaseInPast();
+				var beforeRetract = !$('#use_end_date').is(':checked') || !retractInPast();
+				return afterRelease && beforeRetract;
+			};
+			var syncNotify = function(){ notifyHidden.val(relBox.is(':checked') ? relLvl.val() : 'n'); };
+			// Row 1 "Send on release": locked once released (revert to draft to change)
+			var refreshRelease = function() {
+				var locked = anncReleasedAtLoad && !isDraft();
+				relBox.prop('disabled', locked);
+				relLvl.prop('disabled', locked || !relBox.is(':checked'));
+				relLocked.toggleClass('d-none', !locked);
+				syncNotify();
+			};
+			relBox.add(relLvl).on('change', refreshRelease);
+			// Row 2 "Send now": enabled only when the item is visible now; only ever ticked by the user
+			var refreshNow = function() {
+				var enabled = visibleNow();
+				nowBox.prop('disabled', !enabled);
+				if (!enabled) nowBox.prop('checked', false);
+				nowLvl.prop('disabled', !enabled || !nowBox.is(':checked'));
+			};
+			nowBox.on('change', refreshNow);
+			$('input[name="hidden"], #use_start_date').on('change', function(){ refreshRelease(); refreshNow(); });
+			// once the user edits the release date, fall back to the live client-side check
+			$('input[name^="release_"]').on('change', function(){ releaseEdited = true; refreshNow(); });
+			$('input[name^="retract_"], #use_end_date').on('change', function(){ retractEdited = true; refreshNow(); });
+			$('#opendate').on('change blur', function(){ releaseEdited = true; setTimeout(function(){ refreshRelease(); refreshNow(); }, 50); });
+			$('#closedate').on('change blur', function(){ retractEdited = true; setTimeout(function(){ refreshNow(); }, 50); });
+			refreshRelease(); refreshNow();
+		})();
+
 		updateEmailDropdownOptions();
 		
 	});
@@ -505,24 +571,42 @@ function resizeFrame(){
 				<div id="email-notify-warning" class="sak-banner-error">$tlang.getString("revise.notify_alert")</div>
 				#end
 
-				<div class="form-group row">
-					<label for="notify" class="form-control-label col-md-2">
-      				$tlang.getString("revise.notify")
-					</label>
-					<div class="col-md-10">
-						<select name="notify" id="notify">
-							#if ($noti)
-								<option value="r" #if($noti=="r") selected="selected" #end>$tlang.getString("revise.notify_high")</option>
-								<option value="o" #if($noti=="o") selected="selected" #end>$tlang.getString("revise.notify_low")</option>
-								<option value="n" #if($noti=="n") selected="selected" #end>$tlang.getString("revise.notify_none")</option>
-							#else	
-								<option value="r">$tlang.getString("revise.notify_high")</option>
-								<option value="o">$tlang.getString("revise.notify_low")</option>
-								<option value="n" selected="selected">$tlang.getString("revise.notify_none")</option>
-							#end
-						</select>
+				<div class="form-group">
+					<label class="form-control-label">$tlang.getString("revise.notify")</label>
+					<input type="hidden" name="notify" id="notifyHidden" value="$!noti"/>
+					<div class="mt-1">
+						<div class="d-flex align-items-center gap-2" id="sendOnReleaseRow">
+							<div class="checkbox mb-0">
+								<label for="sendOnRelease" class="mb-0">
+									<input type="checkbox" name="sendOnRelease" id="sendOnRelease" value="true" #if($noti=="r" || $noti=="o")checked="checked"#end/>
+									$tlang.getString("revise.sendonrelease")
+								</label>
+							</div>
+							<select name="releaseLevel" id="releaseLevel" aria-label="$tlang.getString('revise.notify.level')">
+								<option value="r" #if($noti!="o")selected#end>$tlang.getString("revise.notify_high")</option>
+								<option value="o" #if($noti=="o")selected#end>$tlang.getString("revise.notify_low")</option>
+							</select>
+							<i class="fa fa-info-circle" role="img" title="$tlang.getString('revise.sendonrelease.tip')" aria-label="$tlang.getString('revise.sendonrelease.tip')"></i>
+							<span class="small fst-italic ms-1 d-none" id="sendOnReleaseLocked">$tlang.getString("revise.sendonrelease.locked")</span>
+						</div>
+						<div class="d-flex align-items-center gap-2 mt-1" id="sendNowRow">
+							<div class="checkbox mb-0">
+								<label for="notifyNow" class="mb-0">
+									<input type="checkbox" name="notifyNow" id="notifyNow" value="true"/>
+									$tlang.getString("revise.notifynow")
+								</label>
+							</div>
+							<select name="notifyNowLevel" id="notifyNowLevel" disabled aria-label="$tlang.getString('revise.notify.level')">
+								<option value="r" #if($noti!="o")selected#end>$tlang.getString("revise.notify_high")</option>
+								<option value="o" #if($noti=="o")selected#end>$tlang.getString("revise.notify_low")</option>
+							</select>
+							<i class="fa fa-info-circle" role="img" title="$tlang.getString('revise.notifynow.tip')" aria-label="$tlang.getString('revise.notifynow.tip')"></i>
+						</div>
+						#if ($lastEmailSent)
+							<div class="small mt-1" id="lastEmailSent">$tlang.getFormattedMessage("revise.lastemailsent", $lastEmailSent)</div>
+						#end
 					</div>
-				</div>	
+				</div>
 			#end
 		
 		#if ($notiHistory)
@@ -578,7 +662,8 @@ function resizeFrame(){
 			</table>
 			</div>
 		#end
-		<p class="act">
+		<hr class="itemSeparator" />
+		<p class="act mt-2">
 				<input type="button" class="active" name="post" accesskey="s"  id="saveChanges"  value=
 					#if ( $newAnn =="true")				
 						"$tlang.getString("revise.add")"
@@ -610,23 +695,15 @@ function resizeFrame(){
 		function updateEmailDropdownOptions() {
 			var defaultText = "$tlang.getString("revise.notify_high")";
 			var groupsText  = "$tlang.getString("revise.notify_high_groups")";
-
-			//Checks for #notify to prevent errors on MOTD
-			if (document.getElementById('notify') !== null) {
-
-				var options = document.getElementById('notify').children;
-				for (var i = 0; i < options.length; i++) {
-					if (options[i].text == defaultText || options[i].text == groupsText) {
-						var highOption = options[i];
-						break;
-					}
+			var text = theAnnouncementIsForGroups() ? groupsText : defaultText;
+			// keep the "High" option label (all participants vs all group members) in sync on both rows
+			["releaseLevel", "notifyNowLevel"].forEach(function(id) {
+				var sel = document.getElementById(id);
+				if (sel === null) return;
+				for (var i = 0; i < sel.options.length; i++) {
+					if (sel.options[i].value === "r") { sel.options[i].text = text; }
 				}
-				if (theAnnouncementIsForGroups()) {
-					highOption.text = groupsText;
-				} else {
-					highOption.text = defaultText;
-				}
-			}
+			});
 		}
 
 		function theAnnouncementIsForGroups() {


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-44528

## The bug

The Email Notification setting on an announcement silently resets to **None** whenever you edit it (or re-open a draft), so you can't tell whether recipients will actually be notified, and the setting never sticks. It's long-standing and still open (confirmed on 24x), with two duplicates (SAK-32203, SAK-31815) and a lot of "my students say they never got the email" triage pain in the comments.

## The honest trade-off

I'll be upfront: a lot of us have learned to work *around* this bug, so changing the UI here will cause some friction while people re-learn it. But I think making the setting genuinely persist — **across edits and across site copies** — outweighs that short-term friction. Not being able to trust the setting is the more expensive problem.

## Why I split the control

While fixing it I realized the single None/Low/High dropdown is conflating two different things:

- **whether an email is sent at all**, and
- **to whom / how** it's sent — the Low/High student-notification preference.

Those really should be separate. And there's a subtler reason they *have* to be: because all three (None/Low/High) live in one dropdown that wasn't being saved, the moment you make the setting persist you hit the case where **editing an announcement mid-quarter always re-sends an email** — even when the instructor just wanted to fix a typo and didn't want to notify anyone. So I broke the one-off "send an email now" out into its own separate control, so a persisted setting doesn't force an email on every edit.

## The new UI — two consistent rows

- **Send email when posted** `[High / Low]` — **persisted**. The notification that fires when the announcement goes live (immediately, or at a future open date). Saved on the announcement, pre-selected when you re-open it, and carried when the site is copied. It **locks once the announcement is released** (revert to draft to change it) — you can't un-send a notification that already went out.
- **Send an email notification now** `[High / Low]` — a **transient** one-off immediate send (e.g. to re-notify about an edit). Never saved, never copied. Only available when the item is visible now (greyed for a future open date or a draft — and enforced server-side, not just the client control), and it's ticked **deliberately**: editing an announcement never re-sends an email on its own.

The two are mutually exclusive in time, so no one is double-emailed. Existing "when to notify" behaviour is otherwise unchanged: a new post, publishing a draft, or a scheduled release still notify; a plain re-save of a live announcement no longer silently re-emails. The instructor still gets their own confirmation copy — the recipient logic is untouched.

## How it maps to the JIRA

This covers every item raised in SAK-44528: the reset-to-None bug, the "make it sticky" ask, "don't send on every edit," Christina's "*do you want to send a notification that this was modified?*", Andrea's "keep the settings on import," and Laura's triage pain (there's now a "Last email sent" hint too).

## Implementation notes

- No change to the notification/recipient path — only *which level* is committed. The persisted level rides through a hidden `notify` field so the server reads it exactly as before (so a locked row still submits its saved value).
- Site-copy persistence rides on `transferCopyEntities` copying message properties (the level is stored as `notificationLevel`); the imported copy is cleared of the one-time "last email sent" marker so it doesn't look already-sent in the destination site.
- Unit tests cover the send-decision guard and the commit-level resolution.

## Testing

Verified end-to-end on a dev stack: persistence across saves / edits / drafts and site copy; the two locking rules; that a future-dated item can't "send now" (only the release email fires); and that the poster still receives their confirmation copy. Theme-aware controls (correct in dark mode) with accessible labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized email-notification revision strings, including “last email sent” and clearer “send on release” vs “send now” instructions.
  * Updated the revise UI to use separate **Send on release** and **Send now** controls with correct locked/disabled behavior.
* **Bug Fixes**
  * Preserved the chosen notification level across revise/edit and save/preview flows.
  * Corrected when timestamps and notification commits are recorded, including avoiding duplicate sends.
  * Stopped “last email sent” from being copied to new sites.
* **Tests**
  * Added/expanded unit tests covering notification gating, commit-level selection, and send-now eligibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
