### PR TITLE
SAK-52777 site-manage site description displays as HTML source

### DIFF
--- a/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
+++ b/site-manage/site-manage-tool/tool/src/webapp/js/site-manage.js
@@ -28,7 +28,7 @@ sakai.getSiteInfo = function(trigger, dialogTarget, nosd, nold) {
     if (_siteInfoCache[siteId]) { showModal(); return; }
 
     $.getJSON(`/direct/site/${siteId}/info.json`, function(data) {
-      const desc = data.description ? data.description.escapeHTML() : nold;
+      const desc = data.description ? data.description : nold;
       const shortdesc = data.shortDescription ? data.shortDescription.escapeHTML() : nosd;
 
       const content = (


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52777

Unlike the site's short description which is treated as plain text, the site description is rich text and should be prefiltered via Antisamy to scrub out any JavaScript. Thus, the protections added in another jira intended to prevent JavaScript injected within the short description from executing should not (at least in theory) be extended to the site description's rich text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Site information descriptions in the site-info modal now render as intended (using the provided description directly).
  * Preserved the existing fallback behavior when no description is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->