### PR TITLE
SAK-52497 Samigo remove quiz stacktrace for opensearch

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemoveAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemoveAssessmentListener.java
@@ -283,11 +283,11 @@ public class RemoveAssessmentListener implements ActionListener
             getBean("org.sakaiproject.grading.api.GradingService");
         }
         try {
-            log.debug("before gbsHelper.removeGradebook()");
-            gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessmentId, g);
-        } catch (Exception e1) {
-            // Should be the external assessment doesn't exist in GB. So we quiet swallow the exception. Please check the log for the actual error.
-            log.info("Exception thrown in updateGB():" + e1.getMessage());
+            if (!gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessmentId, g)) {
+                log.debug("Published assessment {} was not linked to the gradebook, nothing to remove", assessmentId);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to remove gradebook item for published assessment {}", assessmentId, e);
         }
     }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemovePublishedAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemovePublishedAssessmentListener.java
@@ -158,11 +158,11 @@ public class RemovePublishedAssessmentListener
 		  getBean("org.sakaiproject.grading.api.GradingService");
 	  }
 	  try {
-		  log.debug("before gbsHelper.removeGradebook()");
-		  gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessmentId, g);
-	  } catch (Exception e1) {
-		  // Should be the external assessment doesn't exist in GB. So we quiet swallow the exception. Please check the log for the actual error.
-		  log.info("Exception thrown in updateGB():" + e1.getMessage());
+		  if (!gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessmentId, g)) {
+			  log.debug("Published assessment {} was not linked to the gradebook, nothing to remove", assessmentId);
+		  }
+	  } catch (Exception e) {
+		  log.warn("Failed to remove gradebook item for published assessment {}", assessmentId, e);
 	  }
   }
 }

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -968,12 +968,10 @@ implements ActionListener
 					THIS IS BECAUSE ITEMS CAN BE CREATED IN EXAMS, BUT ONLY IF WE ARE IN CASE 2, SO
 					THESE ITEMS FROM CASE 2 WILL BE DELETED */
 				try {
-					gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingServiceApi);
-					// This variable is only true then the assessment has been removed!
-					existingItemHasBeenRemoved = true;
+					// This variable is only true when the assessment has actually been removed!
+					existingItemHasBeenRemoved = gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingServiceApi);
 				} catch (Exception e1) {
-					// Should be the external assessment doesn't exist in GB. So we quiet swallow the exception. Please check the log for the actual error.
-					log.info("Exception thrown in updateGB():" + e1.getMessage());
+					log.warn("Failed to remove gradebook item for published assessment {}", assessment.getPublishedAssessmentId(), e1);
 				}
 
 				if (existingItemHasBeenRemoved) {
@@ -1101,7 +1099,7 @@ implements ActionListener
             try {
                 gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingServiceApi);
             } catch(Exception e){
-                log.warn("No external assessment to remove: {}", e.getMessage());
+                log.warn("Failed to remove gradebook item for published assessment {}", assessment.getPublishedAssessmentId(), e);
             }
         }
 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/ifc/GradebookServiceHelper.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/ifc/GradebookServiceHelper.java
@@ -44,7 +44,11 @@ import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
  */
 public interface GradebookServiceHelper extends Serializable
 {
-  public void removeExternalAssessment(String gradebookUId,
+  /**
+   * Remove the gradebook item linked to a published assessment, if one exists.
+   * @return true if an item was removed, false if the assessment was not in the gradebook
+   */
+  public boolean removeExternalAssessment(String gradebookUId,
      String publishedAssessmentId, GradingService g) throws Exception;
 
   public boolean addToGradebook(String gradebookUId, PublishedAssessmentData publishedAssessment, Long categoryId,

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/integration/helper/integrated/GradebookServiceHelperImpl.java
@@ -79,16 +79,18 @@ public class GradebookServiceHelperImpl implements GradebookServiceHelper
 	private LocaleService localeService = (LocaleService) ComponentManager.get(LocaleService.class);
 	
    /**
-    * Remove a published assessment from the gradebook.
+    * Remove a published assessment from the gradebook, if it is linked to one.
     * @param gradebookUId the gradebook id
     * @param g  the Gradebook Service
     * @param publishedAssessmentId the id of the published assessment
+    * @return true if a gradebook item was removed, false if the assessment was not in the gradebook
     * @throws java.lang.Exception
     */
-    public void removeExternalAssessment(String gradebookUId, String publishedAssessmentId, GradingService g)
+    public boolean removeExternalAssessment(String gradebookUId, String publishedAssessmentId, GradingService g)
         throws Exception {
         if (gradebookUId == null) {
-            throw new AssessmentNotFoundException("Cannot remove external assessment without a gradebook uid");
+            log.debug("No gradebook uid, nothing to remove for published assessment {}", publishedAssessmentId);
+            return false;
         }
 
         List<String> gradebookUids = new ArrayList<>(List.of(gradebookUId));
@@ -101,22 +103,18 @@ public class GradebookServiceHelperImpl implements GradebookServiceHelper
             }
         }
 
-        AssessmentNotFoundException lastNotFound = null;
         boolean removed = false;
 
         for (String uid : gradebookUids) {
-            try {
+            if (g.isExternalAssignmentDefined(uid, publishedAssessmentId)) {
                 g.removeExternalAssignment(uid, publishedAssessmentId, getAppName());
                 removed = true;
-            } catch (AssessmentNotFoundException e) {
-                lastNotFound = e;
+            } else {
                 log.debug("No external assessment id={} in gradebook uid={}", publishedAssessmentId, uid);
             }
         }
 
-        if (!removed && lastNotFound != null) {
-            throw lastNotFound;
-        }
+        return removed;
     }
 
   public boolean isAssignmentDefined(String assessmentTitle,

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
@@ -778,8 +778,7 @@ public class PublishedAssessmentService extends AssessmentService{
         try {
           gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingService);
         } catch (Exception e1) {
-          // Should be the external assessment doesn't exist in GB. So we quiet swallow the exception. Please check the log for the actual error.
-          log.info("Exception thrown in updateGB():" + e1.getMessage());
+          log.warn("Failed to remove gradebook item for published assessment {}", assessment.getPublishedAssessmentId(), e1);
         }
 
         gbsHelper.manageScoresToNewGradebook(new GradingService(), gradingService, assessmentFacade, evaluation);
@@ -883,7 +882,7 @@ public class PublishedAssessmentService extends AssessmentService{
       try {
         gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingService);
       } catch(Exception e) {
-        log.warn("Something happened while removing the external assessment {}", e.getMessage());
+        log.warn("Failed to remove gradebook item for published assessment {}", assessment.getPublishedAssessmentId(), e);
       }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradebook unlinking so the app now checks whether a linked item was actually removed before updating status.
  * Prevented missing gradebook links from interrupting assessment deletion or save flows.
  * Updated error handling to surface clearer warnings when gradebook removal fails.
  * Added safer handling when no gradebook association exists, avoiding unnecessary exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->