### PR TITLE
SAK-49065 TAGS: Imported assignments should contain tags if the original assignment contain tags

### DIFF
--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -173,6 +173,7 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.taggable.api.TaggingManager;
 import org.sakaiproject.taggable.api.TaggingProvider;
+import org.sakaiproject.tags.api.Tag;
 import org.sakaiproject.tags.api.TagService;
 import org.sakaiproject.tasks.api.Priorities;
 import org.sakaiproject.tasks.api.Task;
@@ -5301,6 +5302,26 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
 
                     transversalMap.put("assignment/" + oAssignmentId, "assignment/" + nAssignmentId);
                     log.info("Old assignment id: {} - new assignment id: {}", oAssignmentId, nAssignmentId);
+
+                    // duplicate tags
+                    if (serverConfigurationService.getBoolean("tagservice.enable.integrations", false)) {
+                        List<Tag> associatedTags = tagService.getAssociatedTagsForItem(oAssignment.getContext(), oAssignmentId);
+
+                        List<String> newTagIds = new ArrayList<>();
+
+                        for (Tag tag : associatedTags) {
+                            List<Tag> tags = tagService.getTagsByExactLabel(tag.getTagLabel(), nAssignment.getContext());
+                            if (tags == null || tags.isEmpty()) {
+                               newTagIds.add(tag.getTagId());
+                            } else {
+                                tagService.saveTagAssociation(nAssignmentId, tags.get(0).getTagId());
+                            }
+                        }
+
+                        if (!newTagIds.isEmpty()) {
+                            tagService.duplicateTags(nAssignment.getContext(), true, newTagIds, nAssignmentId);
+                        }
+                    }
 
                     try {
                         if (taggingManager.isTaggable()) {

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -5304,7 +5304,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
                     log.info("Old assignment id: {} - new assignment id: {}", oAssignmentId, nAssignmentId);
 
                     // duplicate tags
-                    if (serverConfigurationService.getBoolean("tagservice.enable.integrations", false)) {
+                    if (serverConfigurationService.getBoolean("tagservice.enable.integrations", true)) {
                         List<Tag> associatedTags = tagService.getAssociatedTagsForItem(oAssignment.getContext(), oAssignmentId);
 
                         List<String> newTagIds = new ArrayList<>();

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTransferCopyEntitiesTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTransferCopyEntitiesTest.java
@@ -72,6 +72,7 @@ import org.sakaiproject.grading.api.GradebookInformation;
 import org.sakaiproject.grading.api.GradingConstants;
 import org.sakaiproject.grading.api.GradingService;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.taggable.api.TaggingManager;
 import org.sakaiproject.tags.api.Tag;
 import org.sakaiproject.tags.api.TagService;
 import org.sakaiproject.time.api.UserTimeService;
@@ -412,7 +413,7 @@ public class AssignmentTransferCopyEntitiesTest extends AbstractTransactionalJUn
 
     @Test
     public void testTransferCopyEntitiesWithTagIntegration() throws Exception {
-        when(serverConfigurationService.getBoolean("tagservice.enable.integrations", false)).thenReturn(true);
+        when(serverConfigurationService.getBoolean("tagservice.enable.integrations", true)).thenReturn(true);
 
         String fromContext = UUID.randomUUID().toString();
         String toContext = UUID.randomUUID().toString();

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTransferCopyEntitiesTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentTransferCopyEntitiesTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -35,6 +36,8 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -69,6 +72,8 @@ import org.sakaiproject.grading.api.GradebookInformation;
 import org.sakaiproject.grading.api.GradingConstants;
 import org.sakaiproject.grading.api.GradingService;
 import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.tags.api.Tag;
+import org.sakaiproject.tags.api.TagService;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.User;
@@ -94,6 +99,7 @@ public class AssignmentTransferCopyEntitiesTest extends AbstractTransactionalJUn
     @Autowired private SessionManager sessionManager;
     @Autowired private ServerConfigurationService serverConfigurationService;
     @Autowired private GradingService gradingService;
+    @Autowired private TagService tagService;
     @Resource(name = "org.sakaiproject.time.api.UserTimeService")
     private UserTimeService userTimeService;
     @Autowired private UserDirectoryService userDirectoryService;
@@ -402,6 +408,62 @@ public class AssignmentTransferCopyEntitiesTest extends AbstractTransactionalJUn
         when(gradingService.getGradebookInformation(toContext, toContext)).thenReturn(destinationGradebookInformation);
         when(gradingService.getCategoryDefinitions(fromContext, fromContext)).thenReturn(List.of(sourceCategory));
         when(gradingService.getCategoryDefinitions(toContext, toContext)).thenReturn(List.of(destinationCategory));
+    }
+
+    @Test
+    public void testTransferCopyEntitiesWithTagIntegration() throws Exception {
+        when(serverConfigurationService.getBoolean("tagservice.enable.integrations", false)).thenReturn(true);
+
+        String fromContext = UUID.randomUUID().toString();
+        String toContext = UUID.randomUUID().toString();
+
+        stubContextPermissions(toContext);
+        stubContextPermissions(fromContext);
+
+        Assignment sourceAssignment = createPublishedAssignment(fromContext);
+        String oAssignmentId = sourceAssignment.getId();
+
+        sourceAssignment.getProperties().put(AssignmentConstants.NEW_ASSIGNMENT_ADD_TO_GRADEBOOK,
+            AssignmentConstants.GRADEBOOK_INTEGRATION_NO);
+        updateAssignment(sourceAssignment);
+
+        Tag existingTagSource = mock(Tag.class);
+        when(existingTagSource.getTagId()).thenReturn("tag_existing_id");
+        when(existingTagSource.getTagLabel()).thenReturn("Math");
+
+        Tag missingTagSource = mock(Tag.class);
+        when(missingTagSource.getTagId()).thenReturn("tag_missing_id");
+        when(missingTagSource.getTagLabel()).thenReturn("Science");
+
+        List<Tag> sourceTags = Arrays.asList(existingTagSource, missingTagSource);
+
+        when(tagService.getAssociatedTagsForItem(fromContext, oAssignmentId)).thenReturn(sourceTags);
+
+        Tag targetExistingTag = mock(Tag.class);
+        when(targetExistingTag.getTagId()).thenReturn("tag_existing_target_id");
+        when(tagService.getTagsByExactLabel("Math", toContext)).thenReturn(Collections.singletonList(targetExistingTag));
+
+        when(tagService.getTagsByExactLabel("Science", toContext)).thenReturn(Collections.emptyList());
+
+        when(sessionManager.getCurrentSessionUserId()).thenReturn("test_admin_user");
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn("test_admin_user");
+        when(userDirectoryService.getCurrentUser()).thenReturn(mockUser);
+
+        List<String> ids = Collections.singletonList(oAssignmentId);
+        getAssignmentServiceImpl().transferCopyEntities(fromContext, toContext, ids, new ArrayList<>());
+
+        Collection<Assignment> importedAssignments = assignmentService.getAssignmentsForContext(toContext);
+        assertEquals(1, importedAssignments.size());
+        String nAssignmentId = importedAssignments.iterator().next().getId();
+
+        verify(tagService).getAssociatedTagsForItem(fromContext, oAssignmentId);
+        verify(tagService).getTagsByExactLabel("Math", toContext);
+        verify(tagService).saveTagAssociation(nAssignmentId, "tag_existing_target_id");
+        verify(tagService).getTagsByExactLabel("Science", toContext);
+
+        List<String> expectedNewTagIds = Collections.singletonList("tag_missing_id");
+        verify(tagService).duplicateTags(toContext, true, expectedNewTagIds, nAssignmentId);
     }
 
     private AssignmentServiceImpl getAssignmentServiceImpl() {

--- a/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/MetaDataList.java
+++ b/samigo/samigo-qti/src/java/org/sakaiproject/tool/assessment/qti/helper/MetaDataList.java
@@ -175,7 +175,7 @@ import org.sakaiproject.tool.assessment.facade.ItemFacade;
                     Optional collection = tagService.getTagCollections().getForExternalSourceName(tagCollectionName);
                     if (collection.isPresent()) {
                         TagCollection tagCollection = (TagCollection) collection.get();
-                        List<Tag> potentialTags = tagService.getTags().getTagsByExactLabel(tagLabel.trim());
+                        List<Tag> potentialTags = tagService.getTags().getTagsByExactLabel(tagLabel.trim(), tagCollection.getTagCollectionId());
                         potentialTags.stream().filter(t -> t.getCollectionName().equals(tagCollection.getName())).forEach(t -> {
                                 item.addItemTag(t.getTagId(), t.getTagLabel(), t.getTagCollectionId(), t.getCollectionName());
                         });

--- a/tags/tags-api/api/src/java/org/sakaiproject/tags/api/TagService.java
+++ b/tags/tags-api/api/src/java/org/sakaiproject/tags/api/TagService.java
@@ -42,28 +42,28 @@ public interface TagService {
     public void destroy();
 
     /**
-     * Return the tags sub-service.
-     */
+        * Return the tags sub-service.
+    */
     public Tags getTags();
 
     /**
-     * Return the collections sub-service
-     */
+        * Return the collections sub-service
+    */
     public TagCollections getTagCollections();
 
     /**
-     * Return an I18N translator for a given file and locale.
-     */
+        * Return an I18N translator for a given file and locale.
+    */
     public I18n getI18n(ClassLoader loader, String resourceBase);
 
     /**
-     * Return if the service is enabled or not.
-     */
+        * Return if the service is enabled or not.
+    */
     public Boolean getServiceActive ();
 
     /**
-     * Return the max size of the pages
-     */
+        * Return the max size of the pages
+    */
     public int getMaxPageSize();
 
     /**

--- a/tags/tags-api/api/src/java/org/sakaiproject/tags/api/TagService.java
+++ b/tags/tags-api/api/src/java/org/sakaiproject/tags/api/TagService.java
@@ -66,8 +66,65 @@ public interface TagService {
      */
     public int getMaxPageSize();
 
+    /**
+        * Save a new association between an item and a specific tag.
+        * @param itemId
+        * The ID of the item to be associated.
+        * @param tagId
+        * The ID of the tag to associate with the item.
+    */
     public void saveTagAssociation(String itemId, String tagId);
+    /**
+        * Retrieve a list of tags that match an exact label within a specific collection.
+        * @param label
+        * The exact text label of the tag to look for.
+        * @param collectionId
+        * The ID of the collection to search within.
+        * @return A list of tags matching the given label.
+	*/
+    public List<Tag> getTagsByExactLabel(String label, String collectionId);
+    /**
+        * Retrieve the IDs of all tag associations for a given collection and item.
+        * @param collectionId
+        * The ID of the collection context.
+        * @param itemId
+        * The ID of the item whose tag association IDs are being requested.
+        * @return A list of tag IDs associated with the specified item.
+	*/
     public List<String> getTagAssociationIds(String collectionId, String itemId);
+    /**
+        * Retrieve the full tag objects associated with a specific item.
+        * @param collectionId
+        * The ID of the collection context.
+        * @param itemId
+        * The ID of the item whose associated tags are being requested.
+        * @return A list of Tag objects associated with the item, skipping any that no longer exist.
+	*/
     public List<Tag> getAssociatedTagsForItem(String collectionId, String itemId);
+    /**
+        * Duplicate a list of tags into a target collection, creating the collection if it does not exist,
+	    * and optionally associate them with a target item.
+	    * @param targetCollectionId
+	    * The ID of the collection where the tags will be duplicated.
+	    * @param isSite
+	    * Whether the target collection belongs to a site context or a user context.
+	    * @param tagIds
+	    * The collection of IDs of the tags to be duplicated.
+	    * @param targetItemId
+	    * The ID of the item to associate the duplicated tags with, or null if no association is needed.
+	    * @return A list containing the newly duplicated tags.
+    */
+    public List<Tag> duplicateTags(String targetCollectionId, boolean isSite, Collection<String> tagIds, String targetItemId);
+    /**
+        * Update the tag associations for an item by adding new ones and removing those deselected.
+        * @param collectionId
+        * The ID of the collection context.
+        * @param itemId
+        * The ID of the item to update associations for.
+        * @param tagIds
+        * The current collection of tag IDs that should be associated with the item.
+        * @param isSite
+        * Whether the collection belongs to a site context or a user context.
+	*/
     public void updateTagAssociations(String collectionId, String itemId, Collection<String> tagIds, boolean isSite);
 }

--- a/tags/tags-api/api/src/java/org/sakaiproject/tags/api/Tags.java
+++ b/tags/tags-api/api/src/java/org/sakaiproject/tags/api/Tags.java
@@ -50,7 +50,7 @@ public interface Tags {
 
     public List<Tag> getAllInCollection(String tagCollectionId);
 
-    public List<Tag> getTagsByExactLabel(String label);
+    public List<Tag> getTagsByExactLabel(String label, String collectionId);
 
     public List<Tag> getTagsByPartialLabel(String label);
 

--- a/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/TagServiceImpl.java
+++ b/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/TagServiceImpl.java
@@ -98,6 +98,11 @@ public class TagServiceImpl implements TagService {
     }
 
     @Override
+    public List<Tag> getTagsByExactLabel(String label, String collectionId) {
+        return tags.getTagsByExactLabel(label, collectionId);
+    }
+
+    @Override
     public List<String> getTagAssociationIds(String collectionId, String itemId) {
         return tagAssociationRepository.findTagAssociationByCollectionAndItem(collectionId, itemId).stream().map(TagAssociation::getTagId).collect(Collectors.toList());
     }
@@ -115,6 +120,45 @@ public class TagServiceImpl implements TagService {
             }
         }
         return associatedTags;
+    }
+
+    @Override
+    public List<Tag> duplicateTags(String targetCollectionId, boolean isSite, Collection<String> tagIds, String targetItemId) {
+        List<Tag> duplicatedTags = new ArrayList<>();
+
+        // create collection if it doesn't exist
+        TagCollection col = tagCollections.getForId(targetCollectionId).orElse(null);
+        if (col == null) {
+            I18n i18n = getI18n(this.getClass().getClassLoader(), "org.sakaiproject.tags.api.i18n.tagservice");
+            String description = i18n.t("user_collection");
+            if (isSite) {
+                description = i18n.tFormatted("site_collection", targetCollectionId);
+            }
+            col = new TagCollection(targetCollectionId, targetCollectionId, description, null, 0L, null, null, null, 0L, Boolean.FALSE, Boolean.FALSE, 0L, 0L);
+            tagCollections.createTagCollection(col);
+        }
+
+        for (String tagId : tagIds) {
+            Tag tag = tags.getForId(tagId).orElse(null);
+            if (tag == null) {
+                log.warn("Tag with id {} does not exist anymore" + tagId);
+                continue;
+            }
+
+            Tag duplicatedTag = new Tag(null, targetCollectionId, tag.getTagLabel(), tag.getDescription(), null,
+                    0L, null, 0L, null, null, Boolean.FALSE, 0L,
+                    Boolean.FALSE, 0L, null, null, null, null, null);
+            String id = tags.createTag(duplicatedTag);
+            duplicatedTag.setTagId(id);
+
+            duplicatedTags.add(duplicatedTag);
+
+            if (targetItemId != null) {
+                saveTagAssociation(targetItemId, duplicatedTag.getTagId());
+            }
+        }
+
+        return duplicatedTags;
     }
 
     @Override

--- a/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/TagServiceImpl.java
+++ b/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/TagServiceImpl.java
@@ -141,7 +141,7 @@ public class TagServiceImpl implements TagService {
         for (String tagId : tagIds) {
             Tag tag = tags.getForId(tagId).orElse(null);
             if (tag == null) {
-                log.warn("Tag with id {} does not exist anymore" + tagId);
+                log.warn("Tag with id {} does not exist anymore", tagId);
                 continue;
             }
 

--- a/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/storage/TagStorage.java
+++ b/tags/tags-impl/impl/src/java/org/sakaiproject/tags/impl/storage/TagStorage.java
@@ -55,7 +55,7 @@ public class TagStorage implements Tags {
 
     private static final String QUERY_GET_ALL = "SELECT * from tagservice_tag ORDER by tagLabel,tagcollectionid";
     private static final String QUERY_GET_ALL_IN_COLLECTION = "SELECT * from tagservice_tag WHERE tagcollectionid = ? ORDER by tagLabel";
-    private static final String QUERY_GET_TAGS_BY_EXACT_LABEL = "SELECT * from tagservice_tag WHERE taglabel = ? ORDER by tagcollectionid";
+    private static final String QUERY_GET_TAGS_BY_EXACT_LABEL = "SELECT * from tagservice_tag " + "WHERE taglabel = ? AND tagcollectionid = ? " + "ORDER by tagcollectionid";
     private static final String QUERY_GET_TAGS_BY_PARTIAL_LABEL = "SELECT * from tagservice_tag WHERE taglabel LIKE ? ORDER by tagcollectionid";
     private static final String QUERY_GET_TAGS_BY_PREFIX_IN_LABEL = "SELECT * from tagservice_tag WHERE LOWER(taglabel) LIKE LOWER(?) ORDER by taglabel,tagcollectionid";
     private static final String QUERY_GET_TOTAL_TAGS_BY_PREFIX_IN_LABEL = "SELECT COUNT(*) as total_tags from tagservice_tag WHERE LOWER(taglabel) LIKE LOWER(?) ORDER by taglabel,tagcollectionid";
@@ -197,15 +197,16 @@ public class TagStorage implements Tags {
 
 
     @Override
-    public List<Tag> getTagsByExactLabel(final String label) {
+    public List<Tag> getTagsByExactLabel(final String label, final String collectionId) {
         return db.transaction
-                ("Find all tags in a collection",
+                ("Find tags by exact label within a collection",
                         new DBAction<List<Tag>>() {
                             @Override
                             public List<Tag> call(DBConnection db) throws SQLException {
                                 List<Tag> tags = new ArrayList<>();
                                 try (DBResults results = db.run(QUERY_GET_TAGS_BY_EXACT_LABEL)
                                         .param(label)
+                                        .param(collectionId)
                                         .executeQuery()) {
                                     HashMap<String,String> collectionNames = new HashMap<>();
                                     for (ResultSet result : results) {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49065

I also added Javadoc into the TagService methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assignment copies now preserve and duplicate associated tags when tag integrations are enabled.
  * Tag duplication can reuse exact label matches in the destination collection and optionally associate duplicated tags to the imported assignment.
* **Bug Fixes**
  * Exact-label tag lookup is now scoped to the correct tag collection, improving accuracy for assignment tag transfers and QTI metadata tags.
* **Tests**
  * Added coverage for assignment copy behavior with tag integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->