### PR TITLE
SAK-52727 Chat add own chat room permissions and room owner column

### DIFF
--- a/chat/chat-api/api/src/bundle/chat.properties
+++ b/chat/chat-api/api/src/bundle/chat.properties
@@ -146,6 +146,7 @@ view=View
 
 enter_the_chat_room=Enter ''{0}'' Room
 channel_creation_date=Creation Date
+channel_created_by=Created By
 channel_description=Description
 channel_description_colon=Description:
 channel_title=Title
@@ -220,8 +221,10 @@ perm-chat.read=Read chat messages
 perm-chat.delete.any=Delete any chat messages
 perm-chat.delete.own=Delete own chat messages
 perm-chat.delete.channel=Delete a chat room
+perm-chat.delete.own.channel=Delete own chat room
 perm-chat.new.channel=Create a new chat room
 perm-chat.revise.channel=Set chat room options
+perm-chat.revise.own.channel=Set own chat room options
 
 chat_header=Message Headers\n
 chat_from=From 

--- a/chat/chat-api/api/src/java/org/sakaiproject/chat2/model/ChatChannel.java
+++ b/chat/chat-api/api/src/java/org/sakaiproject/chat2/model/ChatChannel.java
@@ -95,6 +95,9 @@ public class ChatChannel implements org.sakaiproject.entity.api.Entity {
    @Temporal(TemporalType.TIMESTAMP)
    private Date creationDate;
 
+   @Column(name = "OWNER", length = 99)
+   private String owner;
+
    @Column(length = 64)
    private String title;
 

--- a/chat/chat-api/api/src/java/org/sakaiproject/chat2/model/ChatFunctions.java
+++ b/chat/chat-api/api/src/java/org/sakaiproject/chat2/model/ChatFunctions.java
@@ -38,6 +38,8 @@ public interface ChatFunctions {
    public static final String CHAT_FUNCTION_DELETE_ANY = CHAT_FUNCTION_DELETE_PREFIX + "any";
    
    public static final String CHAT_FUNCTION_DELETE_CHANNEL = CHAT_FUNCTION_DELETE_PREFIX + "channel";
+   public static final String CHAT_FUNCTION_DELETE_OWN_CHANNEL = CHAT_FUNCTION_DELETE_PREFIX + "own.channel";
    public static final String CHAT_FUNCTION_NEW_CHANNEL = CHAT_FUNCTION_PREFIX + "new.channel";
    public static final String CHAT_FUNCTION_EDIT_CHANNEL = CHAT_FUNCTION_PREFIX + "revise.channel";
+   public static final String CHAT_FUNCTION_EDIT_OWN_CHANNEL = CHAT_FUNCTION_PREFIX + "revise.own.channel";
 }

--- a/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatManagerImpl.java
+++ b/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatManagerImpl.java
@@ -184,8 +184,10 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
                 functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_ANY, true);
                 functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_OWN, true);
                 functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL, true);
+                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_OWN_CHANNEL, true);
                 functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_NEW_CHANNEL, true);
                 functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL, true);
+                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_EDIT_OWN_CHANNEL, true);
             }
 
             pollInterval = serverConfigurationService.getInt("chat.pollInterval", 5000);
@@ -277,6 +279,9 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
 
         channel.setCreationDate(new Date());
         channel.setContext(context);
+        if (checkAuthz) {
+            channel.setOwner(sessionManager.getCurrentSessionUserId());
+        }
         channel.setTitle(title);
         channel.setPlacementDefaultChannel(placementDefaultChannel);
         if (placementDefaultChannel) {
@@ -295,8 +300,12 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
         if (channel == null)
             return;
 
-        if (checkAuthz)
-            checkPermission(ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL, channel.getContext());
+        if (checkAuthz && !getCanEdit(channel)) {
+            String function = isChannelOwner(channel)
+                    ? ChatFunctions.CHAT_FUNCTION_EDIT_OWN_CHANNEL
+                    : ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL;
+            throw new PermissionException(sessionManager.getCurrentSessionUserId(), function, channel.getContext());
+        }
 
         getHibernateTemplate().saveOrUpdate(channel);
     }
