### PR TITLE
SAK-52716 Samigo give disabled Total Scores comment boxes a visible state

### DIFF
--- a/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
@@ -485,7 +485,7 @@
 		font-family: var(--sakai-font-family);
 	}
 
-	//SAK-52716 disabled comment boxes need a visible state in both themes
+	// disabled comment boxes need a visible state in both themes
 	.disabled.awesomplete,
 	textarea:disabled {
 		background-color: transparent;

--- a/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
+++ b/library/src/skins/default/src/sass/modules/tool/samigo/_samigo.scss
@@ -485,9 +485,12 @@
 		font-family: var(--sakai-font-family);
 	}
 
-	.disabled.awesomplete {
+	//SAK-52716 disabled comment boxes need a visible state in both themes
+	.disabled.awesomplete,
+	textarea:disabled {
 		background-color: transparent;
 		color: var(--sakai-text-color-disabled);
+		cursor: not-allowed;
 	}
 
 	.display-flex {


### PR DESCRIPTION
JIRA: https://sakaiproject.atlassian.net/browse/SAK-52716 (reopened by QA)

Follow-up to #14750.

## Problem
#14750 fixed the dark-mode blowout by deleting the page-level
`.disabled { background-color:#f1f1f1 }` rule **and** stripping the `disabled` class
from the three `h:inputTextarea` tags in `totalScores.jsp`. The review asked for that
class removal *plus* adding `form-control`; only the first half landed.

The result is that the disabled "Requires student submission" boxes now render
**identically to the editable ones** — same background, same text colour, no cursor
change. Nothing in the skin styles a bare disabled `input`/`textarea`:
`base/_defaults.scss:79` sets `input, textarea { … }` with no `:disabled` variant, and
without `form-control` Bootstrap's `.form-control:disabled` never matches.

This regressed **light mode too**, not just dark — `--sakai-background-color-1` is
`white` in `_light.scss:101`, so the old `#f1f1f1` was a real grey wash. It was the only
affordance signalling "you can't type here".

## Fix
Broaden Samigo's existing `.disabled.awesomplete` rule to key on the `:disabled`
attribute rather than a class, and add the muted-text + `not-allowed` cursor treatment
already used for disabled `.select` at `base/_extendables.scss:273`.

This covers **both sort states**, which is why the original bug only appeared after
sorting: pre-sort the textareas carry `styleClass="awesomplete"`, post-sort they carry
no class at all. `textarea:disabled` reaches both.

Deliberately **not** adding `form-control`: `_dark.scss:286` compiles to
`:root.sakaiUserTheme-dark textarea.form-control` (specificity 0-3-1) and sets
`color: var(--sakai-text-color-1)` with no `:disabled` exclusion, so it beats Bootstrap's
`.form-control:disabled` (0-2-0) and would make the disabled field look enabled — the
exact outcome raised in review. Bootstrap 5.2 also sets `opacity: 1` there.

Keying on `:disabled` rather than the generic `.disabled` class also avoids the
collision raised in review — Samigo uses `styleClass="disabled"` on `h:commandButton` in
`authorIndex_content.jsp:746,751` and `submissionNav.jsp:3,16`.

## Verification
Checked on a running Sakai 26 build with a published assessment, 18 of 50 students
submitted, so both variants render together:

| | textareas | disabled | editable | `awesomplete` class |
|---|---|---|---|---|
| Pre-sort | 50 | 32 | 18 | present |
| Post-sort (`sortBy=comments`) | 50 | 32 | 18 | absent |

Contrast of `--sakai-text-color-disabled` on the row background, from the compiled
values — all four clear WCAG AA (4.5:1):

| | plain row | striped row |
|---|---|---|
| dark | 6.54:1 | 5.03:1 |
| light | 5.25:1 | 4.75:1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the disabled appearance of comment boxes across both themes.
  * Disabled textareas now use consistent transparent background, disabled text coloring, and a “not allowed” cursor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->