### PR TITLE
SAK-52738 Microsoft - Groups are not created when the Microsoft team has been created from Site Info -> Enable team

### DIFF
--- a/microsoft-integration/admin-tool/src/main/java/org/sakaiproject/microsoft/controller/AutoConfigController.java
+++ b/microsoft-integration/admin-tool/src/main/java/org/sakaiproject/microsoft/controller/AutoConfigController.java
@@ -339,7 +339,7 @@ public class AutoConfigController {
 				.build());
 
 		boolean limitExceeded = site.getGroups().size() > MAX_CHANNELS;
-		List<Group> groupsToProcess = limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).collect(Collectors.toList()));
+		List<Group> groupsToProcess = microsoftCommonService.limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).toList());
 
 		if (limitExceeded) {
 			ss.setCreationStatus(CreationStatus.PARTIAL_OK);
@@ -416,7 +416,7 @@ public class AutoConfigController {
 		microsoftSynchronizationService.saveOrUpdateSiteSynchronization(ss);
 
 		Map<String, MicrosoftChannel> channelsMap = microsoftCommonService.getTeamPrivateChannels(ss.getTeamId(), true);
-		List<Group> groupsToProcess = limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).collect(Collectors.toList()));
+		List<Group> groupsToProcess = microsoftCommonService.limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).toList());
 
 		List<Group> nonExistingGroups = groupsToProcess.stream()
 				.filter(g -> channelsMap.values().stream().noneMatch(c -> c.getName().equalsIgnoreCase(microsoftCommonService.processMicrosoftChannelName(g.getTitle()))))
@@ -483,13 +483,6 @@ public class AutoConfigController {
 				.addData("createChannelsName", channelNames)
 				.build());
 	}
-
-	private List<Group> limitGroups(Collection<Group> groups) {
-		return groups.size() > MAX_CHANNELS ?
-				groups.stream().limit(MAX_ADD_CHANNELS).collect(Collectors.toList()) :
-				new ArrayList<>(groups);
-	}
-
 
 	@GetMapping(value = {"/autoConfig-status"}, produces = MediaType.APPLICATION_JSON_VALUE)
 	@ResponseBody

--- a/microsoft-integration/api/src/java/org/sakaiproject/microsoft/api/MicrosoftCommonService.java
+++ b/microsoft-integration/api/src/java/org/sakaiproject/microsoft/api/MicrosoftCommonService.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.sakaiproject.microsoft.api.data.AttendanceRecord;
 import org.sakaiproject.microsoft.api.data.MeetingRecordingData;
 import org.sakaiproject.microsoft.api.data.MicrosoftChannel;
+import org.sakaiproject.microsoft.api.data.MicrosoftCredentials;
 import org.sakaiproject.microsoft.api.data.MicrosoftDriveItem;
 import org.sakaiproject.microsoft.api.data.MicrosoftDriveItemFilter;
 import org.sakaiproject.microsoft.api.data.MicrosoftMembersCollection;
@@ -32,11 +33,13 @@ import org.sakaiproject.microsoft.api.exceptions.MicrosoftGenericException;
 import org.sakaiproject.microsoft.api.model.GroupSynchronization;
 import org.sakaiproject.microsoft.api.model.SiteSynchronization;
 import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
 import org.sakaiproject.user.api.User;
 
 import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -105,6 +108,8 @@ public interface MicrosoftCommonService {
 	
 	String createGroup(String name, String ownerEmail) throws MicrosoftCredentialsException;
 	String createTeam(String name, String ownerEmail) throws MicrosoftCredentialsException;
+	void processGroupsAndCreateChannels(SiteSynchronization ss, Site site, String teamId, MicrosoftCredentials credentials) throws MicrosoftCredentialsException;
+	List<Group> limitGroups(Collection<Group> groups);
 	void createTeamFromGroup(String groupId) throws MicrosoftCredentialsException;
 	void createTeamFromGroupAsync(String groupId) throws MicrosoftCredentialsException;
 	

--- a/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
+++ b/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -54,9 +55,11 @@ import org.sakaiproject.messaging.api.MicrosoftMessage.MicrosoftMessageBuilder;
 import org.sakaiproject.messaging.api.MicrosoftMessagingService;
 import org.sakaiproject.microsoft.api.MicrosoftAuthorizationService;
 import org.sakaiproject.microsoft.api.MicrosoftCommonService;
+import org.sakaiproject.microsoft.api.MicrosoftSynchronizationService;
 import org.sakaiproject.microsoft.api.SakaiProxy;
 import org.sakaiproject.microsoft.api.data.AttendanceInterval;
 import org.sakaiproject.microsoft.api.data.AttendanceRecord;
+import org.sakaiproject.microsoft.api.data.CreationStatus;
 import org.sakaiproject.microsoft.api.data.MeetingRecordingData;
 import org.sakaiproject.microsoft.api.data.MicrosoftChannel;
 import org.sakaiproject.microsoft.api.data.MicrosoftCredentials;
@@ -183,6 +186,7 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 	@Setter private MicrosoftConfigRepository microsoftConfigRepository;
 	@Setter private MicrosoftLoggingRepository microsoftLoggingRepository;
 	@Setter private MicrosoftMessagingService microsoftMessagingService;
+	@Setter private MicrosoftSynchronizationService microsoftSynchronizationService;
 	@Setter private SakaiProxy sakaiProxy;
 	@Setter private FormattedText formattedText;
 
@@ -943,7 +947,36 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 		}
 		return null;
 	}
