### PR TITLE
SAK-52782 LTI omit unused deep linking data

### DIFF
--- a/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
+++ b/lti/lti-common/src/java/org/sakaiproject/lti/util/SakaiLTIUtil.java
@@ -196,6 +196,8 @@ public class SakaiLTIUtil {
 	public static final String SESSION_LAUNCH_CODE = "launch_code:";
 
 	public static final String FOR_USER = "for_user";
+	private static final Set<String> DEEP_LINK_CONTROL_PARAMETERS = Set.of(
+			"state", "nonce", "redirect_uri", "flow", "lti_storage_target");
 
 	// Message type
 	public static final String MESSAGE_TYPE_PARAMETER = "message_type";
@@ -1430,6 +1432,10 @@ public class SakaiLTIUtil {
 			return dlr;
 		}
 
+		static boolean isDeepLinkControlParameter(String key) {
+			return DEEP_LINK_CONTROL_PARAMETERS.contains(key);
+		}
+
 		/**
 		 * An LTI ContentItemSelectionRequest launch
 		 *
@@ -1514,10 +1520,14 @@ public class SakaiLTIUtil {
 					continue;
 				}
 
-				// Pass in data for use to get back.
-				dataJSON.put(key, value);
+				// Pass opaque integration data through to the Deep Linking response.
+				if (!isDeepLinkControlParameter(key)) {
+					dataJSON.put(key, value);
+				}
 			}
-			setProperty(ltiProps, LTIConstants.DATA, dataJSON.toString());
+			if (!dataJSON.isEmpty()) {
+				setProperty(ltiProps, LTIConstants.DATA, dataJSON.toString());
+			}
 
 			setProperty(ltiProps, LTIConstants.CONTENT_ITEM_RETURN_URL, contentReturn);
 
@@ -2203,7 +2213,7 @@ public class SakaiLTIUtil {
 				ci.auto_create = "true".equals(ltiProps.getProperty("auto_create"));
 				// can_confirm is not there
 				ci.deep_link_return_url = ltiProps.getProperty(LTIConstants.CONTENT_ITEM_RETURN_URL);
-				ci.data = ltiProps.getProperty("data");
+				ci.data = ltiProps.getProperty(LTIConstants.DATA);
 				lj.deep_link = ci;
 			}
 

--- a/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
+++ b/lti/lti-common/src/test/org/sakaiproject/lti/util/SakaiLTIUtilTest.java
@@ -54,6 +54,16 @@ import org.apache.commons.text.StringEscapeUtils;
 @Slf4j
 public class SakaiLTIUtilTest {
 
+	@Test
+	public void identifiesDeepLinkControlParameters() {
+		assertTrue(SakaiLTIUtil.isDeepLinkControlParameter("state"));
+		assertTrue(SakaiLTIUtil.isDeepLinkControlParameter("nonce"));
+		assertTrue(SakaiLTIUtil.isDeepLinkControlParameter("redirect_uri"));
+		assertTrue(SakaiLTIUtil.isDeepLinkControlParameter("flow"));
+		assertTrue(SakaiLTIUtil.isDeepLinkControlParameter("lti_storage_target"));
+		assertFalse(SakaiLTIUtil.isDeepLinkControlParameter("vendor_tenant_id"));
+	}
+
 	public static String [] shouldBeTheSame = {
 		null,
 		"",
@@ -1355,4 +1365,3 @@ public class SakaiLTIUtilTest {
 		assertNull("findBestToolMatchBean should return null when all tools are null", result);
 	}
 }
-

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -3095,9 +3095,6 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		} else {
 			contentData.setProperty(ContentItem.ACCEPT_MEDIA_TYPES, ContentItem.MEDIA_LTILINKITEM);
 		}
-		contentData.setProperty("flow", flow);  // An example
-		contentData.setProperty("remember", "always bring a towel");  // An example
-
 		// Run the contentreturn through the forward servlet
 		contentReturn = serverConfigurationService.getServerUrl() + "/imsoidc/lti13/resigncontentitem?forward=" +
 			Base64DoubleUrlEncodeSafe.encode(contentReturn) + "&tool_id=" + tool.get(LTIService.LTI_ID);
@@ -3420,8 +3417,6 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			contentData.setProperty(ContentItem.ACCEPT_MEDIA_TYPES, ContentItem.MEDIA_ALL);
 			contentData.setProperty(ContentItem.ACCEPT_MULTIPLE, "true");
 		}
-		contentData.setProperty("remember", "the answer is 42");  // An example
-
 		// Run the contentreturn through the forward servlet
 		contentReturn = serverConfigurationService.getServerUrl() + "/imsoidc/lti13/resigncontentitem?forward=" +
 			Base64DoubleUrlEncodeSafe.encode(contentReturn) + "&tool_id=" + tool.get(LTIService.LTI_ID);

--- a/lti/tsugi-util/src/java/org/tsugi/lti13/DeepLinkResponse.java
+++ b/lti/tsugi-util/src/java/org/tsugi/lti13/DeepLinkResponse.java
@@ -217,9 +217,6 @@ public class DeepLinkResponse {
 
 	private JSONArray deep_links = null;
 
-	private String returnedData = null;
-
-
 	/**
 	 * We check for the fields essential for the class to operate here.
 	 */
@@ -235,11 +232,6 @@ public class DeepLinkResponse {
 			throw new java.lang.RuntimeException("Incorrect MESSAGE_TYPE");
 		}
 		
-		String returnedData = (String) body.get(DATA);
-		if ( returnedData == null || returnedData.length() < 1 ) {
-			throw new java.lang.RuntimeException("Missing data element from ContentItem return");
-		}
-
 		// It is OK for this to be null
 		deep_links = LTIUtil.getArray(body, DEEP_LINKS);
 

--- a/lti/tsugi-util/src/test/org/tsugi/lti13/DeepLinkResponseTest.java
+++ b/lti/tsugi-util/src/test/org/tsugi/lti13/DeepLinkResponseTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Apereo Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.tsugi.lti13;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.security.Key;
+
+import org.junit.Test;
+
+import org.tsugi.jackson.JacksonUtil;
+import org.tsugi.lti13.objects.DeepLink;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+public class DeepLinkResponseTest {
+
+	@Test
+	public void acceptsResponseWithoutOptionalDataClaim() {
+		Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+		String idToken = Jwts.builder()
+				.claim(LTI13ConstantsUtil.MESSAGE_TYPE,
+						LTI13ConstantsUtil.MESSAGE_TYPE_LTI_DEEP_LINKING_RESPONSE)
+				.signWith(key)
+				.compact();
+
+		assertNotNull(new DeepLinkResponse(idToken));
+	}
+
+	@Test
+	public void omitsUnsetDataFromRequestSettings() {
+		String deepLinkSettings = JacksonUtil.toString(new DeepLink());
+
+		assertFalse(deepLinkSettings.contains("\"data\""));
+	}
+
+	@Test
+	public void preservesExplicitDataInRequestSettings() {
+		DeepLink deepLink = new DeepLink();
+		deepLink.data = "{\"vendor_tenant_id\":\"school.example.edu\"}";
+
+		String deepLinkSettings = JacksonUtil.toString(deepLink);
+
+		assertTrue(deepLinkSettings.contains("\"data\""));
+		assertTrue(deepLinkSettings.contains("vendor_tenant_id"));
+		assertTrue(deepLinkSettings.contains("school.example.edu"));
+	}
+}


### PR DESCRIPTION
CC: @csev

The LTI 1.3 Deep Linking `data` value is optional. Some tools incorrectly place the returned JWT in a GET redirect URL, so unnecessary opaque data can cause proxy or CDN request-length failures.

This revision preserves integration-supplied opaque data while removing only values that Sakai already carries elsewhere:

- OIDC and Sakai control parameters: `state`, `nonce`, `redirect_uri`, `flow`, and `lti_storage_target`
- Hard-coded demonstration values previously added by `LTIAdminTool`

Unknown values are still serialized into `deep_linking_settings.data` and can be returned by the tool. For example, a custom integration parameter such as `vendor_tenant_id=school.example.edu` is preserved. Configured LTI custom parameters are unaffected and continue to use the standard LTI `custom` claim.

When no opaque data remains, Sakai omits the optional request field. The response parser now accepts a Deep Linking response without a `data` claim, while continuing to accept responses that include it.

Verification:

- `DeepLinkResponseTest`: 3 passed
- `SakaiLTIUtilTest`: 36 passed
- `lti-tool` compilation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deep-link responses now work when optional data is omitted.
  - Deep-link requests no longer include an empty data field when no data is provided.
  - Control parameters are excluded from deep-link data, preventing internal navigation values from being carried into shared content.
  - Explicitly provided data continues to be preserved.
  - Removed outdated example values from content-item selection settings.

- **Tests**
  - Added coverage for optional data handling and control-parameter filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->