### PR TITLE
SAK-49062 Rubrics make PDF link use download attribute

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/RubricsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/RubricsTest.java
@@ -109,4 +109,16 @@ class RubricsTest extends SakaiUiTestBase {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(Pattern.compile("Copy Criterion", Pattern.CASE_INSENSITIVE))).first().click(new Locator.ClickOptions().setForce(true));
         assertThat(page.locator("body")).containsText(Pattern.compile("Criterion", Pattern.CASE_INSENSITIVE));
     }
+
+    @Test
+    @Order(7)
+    void pdfExportUsesDownloadLink() {
+        sakai.login("instructor1");
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Rubrics");
+
+        Locator pdfExport = page.locator("sakai-rubric-pdf a").first();
+        assertThat(pdfExport).isVisible();
+        assertThat(pdfExport).hasAttribute("download", "");
+    }
 }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricPdf.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricPdf.js
@@ -41,6 +41,7 @@ export class SakaiRubricPdf extends RubricsElement {
         title="${this.tr("export_title", [ this.rubricTitle ])}"
         aria-label="${this.tr("export_title", [ this.rubricTitle ])}"
         href="${ifDefined(this._url)}"
+        download
         @click=${e => e.stopPropagation()}
         class="linkStyle pdf fa fa-file-pdf-o">
       </a>

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-pdf.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-pdf.test.js
@@ -66,7 +66,7 @@ describe("sakai-rubric-pdf tests", () => {
     expect(link).to.exist;
     const href = `/api/sites/${data.siteId}/rubrics/${data.rubric1.id}/pdf\\?toolId=${data.toolId}&itemId=${data.entityId}&evaluatedItemId=${data.evaluatedItemId}`;
     expect(link.href).to.match(new RegExp(`.*${href}$`));
+    expect(link.hasAttribute("download")).to.be.true;
 
   });
 });
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rubric PDF exports now download directly when selected, rather than opening only as a link.

* **Tests**
  * Added end-to-end and component coverage to verify that the rubric PDF download link is visible and includes download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->