### PR TITLE
SAK-52784 copySiteContent fails to import content due to immutable collections

### DIFF
--- a/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiScript.java
+++ b/webservices/cxf/src/java/org/sakaiproject/webservices/SakaiScript.java
@@ -3853,7 +3853,7 @@ public class SakaiScript extends AbstractWebService {
 
             Map<String, List<String>> toolsToImport = new HashMap<>();
             toolsToImport.put("sakai.resources", Arrays.asList(new String[]{sourcesiteid}));
-            siteManageService.importToolsIntoSiteThread(site, Collections.EMPTY_LIST, toolsToImport, Collections.EMPTY_MAP, Collections.EMPTY_MAP, false);
+            siteManageService.importToolsIntoSiteThread(site, new ArrayList<>(), toolsToImport, new HashMap<>(), new HashMap<>(), false);
 
         } catch (Exception e) {
             log.error("WS copyResources(): " + e.getClass().getName() + " : " + e.getMessage());
@@ -4314,7 +4314,7 @@ public class SakaiScript extends AbstractWebService {
                 }
             }
 
-            siteManageService.importToolsIntoSiteThread(site, Collections.EMPTY_LIST, toolsToImport, Collections.EMPTY_MAP, Collections.EMPTY_MAP, true);
+            siteManageService.importToolsIntoSiteThread(site, new ArrayList<>(), toolsToImport, new HashMap<>(), new HashMap<>(), true);
 
         } catch (Exception e) {
             log.error("WS copySiteContent(): " + e.getClass().getName() + " : " + e.getMessage(), e);
@@ -4359,7 +4359,7 @@ public class SakaiScript extends AbstractWebService {
 
     		Map<String, List<String>> toolsToImport = new HashMap<>();
     		toolsToImport.put(toolid, Arrays.asList(new String[]{sourcesiteid}));
-			siteManageService.importToolsIntoSiteThread(site, Collections.EMPTY_LIST, toolsToImport, Collections.EMPTY_MAP, Collections.EMPTY_MAP, true);
+			siteManageService.importToolsIntoSiteThread(site, new ArrayList<>(), toolsToImport, new HashMap<>(), new HashMap<>(), true);
     	}
     	catch (Exception e)
     	{


### PR DESCRIPTION
## Summary

The `copyResources`, `copySiteContent` and `copySiteContentForTool` methods of the `SakaiScript` SOAP web service pass `Collections.EMPTY_LIST`/`Collections.EMPTY_MAP` (immutable) to `SiteManageServiceImpl.importToolsIntoSite`. That method unconditionally calls `toolIds.clear()`/`addAll()` on the passed-in list/map whenever `site.setup.import.addmissingtools=true` (the default), which throws `UnsupportedOperationException` on immutable collections and silently breaks content import through the web service (the equivalent "Import from Site" UI flow in `SiteAction` already passes mutable `ArrayList`/`HashMap` instances and is unaffected).

This regressed in 8d314ece4c (SAK-49673, #12403), which changed the call sites from mutable to immutable collections while `importToolsIntoSite` still mutates them.

- Replace `Collections.EMPTY_LIST`/`EMPTY_MAP` with `new ArrayList<>()`/`new HashMap<>()` at the three call sites in `SakaiScript.java`.

Fixes SAK-52784.

## Test plan

- [ ] Create a source site with Overview, Lessons, Resources, Discussion and Web Content tools with content.
- [ ] Create a destination site with `site.setup.import.addmissingtools=true` (default).
- [ ] Call `copySiteContent`/`copySiteContentForTool` via the SOAP web service and confirm content imports without `UnsupportedOperationException` in the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site and resource imports by ensuring empty collection inputs can be safely modified during processing.
  * Import behavior and existing method signatures remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->