### PR TITLE
SAK-52748 LTI Fix Ignite keyset cache name

### DIFF
--- a/kernel/kernel-impl/src/main/webapp/WEB-INF/ignite-components.xml
+++ b/kernel/kernel-impl/src/main/webapp/WEB-INF/ignite-components.xml
@@ -264,7 +264,7 @@
                     <property name="name" value="org.sakaiproject.lti13.ClientAssertionReplay_cache"/>
                 </bean>
                 <bean parent="org.sakaiproject.ignite.cache.eternal">
-                    <property name="name" value="org.sakaiproject.basiclti.util.SakaiKeySetUtil_cache"/>
+                    <property name="name" value="org.sakaiproject.lti.util.SakaiKeySetUtil_cache"/>
                 </bean>
                 <!-- SCORM Caches -->
                 <bean parent="org.sakaiproject.ignite.cache.atomic">


### PR DESCRIPTION
ugh: cache was renamed because basiclti -> lti

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the cache configuration for the LTI utility to ensure the correct cache entry is used.
  * Improved cache-related compatibility following the LTI package update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->