### PR TITLE
SAK-52280 Mobile - Title sites on the menu should be able to be moved

### DIFF
--- a/library/src/skins/default/src/sass/modules/more-sites/_more-sites.scss
+++ b/library/src/skins/default/src/sass/modules/more-sites/_more-sites.scss
@@ -81,7 +81,6 @@ ul#otherSitesMenu {
   .moresites-left-col {
     display: inline-block;
     width: 49%;
-    float: left;
     margin-right: 1%;
     @media #{$more-sites-single-column} {
       width: 100%;
@@ -94,7 +93,6 @@ ul#otherSitesMenu {
   .moresites-right-col {
     display: inline-block;
     width: 49%;
-    float: left;
     @media #{$more-sites-single-column} {
       width: 100%;
       float: none;
@@ -276,6 +274,11 @@ div.fav-title-myworkspace {
     line-height: 29px;
     text-decoration: none !important;
     vertical-align: middle;
+    @media #{$phone} {
+      overflow-x: auto;
+      scrollbar-width: none;
+      text-overflow: unset;
+    }
 
     .fullTitle {
       padding-left: 2px;


### PR DESCRIPTION
Since the “title” attribute isn't visible on mobile, it should be possible to scroll horizontally to see the full site name.

The two lines of “float” were removed because that property doesn't work with “display: inline-block.”. It's just a little cleaning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the More Sites layout by removing float-based positioning.
  * Enabled horizontal scrolling for favorite site titles on phones without visible scrollbars.
  * Prevented favorite site titles from being truncated on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->