### PR TITLE
SAK-52750: Add deterministic email spoofing to reduce unnecessary Tur…

### DIFF
--- a/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
+++ b/content-review/impl/turnitin/src/main/java/org/sakaiproject/contentreview/turnitin/TurnitinReviewServiceImpl.java
@@ -17,6 +17,9 @@ package org.sakaiproject.contentreview.turnitin;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -40,6 +43,7 @@ import java.util.TreeSet;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
@@ -88,8 +92,31 @@ import org.w3c.dom.NodeList;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+
 @Slf4j
 public class TurnitinReviewServiceImpl extends BaseContentReviewService {
+
+	/**
+	 * Strategy used when spoilEmailAddresses is enabled.
+	 *
+	 * RANDOM
+	 *     Existing behaviour. A new randomized email is generated on every request.
+	 *
+	 * DETERMINISTIC
+	 *     Generates a stable pseudonymized email derived from the Sakai user id.
+	 *
+	 * ORIGINAL
+	 *     Leaves the email unchanged.
+	 */
+	private enum SpoilEmailStrategy {
+		RANDOM,
+		DETERMINISTIC,
+		ORIGINAL
+	}
+
+	private static final int DETERMINISTIC_EMAIL_HASH_LENGTH = 10;
+
+	private String spoilEmailStrategy = null;
 
 	public static final String TURNITIN_DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
@@ -256,6 +283,13 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 		defaultClassPassword = turnitinConn.getDefaultClassPassword();
 
 		spoilEmailAddresses = serverConfigurationService.getBoolean("turnitin.spoilEmailAddresses", false);
+		spoilEmailStrategy = serverConfigurationService.getString(
+				"turnitin.spoilEmailStrategy", null);
+
+		if (spoilEmailStrategy != null) {
+			spoilEmailStrategy = spoilEmailStrategy.trim().toUpperCase(Locale.ROOT);
+		}
+
 		preferSystemProfileEmail = serverConfigurationService.getBoolean("turnitin.preferSystemProfileEmail", true);
 		preferGuestEidEmail = serverConfigurationService.getBoolean("turnitin.preferGuestEidEmail", true);
 		enrollAssistantsAsInstructors = serverConfigurationService.getBoolean("turnitin.enroll_assistants_as_instructors", false);
@@ -1882,6 +1916,24 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 		log.info("Finished fetching reports from Turnitin");
 	}
 
