### PR TITLE
SAK-52415 Assignments remove download guard preventing All checkbox from being checked by default on Upload All screen

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_uploadAll.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_uploadAll.vm
@@ -58,7 +58,7 @@
 				#end
 				<p class="checkbox">
 				 ## select-all box
-				 <label for="selectall"><input type="checkbox" name="selectall" id="selectall" title="$tlang.getString('gen.toggle')" #if($!download && $allDataSelected)checked="checked"#end onclick="ASN.toggleSelectAll(this, 'choices')" /> $tlang.getString("all")</label><br/>
+				 <label for="selectall"><input type="checkbox" name="selectall" id="selectall" title="$tlang.getString('gen.toggle')" #if($allDataSelected)checked="checked"#end onclick="ASN.toggleSelectAll(this, 'choices')" /> $tlang.getString("all")</label><br/>
 			 #if ($!includeSubmissionText)
 					## student submission text
 					<label for="studentSubmissionText" class="indnt1"><input id="studentSubmissionText" type="checkbox" value="studentSubmissionText" name="choices" class="toggleSelectedAll" #if($!hasSubmissionText)checked="checked"#end onclick="ASN.deselectSelectAll( this );" /> $tlang.getString("uploadall.choose.file.studentSubmissionText")</label><br/>


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52415

**Problem**
<img width="1075" height="527" alt="image" src="https://github.com/user-attachments/assets/9985ef0a-5195-428a-a708-bf8d91c9caa7" />
When entering the "Upload All" screen, the "All" checkbox was unchecked by default, even though all the individual options underneath it were checked by default. This created a UI inconsistency with the "Download All" screen (improved in SAK-52372) and caused a confusing toggle interaction (clicking "All" once did nothing because the sub-options were already checked).

**Root Cause**
The "Upload All" and "Download All" screens share a single Velocity template (chef_assignments_instructor_uploadAll.vm), differentiated by a `$download` boolean. The "All" checkbox was gated with `#if($!download && $allDataSelected)`, meaning it could only ever be checked on the Download All screen. On the Upload All screen (`$download` is false), the condition short-circuited to false, so the "All" checkbox was never checked—even though all individual options were checked by default.

**Changes Made**
Removed the `$!download` guard from the `#if` directive so the checkbox state is determined solely by `$allDataSelected`, which is computed correctly for both modes in AssignmentAction.java.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Select all” checkbox now correctly reflects whether all available items are selected, including when download mode is not active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->