-	
+
+	public void processGroupsAndCreateChannels(SiteSynchronization ss, org.sakaiproject.site.api.Site site, String teamId, MicrosoftCredentials credentials) throws MicrosoftCredentialsException {
+		boolean limitExceeded = site.getGroups().size() > MAX_CHANNELS;
+		List<org.sakaiproject.site.api.Group> groupsToProcess = this.limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).toList());
+		if (limitExceeded) {
+			ss.setCreationStatus(CreationStatus.PARTIAL_OK);
+		}
+		microsoftSynchronizationService.saveOrUpdateSiteSynchronization(ss);
+		List<MicrosoftChannel> channels = this.createChannels(groupsToProcess, teamId, credentials.getEmail());
+		for (org.sakaiproject.site.api.Group g : groupsToProcess) {
+			Optional<MicrosoftChannel> channelOpt = channels.stream()
+					.filter(c -> c.getName().replace(" ", "").equalsIgnoreCase(this.processMicrosoftChannelName(g.getTitle()).replace(" ", ""))).findFirst();
+			channelOpt.ifPresent(channel -> {
+				GroupSynchronization gs = GroupSynchronization.builder()
+						.siteSynchronization(ss)
+						.groupId(g.getId())
+						.channelId(channel.getId())
+						.build();
+				microsoftSynchronizationService.saveOrUpdateGroupSynchronization(gs);
+			});
+		}
+		log.info("Created {} channels for siteId={} (teamId={})", channels.size(), site.getId(), teamId);
+	}
+
+	public List<org.sakaiproject.site.api.Group> limitGroups(Collection<org.sakaiproject.site.api.Group> groups) {
+		return groups.size() > MAX_CHANNELS ?
+				groups.stream().limit(MAX_ADD_CHANNELS).toList() :
+				new ArrayList<>(groups);
+	}
+
 	@Override
 	public String createGroup(String name, String ownerEmail) throws MicrosoftCredentialsException {
 		try {

--- a/microsoft-integration/impl/src/webapp/WEB-INF/components.xml
+++ b/microsoft-integration/impl/src/webapp/WEB-INF/components.xml
@@ -79,6 +79,7 @@
         <property name="cacheManager" ref="org.sakaiproject.ignite.SakaiCacheManager" />
         <property name="sakaiProxy" ref="org.sakaiproject.microsoft.api.SakaiProxy" />
         <property name="formattedText" ref="org.sakaiproject.util.api.FormattedText" />
+        <property name="microsoftSynchronizationService" ref="org.sakaiproject.microsoft.api.MicrosoftSynchronizationService" />
     </bean>
 
     <!-- Microsoft Authorization Service -->

--- a/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MicrosoftSynchronizationEnabler.java
+++ b/site-manage/site-manage-tool/tool/src/java/org/sakaiproject/site/tool/MicrosoftSynchronizationEnabler.java
@@ -307,7 +307,7 @@ public class MicrosoftSynchronizationEnabler {
                     return false;
                 }
 
-                final SiteSynchronization ss = SiteSynchronization.builder()
+                SiteSynchronization ss = SiteSynchronization.builder()
                         .siteId(site.getId())
                         .teamId(teamId)
                         .forced(true)
@@ -316,6 +316,11 @@ public class MicrosoftSynchronizationEnabler {
                         .build();
 
                 microsoftSynchronizationService.saveOrUpdateSiteSynchronization(ss);
+                try {
+                    microsoftCommonService.processGroupsAndCreateChannels(ss, site, teamId, credentials);
+                } catch (Exception e) {
+                    log.error("Error while processing groups and creating channels for site: {}, teamId: {}, {}", site.getId(), teamId, e.toString());
+                }
                 log.info("Microsoft Team created and SiteSynchronization saved: teamId={}, siteId={}", teamId, site.getId());
             }
         } catch (Exception e) {


### PR DESCRIPTION
SAK-52738 Microsoft - Groups are not created when the Microsoft team has been created from Site Info -> Enable team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microsoft Teams setup now centralizes group processing and channel creation.
  * Sites exceeding channel limits are handled as partially completed, with supported groups synchronized automatically.
* **Bug Fixes**
  * Errors during group processing or channel creation no longer interrupt Microsoft Teams setup for the site.
  * Group and channel synchronization records are created more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->