### PR TITLE
SAK-52763 Sitestats preserve old properties

### DIFF
--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/DetailedEventConfigurationTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/DetailedEventConfigurationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.sitestats.test;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sakaiproject.sitestats.api.StatsManager;
+import org.sakaiproject.sitestats.api.StatsUpdateManager;
+import org.sakaiproject.util.ReversiblePropertyOverrideConfigurer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {
+        SiteStatsTestConfiguration.class,
+        DetailedEventConfigurationTest.LegacyPropertyOverrides.class
+})
+public class DetailedEventConfigurationTest {
+
+    @Autowired private StatsManager statsManager;
+    @Autowired private StatsUpdateManager statsUpdateManager;
+
+    @Test
+    public void legacyDetailedEventPropertiesConfigureManagers() {
+        assertTrue(statsManager.isDisplayDetailedEvents());
+        assertTrue(statsUpdateManager.isCollectDetailedEvents());
+    }
+
+    @Configuration
+    static class LegacyPropertyOverrides {
+
+        @Bean
+        public static ReversiblePropertyOverrideConfigurer detailedEventPropertyOverrides() {
+            Properties properties = new Properties();
+            properties.setProperty(
+                    "displayDetailedEvents@org.sakaiproject.sitestats.api.StatsManager.target", "true");
+            properties.setProperty(
+                    "collectDetailedEvents@org.sakaiproject.sitestats.api.StatsUpdateManager.target", "true");
+
+            ReversiblePropertyOverrideConfigurer configurer = new ReversiblePropertyOverrideConfigurer();
+            configurer.setBeanNameAtEnd(true);
+            configurer.setBeanNameSeparator("@");
+            configurer.setProperties(properties);
+            return configurer;
+        }
+    }
+}

--- a/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
+++ b/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
@@ -32,9 +32,10 @@
 		The preferred way to change these values is on sakai.properties. Please refer to
 		http://bugs.sakaiproject.org/confluence/display/STAT to detailed caonfiguration
 		information.
+		The target bean IDs are retained so existing sakai.properties overrides remain valid.
 	 -->
 	<!-- StatsManager ______________________________________________________________________________ -->
-	<bean id="org.sakaiproject.sitestats.api.StatsManager"
+	<bean id="org.sakaiproject.sitestats.api.StatsManager.target"
 		  class="org.sakaiproject.sitestats.impl.StatsManagerImpl"
 		  depends-on="org.sakaiproject.sitestats.api.DBHelper"
 		  init-method="init"
@@ -97,6 +98,8 @@
 		<property name="contentTypeImageService" ref="org.sakaiproject.content.api.ContentTypeImageService"/>
 		<property name="sessionFactory" ref="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory"/>
 	</bean>
+	<alias name="org.sakaiproject.sitestats.api.StatsManager.target"
+		   alias="org.sakaiproject.sitestats.api.StatsManager"/>
 
 	<!-- DetailedEventsManager ______________________________________________________________________ -->
 	<bean id="org.sakaiproject.sitestats.api.event.detailed.DetailedEventsManager"
@@ -350,7 +353,7 @@
 
 
 	<!-- StatsUpdateManager ____________________________________________________________________________ -->
-	<bean id="org.sakaiproject.sitestats.api.StatsUpdateManager"
+	<bean id="org.sakaiproject.sitestats.api.StatsUpdateManager.target"
 		  class="org.sakaiproject.sitestats.impl.StatsUpdateManagerImpl"
 		  lazy-init="true"
 		  init-method="init"
@@ -380,6 +383,8 @@
 		<property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService"/>
 		<property name="usageSessionService" ref="org.sakaiproject.event.api.UsageSessionService" />
 	</bean>
+	<alias name="org.sakaiproject.sitestats.api.StatsUpdateManager.target"
+		   alias="org.sakaiproject.sitestats.api.StatsUpdateManager"/>
 
 	<!-- ServerWideReportManager ____________________________________________________________________________ -->
 	<bean id="org.sakaiproject.sitestats.api.ServerWideReportManager"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing configuration and references for statistics managers while improving bean wiring compatibility.
  * Ensured legacy detailed-event settings correctly control event display and collection.

* **Tests**
  * Added coverage verifying detailed-event configuration is applied consistently across statistics components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->