### PR TITLE
SAK-52736 Assignments/LTI Add support for the description field in CI/DL Returns

### DIFF
--- a/assignment/api/src/resources/assignment.properties
+++ b/assignment/api/src/resources/assignment.properties
@@ -610,6 +610,7 @@ allowResubmit	= Allow Resubmission
 launchContentId = External Tool to launch
 launchContentNewWindow = Load this tool in a new tab
 launchContentTitle = Do you want to change the assignment title to:
+launchContentDescription = Do you want to replace the assignment instructions with the description from the external tool?
 allowExtension = Allow Extension
 allowExtensionCaption =  - If this student has not submitted yet, you can set a custom extended due date for this student only. 
 allowExtensionCaptionGrader = If this student has not submitted yet, you can set a custom extended due date for this student only. 

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -580,11 +580,35 @@
                             }
                         };
                         window.returnContentTitle = function (newTitle) {
+                            if ( ! newTitle ) return;
                             setTimeout(function(){
-                                if ( confirm('$tlang.getString("launchContentTitle")'+" "+newTitle) ) {
-                                    $("#new_assignment_title").val(newTitle);
+                                var $title = $("#new_assignment_title");
+                                var current = ($title.val() || "").trim();
+                                // Only prompt when replacing an existing title
+                                if ( ! current || confirm('$tlang.getString("launchContentTitle")'+" "+newTitle) ) {
+                                    $title.val(newTitle);
                                 }
                             }, 500);
+                        };
+                        window.returnContentDescription = function (newDescription) {
+                            if ( ! newDescription ) return;
+                            // Run after the title prompt so confirms are not simultaneous
+                            setTimeout(function(){
+                                var editor = (typeof CKEDITOR !== 'undefined') ? CKEDITOR.instances['$name_Description'] : null;
+                                var currentHtml = editor ? editor.getData() : ($("#$name_Description").val() || "");
+                                var currentText = currentHtml.replace(/<[^>]*>/g, "").replace(/&nbsp;/gi, " ").trim();
+                                var applyDescription = function () {
+                                    if ( editor ) {
+                                        editor.setData(newDescription);
+                                    } else {
+                                        $("#$name_Description").val(newDescription);
+                                    }
+                                };
+                                // Only prompt when replacing existing instructions
+                                if ( ! currentText || confirm('$tlang.getString("launchContentDescription")') ) {
+                                    applyDescription();
+                                }
+                            }, 1000);
                         };
                     </script>
 			</div>

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_new_edit_assignment.vm
@@ -585,7 +585,7 @@
                                 var $title = $("#new_assignment_title");
                                 var current = ($title.val() || "").trim();
                                 // Only prompt when replacing an existing title
-                                if ( ! current || confirm('$tlang.getString("launchContentTitle")'+" "+newTitle) ) {
+                                if ( ! current || confirm('$formattedText.escapeJsQuoted($tlang.getString("launchContentTitle"))'+" "+newTitle) ) {
                                     $title.val(newTitle);
                                 }
                             }, 500);
@@ -605,7 +605,7 @@
                                     }
                                 };
                                 // Only prompt when replacing existing instructions
-                                if ( ! currentText || confirm('$tlang.getString("launchContentDescription")') ) {
+                                if ( ! currentText || confirm('$formattedText.escapeJsQuoted($tlang.getString("launchContentDescription"))') ) {
                                     applyDescription();
                                 }
                             }, 1000);

--- a/lti/lti-tool/pom.xml
+++ b/lti/lti-tool/pom.xml
@@ -95,6 +95,11 @@
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-text</artifactId>
          </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -89,6 +89,7 @@ import org.sakaiproject.tool.api.Session;
 import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.util.IframeUrlUtil;
 import org.sakaiproject.util.ResourceLoader;
+import org.sakaiproject.util.api.FormattedText;
 import org.sakaiproject.util.foorm.SakaiFoorm;
 import org.sakaiproject.time.api.UserTimeService;
 
@@ -3501,6 +3502,11 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			item.put("tool_newpage", toolNewPage);
 		}
 
+		String contentDescription = sanitizeLtiDescription((String) content.get(LTIService.LTI_DESCRIPTION));
+		if ( contentDescription != null ) {
+			item.put(ContentItem.TEXT, contentDescription);
+		}
+
 		new_content.add(item);
 
 		context.put("new_content", new_content);
@@ -3510,6 +3516,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		if ( FLOW_PARAMETER_ASSIGNMENT.equals(flow) ) {
 			context.put("contentId",  contentKey);
 			context.put("contentTitle", (String) content.get(LTIService.LTI_TITLE));
+			context.put("contentDescription", contentDescription);
 			context.put("contentLaunchNewWindow", contentNewPage);
 			context.put("contentToolNewpage", toolNewPage);
 
@@ -3578,9 +3585,31 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			context.put("contentId", LTIUtil.toLong(job.get("content_key")));
 			context.put("contentTitle", (String) job.get("title"));
 			context.put("toolTitle", (String) job.get("tool_title"));
+			// CI / DL use "text" for the description; sanitize before returning to Assignments
+			String contentDescription = sanitizeLtiDescription(getString(job, ContentItem.TEXT));
+			if ( contentDescription != null ) {
+				job.put(ContentItem.TEXT, contentDescription);
+				context.put("contentDescription", contentDescription);
+			}
 		}
 
 		return "lti_assignment_return";
