### PR TITLE
SAK-46387 site-manage Role-based group membership now stays synchronized when site roles change

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GroupRoleMembershipTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GroupRoleMembershipTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.options.SelectOption;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+/**
+ * SAK-46387: a group whose membership is based on a site role must keep tracking that role
+ * when the site membership changes.
+ */
+class GroupRoleMembershipTest extends SakaiUiTestBase {
+
+    private static final String ROLE = "Teaching Assistant";
+    private static final String STUDENT_ROLE = "Student";
+    /** Site Info and the group helper are slow to render, the default assertion timeout is too short. */
+    private static final double RENDER_TIMEOUT_MS = 30_000;
+
+    @Test
+    void roleGroupIncludesParticipantWhoGainsTheRoleLater() {
+        sakai.login("instructor1");
+        String siteUrl = sakai.createCourse("instructor1", List.of("sakai\\.announcements"));
+        String groupTitle = "SAK-46387 " + sakai.randomId();
+
+        openManageGroups(siteUrl);
+        createRoleGroup(groupTitle);
+        int membersBefore = groupMemberCount(groupTitle);
+
+        promoteAParticipantTo(siteUrl, ROLE);
+
+        openManageGroups(siteUrl);
+        assertEquals(membersBefore + 1, groupMemberCount(groupTitle),
+            "group built from the " + ROLE + " role did not pick up the new " + ROLE);
+    }
+
+    private void openManageGroups(String siteUrl) {
+        sakai.gotoPath(siteUrl);
+        sakai.toolClick("Site Info");
+        clickNav("Manage Groups");
+    }
+
+    private void createRoleGroup(String groupTitle) {
+        clickNav("Create New Group");
+
+        Locator title = awaitVisible(page.locator("#groupTitle"));
+        title.fill(groupTitle);
+        // the submit button stays disabled until the title input reports a value
+        title.dispatchEvent("keyup");
+
+        // the members select is wrapped by select2, so the underlying element is not clickable
+        page.locator("#groupMembers").selectOption(new SelectOption().setValue(ROLE),
+            new Locator.SelectOptionOptions().setForce(true));
+
+        page.locator("#create-group-submit-button").click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+
+        awaitVisible(groupRow(groupTitle));
+    }
+
+    /**
+     * Gives the role to a participant who does not have it yet. Every demo account is already
+     * enrolled in the course roster, so a participant is promoted rather than added to the site.
+     */
+    private void promoteAParticipantTo(String siteUrl, String role) {
+        sakai.gotoPath(siteUrl);
+        sakai.toolClick("Site Info");
+        clickNav("Manage Participants");
+
+        Locator roleSelects = awaitVisible(page.locator("#siteMembers")).locator("select[id^=\"role\"]");
+        Locator promoted = null;
+        for (int index = roleSelects.count() - 1; index >= 0 && promoted == null; index--) {
+            if (STUDENT_ROLE.equals(roleSelects.nth(index).inputValue())) {
+                promoted = roleSelects.nth(index);
+            }
+        }
+        assertNotNull(promoted, "no participant with the " + STUDENT_ROLE + " role to promote");
+        String promotedSelectId = promoted.getAttribute("id");
+        promoted.selectOption(new SelectOption().setValue(role));
+
+        page.locator("input[type=\"button\"].active").first().click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+
+        Locator reloaded = awaitVisible(page.locator("[id=\"" + promotedSelectId + "\"]"));
+        assertEquals(role, reloaded.inputValue(), "Site Info did not apply the role change");
+    }
+
+    private void clickNav(String label) {
+        awaitVisible(navLink(label)).click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
+    }
+
+    private Locator navLink(String label) {
+        return page.locator(".navIntraTool a")
+            .filter(new Locator.FilterOptions().setHasText(exactly(label)))
+            .first();
+    }
+
+    /** Playwright hands the pattern to the browser, so it must be plain JavaScript regex syntax. */
+    private Pattern exactly(String label) {
+        return Pattern.compile("^" + label + "$", Pattern.CASE_INSENSITIVE);
+    }
+
+    private Locator awaitVisible(Locator locator) {
+        locator.waitFor(new Locator.WaitForOptions()
+            .setState(WaitForSelectorState.VISIBLE)
+            .setTimeout(RENDER_TIMEOUT_MS));
+        return locator;
+    }
+
+    private Locator groupRow(String groupTitle) {
+        return page.locator("#groupTable tbody tr")
+            .filter(new Locator.FilterOptions().setHasText(groupTitle))
+            .first();
+    }
+
+    /** Reads the comma separated Members column of the group row, the columns shown vary per site. */
+    private int groupMemberCount(String groupTitle) {
+        Locator headers = page.locator("#groupTable thead th");
+        int membersColumn = -1;
+        for (int index = 0; index < headers.count(); index++) {
+            if ("Members".equalsIgnoreCase(text(headers.nth(index)).trim())) {
+                membersColumn = index;
+                break;
+            }
+        }
+        assertTrue(membersColumn >= 0, "Members column not found in the group table");
+
+        String members = text(groupRow(groupTitle).locator("td").nth(membersColumn)).trim();
+        return members.isEmpty() ? 0 : members.split(",").length;
+    }
+
+    private String text(Locator locator) {
+        String value = locator.textContent();
+        return value == null ? "" : value;
+    }
+}

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/RoleGroupEventWatcher.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/RoleGroupEventWatcher.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.sitemanage.impl;
+
+import java.util.Observable;
+import java.util.Observer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.AuthzRealmLockException;
+import org.sakaiproject.authz.api.Member;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.entity.api.Entity;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.event.api.Event;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.util.SiteConstants;
+import org.sakaiproject.site.util.SiteGroupHelper;
+import org.sakaiproject.thread_local.api.ThreadLocalManager;
+
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Keeps the membership of role based groups (groups created in Site Info with a role as member,
+ * marked with {@link SiteConstants#GROUP_PROP_ROLE_PROVIDERID}) in sync with the site membership
+ * by watching site realm updates. Originally added for SAK-16362, restored for SAK-46387.
+ */
+@Slf4j
+public class RoleGroupEventWatcher implements Observer {
+
+    private static final String CURRENT_EVENT_RESOURCE_REF = "current.event.resource.ref";
+    private static final String GROUP_REF_SEGMENT = Entity.SEPARATOR + SiteService.GROUP_SUBTYPE;
+    private static final String SITE_REF_PREFIX = SiteService.REFERENCE_ROOT + Entity.SEPARATOR;
+
+    @Setter private AuthzGroupService authzGroupService;
+    @Setter private EntityManager entityManager;
+    @Setter private EventTrackingService eventTrackingService;
+    @Setter private SecurityService securityService;
+    @Setter private SiteService siteService;
+    @Setter private ThreadLocalManager threadLocalManager;
+
+    public void init() {
+        eventTrackingService.addLocalObserver(this);
+    }
+
+    public void destroy() {
+        eventTrackingService.deleteObserver(this);
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        if (!(arg instanceof Event)) return;
+
+        Event event = (Event) arg;
+        String function = event.getEvent();
+        if (!AuthzGroupService.SECURE_UPDATE_AUTHZ_GROUP.equals(function)
+                && !AuthzGroupService.SECURE_JOIN_AUTHZ_GROUP.equals(function)
+                && !AuthzGroupService.SECURE_UNJOIN_AUTHZ_GROUP.equals(function)) {
+            return;
+        }
+
+        // for a group realm event, work with the containing site realm instead
+        String realmId = entityManager.newReference(event.getResource()).getId();
+        if (realmId == null) return;
+        if (realmId.contains(GROUP_REF_SEGMENT)) {
+            realmId = realmId.substring(0, realmId.indexOf(GROUP_REF_SEGMENT));
+        }
+        if (!realmId.startsWith(SITE_REF_PREFIX)) return;
+
+        // guard against the events fired by our own saveGroupMembership below
+        if (threadLocalManager.get(CURRENT_EVENT_RESOURCE_REF) != null) return;
+        threadLocalManager.set(CURRENT_EVENT_RESOURCE_REF, realmId);
+
+        // the sync only propagates changes already made to the site realm, bypass permission checks
+        SecurityAdvisor advisor = (userId, sf, reference) -> SecurityAdvisor.SecurityAdvice.ALLOWED;
+        securityService.pushAdvisor(advisor);
+        try {
+            AuthzGroup realm = authzGroupService.getAuthzGroup(realmId);
+            Site site = siteService.getSite(realmId.substring(SITE_REF_PREFIX.length()));
+
+            boolean needSave = false;
+            for (Group group : site.getGroups()) {
+                if (group.getProperties().getProperty(Group.GROUP_PROP_WSETUP_CREATED) == null) continue;
+                String roleString = group.getProperties().getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID);
+                if (StringUtils.isBlank(roleString)) continue;
+
+                needSave = true;
+                for (String role : SiteGroupHelper.unpack(roleString)) {
+                    try {
+                        // replace the members holding this role with the current site users of the role
+                        for (Member member : group.getMembers()) {
+                            if (role.equals(member.getRole().getId())) {
+                                group.deleteMember(member.getUserId());
+                            }
+                        }
+                        for (String userId : realm.getUsersHasRole(role)) {
+                            group.insertMember(userId, role, true, false);
+                        }
+                    } catch (AuthzRealmLockException e) {
+                        log.warn("Could not sync role {} in locked group {}, {}", role, group.getId(), e.toString());
+                    }
+                }
+            }
+            if (needSave) {
+                siteService.saveGroupMembership(site);
+            }
+        } catch (Exception e) {
+            log.warn("Could not sync role based groups for {}, {}", event.getResource(), e.toString());
+        } finally {
+            securityService.popAdvisor(advisor);
+            threadLocalManager.set(CURRENT_EVENT_RESOURCE_REF, null);
+        }
+    }
+}

--- a/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/RoleGroupEventWatcher.java
+++ b/site-manage/site-manage-impl/impl/src/java/org/sakaiproject/sitemanage/impl/RoleGroupEventWatcher.java
@@ -92,41 +92,44 @@ public class RoleGroupEventWatcher implements Observer {
 
         // the sync only propagates changes already made to the site realm, bypass permission checks
         SecurityAdvisor advisor = (userId, sf, reference) -> SecurityAdvisor.SecurityAdvice.ALLOWED;
-        securityService.pushAdvisor(advisor);
         try {
-            AuthzGroup realm = authzGroupService.getAuthzGroup(realmId);
-            Site site = siteService.getSite(realmId.substring(SITE_REF_PREFIX.length()));
+            securityService.pushAdvisor(advisor);
+            try {
+                AuthzGroup realm = authzGroupService.getAuthzGroup(realmId);
+                Site site = siteService.getSite(realmId.substring(SITE_REF_PREFIX.length()));
 
-            boolean needSave = false;
-            for (Group group : site.getGroups()) {
-                if (group.getProperties().getProperty(Group.GROUP_PROP_WSETUP_CREATED) == null) continue;
-                String roleString = group.getProperties().getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID);
-                if (StringUtils.isBlank(roleString)) continue;
+                boolean needSave = false;
+                for (Group group : site.getGroups()) {
+                    if (group.getProperties().getProperty(Group.GROUP_PROP_WSETUP_CREATED) == null) continue;
+                    String roleString = group.getProperties().getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID);
+                    if (StringUtils.isBlank(roleString)) continue;
 
-                needSave = true;
-                for (String role : SiteGroupHelper.unpack(roleString)) {
-                    try {
-                        // replace the members holding this role with the current site users of the role
-                        for (Member member : group.getMembers()) {
-                            if (role.equals(member.getRole().getId())) {
-                                group.deleteMember(member.getUserId());
+                    needSave = true;
+                    for (String role : SiteGroupHelper.unpack(roleString)) {
+                        try {
+                            // replace the members holding this role with the current site users of the role
+                            for (Member member : group.getMembers()) {
+                                if (role.equals(member.getRole().getId())) {
+                                    group.deleteMember(member.getUserId());
+                                }
                             }
+                            for (String userId : realm.getUsersHasRole(role)) {
+                                group.insertMember(userId, role, true, false);
+                            }
+                        } catch (AuthzRealmLockException e) {
+                            log.warn("Could not sync role {} in locked group {}, {}", role, group.getId(), e.toString());
                         }
-                        for (String userId : realm.getUsersHasRole(role)) {
-                            group.insertMember(userId, role, true, false);
-                        }
-                    } catch (AuthzRealmLockException e) {
-                        log.warn("Could not sync role {} in locked group {}, {}", role, group.getId(), e.toString());
                     }
                 }
-            }
-            if (needSave) {
-                siteService.saveGroupMembership(site);
+                if (needSave) {
+                    siteService.saveGroupMembership(site);
+                }
+            } finally {
+                securityService.popAdvisor(advisor);
             }
         } catch (Exception e) {
-            log.warn("Could not sync role based groups for {}, {}", event.getResource(), e.toString());
+            log.warn("Could not sync role based groups for {}", event.getResource(), e);
         } finally {
-            securityService.popAdvisor(advisor);
             threadLocalManager.set(CURRENT_EVENT_RESOURCE_REF, null);
         }
     }

--- a/site-manage/site-manage-impl/impl/src/test/java/org/sakaiproject/sitemanage/impl/RoleGroupEventWatcherTest.java
+++ b/site-manage/site-manage-impl/impl/src/test/java/org/sakaiproject/sitemanage/impl/RoleGroupEventWatcherTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.sitemanage.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.AuthzRealmLockException;
+import org.sakaiproject.authz.api.Member;
+import org.sakaiproject.authz.api.Role;
+import org.sakaiproject.authz.api.SecurityAdvisor;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.Reference;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.event.api.Event;
+import org.sakaiproject.event.api.EventTrackingService;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.util.SiteConstants;
+import org.sakaiproject.site.util.SiteGroupHelper;
+import org.sakaiproject.thread_local.api.ThreadLocalManager;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RoleGroupEventWatcherTest {
+
+    private static final String CURRENT_EVENT_RESOURCE_REF = "current.event.resource.ref";
+    private static final String SITE_ID = "site1";
+    private static final String SITE_REF = "/site/" + SITE_ID;
+    private static final String REALM_REF = "/realm/" + SITE_REF;
+    private static final String TA_ROLE = "Teaching Assistant";
+
+    private RoleGroupEventWatcher watcher;
+    private AuthzGroupService authzGroupService;
+    private EntityManager entityManager;
+    private SecurityService securityService;
+    private SiteService siteService;
+    private ThreadLocalManager threadLocalManager;
+
+    private AuthzGroup realm;
+    private Site site;
+
+    @Before
+    public void setUp() throws Exception {
+        watcher = new RoleGroupEventWatcher();
+        authzGroupService = mock(AuthzGroupService.class);
+        entityManager = mock(EntityManager.class);
+        securityService = mock(SecurityService.class);
+        siteService = mock(SiteService.class);
+        threadLocalManager = mock(ThreadLocalManager.class);
+        watcher.setAuthzGroupService(authzGroupService);
+        watcher.setEntityManager(entityManager);
+        watcher.setEventTrackingService(mock(EventTrackingService.class));
+        watcher.setSecurityService(securityService);
+        watcher.setSiteService(siteService);
+        watcher.setThreadLocalManager(threadLocalManager);
+
+        realm = mock(AuthzGroup.class);
+        when(authzGroupService.getAuthzGroup(SITE_REF)).thenReturn(realm);
+        site = mock(Site.class);
+        when(siteService.getSite(SITE_ID)).thenReturn(site);
+    }
+
+    private Event mockEvent(String function, String resource, String refId) {
+        Event event = mock(Event.class);
+        when(event.getEvent()).thenReturn(function);
+        when(event.getResource()).thenReturn(resource);
+        Reference ref = mock(Reference.class);
+        when(ref.getId()).thenReturn(refId);
+        when(entityManager.newReference(resource)).thenReturn(ref);
+        return event;
+    }
+
+    private Group mockRoleGroup(String... roles) {
+        Group group = mock(Group.class);
+        ResourceProperties properties = mock(ResourceProperties.class);
+        when(group.getProperties()).thenReturn(properties);
+        when(properties.getProperty(Group.GROUP_PROP_WSETUP_CREATED)).thenReturn(Boolean.TRUE.toString());
+        if (roles.length > 0) {
+            when(properties.getProperty(SiteConstants.GROUP_PROP_ROLE_PROVIDERID))
+                    .thenReturn(SiteGroupHelper.pack(Arrays.asList(roles)));
+        }
+        return group;
+    }
+
+    private Member mockMember(String userId, String roleId) {
+        Member member = mock(Member.class);
+        when(member.getUserId()).thenReturn(userId);
+        Role role = mock(Role.class);
+        when(role.getId()).thenReturn(roleId);
+        when(member.getRole()).thenReturn(role);
+        return member;
+    }
+
+    @Test
+    public void syncsRoleGroupOnSiteRealmUpdate() throws Exception {
+        Member taMember = mockMember("u1", TA_ROLE);
+        Member accessMember = mockMember("u3", "access");
+        Group taGroup = mockRoleGroup(TA_ROLE);
+        when(taGroup.getMembers()).thenReturn(Set.of(taMember, accessMember));
+        when(realm.getUsersHasRole(TA_ROLE)).thenReturn(new LinkedHashSet<>(Arrays.asList("u1", "u2")));
+
+        Group plainGroup = mockRoleGroup();
+        when(site.getGroups()).thenReturn(Arrays.asList(taGroup, plainGroup));
+
+        watcher.update(null, mockEvent(AuthzGroupService.SECURE_UPDATE_AUTHZ_GROUP, REALM_REF, SITE_REF));
+
+        // members holding the role are replaced with the current site users of the role
+        verify(taGroup).deleteMember("u1");
+        verify(taGroup, never()).deleteMember("u3");
+        verify(taGroup).insertMember("u1", TA_ROLE, true, false);
+        verify(taGroup).insertMember("u2", TA_ROLE, true, false);
+        verify(plainGroup, never()).insertMember(anyString(), anyString(), anyBoolean(), anyBoolean());
+        verify(siteService).saveGroupMembership(site);
+        verify(securityService).pushAdvisor(any(SecurityAdvisor.class));
+        verify(securityService).popAdvisor(any(SecurityAdvisor.class));
+        verify(threadLocalManager).set(CURRENT_EVENT_RESOURCE_REF, null);
+    }
+
+    @Test
+    public void mapsGroupRealmEventToContainingSite() throws Exception {
+        when(site.getGroups()).thenReturn(Collections.emptyList());
+
+        String groupRealmRef = "/realm/" + SITE_REF + "/group/g1";
+        watcher.update(null, mockEvent(AuthzGroupService.SECURE_UPDATE_AUTHZ_GROUP, groupRealmRef, SITE_REF + "/group/g1"));
+
+        verify(authzGroupService).getAuthzGroup(SITE_REF);
+        verify(siteService).getSite(SITE_ID);
+        verify(siteService, never()).saveGroupMembership(any(Site.class));
+    }
+
+    @Test
+    public void lockedGroupDoesNotAbortSync() throws Exception {
+        Member taMember = mockMember("u1", TA_ROLE);
+        Group lockedGroup = mockRoleGroup(TA_ROLE);
+        when(lockedGroup.getMembers()).thenReturn(Set.of(taMember));
+        doThrow(new AuthzRealmLockException("locked")).when(lockedGroup).deleteMember("u1");
+
+        Group taGroup = mockRoleGroup(TA_ROLE);
+        when(taGroup.getMembers()).thenReturn(Collections.emptySet());
+        when(realm.getUsersHasRole(TA_ROLE)).thenReturn(Set.of("u2"));
+        when(site.getGroups()).thenReturn(Arrays.asList(lockedGroup, taGroup));
+
+        watcher.update(null, mockEvent(AuthzGroupService.SECURE_UPDATE_AUTHZ_GROUP, REALM_REF, SITE_REF));
+
+        verify(taGroup).insertMember("u2", TA_ROLE, true, false);
+        verify(siteService).saveGroupMembership(site);
+        verify(securityService).popAdvisor(any(SecurityAdvisor.class));
+    }
+
+    @Test
+    public void ignoresUnwatchedEvents() {
+        Event event = mock(Event.class);
+        when(event.getEvent()).thenReturn("content.new");
+
+        watcher.update(null, event);
+
+        verify(entityManager, never()).newReference(anyString());
+    }
+
+    @Test
+    public void ignoresNonSiteRealms() throws Exception {
+        watcher.update(null, mockEvent(AuthzGroupService.SECURE_UPDATE_AUTHZ_GROUP, "/realm//user/u1", "/user/u1"));
+
+        verify(siteService, never()).getSite(anyString());
+    }
+
+    @Test
+    public void skipsWhenSyncAlreadyInProgress() throws Exception {
+        when(threadLocalManager.get(CURRENT_EVENT_RESOURCE_REF)).thenReturn(SITE_REF);
+
+        watcher.update(null, mockEvent(AuthzGroupService.SECURE_UPDATE_AUTHZ_GROUP, REALM_REF, SITE_REF));
+
+        verify(siteService, never()).getSite(anyString());
+        verify(securityService, never()).pushAdvisor(any(SecurityAdvisor.class));
+    }
+}

--- a/site-manage/site-manage-impl/impl/src/webapp/WEB-INF/components.xml
+++ b/site-manage/site-manage-impl/impl/src/webapp/WEB-INF/components.xml
@@ -92,6 +92,19 @@
 		<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService" />
 	</bean>
 
+	<!-- SAK-46387 keeps role-based group membership in sync with site membership changes -->
+	<bean id="org.sakaiproject.sitemanage.impl.RoleGroupEventWatcher"
+		class="org.sakaiproject.sitemanage.impl.RoleGroupEventWatcher"
+		init-method="init"
+		destroy-method="destroy">
+		<property name="authzGroupService" ref="org.sakaiproject.authz.api.AuthzGroupService"/>
+		<property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager"/>
+		<property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
+		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService"/>
+		<property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
+		<property name="threadLocalManager" ref="org.sakaiproject.thread_local.api.ThreadLocalManager"/>
+	</bean>
+
 	<bean id="org.sakaiproject.sitemanage.api.JoinableSetReminderScheduleService"
 		class="org.sakaiproject.sitemanage.impl.JoinableSetReminderScheduleServiceImpl">
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role-based group membership now stays synchronized when site roles change.
  * Promoting or removing participants from site roles is reflected in corresponding groups.
  * Group updates remain reliable when changes originate from either a site or its associated group.
  * Synchronization safely handles locked groups, unrelated updates, and repeated changes.

* **Tests**
  * Added end-to-end and automated coverage for role-based group membership synchronization and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->