### PR TITLE
SAK-52728: Forums reset the tool session after an import

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImpl.java
@@ -74,6 +74,7 @@ import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.ToolConfiguration;
+import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.Tool;
 import org.sakaiproject.tool.api.ToolManager;
@@ -756,8 +757,27 @@ public class DiscussionForumServiceImpl implements DiscussionForumService, Entit
 		catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}
-		
+
+		resetForumsToolSession(toContext);
+
 		return transversalMap;
+	}
+
+	private void resetForumsToolSession(String toContext) {
+
+		Session session = sessionManager.getCurrentSession();
+		if (session == null) {
+			return;
+		}
+
+		try {
+			Site site = siteService.getSite(toContext);
+			for (ToolConfiguration toolConfiguration : site.getTools(FORUMS_TOOL_ID)) {
+				session.getToolSession(toolConfiguration.getId()).clearAttributes();
+			}
+		} catch (IdUnusedException e) {
+			log.warn("Could not reset the forums tool session, site {} not found", toContext);
+		}
 	}
 
 	public String merge(String siteId, Element root, String archivePath, String fromSiteId, MergeConfig mcx) {

--- a/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImplTest.java
+++ b/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/DiscussionForumServiceImplTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.component.app.messageforums;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.sakaiproject.api.app.messageforums.AreaManager;
+import org.sakaiproject.api.app.messageforums.DiscussionForumService;
+import org.sakaiproject.api.app.messageforums.MessageForumsTypeManager;
+import org.sakaiproject.api.app.messageforums.ui.DiscussionForumManager;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.ToolConfiguration;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.tool.api.ToolSession;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiscussionForumServiceImplTest {
+
+    private static final String FROM_CONTEXT = "site-from";
+    private static final String TO_CONTEXT = "site-to";
+    private static final String FORUMS_PLACEMENT_ID = "placement-forums";
+
+    @Mock private AreaManager areaManager;
+    @Mock private DiscussionForumManager dfManager;
+    @Mock private MessageForumsTypeManager typeManager;
+    @Mock private ServerConfigurationService serverConfigurationService;
+    @Mock private SessionManager sessionManager;
+    @Mock private SiteService siteService;
+    @Mock private Session session;
+    @Mock private Site site;
+    @Mock private ToolConfiguration forumsPlacement;
+    @Mock private ToolSession forumsToolSession;
+
+    private DiscussionForumServiceImpl discussionForumService;
+
+    @Before
+    public void setUp() {
+        discussionForumService = new DiscussionForumServiceImpl();
+        discussionForumService.setAreaManager(areaManager);
+        discussionForumService.setDfManager(dfManager);
+        discussionForumService.setTypeManager(typeManager);
+        discussionForumService.setServerConfigurationService(serverConfigurationService);
+        discussionForumService.setSessionManager(sessionManager);
+        discussionForumService.setSiteService(siteService);
+
+        when(dfManager.getDiscussionForumsWithTopicsMembershipNoAttachments(FROM_CONTEXT))
+                .thenReturn(Collections.emptyList());
+        when(dfManager.getDiscussionForumsByContextId(TO_CONTEXT)).thenReturn(Collections.emptyList());
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+    }
+
+    @Test
+    public void transferCopyEntitiesClearsTheForumsToolSessionOfTheDestinationSite() throws Exception {
+        when(siteService.getSite(TO_CONTEXT)).thenReturn(site);
+        when(forumsPlacement.getId()).thenReturn(FORUMS_PLACEMENT_ID);
+        when(site.getTools(DiscussionForumService.FORUMS_TOOL_ID))
+                .thenReturn(Collections.singletonList(forumsPlacement));
+        when(session.getToolSession(FORUMS_PLACEMENT_ID)).thenReturn(forumsToolSession);
+
+        discussionForumService.transferCopyEntities(FROM_CONTEXT, TO_CONTEXT, Collections.emptyList(), null);
+
+        verify(forumsToolSession).clearAttributes();
+    }
+
+    @Test
+    public void transferCopyEntitiesClearsNothingWhenTheDestinationSiteHasNoForumsTool() throws Exception {
+        when(siteService.getSite(TO_CONTEXT)).thenReturn(site);
+        when(site.getTools(DiscussionForumService.FORUMS_TOOL_ID)).thenReturn(Collections.emptyList());
+
+        discussionForumService.transferCopyEntities(FROM_CONTEXT, TO_CONTEXT, Collections.emptyList(), null);
+
+        verify(session, never()).getToolSession(anyString());
+    }
+
+    @Test
+    public void transferCopyEntitiesSurvivesAMissingDestinationSite() throws Exception {
+        when(siteService.getSite(TO_CONTEXT)).thenThrow(new IdUnusedException(TO_CONTEXT));
+
+        discussionForumService.transferCopyEntities(FROM_CONTEXT, TO_CONTEXT, Collections.emptyList(), null);
+
+        verify(session, never()).getToolSession(anyString());
+    }
+
+    @Test
+    public void transferCopyEntitiesWithCleanupClearsTheForumsToolSession() throws Exception {
+        when(siteService.getSite(TO_CONTEXT)).thenReturn(site);
+        when(forumsPlacement.getId()).thenReturn(FORUMS_PLACEMENT_ID);
+        when(site.getTools(DiscussionForumService.FORUMS_TOOL_ID))
+                .thenReturn(Collections.singletonList(forumsPlacement));
+        when(session.getToolSession(FORUMS_PLACEMENT_ID)).thenReturn(forumsToolSession);
+        when(areaManager.getDiscussionArea(anyString(), anyBoolean())).thenReturn(null);
+
+        discussionForumService.transferCopyEntities(FROM_CONTEXT, TO_CONTEXT, Collections.emptyList(), null, true);
+
+        verify(forumsToolSession).clearAttributes();
+    }
+}


### PR DESCRIPTION
The Discussions tool bean is JSF session scoped, which inside a tool is the placement ToolSession, and getForums caches the forum list for the life of that session. Importing into a site whose Discussions tool had already been opened left that cache pointing at the pre import forums.

Clicking Discussions in the site navigation preserves tool state, so the stale list kept rendering. The breadcrumb link goes through page-reset, which clears the ToolSession, which is why only that path appeared to work. Sites without a prior Discussions tool were unaffected because no bean had been created yet.

Clear the ToolSession of the destination site's Discussions placements once a transfer completes, so the next render rebuilds the forum list. Both the merge and the replace paths funnel through this method.

This covers the user performing the import. Other users keep their own cached list until their tool session resets.