### PR TITLE
SAK-52730 Assignments Old attachments from Resources fail to copy

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -3895,7 +3895,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 					log.debug("Copying attachment {} to site {} content toolTitle {}", oAttachmentPath, toContext, toolTitle);
 					attachment = this.addResource(
 							Validator.escapeResourceName(oAttachment.getProperties().getProperty(ResourceProperties.PROP_DISPLAY_NAME)),
-							toContext,
+							getSiteCollection(toContext),
 							1,
 							oAttachment.getContentType(),
 							content,


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where copying attachments into non-attachment site resource areas could save to an incorrectly formatted destination.
  * Improved how the destination collection is determined to ensure the new resource lands in the correct location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->