@@ -310,7 +319,13 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
         if (channel == null)
             return;
 
-        checkPermission(ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL, channel.getContext());
+        if (!getCanDelete(channel)) {
+            String function = isChannelOwner(channel)
+                    ? ChatFunctions.CHAT_FUNCTION_DELETE_OWN_CHANNEL
+                    : ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL;
+            throw new PermissionException(sessionManager.getCurrentSessionUserId(), function, channel.getContext());
+        }
+
         getHibernateTemplate().delete(getHibernateTemplate().merge(channel));
 
         sendDeleteChannel(channel);
@@ -587,7 +602,13 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
      */
     public boolean getCanDelete(ChatChannel channel)
     {
-        return channel == null ? false : can(ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL, channel.getContext());
+        if (channel == null) {
+            return false;
+        }
+        if (can(ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL, channel.getContext())) {
+            return true;
+        }
+        return isChannelOwner(channel) && can(ChatFunctions.CHAT_FUNCTION_DELETE_OWN_CHANNEL, channel.getContext());
     }
 
     /**
@@ -595,7 +616,18 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
      */
     public boolean getCanEdit(ChatChannel channel)
     {
-        return channel == null ? false : can(ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL, channel.getContext());
+        if (channel == null) {
+            return false;
+        }
+        if (can(ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL, channel.getContext())) {
+            return true;
+        }
+        return isChannelOwner(channel) && can(ChatFunctions.CHAT_FUNCTION_EDIT_OWN_CHANNEL, channel.getContext());
+    }
+
+    private boolean isChannelOwner(ChatChannel channel) {
+        String currentUserId = sessionManager.getCurrentSessionUserId();
+        return currentUserId != null && currentUserId.equals(channel.getOwner());
     }
 
     /**

--- a/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatManagerImpl.java
+++ b/chat/chat-impl/impl/src/java/org/sakaiproject/chat2/model/impl/ChatManagerImpl.java
@@ -178,16 +178,21 @@ public class ChatManagerImpl extends HibernateDaoSupport implements ChatManager,
         try {
 
             // register functions
-            if(functionManager.getRegisteredFunctions(ChatFunctions.CHAT_FUNCTION_PREFIX).size() == 0) {
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_READ, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_NEW, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_ANY, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_OWN, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_DELETE_OWN_CHANNEL, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_NEW_CHANNEL, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL, true);
-                functionManager.registerFunction(ChatFunctions.CHAT_FUNCTION_EDIT_OWN_CHANNEL, true);
+            List<String> chatFunctions = List.of(
+                    ChatFunctions.CHAT_FUNCTION_READ,
+                    ChatFunctions.CHAT_FUNCTION_NEW,
+                    ChatFunctions.CHAT_FUNCTION_DELETE_ANY,
+                    ChatFunctions.CHAT_FUNCTION_DELETE_OWN,
+                    ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL,
+                    ChatFunctions.CHAT_FUNCTION_DELETE_OWN_CHANNEL,
+                    ChatFunctions.CHAT_FUNCTION_NEW_CHANNEL,
+                    ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL,
+                    ChatFunctions.CHAT_FUNCTION_EDIT_OWN_CHANNEL);
+            List<String> registeredChatFunctions = functionManager.getRegisteredFunctions(ChatFunctions.CHAT_FUNCTION_PREFIX);
+            for (String chatFunction : chatFunctions) {
+                if (!registeredChatFunctions.contains(chatFunction)) {
+                    functionManager.registerFunction(chatFunction, true);
+                }
             }
 
             pollInterval = serverConfigurationService.getInt("chat.pollInterval", 5000);

--- a/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
+++ b/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
@@ -1186,7 +1186,7 @@ public class ChatTool {
       try {
          return userDirectoryService.getUser(channel.getOwner()).getDisplayName(channel.getContext());
       } catch (UserNotDefinedException e) {
-         log.debug("Failed to find user for ID: " + channel.getOwner(), e);
+         log.debug("Failed to find the owner of chat room [{}]", channel.getId(), e);
          return channel.getOwner();
       }
    }

--- a/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
+++ b/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/ChatTool.java
@@ -545,7 +545,7 @@ public class ChatTool {
 
                }
            catch (PermissionException e) {
-               setErrorMessage(PERMISSION_ERROR, new String[] {ChatFunctions.CHAT_FUNCTION_EDIT_CHANNEL});
+               setErrorMessage(PERMISSION_ERROR, new String[] {e.getLock()});
                return "";
            }
            else {
@@ -602,7 +602,7 @@ public class ChatTool {
          return PAGE_LIST_ROOMS;
       }
       catch (PermissionException e) {
-         setErrorMessage(PERMISSION_ERROR, new String[] {ChatFunctions.CHAT_FUNCTION_DELETE_CHANNEL});
+         setErrorMessage(PERMISSION_ERROR, new String[] {e.getLock()});
          return "";
       }
    }
@@ -1176,6 +1176,19 @@ public class ChatTool {
          return message.getOwner();
       }
       return sender.getDisplayName(message.getChatChannel().getContext());
+   }
+
+   public String getChannelOwnerDisplayName(ChatChannel channel)
+   {
+      if (channel == null || StringUtils.isBlank(channel.getOwner())) {
+         return "";
+      }
+      try {
+         return userDirectoryService.getUser(channel.getOwner()).getDisplayName(channel.getContext());
+      } catch (UserNotDefinedException e) {
+         log.debug("Failed to find user for ID: " + channel.getOwner(), e);
+         return channel.getOwner();
+      }
    }
 
    protected String getPastXDaysText(int x) {

--- a/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/DecoratedChatChannel.java
+++ b/chat/chat-tool/tool/src/java/org/sakaiproject/chat2/tool/DecoratedChatChannel.java
@@ -124,6 +124,10 @@ public class DecoratedChatChannel {
    public boolean getCanRead() {
       return chatTool.getCanRead(chatChannel);
    }
+
+   public String getOwnerDisplayName() {
+      return chatTool.getChannelOwnerDisplayName(chatChannel);
+   }
    
    /**
     * Returns the bundle message with key "enter_the_chat_room", inserting the chat channel's title

--- a/chat/chat-tool/tool/src/webapp/jsp/listRooms.jsp
+++ b/chat/chat-tool/tool/src/webapp/jsp/listRooms.jsp
@@ -66,6 +66,12 @@
 				</h:column>
 				<h:column>
 					<f:facet name="header">
+						<h:outputText value="#{msgs.channel_created_by}" />
+					</f:facet>
+					<h:outputText value="#{channel.ownerDisplayName}" />
+				</h:column>
+				<h:column>
+					<f:facet name="header">
 						<h:outputText value="#{msgs.channel_description}" />
 					</f:facet>
 					<h:outputText value="#{channel.chatChannel.description}" />


### PR DESCRIPTION
Chat rooms had no owner, so permissions could not distinguish a room a user created from any other room. Granting chat.new.channel alone failed on save because updateChannel always required chat.revise.channel.

Record the owner on channel creation and add chat.revise.own.channel and chat.delete.own.channel. Edit and delete now resolve through getCanEdit and getCanDelete so enforcement matches the links shown in the room list. Permission errors report the function actually missing.

Rooms created without an authz check, such as the auto created default room and imported rooms, are left unowned and stay governed by the existing site wide permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat rooms now display their creator in the room list.
  - Room owners can be identified and manage their own rooms when permitted.
  - Added separate permissions for deleting and editing one’s own chat rooms.

- **Bug Fixes**
  - Permission errors now provide more accurate, action-specific feedback.
  - Room creator information remains readable even when a display name is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->