### PR TITLE
SAK-52756 LTI Allow Lessons to accept multiple deep links

### DIFF
--- a/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDao.java
+++ b/lessonbuilder/api/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDao.java
@@ -177,6 +177,12 @@ public interface SimplePageToolDao {
     //   to use this convoluted approach to getting back errors
 	public boolean saveItem(Object o, List<String> elist, String nowriteerr, boolean requiresEditPermission);
 
+	/**
+	 * Saves a group of new page items and their sequence updates in one transaction.
+	 */
+	public boolean saveItemBatch(List<SimplePageItem> newItems, List<SimplePageItem> updatedItems,
+			List<String> elist, String nowriteerr);
+
     // like saveItem but uses saveOrUpdate
 	public boolean saveOrUpdate(Object o, List<String> elist, String nowriteerr, boolean requiresEditPermission);
 

--- a/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
+++ b/lessonbuilder/components/src/java/org/sakaiproject/lessonbuildertool/model/SimplePageToolDaoImpl.java
@@ -42,6 +42,9 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -755,6 +758,48 @@ public class SimplePageToolDaoImpl extends HibernateDaoSupport implements Simple
 			getCause(e, elist);
 			return false;
 		} catch (DataAccessException e) {
+			getCause(e, elist);
+			return false;
+		}
+	}
+
+	@Override
+	public boolean saveItemBatch(List<SimplePageItem> newItems, List<SimplePageItem> updatedItems,
+			List<String> elist, String nowriteerr) {
+		for (SimplePageItem item : newItems) {
+			if (!canEditPage(item.getPageId())) {
+				elist.add(nowriteerr);
+				return false;
+			}
+		}
+		for (SimplePageItem item : updatedItems) {
+			if (!canEditPage(item.getPageId())) {
+				elist.add(nowriteerr);
+				return false;
+			}
+		}
+
+		try {
+			for (SimplePageItem item : updatedItems) {
+				getHibernateTemplate().merge(item);
+			}
+			for (SimplePageItem item : newItems) {
+				getHibernateTemplate().save(item);
+				updateStudentPage(item);
+			}
+			getHibernateTemplate().flush();
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					for (SimplePageItem item : newItems) {
+						eventTrackingService.post(eventTrackingService.newEvent(LessonBuilderEvents.ITEM_CREATE,
+								"/lessonbuilder/item/" + item.getId(), true));
+					}
+				}
+			});
+			return true;
+		} catch (RuntimeException e) {
+			TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
 			getCause(e, elist);
 			return false;
 		}

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/BltiEntity.java
@@ -298,10 +298,13 @@ public class BltiEntity implements LessonEntity, BltiInterface {
     }
 
     public String getDescription() {
-        if(tool != null){
-            return (String) tool.get(LTIService.LTI_DESCRIPTION);
-        }
         loadContent();
+        if (content != null) {
+            String contentDescription = (String) content.get(LTIService.LTI_DESCRIPTION);
+            if (StringUtils.isNotBlank(contentDescription)) {
+                return contentDescription;
+            }
+        }
         return tool == null ? null : (String) tool.get(LTIService.LTI_DESCRIPTION);
     }
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -3272,15 +3272,9 @@ public class SimplePageBean {
 			    i.setSameWindow(false);
 
 			if (i.getType() == SimplePageItem.BLTI) {
-			    if (StringUtils.isBlank(format))
-				i.setFormat("");
-			    else
-				i.setFormat(format);
+			    i.setFormat(StringUtils.trimToEmpty(format));
 			    // this is redundant, but the display code uses it
-			    if ("window".equals(format))
-				i.setSameWindow(false);
-			    else
-				i.setSameWindow(true);
+			    i.setSameWindow(!"window".equals(format));
 			    i.setHeight(height);
 			} else if (i.getType() == SimplePageItem.SCORM) {
 			    String scormHeight = StringUtils.isBlank(height) ? "" : height.replace("px", "").trim();
@@ -3685,18 +3679,9 @@ public class SimplePageBean {
 					// logic from other item types
 					i.setSakaiId(selected);
 					i.setName(selectedObject.getTitle());
-					if (StringUtils.isBlank(format)) {
-						i.setFormat("");
-					} else {
-						i.setFormat(format);
-					}
-
+					i.setFormat(StringUtils.trimToEmpty(format));
 					// this is redundant, but the display code uses it
-					if ("window".equals(format)) {
-						i.setSameWindow(false);
-					} else {
-						i.setSameWindow(true);
-					}
+					i.setSameWindow(!"window".equals(format));
 
 					i.setHeight(height);
 					setItemGroups(i, selectedGroups);
@@ -3723,10 +3708,7 @@ public class SimplePageBean {
 							SimplePageItem.BLTI, selected, selectedObject.getTitle());
 					clearImageSize(i);
 
-					String itemDescription = selectedObject.getDescription();
-					if (StringUtils.isBlank(itemDescription)) {
-						itemDescription = description;
-					}
+					String itemDescription = StringUtils.defaultIfBlank(selectedObject.getDescription(), description);
 					if (StringUtils.isNotBlank(itemDescription)) {
 						i.setDescription(itemDescription);
 					}
@@ -3734,16 +3716,8 @@ public class SimplePageBean {
 					if (selectedObject instanceof BltiInterface) {
 						BltiInterface blti = (BltiInterface) selectedObject;
 						int frameHeight = blti.frameSize();
-						if (frameHeight > 0) {
-							i.setHeight(Integer.toString(frameHeight));
-						} else {
-							i.setHeight("");
-						}
-						if (StringUtils.isBlank(format)) {
-							i.setFormat("");
-						} else {
-							i.setFormat(format);
-						}
+						i.setHeight(frameHeight > 0 ? Integer.toString(frameHeight) : "");
+						i.setFormat(StringUtils.trimToEmpty(format));
 					}
 					newItems.add(i);
 				}
@@ -3785,11 +3759,8 @@ public class SimplePageBean {
 	 */
 	private int resolveInsertionSequence(List<SimplePageItem> items, String placement) {
 		String beforeStr = placement;
-		boolean addAfter = false;
-		if (beforeStr != null && beforeStr.startsWith("-")) {
-			addAfter = true;
-			beforeStr = beforeStr.substring(1);
-		}
+		boolean addAfter = StringUtils.startsWith(beforeStr, "-");
+		beforeStr = StringUtils.removeStart(beforeStr, "-");
 
 		long before = 0;
 		if (StringUtils.isNotBlank(beforeStr)) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -232,7 +232,7 @@ public class SimplePageBean {
 	private String filterHtml = ServerConfigurationService.getString(FILTERHTML);
 
 	public String selectedAssignment = null;
-	public String selectedBlti = null;
+	public String[] selectedBlti = new String[] {};
 
     // generic entity stuff. selectedEntity is the string
     // coming from the picker. We'll use the same variable for any entity type
@@ -1983,63 +1983,12 @@ public class SimplePageBean {
 	        // we're going to update directly from the database
 		simplePageToolDao.setRefreshMode();
 	        List<SimplePageItem> items = getItemsOnPage(getCurrentPageId());
-		// ideally the following should be the same, but there can be odd cases. So be safe
-		long before = 0;
-		String beforeStr = addBefore;
-		boolean addAfter = false;
-		if (beforeStr != null && beforeStr.startsWith("-")) {
-		    addAfter = true;
-		    beforeStr = beforeStr.substring(1);
-		}
-		if (StringUtils.isNotBlank(beforeStr)) {
-		    try {
-			before = Long.parseLong(beforeStr);
-		    } catch (Exception e) {
-			// nothing. ignore bad arg
-		    }
-		}
-
-		// we have an item id. insert before it
-		int nseq = 0;  // sequence number of new item
-		boolean after = false; // we found the item to insert before
-		if (before > 0) {
-		    // have an item number specified, look for the item to insert before
-		    for (SimplePageItem item: items) {
-			if (item.getId() == before) {
-				//if Comments Section item, find the biggest sequence
-				//and assign nseq to be after it for the new item
-				if(isCommentsItem(item)) {
-					nseq = findNextSequence(items);
-				}
-				//for all the other regular items
-				else {
-					// found item to insert before
-					// use its sequence and bump up it and all after
-					nseq = item.getSequence();
-					after = true;
-					if (addAfter) {
-						nseq++;
-						continue;
-					}
-				}
-			}
-			if (after && item.getPageId() >= 0) {
+		int nseq = resolveInsertionSequence(items, addBefore);
+		for (SimplePageItem item: items) {
+			if (item.getPageId() >= 0 && item.getSequence() >= nseq) {
 			    item.setSequence(item.getSequence() + 1);
 			    simplePageToolDao.quickUpdate(item);
 			}
-		    }			    
-		}
-
-		// if after not set, we didn't find the item; either no item specified or it
-		// isn't on the page
-		if (!after) {
-		    nseq = items.size();
-		    if (nseq > 0) {
-			int seq = items.get(nseq-1).getSequence();
-			if (seq > nseq)
-			    nseq = seq;
-		    }
-		    nseq++;
 		}
 		    
 		SimplePageItem i = simplePageToolDao.makeItem(getCurrentPageId(), nseq, type, id, name);
@@ -3533,7 +3482,7 @@ public class SimplePageBean {
 		this.selectedScorm = selectedScorm;
 	}
 
-	public void setSelectedBlti(String selectedBlti) {
+	public void setSelectedBlti(String[] selectedBlti) {
 		this.selectedBlti = selectedBlti;
 	}
 
@@ -3679,87 +3628,194 @@ public class SimplePageBean {
 		}
 	}
 
-    // called by add blti picker. Create a new item that points to an assigment
-    // or update an existing item, depending upon whether itemid is set
+    // Called by the BLTI picker. Deep Linking can add several new items, but editing
+    // an existing Lessons item intentionally remains a single-item operation.
 	public String addBlti() {
-		if (!itemOk(itemId))
-		    return "permission-failed";
-		if (!canEditPage())
-		    return "permission-failed";
-		if (!checkCsrf())
-		    return "permission-failed";
+		if (!itemOk(itemId)) {
+			return "permission-failed";
+		}
+		if (!canEditPage()) {
+			return "permission-failed";
+		}
+		if (!checkCsrf()) {
+			return "permission-failed";
+		}
 
-		if (selectedBlti == null || bltiEntity == null) {
+		if (selectedBlti == null || selectedBlti.length == 0 || bltiEntity == null) {
 			return "failure";
-		} else {
-			try {
-			    LessonEntity selectedObject = bltiEntity.getEntity(selectedBlti);
-			    if (selectedObject == null)
-				return "failure";
+		}
 
-			    SimplePageItem i;
-			    // editing existing item?
-			    if (itemId != null && itemId != -1) {
+		// Hoisted so exception cleanup can discard bumped in-memory sequences.
+		List<SimplePageItem> shiftedItems = Collections.emptyList();
+		try {
+			boolean editing = itemId != null && itemId != -1;
+			if (editing && selectedBlti.length != 1) {
+				return "failure";
+			}
+
+			List<LessonEntity> selectedObjects = new ArrayList<>();
+			for (String selected : selectedBlti) {
+				if (StringUtils.isBlank(selected)) {
+					return "failure";
+				}
+				LessonEntity selectedObject = bltiEntity.getEntity(selected);
+				if (selectedObject == null) {
+					return "failure";
+				}
+				selectedObjects.add(selectedObject);
+			}
+
+			SimplePageItem i;
+			// editing existing item?
+			if (editing) {
+				String selected = selectedBlti[0];
+				LessonEntity selectedObject = selectedObjects.get(0);
 				i = findItem(itemId);
 
 				// if no change, don't worry
 				LessonEntity existing = bltiEntity.getEntity(i.getSakaiId());
 				String ref = null;
-				if (existing != null)
-				    ref = existing.getReference();
+				if (existing != null) {
+					ref = existing.getReference();
+				}
 				// if same item, nothing to do
-				if ((existing == null) || !ref.equals(selectedBlti)) {
-				    // if access controlled, clear restriction from old assignment and add to new
-				    // group access not used for BLTI items, so don't need the setcontrolgroup
-				    // logic from other item types
-				    i.setSakaiId(selectedBlti);
-				    i.setName(selectedObject.getTitle());
-				    if (StringUtils.isBlank(format))
-					i.setFormat("");
-				    else
-					i.setFormat(format);
+				if ((existing == null) || !ref.equals(selected)) {
+					// if access controlled, clear restriction from old assignment and add to new
+					// group access not used for BLTI items, so don't need the setcontrolgroup
+					// logic from other item types
+					i.setSakaiId(selected);
+					i.setName(selectedObject.getTitle());
+					if (StringUtils.isBlank(format)) {
+						i.setFormat("");
+					} else {
+						i.setFormat(format);
+					}
 
-				    // this is redundant, but the display code uses it
-				    if ("window".equals(format))
-					i.setSameWindow(false);
-				    else
-					i.setSameWindow(true);
+					// this is redundant, but the display code uses it
+					if ("window".equals(format)) {
+						i.setSameWindow(false);
+					} else {
+						i.setSameWindow(true);
+					}
 
-				    i.setHeight(height);
-				    setItemGroups(i, selectedGroups);
-				    update(i);
+					i.setHeight(height);
+					setItemGroups(i, selectedGroups);
+					update(i);
 				}
-			    } else {
-				// no, add new item
-				i = appendItem(selectedBlti, selectedObject.getTitle(), SimplePageItem.BLTI);
-
-				//Copy the LTI tool description to the item description.
-				if(StringUtils.isNotBlank(description)){
-					i.setDescription(description);
+			} else {
+				simplePageToolDao.setRefreshMode();
+				itemsCache.remove(getCurrentPageId());
+				List<SimplePageItem> pageItems = getItemsOnPage(getCurrentPageId());
+				int insertionSequence = resolveInsertionSequence(pageItems, addBefore);
+				shiftedItems = new ArrayList<>();
+				for (SimplePageItem pageItem : pageItems) {
+					if (pageItem.getPageId() >= 0 && pageItem.getSequence() >= insertionSequence) {
+						pageItem.setSequence(pageItem.getSequence() + selectedBlti.length);
+						shiftedItems.add(pageItem);
+					}
 				}
 
-				BltiInterface blti = (BltiInterface)bltiEntity.getEntity(selectedBlti);
-				if (blti != null) {
-				    int height = blti.frameSize();
-				    if (height > 0)
-					i.setHeight(Integer.toString(height));
-				    else
-					i.setHeight("");
-				    if (StringUtils.isBlank(format))
-					i.setFormat("");
-				    else
-					i.setFormat(format);
+				List<SimplePageItem> newItems = new ArrayList<>();
+				for (int index = 0; index < selectedBlti.length; index++) {
+					String selected = selectedBlti[index];
+					LessonEntity selectedObject = selectedObjects.get(index);
+					i = simplePageToolDao.makeItem(getCurrentPageId(), insertionSequence + index,
+							SimplePageItem.BLTI, selected, selectedObject.getTitle());
+					clearImageSize(i);
+
+					String itemDescription = selectedObject.getDescription();
+					if (StringUtils.isBlank(itemDescription)) {
+						itemDescription = description;
+					}
+					if (StringUtils.isNotBlank(itemDescription)) {
+						i.setDescription(itemDescription);
+					}
+
+					if (selectedObject instanceof BltiInterface) {
+						BltiInterface blti = (BltiInterface) selectedObject;
+						int frameHeight = blti.frameSize();
+						if (frameHeight > 0) {
+							i.setHeight(Integer.toString(frameHeight));
+						} else {
+							i.setHeight("");
+						}
+						if (StringUtils.isBlank(format)) {
+							i.setFormat("");
+						} else {
+							i.setFormat(format);
+						}
+					}
+					newItems.add(i);
 				}
-				saveItem(i);
-			    }
-			    return "success";
-			} catch (Exception ex) {
-			    log.error(ex.getMessage(), ex);
-			    return "failure";
-			} finally {
-			    selectedBlti = null;
+
+				List<String> errors = new ArrayList<>();
+				if (!simplePageToolDao.saveItemBatch(newItems, shiftedItems, errors,
+						messageLocator.getMessage("simplepage.nowrite"))) {
+					setErrMessage(messageLocator.getMessage("simplepage.savefailed"));
+					discardBltiBatchCaches(shiftedItems);
+					return "failure";
+				}
+				itemsCache.remove(getCurrentPageId());
+				ToolSession toolSession = sessionManager.getCurrentToolSession();
+				toolSession.setAttribute("lessonbuilder.newitem", Long.toString(newItems.get(newItems.size() - 1).getId()));
+			}
+			return "success";
+		} catch (Exception ex) {
+			log.error("Unable to add LTI content items to Lessons", ex);
+			discardBltiBatchCaches(shiftedItems);
+			return "failure";
+		} finally {
+			selectedBlti = new String[] {};
+		}
+	}
+
+	private void discardBltiBatchCaches(List<SimplePageItem> shiftedItems) {
+		itemsCache.remove(getCurrentPageId());
+		if (shiftedItems == null) {
+			return;
+		}
+		for (SimplePageItem shiftedItem : shiftedItems) {
+			itemCache.remove(shiftedItem.getId());
+		}
+	}
+
+	/**
+	 * Shared placement for {@link #appendItem} and multi-item {@link #addBlti}.
+	 * Comments-section anchors fall through to end-of-page (same effective behavior as appendItem).
+	 */
+	private int resolveInsertionSequence(List<SimplePageItem> items, String placement) {
+		String beforeStr = placement;
+		boolean addAfter = false;
+		if (beforeStr != null && beforeStr.startsWith("-")) {
+			addAfter = true;
+			beforeStr = beforeStr.substring(1);
+		}
+
+		long before = 0;
+		if (StringUtils.isNotBlank(beforeStr)) {
+			try {
+				before = Long.parseLong(beforeStr);
+			} catch (NumberFormatException e) {
+				log.debug("Ignoring invalid Lessons insertion anchor {}", beforeStr);
 			}
 		}
+
+		if (before > 0) {
+			for (SimplePageItem item : items) {
+				if (item.getId() == before) {
+					if (isCommentsItem(item)) {
+						break;
+					}
+					return item.getSequence() + (addAfter ? 1 : 0);
+				}
+			}
+		}
+
+		int insertionSequence = items.size();
+		if (!items.isEmpty()) {
+			insertionSequence = Math.max(insertionSequence, items.get(items.size() - 1).getSequence());
+		}
+		return insertionSequence + 1;
 	}
 
     /// ShowPageProducers needs the item ID list anyway. So to avoid calling the underlying
@@ -6260,16 +6316,6 @@ public class SimplePageBean {
 
 	private boolean isCommentsItem(SimplePageItem item) {
 		return item.getType() == SimplePageItem.COMMENTS;
-	}
-
-	private int findNextSequence(List<SimplePageItem> items) {
-		int nseq = 0;
-		for (SimplePageItem item : items) {
-			if( item.getSequence() > nseq) {
-				nseq = item.getSequence();
-			}
-		}
-		return nseq++;
 	}
 
 	public boolean isItemAvailable(SimplePageItem item) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -3659,12 +3659,11 @@ public class SimplePageBean {
 				selectedObjects.add(selectedObject);
 			}
 
-			SimplePageItem i;
 			// editing existing item?
 			if (editing) {
 				String selected = selectedBlti[0];
 				LessonEntity selectedObject = selectedObjects.get(0);
-				i = findItem(itemId);
+				SimplePageItem i = findItem(itemId);
 
 				// if no change, don't worry
 				LessonEntity existing = bltiEntity.getEntity(i.getSakaiId());
@@ -3688,50 +3687,11 @@ public class SimplePageBean {
 					update(i);
 				}
 			} else {
-				simplePageToolDao.setRefreshMode();
-				itemsCache.remove(getCurrentPageId());
-				List<SimplePageItem> pageItems = getItemsOnPage(getCurrentPageId());
-				int insertionSequence = resolveInsertionSequence(pageItems, addBefore);
 				shiftedItems = new ArrayList<>();
-				for (SimplePageItem pageItem : pageItems) {
-					if (pageItem.getPageId() >= 0 && pageItem.getSequence() >= insertionSequence) {
-						pageItem.setSequence(pageItem.getSequence() + selectedBlti.length);
-						shiftedItems.add(pageItem);
-					}
+				String insertResult = insertBltiItems(selectedBlti, selectedObjects, shiftedItems);
+				if (!"success".equals(insertResult)) {
+					return insertResult;
 				}
-
-				List<SimplePageItem> newItems = new ArrayList<>();
-				for (int index = 0; index < selectedBlti.length; index++) {
-					String selected = selectedBlti[index];
-					LessonEntity selectedObject = selectedObjects.get(index);
-					i = simplePageToolDao.makeItem(getCurrentPageId(), insertionSequence + index,
-							SimplePageItem.BLTI, selected, selectedObject.getTitle());
-					clearImageSize(i);
-
-					String itemDescription = StringUtils.defaultIfBlank(selectedObject.getDescription(), description);
-					if (StringUtils.isNotBlank(itemDescription)) {
-						i.setDescription(itemDescription);
-					}
-
-					if (selectedObject instanceof BltiInterface) {
-						BltiInterface blti = (BltiInterface) selectedObject;
-						int frameHeight = blti.frameSize();
-						i.setHeight(frameHeight > 0 ? Integer.toString(frameHeight) : "");
-						i.setFormat(StringUtils.trimToEmpty(format));
-					}
-					newItems.add(i);
-				}
-
-				List<String> errors = new ArrayList<>();
-				if (!simplePageToolDao.saveItemBatch(newItems, shiftedItems, errors,
-						messageLocator.getMessage("simplepage.nowrite"))) {
-					setErrMessage(messageLocator.getMessage("simplepage.savefailed"));
-					discardBltiBatchCaches(shiftedItems);
-					return "failure";
-				}
-				itemsCache.remove(getCurrentPageId());
-				ToolSession toolSession = sessionManager.getCurrentToolSession();
-				toolSession.setAttribute("lessonbuilder.newitem", Long.toString(newItems.get(newItems.size() - 1).getId()));
 			}
 			return "success";
 		} catch (Exception ex) {
@@ -3741,6 +3701,58 @@ public class SimplePageBean {
 		} finally {
 			selectedBlti = new String[] {};
 		}
+	}
+
+	/**
+	 * Insert new BLTI items in provider order at {@link #addBefore}.
+	 * Populates {@code shiftedItems} with page items whose sequences were bumped for failure cleanup.
+	 */
+	private String insertBltiItems(String[] selectedBlti, List<LessonEntity> selectedObjects,
+			List<SimplePageItem> shiftedItems) {
+		simplePageToolDao.setRefreshMode();
+		itemsCache.remove(getCurrentPageId());
+		List<SimplePageItem> pageItems = getItemsOnPage(getCurrentPageId());
+		int insertionSequence = resolveInsertionSequence(pageItems, addBefore);
+		for (SimplePageItem pageItem : pageItems) {
+			if (pageItem.getPageId() >= 0 && pageItem.getSequence() >= insertionSequence) {
+				pageItem.setSequence(pageItem.getSequence() + selectedBlti.length);
+				shiftedItems.add(pageItem);
+			}
+		}
+
+		List<SimplePageItem> newItems = new ArrayList<>();
+		for (int index = 0; index < selectedBlti.length; index++) {
+			String selected = selectedBlti[index];
+			LessonEntity selectedObject = selectedObjects.get(index);
+			SimplePageItem i = simplePageToolDao.makeItem(getCurrentPageId(), insertionSequence + index,
+					SimplePageItem.BLTI, selected, selectedObject.getTitle());
+			clearImageSize(i);
+
+			String itemDescription = StringUtils.defaultIfBlank(selectedObject.getDescription(), description);
+			if (StringUtils.isNotBlank(itemDescription)) {
+				i.setDescription(itemDescription);
+			}
+
+			if (selectedObject instanceof BltiInterface) {
+				BltiInterface blti = (BltiInterface) selectedObject;
+				int frameHeight = blti.frameSize();
+				i.setHeight(frameHeight > 0 ? Integer.toString(frameHeight) : "");
+				i.setFormat(StringUtils.trimToEmpty(format));
+			}
+			newItems.add(i);
+		}
+
+		List<String> errors = new ArrayList<>();
+		if (!simplePageToolDao.saveItemBatch(newItems, shiftedItems, errors,
+				messageLocator.getMessage("simplepage.nowrite"))) {
+			setErrMessage(messageLocator.getMessage("simplepage.savefailed"));
+			discardBltiBatchCaches(shiftedItems);
+			return "failure";
+		}
+		itemsCache.remove(getCurrentPageId());
+		ToolSession toolSession = sessionManager.getCurrentToolSession();
+		toolSession.setAttribute("lessonbuilder.newitem", Long.toString(newItems.get(newItems.size() - 1).getId()));
+		return "success";
 	}
 
 	private void discardBltiBatchCaches(List<SimplePageItem> shiftedItems) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/BltiPickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/BltiPickerProducer.java
@@ -40,6 +40,8 @@ import uk.org.ponder.rsf.components.UIForm;
 import uk.org.ponder.rsf.components.UIInput;
 import uk.org.ponder.rsf.components.UILink;
 import uk.org.ponder.rsf.components.UIOutput;
+import uk.org.ponder.rsf.components.UISelect;
+import uk.org.ponder.rsf.components.UISelectChoice;
 import uk.org.ponder.rsf.components.UIVerbatim;
 import uk.org.ponder.rsf.components.decorators.UIFreeAttributeDecorator;
 import uk.org.ponder.rsf.flow.jsfnav.NavigationCase;
@@ -54,10 +56,9 @@ import org.sakaiproject.lessonbuildertool.SimplePage;
 import org.sakaiproject.lessonbuildertool.SimplePageItem;
 import org.sakaiproject.lessonbuildertool.service.BltiEntity;
 import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean;
-import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.UrlItem;
 import org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.BltiTool;
 import org.sakaiproject.lessonbuildertool.tool.view.GeneralViewParameters;
-import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;   
+import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
 import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.tool.cover.SessionManager;
 import org.sakaiproject.tool.cover.ToolManager;
@@ -140,8 +141,7 @@ public class BltiPickerProducer implements ViewComponentProducer, NavigationCase
 
 		Long itemId = ((GeneralViewParameters) viewparams).getItemId();
 
-		// Reach down and grab a GET parameter from ThreadLocal
-		String ltiItemId = ToolUtils.getRequestParameter("ltiItemId");
+		String[] ltiItemIds = ToolUtils.getRequestFromThreadLocal().getParameterValues("ltiItemId");
 
 		simplePageBean.setItemId(itemId);
 
@@ -157,8 +157,10 @@ public class BltiPickerProducer implements ViewComponentProducer, NavigationCase
 
 		String toolId = getCurrentTool("sakai.siteinfo");
 
+		boolean acceptMultiple = itemId == null || itemId == -1;
         String url = ServerConfigurationService.getToolUrl() + "/" + toolId + "/sakai.lti.admin.helper.helper?panel=LessonsMain&flow=lessons"
-            + "&returnUrl=" + URLEncoder.encode(comeBack);
+            + "&returnUrl=" + URLEncoder.encode(comeBack)
+            + "&acceptMultiple=" + acceptMultiple;
 
 		UILink launchlink = UILink.make(tofill, "blti-launch-link", url);
 		UIOutput.make(tofill, "blti-select-text", messageLocator.getMessage("simplepage.blti.chooser"));
@@ -178,13 +180,19 @@ public class BltiPickerProducer implements ViewComponentProducer, NavigationCase
 			    currentItem = i.getSakaiId();
 			}
 
-			// If this is an autosubmit situation, we do not need to list the links
+			// If this is an autosubmit situation, carry all selected links into the RSF action.
 			Object sessionToken = SessionManager.getCurrentSession().getAttribute("sakai.csrf.token");
-			if ( ltiItemId != null ) {
+			if ( ltiItemIds != null && ltiItemIds.length > 0 ) {
 				UIForm fb = UIForm.make(tofill, "blti-autosubmit");
-				if (sessionToken != null)
+				if (sessionToken != null) {
 					UIInput.make(fb, "csrf", "simplePageBean.csrfToken", sessionToken.toString());
-				UIInput.make(fb, "select", "simplePageBean.selectedBlti", ltiItemId);
+				}
+				UISelect select = UISelect.makeMultiple(fb, "select-span", ltiItemIds,
+						"#{simplePageBean.selectedBlti}", ltiItemIds);
+				for (int index = 0; index < ltiItemIds.length; index++) {
+					UIBranchContainer row = UIBranchContainer.make(fb, "select-row:");
+					UISelectChoice.make(row, "select", select.getFullID(), index);
+				}
 				UIInput.make(fb, "add-before", "#{simplePageBean.addBefore}", ((GeneralViewParameters) viewparams).getAddBefore());
 				UIInput.make(fb, "item-id", "#{simplePageBean.itemId}");
 				UIInput.make(fb, "item-description", "simplePageBean.description", ltiItemDescription);
@@ -195,9 +203,9 @@ public class BltiPickerProducer implements ViewComponentProducer, NavigationCase
 			UICommand.make(tofill, "cancel", messageLocator.getMessage("simplepage.cancel"), "#{simplePageBean.cancel}");
 
 			UIForm cancelform = UIForm.make(tofill, "blti-cancel");
-			if (sessionToken != null)
+			if (sessionToken != null) {
 				UIInput.make(cancelform, "csrf", "simplePageBean.csrfToken", sessionToken.toString());
-			UIInput.make(cancelform, "select", "simplePageBean.selectedBlti", ltiItemId);
+			}
 			UICommand.make(cancelform, "cancel", messageLocator.getMessage("simplepage.cancel"), "#{simplePageBean.cancel}");
 			UICommand.make(cancelform, "cancel2", messageLocator.getMessage("simplepage.cancel"), "#{simplePageBean.cancel}");
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/BltiPickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/BltiPickerProducer.java
@@ -151,7 +151,7 @@ public class BltiPickerProducer implements ViewComponentProducer, NavigationCase
 		}
 
 		// here is a URL to return to this page
-		String comeBack = ToolUtils.getToolBaseUrl()+ "/" + ToolManager.getCurrentPlacement().getId() + "/BltiPicker?" +
+		String comeBack = ToolUtils.getToolBaseUrl()+ "/" + ToolManager.getCurrentPlacement().getId() + "/BltiPicker?sendingPage=" +
 		    ((GeneralViewParameters) viewparams).getSendingPage() + "&itemId=" + itemId + "&addBefore=" + ((GeneralViewParameters) viewparams).getAddBefore() + (bltiTool == null? "" : "&addTool=" + bltiToolId);
 		if ( bltiEntity instanceof BltiEntity ) ( (BltiEntity) bltiEntity).setReturnUrl(comeBack);
 

--- a/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBeanTest.java
+++ b/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *             http://opensource.org/licenses/ecl2
+ *             http://www.opensource.org/licenses/ecl2
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,33 +15,65 @@
  */
  package org.sakaiproject.lessonbuildertool.tool.beans;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
+import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
+import org.sakaiproject.lessonbuildertool.SimplePage;
 import org.sakaiproject.lessonbuildertool.SimplePageItem;
 import org.sakaiproject.lessonbuildertool.SimplePageItemImpl;
 import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
+import org.sakaiproject.lessonbuildertool.service.BltiInterface;
+import org.sakaiproject.lessonbuildertool.service.LessonEntity;
 import org.sakaiproject.memory.api.MemoryService;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.tool.api.ToolSession;
 
 import uk.org.ponder.messageutil.MessageLocator;
 
 public class SimplePageBeanTest {
 
+    private static final String CSRF = "csrf-token";
+    private static final String SITE_ID = "site-1";
+
     private SimplePageBean simplePageBean;
+    private SimplePageToolDao dao;
+    private SessionManager sessionManager;
+    private Session session;
+    private SecurityService securityService;
 
     @Before
     public void before() {
         MessageLocator messageLocator = mock(MessageLocator.class);
-        SimplePageToolDao dao = mock(SimplePageToolDao.class);
+        dao = mock(SimplePageToolDao.class);
         MemoryService memoryService = mock(MemoryService.class);
+        sessionManager = mock(SessionManager.class);
+        session = mock(Session.class);
+        securityService = mock(SecurityService.class);
+        ToolSession toolSession = mock(ToolSession.class);
 
         try (MockedStatic<ComponentManager> cm = mockStatic(ComponentManager.class);
              MockedStatic<ServerConfigurationService> scs = mockStatic(ServerConfigurationService.class)) {
@@ -50,8 +82,20 @@ public class SimplePageBeanTest {
             simplePageBean = new SimplePageBean();
         }
 
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        when(sessionManager.getCurrentToolSession()).thenReturn(toolSession);
+        when(session.getAttribute("sakai.csrf.token")).thenReturn(CSRF);
+        when(securityService.unlock(eq(SimplePage.PERMISSION_LESSONBUILDER_UPDATE), anyString())).thenReturn(true);
+        when(messageLocator.getMessage(anyString())).thenReturn("message");
+        when(dao.saveItemBatch(any(), any(), any(), anyString())).thenReturn(true);
+
         simplePageBean.setMessageLocator(messageLocator);
         simplePageBean.setSimplePageToolDao(dao);
+        simplePageBean.setSessionManager(sessionManager);
+        simplePageBean.setSecurityService(securityService);
+        simplePageBean.setCsrfToken(CSRF);
+        simplePageBean.setCurrentSiteId(SITE_ID);
+        simplePageBean.setCurrentPageId(99L);
 
         // common data for tests
         SimplePageItem i1 = new SimplePageItemImpl(1, 0, 0, 2, "1", "Lessons");
@@ -95,5 +139,83 @@ public class SimplePageBeanTest {
         String path = simplePageBean.getSubPagePath(i5, false);
         Assert.assertEquals("Infinite > Lessons > SubPage 1", path);
         verify(simplePageBean.getSimplePageToolDao(), times(2)).findItemsBySakaiId("0");
+    }
+
+    @Test
+    public void addBlti_addsEverySelectedLinkInProviderOrder() {
+        LessonEntity entityProducer = mock(LessonEntity.class);
+        LessonEntity first = mock(LessonEntity.class, withSettings().extraInterfaces(BltiInterface.class));
+        LessonEntity second = mock(LessonEntity.class, withSettings().extraInterfaces(BltiInterface.class));
+        when(entityProducer.getEntity("/blti/101")).thenReturn(first);
+        when(entityProducer.getEntity("/blti/102")).thenReturn(second);
+        when(first.getTitle()).thenReturn("First assignment");
+        when(second.getTitle()).thenReturn("Second assignment");
+        when(first.getDescription()).thenReturn("First description");
+        when(second.getDescription()).thenReturn("Second description");
+        when(((BltiInterface) first).frameSize()).thenReturn(0);
+        when(((BltiInterface) second).frameSize()).thenReturn(0);
+
+        SimplePageItem firstItem = new SimplePageItemImpl(101, 99, 1, SimplePageItem.BLTI, "/blti/101", "First assignment");
+        SimplePageItem secondItem = new SimplePageItemImpl(102, 99, 2, SimplePageItem.BLTI, "/blti/102", "Second assignment");
+        when(dao.findItemsOnPage(99L)).thenReturn(new ArrayList<>());
+        when(dao.makeItem(99, 1, SimplePageItem.BLTI, "/blti/101", "First assignment")).thenReturn(firstItem);
+        when(dao.makeItem(99, 2, SimplePageItem.BLTI, "/blti/102", "Second assignment")).thenReturn(secondItem);
+
+        simplePageBean.setTaskService(mock(org.sakaiproject.tasks.api.TaskService.class));
+        simplePageBean.setBltiEntity(entityProducer);
+        simplePageBean.setItemId(-1L);
+        simplePageBean.setSelectedBlti(new String[] { "/blti/101", "/blti/102" });
+
+        Assert.assertEquals("success", simplePageBean.addBlti());
+
+        InOrder order = inOrder(dao);
+        order.verify(dao).makeItem(99, 1, SimplePageItem.BLTI, "/blti/101", "First assignment");
+        order.verify(dao).makeItem(99, 2, SimplePageItem.BLTI, "/blti/102", "Second assignment");
+        verify(dao).saveItemBatch(any(), any(), any(), anyString());
+        Assert.assertEquals("First description", firstItem.getDescription());
+        Assert.assertEquals("Second description", secondItem.getDescription());
+        Assert.assertEquals(0, simplePageBean.selectedBlti.length);
+    }
+
+    @Test
+    public void addBlti_rejectsMultipleLinksWhenEditingAnExistingItem() {
+        simplePageBean.setBltiEntity(mock(LessonEntity.class));
+        simplePageBean.setItemId(10L);
+        simplePageBean.setSelectedBlti(new String[] { "/blti/101", "/blti/102" });
+
+        Assert.assertEquals("failure", simplePageBean.addBlti());
+        verify(dao, never()).makeItem(anyLong(), anyInt(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void addBlti_keepsProviderOrderWhenInsertingAfterAnItem() {
+        LessonEntity entityProducer = mock(LessonEntity.class);
+        LessonEntity first = mock(LessonEntity.class, withSettings().extraInterfaces(BltiInterface.class));
+        LessonEntity second = mock(LessonEntity.class, withSettings().extraInterfaces(BltiInterface.class));
+        when(entityProducer.getEntity("/blti/101")).thenReturn(first);
+        when(entityProducer.getEntity("/blti/102")).thenReturn(second);
+        when(first.getTitle()).thenReturn("First assignment");
+        when(second.getTitle()).thenReturn("Second assignment");
+        when(((BltiInterface) first).frameSize()).thenReturn(0);
+        when(((BltiInterface) second).frameSize()).thenReturn(0);
+
+        SimplePageItem anchor = new SimplePageItemImpl(50, 99, 5, SimplePageItem.TEXT, "", "Anchor");
+        SimplePageItem firstItem = new SimplePageItemImpl(101, 99, 6, SimplePageItem.BLTI, "/blti/101", "First assignment");
+        SimplePageItem secondItem = new SimplePageItemImpl(102, 99, 7, SimplePageItem.BLTI, "/blti/102", "Second assignment");
+        when(dao.findItemsOnPage(99L)).thenReturn(new ArrayList<>(List.of(anchor)));
+        when(dao.makeItem(99, 6, SimplePageItem.BLTI, "/blti/101", "First assignment")).thenReturn(firstItem);
+        when(dao.makeItem(99, 7, SimplePageItem.BLTI, "/blti/102", "Second assignment")).thenReturn(secondItem);
+
+        simplePageBean.setBltiEntity(entityProducer);
+        simplePageBean.setItemId(-1L);
+        simplePageBean.setAddBefore("-50");
+        simplePageBean.setSelectedBlti(new String[] { "/blti/101", "/blti/102" });
+
+        Assert.assertEquals("success", simplePageBean.addBlti());
+
+        InOrder order = inOrder(dao);
+        order.verify(dao).makeItem(99, 6, SimplePageItem.BLTI, "/blti/101", "First assignment");
+        order.verify(dao).makeItem(99, 7, SimplePageItem.BLTI, "/blti/102", "Second assignment");
+        verify(dao).saveItemBatch(any(), any(), any(), anyString());
     }
 }

--- a/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBeanTest.java
+++ b/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *             http://www.opensource.org/licenses/ecl2
+ *             http://opensource.org/licenses/ecl2
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -26,7 +26,9 @@
 		<form action="#" rsf:id="blti-autosubmit" id="blti-autosubmit">
 			<input type="hidden" rsf:id="csrf"/>
 			<input type="hidden" rsf:id="item-id" id="item-id" />
-			<input type="hidden" rsf:id="select"/>
+			<span rsf:id="select-span" style="display:none">
+				<span rsf:id="select-row:"><input type="checkbox" rsf:id="select" /></span>
+			</span>
 			<input type="hidden" rsf:id="add-before" id="add-before" />
 			<input type="hidden" rsf:id="item-description" id="item-description" />
 			<input type="hidden" class="bold" rsf:id="submit" />

--- a/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
+++ b/lessonbuilder/tool/src/webapp/templates/BltiPicker.html
@@ -26,9 +26,8 @@
 		<form action="#" rsf:id="blti-autosubmit" id="blti-autosubmit">
 			<input type="hidden" rsf:id="csrf"/>
 			<input type="hidden" rsf:id="item-id" id="item-id" />
-			<span rsf:id="select-span" style="display:none">
-				<span rsf:id="select-row:"><input type="checkbox" rsf:id="select" /></span>
-			</span>
+			<span rsf:id="select-span" style="display:none"></span>
+			<span rsf:id="select-row:" style="display:none"><input type="checkbox" rsf:id="select" /></span>
 			<input type="hidden" rsf:id="add-before" id="add-before" />
 			<input type="hidden" rsf:id="item-description" id="item-description" />
 			<input type="hidden" class="bold" rsf:id="submit" />
@@ -75,7 +74,7 @@
 
       el.addEventListener("shown.bs.modal", e => {
         console.log('Height', modalDialogHeight());
-        document.getElementById('#modal-iframe-div').setAttribute('height', modalDialogHeight());
+        el.setAttribute('height', modalDialogHeight());
       });
 
       el.addEventListener("hidden.bs.modal", e => {

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -39,6 +39,7 @@ import java.time.ZoneOffset;
 import java.time.format.FormatStyle;
 
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import java.text.MessageFormat;
 
@@ -117,7 +118,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 	private static String STATE_TOOL_ID = "lti:state_tool_id";
 	private static String STATE_CONTENT_ID = "lti:state_content_id";
 	private static String STATE_REDIRECT_URL = "lti:state_redirect_url";
-	private static String STATE_LESSONS_CONTENT_ITEMS = "lti:state_lessons_content_items";
 	private static String STATE_CONTENT_ITEM = "lti:state_content_item";
 	private static String STATE_CONTENT_ITEM_FAILURES = "lti:state_content_item_failures";
 	private static String STATE_CONTENT_ITEM_SUCCESSES = "lti:state_content_item_successes";
@@ -258,7 +258,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		state.removeAttribute(STATE_POST);
 		state.removeAttribute(STATE_SUCCESS);
 		state.removeAttribute(STATE_REDIRECT_URL);
-		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		return "lti_error";
 	}
 
@@ -274,7 +273,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		state.removeAttribute(STATE_POST);
 		state.removeAttribute(STATE_SUCCESS);
 		state.removeAttribute(STATE_REDIRECT_URL);
-		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		return "lti_finished";
 	}
 
@@ -1002,7 +1000,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		forwardUrl += "&registration_token=" + URLEncoder.encode(registration_token);
 
 		state.setAttribute(STATE_REDIRECT_URL, forwardUrl);
-		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		switchPanel(state, "Forward");
 	}
 
@@ -2066,7 +2063,6 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			log.debug("flow={} newPanelState={} to returnUrl={}", flow, newPanelState, returnUrl);
 			switchPanel(state, newPanelState);
 			state.setAttribute(STATE_REDIRECT_URL, returnUrl);
-			state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 			return;
 		}
 
@@ -2702,10 +2698,13 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				return;
 			}
 
-			log.debug("Lessons flow, posting {} content item(s) to returnUrl {}",
+			log.debug("Lessons flow, returning {} content item(s) to returnUrl {}",
 					lessonsContentItems.size(), returnUrl);
+			for (String contentItem : lessonsContentItems) {
+				returnUrl += (returnUrl.contains("?") ? "&" : "?") + "ltiItemId="
+						+ URLEncoder.encode(contentItem, StandardCharsets.UTF_8);
+			}
 			state.setAttribute(STATE_REDIRECT_URL, returnUrl);
-			state.setAttribute(STATE_LESSONS_CONTENT_ITEMS, lessonsContentItems);
 			forward = "Redirect";
 		} else if ( flow.equals(FLOW_PARAMETER_ASSIGNMENT) ) {
 			forward = "AssignmentDone";
@@ -2950,15 +2949,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		context.put("tlang", rb);
 		context.put("includeLatestJQuery", PortalUtils.includeLatestJQuery("LTIAdminTool"));
 		String returnUrl = (String) state.getAttribute(STATE_REDIRECT_URL);
-		List<String> lessonsContentItems = (List<String>) state.getAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		state.removeAttribute(STATE_REDIRECT_URL);
-		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		if (returnUrl == null) {
-			return "lti_content_redirect";
-		}
-		if (lessonsContentItems != null && !lessonsContentItems.isEmpty()) {
-			context.put("postReturnUrl", StringEscapeUtils.escapeHtml4(returnUrl));
-			context.put("lessonsContentItems", lessonsContentItems);
 			return "lti_content_redirect";
 		}
 		log.debug("Redirecting parent frame back to={}", returnUrl);
@@ -3925,7 +3917,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		For DL/CI - launch to the tool with response sent to doMultipleContentItemResponse
 			Allow multiple selections when adding new Lessons items; edits remain single-item
 			doMultipleContentItemResponse - loops through the graph and makes Sakai content items
-			POST resulting bltiItem references to the returnUrl in provider order
+			Redirect with resulting bltiItem references in the returnUrl in provider order
 			(inside the modal / popup iframe created by Lessons)
 
 */

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -117,6 +117,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 	private static String STATE_TOOL_ID = "lti:state_tool_id";
 	private static String STATE_CONTENT_ID = "lti:state_content_id";
 	private static String STATE_REDIRECT_URL = "lti:state_redirect_url";
+	private static String STATE_LESSONS_CONTENT_ITEMS = "lti:state_lessons_content_items";
 	private static String STATE_CONTENT_ITEM = "lti:state_content_item";
 	private static String STATE_CONTENT_ITEM_FAILURES = "lti:state_content_item_failures";
 	private static String STATE_CONTENT_ITEM_SUCCESSES = "lti:state_content_item_successes";
@@ -257,6 +258,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		state.removeAttribute(STATE_POST);
 		state.removeAttribute(STATE_SUCCESS);
 		state.removeAttribute(STATE_REDIRECT_URL);
+		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		return "lti_error";
 	}
 
@@ -272,6 +274,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		state.removeAttribute(STATE_POST);
 		state.removeAttribute(STATE_SUCCESS);
 		state.removeAttribute(STATE_REDIRECT_URL);
+		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		return "lti_finished";
 	}
 
@@ -999,6 +1002,7 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 		forwardUrl += "&registration_token=" + URLEncoder.encode(registration_token);
 
 		state.setAttribute(STATE_REDIRECT_URL, forwardUrl);
+		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		switchPanel(state, "Forward");
 	}
 
@@ -2062,6 +2066,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			log.debug("flow={} newPanelState={} to returnUrl={}", flow, newPanelState, returnUrl);
 			switchPanel(state, newPanelState);
 			state.setAttribute(STATE_REDIRECT_URL, returnUrl);
+			state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 			return;
 		}
 
@@ -2456,6 +2461,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		JSONArray new_content = new JSONArray();
 		int goodcount = 0;
 		List<String> failures = new ArrayList<String>();
+		List<String> lessonsContentItems = new ArrayList<String>();
 
 		// doMultipleContentItemResponse
 		// Check if this is Deep Link 1.0 or 2.0
@@ -2577,6 +2583,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				item.put("tool_newpage", LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE)));
 				new_content.add(item);
 				goodcount++;
+				lessonsContentItems.add("/blti/" + contentKey);
 			}
 
 		} else {
@@ -2677,22 +2684,28 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 				item.put("tool_newpage", LTIUtil.toLong(tool.get(LTIService.LTI_NEWPAGE)));
 				new_content.add(item);
 				goodcount++;
+				lessonsContentItems.add("/blti/" + contentKey);
 			}
 		}
 
 		String forward;
 		if ( flow.equals(FLOW_PARAMETER_LESSONS) ) {
-			if  (contentKey == null ) {
-				log.warn("Returning content item to Lessons, but contentKey={}", contentKey);
+			if (StringUtils.isBlank(returnUrl)) {
+				addAlert(state, rb.getString("error.contentitem.missing.returnurl"));
+				switchPanel(state, errorPanel);
+				return;
 			}
-			if (returnUrl.indexOf("?") > 0) {
-			   returnUrl += "&ltiItemId=/blti/" + contentKey;
-			} else {
-				returnUrl += "?ltiItemId=/blti/" + contentKey;
+			if (lessonsContentItems.isEmpty()) {
+				log.warn("Deep Link response did not contain any usable LTI resource links for Lessons");
+				addAlert(state, rb.getString("error.deeplink.no.ltilink"));
+				switchPanel(state, errorPanel);
+				return;
 			}
 
-			log.debug("Lessons flow, redirecting to returnUrl {}", returnUrl);
+			log.debug("Lessons flow, posting {} content item(s) to returnUrl {}",
+					lessonsContentItems.size(), returnUrl);
 			state.setAttribute(STATE_REDIRECT_URL, returnUrl);
+			state.setAttribute(STATE_LESSONS_CONTENT_ITEMS, lessonsContentItems);
 			forward = "Redirect";
 		} else if ( flow.equals(FLOW_PARAMETER_ASSIGNMENT) ) {
 			forward = "AssignmentDone";
@@ -2937,8 +2950,15 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		context.put("tlang", rb);
 		context.put("includeLatestJQuery", PortalUtils.includeLatestJQuery("LTIAdminTool"));
 		String returnUrl = (String) state.getAttribute(STATE_REDIRECT_URL);
+		List<String> lessonsContentItems = (List<String>) state.getAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		state.removeAttribute(STATE_REDIRECT_URL);
+		state.removeAttribute(STATE_LESSONS_CONTENT_ITEMS);
 		if (returnUrl == null) {
+			return "lti_content_redirect";
+		}
+		if (lessonsContentItems != null && !lessonsContentItems.isEmpty()) {
+			context.put("postReturnUrl", StringEscapeUtils.escapeHtml4(returnUrl));
+			context.put("lessonsContentItems", lessonsContentItems);
 			return "lti_content_redirect";
 		}
 		log.debug("Redirecting parent frame back to={}", returnUrl);
@@ -3259,10 +3279,15 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			String previousFlow = previousPost.getProperty(FLOW_PARAMETER);
 			if ( previousFlow != null ) flow = previousFlow;
 		}
+		String acceptMultipleParam = data.getParameters().getString("acceptMultiple");
+		if (acceptMultipleParam == null && previousPost != null) {
+			acceptMultipleParam = previousPost.getProperty("acceptMultiple");
+		}
+		boolean acceptMultiple = isMultipleLessonsDeepLink(flow, acceptMultipleParam);
 
 		Long toolKey = LTIUtil.toLongNull(data.getParameters().getString(LTIService.LTI_TOOL_ID));
 
-		log.debug("flow={} toolKey={} returnUrl={}", flow, toolKey, returnUrl);
+		log.debug("flow={} toolKey={} returnUrl={} acceptMultiple={}", flow, toolKey, returnUrl, acceptMultiple);
 
 		Placement placement = toolManager.getCurrentPlacement();
 
@@ -3347,6 +3372,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			context.put("allTools", allTools);
 			context.put("returnUrl", Base64DoubleUrlEncodeSafe.encode(returnUrl));
 			context.put("flow", flow);
+			context.put("acceptMultiple", acceptMultiple);
 			return "lti_editor_select";
 		}
 
@@ -3412,8 +3438,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		// to the access servlet.
 		Properties contentData = new Properties();
 
-		// Lessons and Assignments only want one returned value
-		if ( flow.equals(FLOW_PARAMETER_ASSIGNMENT) || flow.equals(FLOW_PARAMETER_LESSONS) ) {
+		// Assignments and edits of existing Lessons items only accept one returned value.
+		if ( flow.equals(FLOW_PARAMETER_ASSIGNMENT) || (flow.equals(FLOW_PARAMETER_LESSONS) && !acceptMultiple) ) {
 			contentData.setProperty(ContentItem.ACCEPT_MEDIA_TYPES, ContentItem.MEDIA_LTILINKITEM);
 			contentData.setProperty(ContentItem.ACCEPT_MULTIPLE, "false");
 		} else {
@@ -3434,6 +3460,10 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		context.put("forwardUrl", contentLaunch);
 		context.put("forceLight", Boolean.TRUE);
 		return "lti_content_redirect";
+	}
+
+	static boolean isMultipleLessonsDeepLink(String flow, String acceptMultiple) {
+		return FLOW_PARAMETER_LESSONS.equals(flow) && Boolean.parseBoolean(acceptMultiple);
 	}
 
 	// This is called in the non CI/DL flow when we are done configuring a Sakai content item
@@ -3858,7 +3888,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			ContentPutInternal goes back to the returnUrl (PostContentConfig)
 			buildCKEditorDonePanelContext
 		For DL/CI - launch to the tool with response sent to doMultipleContentItemResponse
-			Mark the CI/DL launch as only allowing a single response
+			Allow multiple items to be selected in the CI/DL launch
 			doMultipleContentItemResponse - loops through graph and makes Sakai content items
 			with flow editor send to CKEditorDone
 			CKEditorDone sends data to its parent frame and closes itself
@@ -3877,7 +3907,7 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		For DL/CI- launch to the tool with response sent to doMultipleContentItemResponse
 			Only allow a single item to be selected in the CI/DL launch
 			doMultipleContentItemResponse - loops through graph and makes Sakai content items
-			with flow editor send to AssignmentDone
+			with flow assignment send to AssignmentDone
 			AssignmentDone sends data to its parent frame and closes itself
 
 	Lessons:
@@ -3893,10 +3923,10 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			ContentPutInternal goes back to the returnUrl (PostContentConfig)
 			buildAssignmentDonePanelContext
 		For DL/CI - launch to the tool with response sent to doMultipleContentItemResponse
-			Mark the CI/DL launch as only allowing a single response
-			doMultipleContentItemResponse - loops through graph and makes the Sakai content item
-			Then augments the returnUrl with the bltiItem and redirects the frame to the
-			returnUrl (inside the modal / popup iframe creates by Lessons)
+			Allow multiple selections when adding new Lessons items; edits remain single-item
+			doMultipleContentItemResponse - loops through the graph and makes Sakai content items
+			POST resulting bltiItem references to the returnUrl in provider order
+			(inside the modal / popup iframe created by Lessons)
 
 */
 }

--- a/lti/lti-tool/src/test/org/sakaiproject/lti/tool/LTIAdminToolContentDescriptionTest.java
+++ b/lti/lti-tool/src/test/org/sakaiproject/lti/tool/LTIAdminToolContentDescriptionTest.java
@@ -59,4 +59,15 @@ public class LTIAdminToolContentDescriptionTest {
 		assertTrue(job.toJSONString().contains("ok"));
 		assertFalse(job.toJSONString().contains("script"));
 	}
+
+	@Test
+	public void multipleDeepLinking_isOnlyEnabledForExplicitLessonsAdds() {
+		assertTrue(LTIAdminTool.isMultipleLessonsDeepLink("lessons", "true"));
+		assertFalse(LTIAdminTool.isMultipleLessonsDeepLink("lessons", "false"));
+		assertFalse(LTIAdminTool.isMultipleLessonsDeepLink("lessons", null));
+		assertFalse(LTIAdminTool.isMultipleLessonsDeepLink("lessons", "1"));
+		assertFalse(LTIAdminTool.isMultipleLessonsDeepLink("assignment", "true"));
+		assertFalse(LTIAdminTool.isMultipleLessonsDeepLink("editor", "true"));
+		assertFalse(LTIAdminTool.isMultipleLessonsDeepLink(null, "true"));
+	}
 }

--- a/lti/lti-tool/src/webapp/vm/lti_content_redirect.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_content_redirect.vm
@@ -1,14 +1,5 @@
 <div class="portletBody">
-#if ( $postReturnUrl && $lessonsContentItems )
-<form id="lessons-deep-link-return" method="post" action="$postReturnUrl" target="_parent">
-#foreach($contentItem in $lessonsContentItems)
-<input type="hidden" name="ltiItemId" value="$contentItem" />
-#end
-</form>
-<script type="text/javascript">
-document.getElementById("lessons-deep-link-return").submit();
-</script>
-#elseif ( $returnUrl )
+#if ( $returnUrl )
 <script type="text/javascript"><!--
 parent.location = "$returnUrl";
 // -->

--- a/lti/lti-tool/src/webapp/vm/lti_content_redirect.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_content_redirect.vm
@@ -1,5 +1,14 @@
 <div class="portletBody">
-#if ( $returnUrl ) 
+#if ( $postReturnUrl && $lessonsContentItems )
+<form id="lessons-deep-link-return" method="post" action="$postReturnUrl" target="_parent">
+#foreach($contentItem in $lessonsContentItems)
+<input type="hidden" name="ltiItemId" value="$contentItem" />
+#end
+</form>
+<script type="text/javascript">
+document.getElementById("lessons-deep-link-return").submit();
+</script>
+#elseif ( $returnUrl )
 <script type="text/javascript"><!--
 parent.location = "$returnUrl";
 // -->

--- a/lti/lti-tool/src/webapp/vm/lti_editor_select.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_editor_select.vm
@@ -17,7 +17,7 @@ border-bottom: 1px solid gray;
 #if( $tool.get("fa_icon"))
 <i class="fa $tool.get("fa_icon")" aria-hidden="true"></i>
 #end
-<a href="$sakai_ActionURL.setPanel("ContentItemMain")&flow=$flow&tool_id=$tool.get("id")&returnUrl=$returnUrl">$tool.get('title')
+<a href="$sakai_ActionURL.setPanel("ContentItemMain")&flow=$flow&tool_id=$tool.get("id")&returnUrl=$returnUrl#if($acceptMultiple)&acceptMultiple=true#end">$tool.get('title')
 #if ( $tool.get('pl_linkselection') )
 <i class="fa fa-search" style="color:blue;" aria-hidden="true"></i>
 #end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-selection for adding LTI items to Lessons, including autosubmission and deep-link handling.
  * Supports inserting multiple items at a chosen position while preserving provider order.
* **Bug Fixes**
  * Editing an existing page item remains limited to one LTI selection.
  * Descriptions now prefer content-specific text, with tool descriptions as fallback.
  * Improved batch-add reliability and recovery after failed additions.
* **Tests**
  * Expanded coverage for multi-add behavior, ordering, and selection restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->