### PR TITLE
SAK-52779 Calendar iCal export uses DURATION instead of DTEND

### DIFF
--- a/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/writers/CalendarIcalExporter.java
+++ b/calendar/calendar-impl/impl/src/java/org/sakaiproject/calendar/impl/writers/CalendarIcalExporter.java
@@ -21,7 +21,6 @@
 package org.sakaiproject.calendar.impl.writers;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -150,12 +149,17 @@ public class CalendarIcalExporter
 	private VEvent buildVEvent(CalendarEvent event, RecurrenceRule rule)
 	{
 		DateTime icalStartDate = new DateTime(event.getRange().firstTime().getTime());
-		long seconds = event.getRange().duration() / 1000;
-		VEvent icalEvent = new VEvent(icalStartDate, Duration.ofSeconds(seconds), event.getDisplayName());
+		// Export an explicit DTEND rather than a DURATION: IcalendarReader (used when one Sakai
+		// instance subscribes to another) only understands DTEND, so a DURATION-only VEVENT
+		// silently fails to import.
+		DateTime icalEndDate = new DateTime(event.getRange().lastTime().getTime());
+		VEvent icalEvent = new VEvent(icalStartDate, icalEndDate, event.getDisplayName());
 
 		TzId tzId = new TzId(timeService.getLocalTimeZone().getID());
 		icalEvent.getProperty(Property.DTSTART).getParameters().add(tzId);
 		icalEvent.getProperty(Property.DTSTART).getParameters().add(Value.DATE_TIME);
+		icalEvent.getProperty(Property.DTEND).getParameters().add(new TzId(timeService.getLocalTimeZone().getID()));
+		icalEvent.getProperty(Property.DTEND).getParameters().add(Value.DATE_TIME);
 		icalEvent.getProperties().add(new Uid(event.getId()));
 
 		// Build the description, appending attachment URLs if present.


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52779

## Problem

`CalendarIcalExporter.buildVEvent()` was constructing `VEvent` objects using a `DURATION` property instead of an explicit `DTEND`. While `DURATION` is valid per RFC 5545, many iCal consumers — including Sakai's own `IcalendarReader` — do not implement `DURATION` parsing and silently skip events that lack a `DTEND`, causing imported events to disappear.

## Fix

Replace the `Duration.ofSeconds(seconds)`-based `VEvent` constructor with one that takes explicit `DTSTART` and `DTEND` `DateTime` values derived from `event.getRange().firstTime()` and `event.getRange().lastTime()`. Both properties receive the local timezone `TzId` and `VALUE=DATE-TIME` parameters, consistent with the existing `DTSTART` handling.

The unused `java.time.Duration` import is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar exports by including explicit event start and end date-time values.
  * Added timezone information to exported event times for more consistent interpretation across calendar applications.
  * Removed duration-based end-time handling in favor of the event’s defined end time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->