+	}
+
+	/**
+	 * Run LTI content-item / deep-link description HTML through FormattedText (AntiSamy).
+	 * Returns null when there is nothing useful to return to the assignment UI.
+	 */
+	private String sanitizeLtiDescription(String description) {
+		if ( StringUtils.isBlank(description) ) {
+			return null;
+		}
+		FormattedText formattedText = ComponentManager.get(FormattedText.class);
+		String cleaned = formattedText.processFormattedText(description, new StringBuilder());
+		if ( StringUtils.isBlank(cleaned) ) {
+			return null;
+		}
+		return cleaned;
 	}
 
 

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -3586,14 +3586,31 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			context.put("contentTitle", (String) job.get("title"));
 			context.put("toolTitle", (String) job.get("tool_title"));
 			// CI / DL use "text" for the description; sanitize before returning to Assignments
-			String contentDescription = sanitizeLtiDescription(getString(job, ContentItem.TEXT));
+			String contentDescription = applySanitizedDescriptionToJob(job,
+					sanitizeLtiDescription(getString(job, ContentItem.TEXT)));
 			if ( contentDescription != null ) {
-				job.put(ContentItem.TEXT, contentDescription);
 				context.put("contentDescription", contentDescription);
 			}
 		}
 
 		return "lti_assignment_return";
+	}
+
+	/**
+	 * Replace ContentItem.TEXT on a content-item job with a sanitized description.
+	 * Always removes any prior text first so unsafe HTML cannot remain on the serialized job
+	 * (which is passed to the assignment UI via returnContentItem). Puts the sanitized value
+	 * back only when non-null.
+	 *
+	 * @return the sanitized description when applied, otherwise null
+	 */
+	static String applySanitizedDescriptionToJob(JSONObject job, String sanitizedDescription) {
+		job.remove(ContentItem.TEXT);
+		if ( sanitizedDescription == null ) {
+			return null;
+		}
+		job.put(ContentItem.TEXT, sanitizedDescription);
+		return sanitizedDescription;
 	}
 
 	/**

--- a/lti/lti-tool/src/test/org/sakaiproject/lti/tool/LTIAdminToolContentDescriptionTest.java
+++ b/lti/lti-tool/src/test/org/sakaiproject/lti/tool/LTIAdminToolContentDescriptionTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lti.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import org.tsugi.lti.ContentItem;
+
+/**
+ * Regression coverage for sanitizing CI/DL description text on assignment return jobs.
+ */
+public class LTIAdminToolContentDescriptionTest {
+
+	@Test
+	public void applySanitizedDescriptionToJob_omitsTextWhenOnlyDisallowedHtml() {
+		// AntiSamy/FormattedText leaves nothing usable for a script-only payload → null
+		JSONObject job = new JSONObject();
+		job.put("title", "Quiz");
+		job.put(ContentItem.TEXT, "<script>alert(1)</script>");
+
+		String applied = LTIAdminTool.applySanitizedDescriptionToJob(job, null);
+
+		assertNull(applied);
+		assertFalse(job.containsKey(ContentItem.TEXT));
+		String serialized = job.toJSONString();
+		assertFalse(serialized.contains("\"text\""));
+		assertFalse(serialized.contains("script"));
+		assertFalse(serialized.contains("alert"));
+	}
+
+	@Test
+	public void applySanitizedDescriptionToJob_putsSanitizedTextWhenPresent() {
+		JSONObject job = new JSONObject();
+		job.put(ContentItem.TEXT, "<script>alert(1)</script><p>ok</p>");
+		String sanitized = "<p>ok</p>";
+
+		String applied = LTIAdminTool.applySanitizedDescriptionToJob(job, sanitized);
+
+		assertEquals(sanitized, applied);
+		assertEquals(sanitized, job.get(ContentItem.TEXT));
+		assertTrue(job.toJSONString().contains("ok"));
+		assertFalse(job.toJSONString().contains("script"));
+	}
+}

--- a/lti/lti-tool/src/webapp/vm/lti_assignment_return.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_assignment_return.vm
@@ -18,6 +18,9 @@ window.parent.$("#returnContentLaunchNewWindow").val($contentLaunchNewWindow);
 window.parent.$("#returnContentToolNewpage").val($contentToolNewpage);
 #end
 window.parent.returnContentTitle("$formattedText.escapeHtml($contentTitle)");
+#if ( $contentDescription )
+window.parent.returnContentDescription("$formattedText.escapeJsQuoted($contentDescription)");
+#end
 // This is a tweaked SakaiLineItem that compensated for the CI / DL differences
 #if ($new_content)
 window.parent.returnContentItem($new_content);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External tools can now supply an assignment “content description” that’s returned to the editor and applied to instructions.
  * Added a localized prompt to confirm replacing existing assignment instructions with external-tool content.

* **Bug Fixes**
  * Title/description replacement now prompts only when existing content is present; empty inputs no longer overwrite current content.
  * Returned assignment descriptions are now sanitized to prevent unsafe/blank content from being displayed.

* **Tests**
  * Added regression coverage to ensure sanitized descriptions are correctly omitted or persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->