+	private SpoilEmailStrategy getSpoilEmailStrategy() {
+		if (StringUtils.isBlank(spoilEmailStrategy)) {
+			return spoilEmailAddresses
+					? SpoilEmailStrategy.RANDOM
+					: SpoilEmailStrategy.ORIGINAL;
+		}
+
+		try {
+			return SpoilEmailStrategy.valueOf(spoilEmailStrategy.toUpperCase(Locale.ROOT));
+		}
+		catch (IllegalArgumentException e) {
+			log.warn("Unknown Turnitin spoil email strategy '{}', falling back to default", spoilEmailStrategy);
+			return spoilEmailAddresses
+					? SpoilEmailStrategy.RANDOM
+					: SpoilEmailStrategy.ORIGINAL;
+		}
+	}
+
 	// returns null if no valid email exists
 	public String getEmail(User user) {
 
@@ -1916,28 +1968,82 @@ public class TurnitinReviewServiceImpl extends BaseContentReviewService {
 			uem = account_email;
 		}
 
-		// Randomize the email address if preferred
-		if (spoilEmailAddresses && uem != null) {
-			// Scramble it
-			String[] parts = uem.split("@");
+		// Apply configured email obfuscation strategy
+		if (uem != null) {
+			SpoilEmailStrategy strategy = getSpoilEmailStrategy();
 
-			String emailName = parts[0];
+			switch (strategy) {
+			case RANDOM:
+				uem = randomizeEmail(uem);
+				break;
 
-			Random random = new Random();
-			int int1 = random.nextInt();
-			int int2 = random.nextInt();
-			int int3 = random.nextInt();
+			case DETERMINISTIC:
+				uem = deterministicEmail(user, uem);
+				break;
 
-			emailName += (int1 + int2 + int3);
-
-			uem = emailName + "@" + parts[1];
-
-			if (log.isDebugEnabled())
-				log.debug("SCRAMBLED EMAIL:" + uem);
+			case ORIGINAL:
+			default:
+				break;
+			}
 		}
 
 		log.debug("Using email " + uem + " for user eid " + user.getEid() + " id " + user.getId());
 		return uem;
+	}
+
+	private String randomizeEmail(String uem) {
+		// Scramble it
+		String[] parts = uem.split("@");
+
+		String emailName = parts[0];
+
+		Random random = new Random();
+		int int1 = random.nextInt();
+		int int2 = random.nextInt();
+		int int3 = random.nextInt();
+
+		emailName += (int1 + int2 + int3);
+
+		uem = emailName + "@" + parts[1];
+
+		if (log.isDebugEnabled())
+			log.debug("SCRAMBLED EMAIL:" + uem);
+		return uem;
+	}
+
+	private String deterministicEmail(User user, String email) {
+		if (user == null || StringUtils.isBlank(user.getId()) || StringUtils.isBlank(email)) {
+			return email;
+		}
+
+		String[] parts = email.split("@", 2);
+
+		if (parts.length != 2) {
+			log.warn("Unable to generate deterministic email for invalid address: {}", email);
+			return email;
+		}
+
+		String localPart = parts[0];
+		String domainPart = parts[1];
+
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(user.getId().getBytes(StandardCharsets.UTF_8));
+
+			String hashString = Hex.encodeHexString(hash).substring(0, DETERMINISTIC_EMAIL_HASH_LENGTH );
+
+			String deterministicEmail = localPart + "-" + hashString + "@" + domainPart;
+
+			if (log.isDebugEnabled()) {
+				log.debug("DETERMINISTIC EMAIL: {}", deterministicEmail);
+			}
+
+			return deterministicEmail;
+
+		} catch (NoSuchAlgorithmException e) {
+			// SHA-256 is required by every Java implementation
+			throw new IllegalStateException("SHA-256 algorithm not available", e);
+		}
 	}
 
 	/**


### PR DESCRIPTION
…nitin user updates

JIRA:
https://sakaiproject.atlassian.net/browse/SAK-52750
Related issue: SAK-52750

Thank you for the feedback.

1. Regarding the original purpose of `spoilEmailAddresses`:

The exact original motivation for introducing this option is not fully documented. The existing code comment only describes the technical behavior:

> If set to true in properties, will result in 3 random digits being appended to the email name.

The intention appears to have been to avoid sending the actual user email address to Turnitin, most likely to prevent user identity conflicts caused by existing Turnitin accounts with the same email address outside of the institution's Turnitin account scope.

Turnitin Support confirmed that the current user conflicts are caused by existing accounts with the same email address that are not associated with our institution. Their suggested resolution is to merge those accounts.

However, the current implementation introduces another issue: because the spoofed email address is randomly generated for every request, Turnitin interprets every subsequent request as an email address change for the same user. This results in unnecessary user updates on the Turnitin side and additional load.

This PR keeps the original purpose of the feature but introduces a deterministic spoofing strategy. The same Sakai user will now always map to the same spoofed Turnitin email address, avoiding unnecessary updates while preserving the ability to avoid sending the original email address.

2. Regarding the target branch:

Thank you for pointing this out. The previous PR was incorrectly created against the 23.x branch. This PR has now been recreated against master according to the Sakai contribution guidelines.

The original intent may be better documented by Adrian Fish, who is referenced in the original code comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable email obfuscation strategies for Turnitin integrations.
  * Supports randomized, deterministic, or original email handling.
  * Deterministic obfuscation generates consistent pseudonymous email addresses while protecting users’ actual addresses.
* **Bug Fixes**
  * Preserved previous email-handling behavior when no valid strategy is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->