### PR TITLE
SAK-52762 Lessons Prevent moving a top-level parent page to the left margin

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
@@ -75,4 +75,52 @@ class LessonsTest extends SakaiUiTestBase {
         page.locator("#save").click(new Locator.ClickOptions().setForce(true));
         assertThat(page.locator("#content")).isVisible();
     }
+
+    @Test
+    @Order(3)
+    void canPromoteOnlySubpagesToSiteNavigation() {
+        sakai.login("instructor1");
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Lessons");
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Content")).first().click(new Locator.ClickOptions().setForce(true));
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Subpage")).click(new Locator.ClickOptions().setForce(true));
+        page.locator("#subpage-title:visible").fill("Promote Me");
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create")).click(new Locator.ClickOptions().setForce(true));
+
+        sakai.toolClick("Lessons");
+        openAddMorePages();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(Pattern.compile("Put existing page", Pattern.CASE_INSENSITIVE))).click();
+
+        Locator lessonsRadio = page.locator("input[type=radio][title^=\"Lessons \"]").first();
+        assertThat(lessonsRadio).isDisabled();
+        lessonsRadio.evaluate("element => element.removeAttribute('disabled')");
+        lessonsRadio.check();
+        useSelectedItem();
+        assertThat(page.locator("body")).containsText("The page could not be added to site navigation.");
+        Locator currentSiteNavigation = page.locator("li.site-list-item.is-current-site .site-page-list a.btn-nav");
+        assertThat(currentSiteNavigation.filter(new Locator.FilterOptions()
+            .setHasText(Pattern.compile("^\\s*Lessons\\s*$", Pattern.CASE_INSENSITIVE)))).hasCount(1);
+
+        openAddMorePages();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(Pattern.compile("Put existing page", Pattern.CASE_INSENSITIVE))).click();
+        Locator subpageRadio = page.locator("input[type=radio][title^=\"Promote Me \"]").first();
+        assertThat(subpageRadio).isEnabled();
+        subpageRadio.check();
+        useSelectedItem();
+
+        sakai.toolClick("Promote Me");
+        assertThat(page.locator(".neoPortletTitleWrap")).containsText("Promote Me");
+        assertThat(page.locator(".itemclass[role=main]")).isVisible();
+    }
+
+    private void openAddMorePages() {
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("More Tools")).click();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add More Pages")).click();
+    }
+
+    private void useSelectedItem() {
+        page.locator(".PagePicker").getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions()
+            .setName(Pattern.compile("Use selected item", Pattern.CASE_INSENSITIVE))).click();
+    }
 }

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
@@ -83,14 +83,11 @@ class LessonsTest extends SakaiUiTestBase {
         page.navigate(sakaiUrl);
         sakai.toolClick("Lessons");
 
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Content")).first().click(new Locator.ClickOptions().setForce(true));
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Subpage")).click(new Locator.ClickOptions().setForce(true));
-        page.locator("#subpage-title:visible").fill("Promote Me");
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create")).click(new Locator.ClickOptions().setForce(true));
+        addSubpage("Promote Me");
 
         sakai.toolClick("Lessons");
         openAddMorePages();
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(Pattern.compile("Put existing page", Pattern.CASE_INSENSITIVE))).click();
+        chooseExistingPageForSiteNavigation();
 
         Locator lessonsRadio = page.locator("input[type=radio][title^=\"Lessons \"]").first();
         assertThat(lessonsRadio).isDisabled();
@@ -103,7 +100,7 @@ class LessonsTest extends SakaiUiTestBase {
             .setHasText(Pattern.compile("^\\s*Lessons\\s*$", Pattern.CASE_INSENSITIVE)))).hasCount(1);
 
         openAddMorePages();
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(Pattern.compile("Put existing page", Pattern.CASE_INSENSITIVE))).click();
+        chooseExistingPageForSiteNavigation();
         Locator subpageRadio = page.locator("input[type=radio][title^=\"Promote Me \"]").first();
         assertThat(subpageRadio).isEnabled();
         subpageRadio.check();
@@ -114,9 +111,35 @@ class LessonsTest extends SakaiUiTestBase {
         assertThat(page.locator(".itemclass[role=main]")).isVisible();
     }
 
