### PR TITLE
SAK-48360 Site Info fix group membership button visibility logic

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
+++ b/site-manage/site-manage-tool/tool/src/webapp/vm/sitesetup/chef_site-siteInfo-list.vm
@@ -434,12 +434,12 @@
 							</td>
 							#if ($!viewRoster || !$viewMembershipGroups.isEmpty())
 							<td>
-								#if ($viewMembershipGroups.contains($g.Id))
+								#if ($!viewRoster || $viewMembershipGroups.contains($g.Id))
 								<input type="button"
 										class="group-membership-button"
 										data-group-id="$g.Id"
 										value="$tlang.getString("sinfo.list.groups.memb.view")"
-										title="$tlang.getString("sinfo.list.joinable.unjoin") $formattedText.escapeHtml($g.Title)" />
+										title="$tlang.getString("sinfo.list.groups.memb.view") $formattedText.escapeHtml($g.Title)" />
 								#end
 							</td>
 							#end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the membership action tooltip to accurately indicate “View members.”
  * Ensured the membership-view action appears for eligible groups when roster viewing is enabled or the group is included in the membership list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->