### PR TITLE
SAK-52732 LTI accept one-hour client assertions

### DIFF
--- a/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
+++ b/lti/lti-blis/src/java/org/sakaiproject/lti13/LTI13TokenRequestValidator.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 final class LTI13TokenRequestValidator {
 
 	static final long CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS = 60_000L;
-	static final long CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS = 600_000L;
 
 	private static final String CACHE_CLIENT_ASSERTION_JTI = "client_assertion_jti::";
 
@@ -100,10 +99,6 @@ final class LTI13TokenRequestValidator {
 		}
 		if (claims.getIssuedAt().after(claims.getExpiration())) {
 			return "Invalid iat";
-		}
-		if (claims.getExpiration().getTime() - claims.getIssuedAt().getTime()
-				> CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS + CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS) {
-			return "Invalid exp";
 		}
 		return null;
 	}

--- a/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
+++ b/lti/lti-blis/src/test/org/sakaiproject/lti13/LTI13TokenRequestValidatorTest.java
@@ -99,15 +99,13 @@ public class LTI13TokenRequestValidatorTest {
 	}
 
 	@Test
-	public void validateClientAssertionClaimsRejectsExcessiveLifetime() {
+	public void validateClientAssertionClaimsAcceptsLongLivedClientAssertion() {
 		Claims claims = validClaims("jti-1");
-		claims.setIssuedAt(new Date(System.currentTimeMillis()));
-		claims.setExpiration(new Date(System.currentTimeMillis()
-				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_MAX_LIFETIME_MILLISECONDS
-				+ LTI13TokenRequestValidator.CLIENT_ASSERTION_CLOCK_SKEW_MILLISECONDS
-				+ 1_000L));
+		long now = System.currentTimeMillis();
+		claims.setIssuedAt(new Date(now));
+		claims.setExpiration(new Date(now + 7_200_000L));
 
-		assertEquals("Invalid exp", LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
+		assertNull(LTI13TokenRequestValidator.validateClientAssertionClaims(claims, CLIENT_ID, TOKEN_AUDIENCE));
 	}
 
 	@Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by no longer rejecting long-lived client assertions.
  * Client assertions with extended lifetimes are now accepted as valid.

* **Tests**
  * Updated and added test coverage to verify acceptance of long-lived client assertion lifetimes (including cases beyond the previous cutoff).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->