+    private void addSubpage(String title) {
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Content")).first().click();
+
+        Locator addContentDialog = page.locator("#addContentDiv");
+        assertThat(addContentDialog).isVisible();
+        addContentDialog.getByRole(AriaRole.BUTTON,
+            new Locator.GetByRoleOptions().setName("Add Subpage").setExact(true)).click();
+
+        Locator subpageDialog = page.locator("#subpage-dialog");
+        assertThat(subpageDialog).isVisible();
+        subpageDialog.locator("#subpage-title").fill(title);
+        subpageDialog.getByRole(AriaRole.BUTTON,
+            new Locator.GetByRoleOptions().setName("Create").setExact(true)).click();
+
+        assertThat(page.locator("#subpage-breadcrumb-div")).containsText(title);
+    }
+
     private void openAddMorePages() {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("More Tools")).click();
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add More Pages")).click();
+        Locator moreToolsDialog = page.locator("#moreDiv");
+        assertThat(moreToolsDialog).isVisible();
+        moreToolsDialog.getByRole(AriaRole.BUTTON,
+            new Locator.GetByRoleOptions().setName("Add More Pages").setExact(true)).click();
+        assertThat(page.locator("#new-page-dialog")).isVisible();
+    }
+
+    private void chooseExistingPageForSiteNavigation() {
+        page.locator("#new-page-dialog").getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions()
+            .setName(Pattern.compile("Put existing page", Pattern.CASE_INSENSITIVE))).click();
     }
 
     private void useSelectedItem() {

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
@@ -108,7 +108,11 @@ class LessonsTest extends SakaiUiTestBase {
 
         sakai.toolClick("Promote Me");
         assertThat(page.locator(".neoPortletTitleWrap")).containsText("Promote Me");
-        assertThat(page.locator(".itemclass[role=main]")).isVisible();
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("More Tools")).click();
+        Locator moreToolsDialog = page.locator("#moreDiv");
+        assertThat(moreToolsDialog).isVisible();
+        assertThat(moreToolsDialog.getByRole(AriaRole.BUTTON,
+            new Locator.GetByRoleOptions().setName("Add More Pages").setExact(true))).isVisible();
     }
 
     private void addSubpage(String title) {

--- a/lessonbuilder/api/src/resources/lessons.properties
+++ b/lessonbuilder/api/src/resources/lessons.properties
@@ -652,6 +652,7 @@ simplepage.student=Student Pages
 simplepage.missing-students=Missing Pages
 simplepage.add-page=Add Your Own Page
 simplepage.page-exists=You already have a page in that tool.
+simplepage.page-promotion-failed=The page could not be added to site navigation.
 simplepage.new-student-page=New
 simplepage.new-student-content-page=New Page
 simplepage.new-student-content=New Content on Page

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/PagePromotionService.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/PagePromotionService.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lessonbuildertool.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.lessonbuildertool.SimplePage;
+import org.sakaiproject.lessonbuildertool.SimplePageItem;
+import org.sakaiproject.lessonbuildertool.api.LessonBuilderConstants;
+import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SitePage;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.api.ToolConfiguration;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+public class PagePromotionService {
+
+    public enum PagePromotionResult {
+        SUCCESS,
+        INVALID_PAGE_ID,
+        PAGE_NOT_FOUND,
+        STUDENT_PAGE,
+        ALREADY_TOP_LEVEL,
+        NAVIGATION_CREATION_FAILED,
+        PAGE_UPDATE_FAILED,
+        TOP_LEVEL_ITEM_SAVE_FAILED,
+        SITE_SAVE_FAILED,
+        PERSISTENCE_FAILED
+    }
+
+    private final SimplePageToolDao simplePageToolDao;
+    private final SiteService siteService;
+    private final TransactionTemplate transactionTemplate;
+
+    private static final class PromotionState {
+        private boolean siteSaved;
+    }
+
+    public PagePromotionService(SimplePageToolDao simplePageToolDao, SiteService siteService, TransactionTemplate transactionTemplate) {
+        this.simplePageToolDao = simplePageToolDao;
+        this.siteService = siteService;
+        this.transactionTemplate = transactionTemplate;
+    }
+
+    public PagePromotionResult promote(String submittedPageId, String siteId) {
+        Long pageId = parsePageId(submittedPageId);
+        if (pageId == null) {
+            log.warn("Unable to add an existing page as top level: invalid page ID");
+            return PagePromotionResult.INVALID_PAGE_ID;
+        }
+
+        SimplePage target = simplePageToolDao.getPage(pageId);
+        if (target == null || !siteId.equals(target.getSiteId())) {
+            log.warn("Unable to add page {} as top level in site {}: page was not found in the site", pageId, siteId);
+            return PagePromotionResult.PAGE_NOT_FOUND;
+        }
+        if (isStudentPage(target)) {
+            log.warn("Unable to add page {} as top level in site {}: student pages cannot be promoted", pageId, siteId);
+            return PagePromotionResult.STUDENT_PAGE;
+        }
+
+        String canonicalPageId = pageId.toString();
+        if (simplePageToolDao.findTopLevelPageItemBySakaiId(canonicalPageId) != null) {
+            log.warn("Unable to add page {} as top level in site {}: page is already top level", pageId, siteId);
+            return PagePromotionResult.ALREADY_TOP_LEVEL;
+        }
+
+        Site site;
+        try {
+            site = siteService.getSite(siteId);
+        } catch (Exception e) {
+            log.error("Unable to add page {} as top level in site {}: site lookup failed", pageId, siteId, e);
+            return PagePromotionResult.NAVIGATION_CREATION_FAILED;
+        }
+
+        String oldToolId = target.getToolId();
+        Long oldParent = target.getParent();
+        Long oldTopParent = target.getTopParent();
+        SitePage sitePage = null;
+
+        try {
+            sitePage = site.addPage();
+            ToolConfiguration tool = sitePage.addTool(LessonBuilderConstants.TOOL_ID);
+            target.setToolId(tool.getPageId());
+            target.setParent(null);
+            target.setTopParent(null);
+            tool.setTitle(target.getTitle());
+            sitePage.setTitle(target.getTitle());
+            sitePage.setTitleCustom(true);
+        } catch (RuntimeException e) {
+            restore(target, oldToolId, oldParent, oldTopParent, site, sitePage, false);
+            log.error("Unable to create site navigation while promoting page {} in site {}", pageId, siteId, e);
+            return PagePromotionResult.NAVIGATION_CREATION_FAILED;
+        }
+
+        PromotionState promotionState = new PromotionState();
+        try {
+            PagePromotionResult result = transactionTemplate.execute(status -> promote(target, canonicalPageId, site, status, promotionState));
+            if (result == null) {
+                result = PagePromotionResult.PERSISTENCE_FAILED;
+            }
+            if (result != PagePromotionResult.SUCCESS) {
+                restore(target, oldToolId, oldParent, oldTopParent, site, sitePage, promotionState.siteSaved);
+                if (result == PagePromotionResult.PERSISTENCE_FAILED) {
+                    log.error("Unable to add page {} as top level in site {}: {}", pageId, siteId, result);
+                }
+            }
+            return result;
+        } catch (RuntimeException e) {
+            restore(target, oldToolId, oldParent, oldTopParent, site, sitePage, promotionState.siteSaved);
+            log.error("Unable to add page {} as top level in site {}", pageId, siteId, e);
+            return PagePromotionResult.PERSISTENCE_FAILED;
+        }
+    }
+
+    private boolean isStudentPage(SimplePage page) {
+        return page != null && page.getOwner() != null && !page.isOwned();
+    }
+
+    private PagePromotionResult promote(SimplePage target, String canonicalPageId, Site site, TransactionStatus status,
+            PromotionState promotionState) {
+        List<String> updateErrors = new ArrayList<>();
+        if (!simplePageToolDao.update(target, updateErrors, "Unable to update page", true)) {
+            status.setRollbackOnly();
+            log.warn("Unable to update page {} while promoting it in site {}: {}", canonicalPageId, site.getId(), updateErrors);
+            return PagePromotionResult.PAGE_UPDATE_FAILED;
+        }
+
+        SimplePageItem item = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, canonicalPageId, target.getTitle());
+        List<String> itemErrors = new ArrayList<>();
+        if (!simplePageToolDao.saveItem(item, itemErrors, "Unable to save page", true)) {
+            status.setRollbackOnly();
+            log.warn("Unable to save a top-level item for page {} in site {}: {}", canonicalPageId, site.getId(), itemErrors);
+            return PagePromotionResult.TOP_LEVEL_ITEM_SAVE_FAILED;
+        }
+
+        try {
+            simplePageToolDao.flush();
+            siteService.save(site);
+            promotionState.siteSaved = true;
+            return PagePromotionResult.SUCCESS;
+        } catch (Exception e) {
+            status.setRollbackOnly();
+            log.error("Unable to save site navigation while promoting page {} in site {}", canonicalPageId, site.getId(), e);
+            return PagePromotionResult.SITE_SAVE_FAILED;
+        }
+    }
+
+    private Long parsePageId(String submittedPageId) {
+        if (!StringUtils.isNumeric(submittedPageId)) {
+            return null;
+        }
+
+        try {
+            long parsedPageId = Long.parseLong(submittedPageId);
+            return parsedPageId > 0 ? parsedPageId : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void restore(SimplePage target, String toolId, Long parent, Long topParent, Site site, SitePage sitePage,
+            boolean persistSiteRestore) {
+        target.setToolId(toolId);
+        target.setParent(parent);
+        target.setTopParent(topParent);
+        if (sitePage != null) {
+            site.removePage(sitePage);
+            if (persistSiteRestore) {
+                try {
+                    siteService.save(site);
+                } catch (Exception e) {
+                    log.error("Unable to remove site page {} while restoring site {}", sitePage.getId(), site.getId(), e);
+                }
+            }
+        }
+    }
+}

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -148,6 +148,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -636,6 +637,7 @@ public class SimplePageBean {
 	static MemoryService memoryService = (MemoryService)org.sakaiproject.component.cover.ComponentManager.get("org.sakaiproject.memory.api.MemoryService");
 	private static Cache<String, Object> groupCache = memoryService.getCache("org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.groupCache");  // itemId => grouplist
 	private static Cache<String, List> resourceCache = memoryService.getCache("org.sakaiproject.lessonbuildertool.tool.beans.SimplePageBean.resourceCache");
+	private static final ConcurrentHashMap<String, Object> ADD_OLD_PAGE_LOCKS = new ConcurrentHashMap<>();
 	protected static final int DEFAULT_EXPIRATION = 10 * 60;
 
 	public static class PathEntry {
@@ -5130,12 +5132,25 @@ public class SimplePageBean {
 		    return "permission-failed";
 		if (!checkCsrf())
 		    return "permission-failed";
-		
-		SimplePage target = getPage(Long.valueOf(selectedEntity));
-		if(target != null)
-			addPage(target.getTitle(), target.getPageId(), false, true);
-		
-		return "success";
+
+		if (selectedEntity == null || selectedEntity.isEmpty()) {
+			log.warn("addOldPage rejected invalid or already top-level page: {}", selectedEntity);
+			return "failure";
+		}
+
+		Object lock = ADD_OLD_PAGE_LOCKS.computeIfAbsent(selectedEntity, k -> new Object());
+		synchronized (lock) {
+			if (simplePageToolDao.findTopLevelPageItemBySakaiId(selectedEntity) != null) {
+				log.warn("addOldPage rejected invalid or already top-level page: {}", selectedEntity);
+				return "failure";
+			}
+
+			SimplePage target = getPage(Long.valueOf(selectedEntity));
+			if (target != null)
+				addPage(target.getTitle(), target.getPageId(), false, true);
+
+			return "success";
+		}
 	}
 
 	public SimplePage addPage(String title, boolean copyCurrent) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -94,6 +94,8 @@ import org.sakaiproject.lessonbuildertool.service.LessonBuilderEntityProducer;
 import org.sakaiproject.lessonbuildertool.service.LessonEntity;
 import org.sakaiproject.lessonbuildertool.service.LessonSubmission;
 import org.sakaiproject.lessonbuildertool.service.LessonsAccess;
+import org.sakaiproject.lessonbuildertool.service.PagePromotionService;
+import org.sakaiproject.lessonbuildertool.service.PagePromotionService.PagePromotionResult;
 import org.sakaiproject.lessonbuildertool.service.RemovedPageService;
 import org.sakaiproject.lessonbuildertool.service.RemovedPageService.DeleteResult;
 import org.sakaiproject.lessonbuildertool.service.RemovedPageService.OperationStatus;
@@ -481,6 +483,7 @@ public class SimplePageBean {
     @Setter private LessonsAccess lessonsAccess;
     @Setter private LessonBuilderAccessService lessonBuilderAccessService;
     @Setter private RemovedPageService removedPageService;
+    @Setter private PagePromotionService pagePromotionService;
     @Getter @Setter private MessageLocator messageLocator;
     @Setter private HttpServletResponse httpServletResponse;
     @Setter private LessonBuilderEntityProducer lessonBuilderEntityProducer;
@@ -4907,7 +4910,7 @@ public class SimplePageBean {
 			itemNow.setAttribute(CHECKLIST_ITEMS,null);
 			update(itemNow);	//finish writing break before subpages
 			for(int count=1; count<=pageSubpageCount; count++){
-				pageNow = addPage(pageSubpageTitle + ' ' + count, null, false, false);	//make new page
+				pageNow = addPage(pageSubpageTitle + ' ' + count, false, false);	//make new page
 				pageNow.setParent(getCurrentPageId());	//clean up page data
 				pageNow.setTopParent(getCurrentPage().getPageId());
 				update(pageNow);	//save revised page data
@@ -5098,7 +5101,7 @@ public class SimplePageBean {
 			
 			while (numPages > 0) {
 				String title = prefix + Integer.toString(start) + suffix;
-				addPage(title, null, copyPage, (numPages == 1));  // only save the last time
+				addPage(title, copyPage, (numPages == 1));  // only save the last time
 				numPages--;
 				start++;
 			}
@@ -5115,19 +5118,23 @@ public class SimplePageBean {
 		    return "permission-failed";
 		if (!checkCsrf())
 		    return "permission-failed";
-		
-		SimplePage target = getPage(Long.valueOf(selectedEntity));
-		if(target != null)
-			addPage(target.getTitle(), target.getPageId(), false, true);
-		
-		return "success";
+
+		PagePromotionResult result = pagePromotionService.promote(selectedEntity, getCurrentSiteId());
+		currentSite = null;
+		if (result == PagePromotionResult.SUCCESS) {
+			setTopRefresh();
+			return "success";
+		}
+
+		setErrMessage(messageLocator.getMessage("simplepage.page-promotion-failed"));
+		return "failure";
 	}
 
 	public SimplePage addPage(String title, boolean copyCurrent) {
-		return addPage(title, null, copyCurrent, true);
+		return addPage(title, copyCurrent, true);
 	}
 	
-        public SimplePage addPage(String title, Long pageId, boolean copyCurrent, boolean doSave) {
+	private SimplePage addPage(String title, boolean copyCurrent, boolean doSave) {
 
 		Site site = getCurrentSite();
 		SitePage sitePage = site.addPage();
@@ -5135,28 +5142,13 @@ public class SimplePageBean {
 		ToolConfiguration tool = sitePage.addTool(LessonBuilderConstants.TOOL_ID);
 		String toolId = tool.getPageId();
 		
-		SimplePage page;
-		
-		if(pageId == null) {
-			page = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, null, null);
-			saveItem(page);
-		}else {
-			page = getPage(pageId);
-			page.setToolId(toolId);
-			page.setParent(null);
-			page.setTopParent(null);
-			update(page);
-			title = page.getTitle();
-		}
+		SimplePage page = simplePageToolDao.makePage(toolId, getCurrentSiteId(), title, null, null);
+		saveItem(page);
 
 		tool.setTitle(title);
 		
-		// Does the top-level page item already exist, as in the case of adding a pre-existing page? If so, don't create another item.
-		SimplePageItem existingTop = simplePageToolDao.findTopLevelPageItemBySakaiId(Long.toString(page.getPageId()));
-		if (existingTop == null) {
-			SimplePageItem item = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, Long.toString(page.getPageId()), title);
-			saveItem(item);
-		}
+		SimplePageItem item = simplePageToolDao.makeItem(0, 0, SimplePageItem.PAGE, Long.toString(page.getPageId()), title);
+		saveItem(item);
 
 		sitePage.setTitle(title);
 		sitePage.setTitleCustom(true);

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/PagePickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/PagePickerProducer.java
@@ -305,6 +305,7 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
         // otherwise we have the chooser page for the "add subpage" command
         boolean summaryPage = "summary".equals(source);
         String returnView = ((GeneralViewParameters) viewparams).getReturnView();
+        boolean newTopLevel = ((GeneralViewParameters) viewparams).newTopLevel;
 
         UIOutput.make(tofill, "html").decorate(new UIFreeAttributeDecorator("lang", localeGetter.get().getLanguage()))
             .decorate(new UIFreeAttributeDecorator("xml:lang", localeGetter.get().getLanguage()));
@@ -477,6 +478,7 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
 
         int index = 0;
         boolean showDeleteButton = false;
+        final Set<Long> topLevelPagesForCheck = topLevelPages;
 
         for (PageEntry entry: entries) {
             UIBranchContainer row = UIBranchContainer.make(form, "page:");
@@ -605,8 +607,14 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
                 }
                 if (!summaryPage) {
                     // i.e. pagepicker; for the moment to edit something you need to attach it to something
-                    UISelectChoice.make(row, "select", select.getFullID(), index).
-                            decorate(new UIFreeAttributeDecorator("title", entry.title + " " + messageLocator.getMessage("simplepage.select")));
+                    UISelectChoice radio = UISelectChoice.make(row, "select", select.getFullID(), index);
+                    radio.decorate(new UIFreeAttributeDecorator("title", entry.title + " " + messageLocator.getMessage("simplepage.select")));
+                    // In newTopLevel mode, disable selection of top-level pages (only subpages can be selected)
+                    // Check if the page ID is in the topLevelPages set, not just if it's marked as toplevel
+                    // because a top-level page can also appear as a shared subpage elsewhere
+                    if (newTopLevel && topLevelPagesForCheck.contains(entry.pageId)) {
+                        radio.decorate(new UIFreeAttributeDecorator("disabled", "disabled"));
+                    }
                 } else if (summaryPage) {
                     // i.e. summary if canEdit and page doesn't have an item
                     UISelectChoice.make(row, "select-for-deletion", select.getFullID(), index).

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/PagePickerProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/PagePickerProducer.java
@@ -182,10 +182,17 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
         UISelect select = UISelect.make(form, "page-span", values.toArray(new String[0]),
                 "#{simplePageBean.selectedEntity}", null);
 
+        // In newTopLevel mode, disable top-level pages (including when they also appear as shared subpages).
+        Set<Long> topLevelPageIds = activePages.stream()
+                .filter(PageNode::topLevel)
+                .map(node -> node.page().getPageId())
+                .collect(Collectors.toUnmodifiableSet());
+
         int index = 0;
         for (PageNode node : activePages) {
             renderPageChoice(form, "active-page:", select, index++, node.page(), node.pageItem().getName(),
-                    node.level(), node.topLevel(), node.pageItem().getId(), pageIndex.sharedPageIds(), siteId);
+                    node.level(), node.topLevel(), node.pageItem().getId(), pageIndex.sharedPageIds(), siteId,
+                    params.newTopLevel && topLevelPageIds.contains(node.page().getPageId()));
         }
 
         if (!removedPages.isEmpty()) {
@@ -193,7 +200,8 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
             UIOutput.make(section, "heading", messageLocator.getMessage("simplepage.chooser.unused"));
             for (SimplePage page : removedPages) {
                 renderPageChoice(section, "removed-page:", select, index++, page, page.getTitle(), 0, false, null,
-                        pageIndex.sharedPageIds(), siteId);
+                        pageIndex.sharedPageIds(), siteId,
+                        params.newTopLevel && topLevelPageIds.contains(page.getPageId()));
             }
         }
 
@@ -223,14 +231,18 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
 
     private void renderPageChoice(UIContainer rowContainer, String branchId, UISelect select, int index,
             SimplePage page, String title,
-            int level, boolean topLevel, Long itemId, Set<Long> sharedPageIds, String siteId) {
+            int level, boolean topLevel, Long itemId, Set<Long> sharedPageIds, String siteId,
+            boolean disableSelection) {
         UIBranchContainer row = UIBranchContainer.make(rowContainer, branchId);
         if (topLevel) {
             row.decorate(new UIFreeAttributeDecorator("class", "top-level-page"));
         }
-        UISelectChoice.make(row, "select", select.getFullID(), index)
-                .decorate(new UIFreeAttributeDecorator("title",
-                        title + " " + messageLocator.getMessage("simplepage.select")));
+        UISelectChoice radio = UISelectChoice.make(row, "select", select.getFullID(), index);
+        radio.decorate(new UIFreeAttributeDecorator("title",
+                title + " " + messageLocator.getMessage("simplepage.select")));
+        if (disableSelection) {
+            radio.decorate(new UIFreeAttributeDecorator("disabled", "disabled"));
+        }
 
         GeneralViewParameters preview = new GeneralViewParameters(PreviewProducer.VIEW_ID);
         preview.setSendingPage(page.getPageId());
@@ -316,7 +328,7 @@ public class PagePickerProducer implements ViewComponentProducer, NavigationCase
     public List reportNavigationCases() {
         List<NavigationCase> cases = new ArrayList<>();
         cases.add(new NavigationCase("success", new SimpleViewParameters(ShowPageProducer.VIEW_ID)));
-        cases.add(new NavigationCase("failure", new SimpleViewParameters(ForumPickerProducer.VIEW_ID)));
+        cases.add(new NavigationCase("failure", new SimpleViewParameters(ShowPageProducer.VIEW_ID)));
         cases.add(new NavigationCase("cancel", new SimpleViewParameters(ShowPageProducer.VIEW_ID)));
         cases.add(new NavigationCase("selectpage", new GeneralViewParameters(ReorderProducer.VIEW_ID)));
         GeneralViewParameters selectSite = new GeneralViewParameters(PagePickerProducer.VIEW_ID);

--- a/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -391,6 +391,17 @@ simplePageBean.addForumSummary,
 
   </bean>
 
+  <bean id="org.sakaiproject.lessonbuildertool.service.PagePromotionService"
+	class="org.sakaiproject.lessonbuildertool.service.PagePromotionService">
+	<constructor-arg ref="org.sakaiproject.lessonbuildertool.model.SimplePageToolDao" />
+	<constructor-arg ref="org.sakaiproject.site.api.SiteService" />
+	<constructor-arg>
+	  <bean class="org.springframework.transaction.support.TransactionTemplate">
+		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
+	  </bean>
+	</constructor-arg>
+  </bean>
+
 	<bean id="org.sakaiproject.lessonbuildertool.util.ImageToMimeMap" class="java.util.HashMap">       
 		<constructor-arg>
 			<map>

--- a/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/lessonbuilder/tool/src/webapp/WEB-INF/requestContext.xml
@@ -342,6 +342,7 @@
 		<property name="lessonsAccess" ref="org.sakaiproject.lessonbuildertool.service.LessonsAccess"/>
 		<property name="lessonBuilderAccessService" ref="org.sakaiproject.lessonbuildertool.service.LessonBuilderAccessService" />
 		<property name="removedPageService" ref="org.sakaiproject.lessonbuildertool.service.RemovedPageService" />
+		<property name="pagePromotionService" ref="org.sakaiproject.lessonbuildertool.service.PagePromotionService" />
 		<property name="ltiService" ref="org.sakaiproject.lti.api.LTIService" />
 		<property name="sqlService" ref="org.sakaiproject.db.api.SqlService"/>
 		<property name="contentTypeImageService" ref="org.sakaiproject.content.api.ContentTypeImageService"/>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to promote eligible Lesson subpages to site navigation.
  * Newly created pages are always added as new top-level items.
  * Added clearer, localized feedback when page promotion fails.

* **Bug Fixes**
  * Disabled top-level pages when selecting pages for site navigation.
  * Prevented invalid, duplicate, student, or already top-level pages from being promoted.
  * Ensured failed promotions do not leave partial navigation or page changes.
  * Returned users to the appropriate Lesson page after promotion failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->