### PR TITLE
SAK-52126 LTI improve transfer screen

### DIFF
--- a/lti/lti-impl/src/bundle/ltiservice.properties
+++ b/lti/lti-impl/src/bundle/ltiservice.properties
@@ -139,6 +139,7 @@ error.tool.not.found = Tool not found
 error.need.key.secret = This tool will not function without a key and secret.
 error.placement.not.removed = Unable to remove tool placement
 error.transfer.bad.tools=You must have access to the source and destination tools to transfer
+error.transfer.site.tool=The destination must be a system-wide tool
 error.tool.not.available = Tool is not available in this site
 tool.added.by.insert.content = Added deployment while inserting content (admin)
 

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -964,15 +964,44 @@ public abstract class BaseLTIService implements LTIService {
 			return rb.getString("error.transfer.bad.tools");
 		}
 
-		return transferToolContentLinksDao(currentTool, newTool, siteId, isAdmin(siteId));
+		boolean isAdminRole = isAdmin(siteId);
+		if (isAdminRole && StringUtils.isNotBlank((String) new_tool.get(LTI_SITE_ID))) {
+			return rb.getString("error.transfer.site.tool");
+		}
+
+		Object retval = transferToolContentLinksDao(currentTool, newTool, siteId, isAdminRole);
+		if ( !(retval instanceof String) && isAdminRole ) {
+			deployStealthToolAfterTransfer(new_tool, newTool);
+		}
+		return retval;
 	}
 
 	public Object transferToolContentLinksDao(Long currentTool, Long newTool)
 	{
 		boolean isAdminRole = true;
 		String siteId = null;
-		return transferToolContentLinksDao(currentTool, newTool, siteId, isAdminRole);
+		Map<String, Object> new_tool = getToolDao(newTool, siteId, isAdminRole);
+		if ( new_tool == null ) {
+			return rb.getString("error.transfer.bad.tools");
+		}
+		if ( StringUtils.isNotBlank((String) new_tool.get(LTI_SITE_ID)) ) {
+			return rb.getString("error.transfer.site.tool");
+		}
+		Object retval = transferToolContentLinksDao(currentTool, newTool, siteId, isAdminRole);
+		if ( !(retval instanceof String) ) {
+			deployStealthToolAfterTransfer(new_tool, newTool);
+		}
+		return retval;
 	}
+
+	protected void deployStealthToolAfterTransfer(Map<String, Object> destinationTool, Long newTool) {
+		Long visible = LTIUtil.toLongNull(destinationTool.get(LTI_VISIBLE));
+		if ( Long.valueOf(LTIService.LTI_VISIBLE_STEALTH).equals(visible) ) {
+			deployToolToContentSites(newTool, true, true);
+		}
+	}
+
+	protected abstract void deployToolToContentSites(Long toolKey, boolean isAdminRole, boolean isMaintainRole);
 
 	protected abstract Object transferToolContentLinksDao(Long currentTool, Long newTool, String siteId, boolean isAdminRole);
 

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/DBLTIService.java
@@ -172,7 +172,8 @@ public class DBLTIService extends BaseLTIService implements LTIService {
 		return insertThingDao("lti_tools", LTIService.TOOL_MODEL, null, newProps, siteId, isAdminRole, isMaintainRole);
 	}
 
-	private void deployToolToContentSites(Long toolKey, boolean isAdminRole, boolean isMaintainRole) {
+	@Override
+	protected void deployToolToContentSites(Long toolKey, boolean isAdminRole, boolean isMaintainRole) {
 		if (toolKey == null || !isAdminRole || !isMaintainRole) {
 			return;
 		}

--- a/lti/lti-tool/src/bundle/ltitool.properties
+++ b/lti/lti-tool/src/bundle/ltitool.properties
@@ -47,6 +47,7 @@ tool.site.delete=Remove Tool Deployment for Site
 tool.site.delete.note=When you undeploy a tool from a site, it does not remove all of the tool’s links from the site. The links will still be present but appear as missing or broken; they can be edited or removed. This way, if you mistakenly remove a tool deployment and later redeploy the tool to the site, the tool’s links will start working again.
 tool.site.delete.success=Tool Deployment Removed from Site.
 tool.transfer=Transferring tool links from this tool to another tool
+tool.transfer.info=The Transfer option is meant to update all of the existing tool links from one tool to another tool. However, the tool link title is not changed. This is usually done when an existing LTI tool with many tool links is being replaced with a newer version of the same tool.
 tool.transfer.sure=It is not easy to undo this operation.  So be careful.
 tool.transfer.select=Choose the new tool
 tool.transfer.success=Transferred {0} links
@@ -292,4 +293,3 @@ lti13_sakai_config=URL that provides a JSON representation of these values
 lti13_show=Show
 
 error.submit.timeout=Unable to send launch to remote URL
-

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -1476,6 +1476,10 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 
 		String contextString = toolManager.getCurrentPlacement().getContext();
 		List<LtiToolBean> systemToolBeans = getAvailableToolsAsBeans(getSiteId(state), contextString);
+		// Admin transfers affect links across all sites, so the destination must be system-wide.
+		if (ltiService.isAdmin(getSiteId(state))) {
+			systemToolBeans.removeIf(t -> StringUtils.trimToNull(t.getSiteId()) != null);
+		}
 		context.put("tools", systemToolBeans);
 
 		state.removeAttribute(STATE_SUCCESS);
@@ -1491,7 +1495,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			switchPanel(state, "Error");
 			return;
 		}
-		Properties reqProps = data.getParameters().getProperties();
 		String new_tool_id = StringUtils.trimToNull(data.getParameters().getString("new_tool_id"));
 		if (new_tool_id == null) {
 			addAlert(state, rb.getString("error.transfer.missing"));

--- a/lti/lti-tool/src/webapp/vm/lti_tool_transfer.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_tool_transfer.vm
@@ -4,6 +4,7 @@
 	</h3>
 	#if ($messageSuccess)<div class="sak-banner-success">$tlang.getString("gen.success") $formattedText.escapeHtml($messageSuccess)</div>#end
 	#if ($alertMessage)<div class="sak-banner-error">$tlang.getString("gen.alert") $formattedText.escapeHtml($alertMessage)</div>#end
+	<p>$tlang.getString("tool.transfer.info")</p>
 	<div class="sak-banner-warn">$tlang.getString("tool.transfer.sure")</div>
 	<form action="#toolForm("")" method="post" name="customizeForm" >
 		$formOutput


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance to the tool transfer page explaining how transfers update existing links while preserving link titles.
  * Destination tools that are visible only to administrators are automatically deployed to applicable content sites after a successful transfer.

* **Bug Fixes**
  * Restricted administrator transfers to system-wide destination tools; site-specific tools are no longer available for selection.
  * Added clearer validation errors when attempting transfers to site-specific tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->