### PR TITLE
SAK-52739 Microsoft - Avoid creating channels from Signup tool

### DIFF
--- a/microsoft-integration/admin-tool/src/main/java/org/sakaiproject/microsoft/controller/AutoConfigController.java
+++ b/microsoft-integration/admin-tool/src/main/java/org/sakaiproject/microsoft/controller/AutoConfigController.java
@@ -339,7 +339,7 @@ public class AutoConfigController {
 				.build());
 
 		boolean limitExceeded = site.getGroups().size() > MAX_CHANNELS;
-		List<Group> groupsToProcess = microsoftCommonService.limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).toList());
+		List<Group> groupsToProcess = microsoftCommonService.limitGroups(site.getGroups().stream().filter(g -> !microsoftCommonService.isExcludedGroup(g)).toList());
 
 		if (limitExceeded) {
 			ss.setCreationStatus(CreationStatus.PARTIAL_OK);
@@ -416,7 +416,7 @@ public class AutoConfigController {
 		microsoftSynchronizationService.saveOrUpdateSiteSynchronization(ss);
 
 		Map<String, MicrosoftChannel> channelsMap = microsoftCommonService.getTeamPrivateChannels(ss.getTeamId(), true);
-		List<Group> groupsToProcess = microsoftCommonService.limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).toList());
+		List<Group> groupsToProcess = microsoftCommonService.limitGroups(site.getGroups().stream().filter(g -> !microsoftCommonService.isExcludedGroup(g)).toList());
 
 		List<Group> nonExistingGroups = groupsToProcess.stream()
 				.filter(g -> channelsMap.values().stream().noneMatch(c -> c.getName().equalsIgnoreCase(microsoftCommonService.processMicrosoftChannelName(g.getTitle()))))

--- a/microsoft-integration/api/src/java/org/sakaiproject/microsoft/api/MicrosoftCommonService.java
+++ b/microsoft-integration/api/src/java/org/sakaiproject/microsoft/api/MicrosoftCommonService.java
@@ -55,6 +55,7 @@ public interface MicrosoftCommonService {
 	public static final String PERM_UPLOAD_FILES = "microsoft.documents.upload.files";
 	public static final int MAX_CHANNELS = 30;
 	public static final int MAX_ADD_CHANNELS = 20;
+	public static final List<String> EXCLUDED_GROUP_PREFIXES = List.of("Access:", "SIGNUP_");
 
 	Map<String, Set<User>> errorUsers = new HashMap<>();
 	Map<String, Set<User>> groupErrors = new HashMap<>();
@@ -110,6 +111,7 @@ public interface MicrosoftCommonService {
 	String createTeam(String name, String ownerEmail) throws MicrosoftCredentialsException;
 	void processGroupsAndCreateChannels(SiteSynchronization ss, Site site, String teamId, MicrosoftCredentials credentials) throws MicrosoftCredentialsException;
 	List<Group> limitGroups(Collection<Group> groups);
+	boolean isExcludedGroup(Group group);
 	void createTeamFromGroup(String groupId) throws MicrosoftCredentialsException;
 	void createTeamFromGroupAsync(String groupId) throws MicrosoftCredentialsException;
 	

--- a/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
+++ b/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftCommonServiceImpl.java
@@ -950,7 +950,7 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 
 	public void processGroupsAndCreateChannels(SiteSynchronization ss, org.sakaiproject.site.api.Site site, String teamId, MicrosoftCredentials credentials) throws MicrosoftCredentialsException {
 		boolean limitExceeded = site.getGroups().size() > MAX_CHANNELS;
-		List<org.sakaiproject.site.api.Group> groupsToProcess = this.limitGroups(site.getGroups().stream().filter(g -> !g.getTitle().startsWith("Access:")).toList());
+		List<org.sakaiproject.site.api.Group> groupsToProcess = this.limitGroups(site.getGroups().stream().filter(g -> !this.isExcludedGroup(g)).toList());
 		if (limitExceeded) {
 			ss.setCreationStatus(CreationStatus.PARTIAL_OK);
 		}
@@ -975,6 +975,10 @@ public class MicrosoftCommonServiceImpl implements MicrosoftCommonService {
 		return groups.size() > MAX_CHANNELS ?
 				groups.stream().limit(MAX_ADD_CHANNELS).toList() :
 				new ArrayList<>(groups);
+	}
+
+	public boolean isExcludedGroup(org.sakaiproject.site.api.Group group) {
+		return group != null && group.getTitle() != null  && EXCLUDED_GROUP_PREFIXES.stream().anyMatch(group.getTitle()::startsWith);
 	}
 
 	@Override

--- a/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftSynchronizationServiceImpl.java
+++ b/microsoft-integration/impl/src/main/java/org/sakaiproject/microsoft/impl/MicrosoftSynchronizationServiceImpl.java
@@ -1201,8 +1201,7 @@ public class MicrosoftSynchronizationServiceImpl implements MicrosoftSynchroniza
 					if(site != null) {
 						Group group = site.getGroup(groupId);
 						if(group != null) {
-							//exclude automatic lesson groups
-							if(group.getTitle().startsWith("Access:")) {
+							if(microsoftCommonService.isExcludedGroup(group)) {
 								return;
 							}
 							


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group filtering during Microsoft Teams synchronization.
  * Groups with titles starting with `Access:` or `SIGNUP_` are now consistently excluded from channel creation, team binding, and synchronization.
  * Applied the same exclusion behavior for both newly created groups and existing team workflows.
  * Centralized the exclusion rules so the same criteria are used across Microsoft provisioning paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->