### PR TITLE
SAK-52800 Rubrics harden async state and self-report

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -474,7 +474,9 @@
 													evaluated-item-id="$submission.Id"
 												#end
 												#if($!assignment.IsGroup)
-													evaluated-item-owner-id="$submission.GroupId"
+													#if ($submission && $submission.Graded && ($submission.GradeReleased || $submission.Returned))
+														evaluated-item-owner-id="$submission.GroupId"
+													#end
 												#else
 													evaluated-item-owner-id="$user.getId()"
 												#end

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_list_assignments.vm
@@ -466,15 +466,13 @@
 												<a name="asnActionLink" href="#toolLinkParam("AssignmentAction" "doView_submission" "assignmentReference=$formattedText.escapeUrl($assignmentReference)")" title="$formattedText.escapeHtml($!assignment.Title)">$formattedText.escapeHtml($assignment.Title)</a>
 												#assignmentIcons($assignment)
 											</strong>
-											#set($submissionId="undefined")
-											#if ($submission && $submission.Graded && ($submission.GradeReleased || $submission.Returned))
-												#set($submissionId=$submission.Id)
-											#end
 										    #if ($rubricMap.containsKey($assignment.getId()))
 											<sakai-rubric-student-button
 												site-id="$assignment.getContext()"
 												tool-id="sakai.assignment.grades"
-												evaluated-item-id="$submissionId"
+												#if ($submission && $submission.Graded && ($submission.GradeReleased || $submission.Returned))
+													evaluated-item-id="$submission.Id"
+												#end
 												#if($!assignment.IsGroup)
 													evaluated-item-owner-id="$submission.GroupId"
 												#else

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -301,7 +301,7 @@
         site-id="$assignment.context"
         tool-id="sakai.assignment.grades"
         entity-id="$assignment.Id"
-        instructor="true"
+        student-self-report
         is-peer-or-self="true"
         #if($!assignment.IsGroup)
             evaluated-item-id="$submission.GroupId"

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
@@ -22,6 +22,7 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
     forcePreview: { attribute: "force-preview", type: Boolean },
     enablePdfExport: { attribute: "enable-pdf-export", type: Object },
     isPeerOrSelf: { attribute: "is-peer-or-self", type: Boolean },
+    studentSelfReport: { attribute: "student-self-report", type: Boolean },
 
     _rubric: { state: true },
     _currentView: { state: true },
@@ -31,9 +32,9 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
 
     super();
 
-    this.setRubricRequirements = [ "site-id", "rubric-id", "preview" ];
-
     this._currentView = GRADING_RUBRIC;
+    this._loadId = 0;
+    this._loadScheduled = false;
 
     this.options = {};
     this.instanceSalt = Math.floor(Math.random() * Date.now());
@@ -45,18 +46,35 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
 
     super.attributeChangedCallback(name, oldValue, newValue);
 
-    if ((name === "entity-id" && this.toolId) || (name === "tool-id" && this.entityId) || (name === "evaluated-item-id" && this.evaluatedItemId)) {
-      this._init();
+    if ([ "site-id", "rubric-id", "preview", "tool-id", "entity-id", "evaluated-item-id", "evaluated-item-owner-id", "is-peer-or-self" ].includes(name)) {
+      this._scheduleRubricLoad();
+    }
+  }
+
+  _scheduleRubricLoad() {
+
+    this._loadId += 1;
+    if (this._loadScheduled) {
+      return;
     }
 
-    if (this.setRubricRequirements.includes(name)) {
-      this._setRubric();
-    }
+    this._loadScheduled = true;
+    queueMicrotask(() => {
 
-    // If rubric-id has been removed, undefine the rubric
-    if (name === "rubric-id" && !newValue) {
+      this._loadScheduled = false;
+      const loadId = this._loadId;
+
       this._rubric = undefined;
-    }
+      this.association = undefined;
+      this.evaluation = undefined;
+      this.options = {};
+
+      if (this.siteId && this.rubricId && this.preview) {
+        this._setRubric(loadId);
+      } else if (this.siteId && this.toolId && this.entityId) {
+        this._init(loadId);
+      }
+    });
   }
 
   _viewSelected(e) {
@@ -83,15 +101,19 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
   }
 
   shouldUpdate() {
-    // Render when loaded and either instructor is viewing, or student preview is allowed
-    // and the association is not dynamic (rbcs-associate != 2).
-    return this.siteId
-      && this._i18nLoaded
-      && this._rubric
-      && (this.instructor || (!this.options.hideStudentPreview && Number(this.options?.["rbcs-associate"]) !== 2));
+    return Boolean(this.siteId && this._i18n);
   }
 
   render() {
+
+    // Self-report results must remain visible even when the associated rubric is hidden from
+    // the normal student preview. This does not grant access to instructor summary views.
+    const rubricIsVisible = this.instructor
+      || this.studentSelfReport
+      || (!this.options.hideStudentPreview && !this.dynamic);
+    if (!this._rubric || !rubricIsVisible) {
+      return nothing;
+    }
 
     return html`
       <div class="rubric-details grading student-view">
@@ -143,100 +165,96 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
     `;
   }
 
-  _setRubric() {
+  async _setRubric(loadId) {
 
-    if (!this.siteId || !this.rubricId || !this.preview) return;
+    const siteId = this.siteId;
+    const rubricId = this.rubricId;
+    const url = `/api/sites/${siteId}/rubrics/${rubricId}`;
 
-    const url = `/api/sites/${this.siteId}/rubrics/${this.rubricId}`;
-    fetch(url, { credentials: "include", headers: { "Content-Type": "application/json" } })
-    .then(r => {
+    try {
+      const response = await fetch(url, { credentials: "include", headers: { "Content-Type": "application/json" } });
 
-      if (r.ok) {
-        return r.json();
+      if (!response.ok) {
+        throw new Error(`Network error while getting rubric at ${url}`);
       }
-      throw new Error(`Network error while getting rubric at ${url}`);
-    })
-    .then(rubric => this._rubric = rubric)
-    .catch (error => console.error(error));
+
+      const rubric = await response.json();
+      if (loadId === this._loadId) {
+        this._rubric = rubric;
+      }
+    } catch (error) {
+      if (loadId === this._loadId) {
+        console.error(error);
+      }
+    }
   }
 
-  _init() {
+  async _init(loadId) {
 
-    // First, grab the tool association
-    this.apiGetAssociation()
-      .then(association => {
+    const toolId = this.toolId;
+    const entityId = this.entityId;
+    const evaluatedItemId = this.evaluatedItemId;
+    const evaluatedItemOwnerId = this.evaluatedItemOwnerId;
+    const isPeerOrSelf = this.isPeerOrSelf;
 
-        if (association) {
-          this.association = association;
-          this.options = association.parameters;
-          const rubricId = association.rubricId;
+    try {
+      const association = await this.apiGetAssociation();
+      if (loadId !== this._loadId || !association) {
+        return;
+      }
 
-          // Now, get the rubric
-          const rubricUrl = `/api/sites/${association.siteId}/rubrics/${rubricId}`;
-          fetch(rubricUrl, {
-            credentials: "include",
-            headers: { "Content-Type": "application/json" },
-          })
-          .then(r => {
+      const options = {
+        ...(association.parameters ?? {}),
+        hideStudentPreview: association.parameters?.hideStudentPreview ?? false,
+      };
+      const rubricUrl = `/api/sites/${association.siteId}/rubrics/${association.rubricId}`;
+      const rubricResponse = await fetch(rubricUrl, {
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      });
 
-            if (r.ok) {
-              return r.json();
-            }
-            throw new Error("Server error while getting rubric");
-          })
-          .then(rubric => {
+      if (!rubricResponse.ok) {
+        throw new Error("Server error while getting rubric");
+      }
 
-            if (this.evaluatedItemId) {
-              // Now, get the evaluation
-              let evalUrl = `/api/sites/${association.siteId}/rubric-evaluations/tools/${this.toolId}/items/${this.entityId}/evaluations/${this.evaluatedItemId}/owners/${this.evaluatedItemOwnerId}`;
-              if (this.isPeerOrSelf) {
-                //for permission filters
-                evalUrl += "?isPeer=true";
-              }
-              fetch(evalUrl, {
-                credentials: "include",
-                headers: { "Content-Type": "application/json" },
-              })
-              .then(r => {
+      const rubric = await rubricResponse.json();
+      if (loadId !== this._loadId) {
+        return;
+      }
 
-                if (r.status === 200) {
-                  return r.json();
-                }
-
-                if (r.status !== 204) {
-                  throw new Error(`Network error while getting evaluation at ${evalUrl}`);
-                }
-
-                return null;
-              })
-              .then(evaluation => {
-
-                if (evaluation) {
-                  this.evaluation = evaluation;
-                  this.preview = false;
-                } else {
-                  this.evaluation = { criterionOutcomes: [] };
-                  this.preview = true;
-                }
-
-                // Set the rubric, thus triggering a render
-                this._rubric = rubric;
-              })
-              .catch (error => console.error(error));
-            } else {
-              this.evaluation = { criterionOutcomes: [] };
-              this.preview = true;
-              this._rubric = rubric;
-            }
-          })
-          .catch (error => console.error(error));
-
-          if (this.options.hideStudentPreview == null) {
-            this.options.hideStudentPreview = false;
-          }
+      let evaluation = null;
+      if (evaluatedItemId) {
+        let evalUrl = `/api/sites/${association.siteId}/rubric-evaluations/tools/${toolId}/items/${entityId}/evaluations/${evaluatedItemId}/owners/${evaluatedItemOwnerId}`;
+        if (isPeerOrSelf) {
+          evalUrl += "?isPeer=true";
         }
-      })
-      .catch (error => console.error(error));
+
+        const evaluationResponse = await fetch(evalUrl, {
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        if (evaluationResponse.status === 200) {
+          evaluation = await evaluationResponse.json();
+        } else if (evaluationResponse.status !== 204) {
+          throw new Error(`Network error while getting evaluation at ${evalUrl}`);
+        }
+      }
+
+      if (loadId !== this._loadId) {
+        return;
+      }
+
+      this.association = association;
+      this.options = options;
+      this.evaluation = evaluation ?? { criterionOutcomes: [] };
+      this.preview = !evaluation;
+      this._rubric = rubric;
+    } catch (error) {
+      if (loadId === this._loadId) {
+        console.error(error);
+      }
+    }
   }
 
   displayGradingTab() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
@@ -208,39 +208,43 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
         hideStudentPreview: association.parameters?.hideStudentPreview ?? false,
       };
       const rubricUrl = `/api/sites/${association.siteId}/rubrics/${association.rubricId}`;
-      const rubricResponse = await fetch(rubricUrl, {
+      const rubricPromise = fetch(rubricUrl, {
         credentials: "include",
         headers: { "Content-Type": "application/json" },
+      }).then(response => {
+
+        if (!response.ok) {
+          throw new Error("Server error while getting rubric");
+        }
+
+        return response.json();
       });
 
-      if (!rubricResponse.ok) {
-        throw new Error("Server error while getting rubric");
-      }
-
-      const rubric = await rubricResponse.json();
-      if (loadId !== this._loadId) {
-        return;
-      }
-
-      let evaluation = null;
+      let evaluationPromise = Promise.resolve(null);
       if (evaluatedItemId) {
         let evalUrl = `/api/sites/${association.siteId}/rubric-evaluations/tools/${toolId}/items/${entityId}/evaluations/${evaluatedItemId}/owners/${evaluatedItemOwnerId}`;
         if (isPeerOrSelf) {
           evalUrl += "?isPeer=true";
         }
 
-        const evaluationResponse = await fetch(evalUrl, {
+        evaluationPromise = fetch(evalUrl, {
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-        });
+        }).then(response => {
 
-        if (evaluationResponse.status === 200) {
-          evaluation = await evaluationResponse.json();
-        } else if (evaluationResponse.status !== 204) {
-          throw new Error(`Network error while getting evaluation at ${evalUrl}`);
-        }
+          if (response.status === 200) {
+            return response.json();
+          }
+
+          if (response.status !== 204) {
+            throw new Error(`Network error while getting evaluation at ${evalUrl}`);
+          }
+
+          return null;
+        });
       }
 
+      const [ rubric, evaluation ] = await Promise.all([ rubricPromise, evaluationPromise ]);
       if (loadId !== this._loadId) {
         return;
       }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
@@ -1,5 +1,5 @@
 import { RubricsElement } from "./RubricsElement.js";
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { rubricsApiMixin } from "./SakaiRubricsApiMixin.js";
 
 export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
@@ -21,6 +21,8 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     super();
 
     this.forcePreview = false;
+    this._associationLoadId = 0;
+    this._associationLoadScheduled = false;
   }
 
   set siteId(value) {
@@ -35,16 +37,20 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
 
     super.attributeChangedCallback(name, oldValue, newValue);
 
-    if (this.toolId && this.entityId) {
-      this._setRubricId();
+    if ([ "site-id", "tool-id", "entity-id", "instructor" ].includes(name)) {
+      this._scheduleAssociationLoad();
     }
   }
 
   shouldUpdate() {
-    return this._rubricId;
+    return this._i18n;
   }
 
   render() {
+
+    if (!this._rubricId) {
+      return nothing;
+    }
 
     return html`
       <a @click=${this.showRubric} href="javascript:;" title="${this._i18n.preview_rubric}">
@@ -53,16 +59,43 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     `;
   }
 
-  _setRubricId() {
+  _scheduleAssociationLoad() {
 
-    this.apiGetAssociation()
-      .then(association => {
+    this._associationLoadId += 1;
+    if (this._associationLoadScheduled) {
+      return;
+    }
 
-        if (association && (this.instructor || !association.parameters.hideStudentPreview)) {
-          this._rubricId = association.rubricId;
-        }
-      })
-    .catch(error => console.error(error));
+    this._associationLoadScheduled = true;
+    queueMicrotask(() => {
+
+      this._associationLoadScheduled = false;
+      const loadId = this._associationLoadId;
+      this._rubricId = undefined;
+
+      if (this.siteId && this.toolId && this.entityId) {
+        this._setRubricId(loadId);
+      }
+    });
+  }
+
+  async _setRubricId(loadId) {
+
+    try {
+      const association = await this.apiGetAssociation();
+      if (loadId !== this._associationLoadId) {
+        return;
+      }
+
+      const visibleToStudent = !association?.parameters?.hideStudentPreview;
+      this._rubricId = association && (this.instructor || visibleToStudent)
+        ? association.rubricId
+        : undefined;
+    } catch (error) {
+      if (loadId === this._associationLoadId) {
+        console.error(error);
+      }
+    }
   }
 
   showRubric() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
@@ -43,7 +43,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
   }
 
   shouldUpdate() {
-    return this._i18n;
+    return Boolean(this._i18n);
   }
 
   render() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student-button-state.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student-button-state.test.js
@@ -1,0 +1,126 @@
+import "../sakai-rubric-student-button.js";
+import "../sakai-rubric-student.js";
+import "../sakai-rubrics-utils.js";
+import * as data from "./data.js";
+import { elementUpdated, expect, fixture, html, waitUntil } from "@open-wc/testing";
+import fetchMock from "fetch-mock";
+
+describe("sakai-rubric-student-button state tests", () => {
+
+  beforeEach(() => {
+    fetchMock.mockGlobal();
+    fetchMock
+      .get(data.i18nUrl, data.i18n)
+      .get(data.associationUrl, data.association)
+      .get(data.rubric1Url, data.rubric1)
+      .get(data.evaluationUrl, data.evaluation)
+      .get("*", 500);
+  });
+
+  afterEach(async () => {
+
+    await fetchMock.callHistory.flush(true);
+
+    const utils = window.top.rubrics.utils;
+    const modal = utils.lightbox;
+    if (modal) {
+      bootstrap.Modal.getInstance(modal)?.dispose();
+      modal.remove();
+      utils.lightbox = null;
+    }
+
+    document.querySelectorAll(".modal-backdrop").forEach(backdrop => backdrop.remove());
+    document.body.classList.remove("modal-open");
+    document.body.style.removeProperty("overflow");
+    document.body.style.removeProperty("padding-right");
+    fetchMock.hardReset();
+  });
+
+  it("coalesces sequential attributes into one association request", async () => {
+
+    const button = await fixture(html`
+      <sakai-rubric-student-button
+          site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          evaluated-item-id="${data.evaluatedItemId}"
+          evaluated-item-owner-id="${data.evaluatedItemOwnerId}">
+      </sakai-rubric-student-button>
+    `);
+
+    await waitUntil(() => button.querySelector("a"), "Rubric button was not rendered");
+
+    expect(fetchMock.callHistory.calls(data.associationUrl)).to.have.length(1);
+  });
+
+  it("clears a previously visible button when the new association is hidden", async () => {
+
+    const hiddenEntityId = "hidden-entity";
+    const hiddenAssociationUrl = `/api/sites/${data.siteId}/rubric-associations/tools/${data.toolId}/items/${hiddenEntityId}`;
+
+    fetchMock.removeRoutes();
+    fetchMock
+      .get(data.i18nUrl, data.i18n)
+      .get(data.associationUrl, data.association)
+      .get(hiddenAssociationUrl, {
+        ...data.association,
+        parameters: { hideStudentPreview: true },
+      })
+      .get("*", 500);
+
+    const button = await fixture(html`
+      <sakai-rubric-student-button
+          site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}">
+      </sakai-rubric-student-button>
+    `);
+
+    await waitUntil(() => button.querySelector("a"), "Initial rubric button was not rendered");
+    button.setAttribute("entity-id", hiddenEntityId);
+    await waitUntil(() => fetchMock.callHistory.called(hiddenAssociationUrl), "Hidden association was not requested");
+    await fetchMock.callHistory.flush(true);
+    await elementUpdated(button);
+
+    expect(button.querySelector("a")).to.not.exist;
+  });
+
+  it("ignores an obsolete association response after the entity changes", async () => {
+
+    const newEntityId = "entity2";
+    const newAssociationUrl = `/api/sites/${data.siteId}/rubric-associations/tools/${data.toolId}/items/${newEntityId}`;
+    const rubric2Url = `/api/sites/${data.siteId}/rubrics/${data.rubric2.id}`;
+    let resolveOldAssociation;
+    const oldAssociation = new Promise(resolve => resolveOldAssociation = resolve);
+
+    fetchMock.removeRoutes();
+    fetchMock
+      .get(data.i18nUrl, data.i18n)
+      .get(data.associationUrl, oldAssociation)
+      .get(newAssociationUrl, { ...data.association, rubricId: data.rubric2.id })
+      .get(data.rubric1Url, data.rubric1)
+      .get(rubric2Url, data.rubric2)
+      .get("*", 500);
+
+    const button = await fixture(html`
+      <sakai-rubric-student-button
+          site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          force-preview>
+      </sakai-rubric-student-button>
+    `);
+
+    await waitUntil(() => fetchMock.callHistory.called(data.associationUrl), "Initial association was not requested");
+    button.setAttribute("entity-id", newEntityId);
+    await waitUntil(() => button.querySelector("a"), "New association was not rendered");
+
+    resolveOldAssociation(data.association);
+    await fetchMock.callHistory.flush(true);
+    button.querySelector("a").click();
+
+    const rubric = window.top.rubrics.utils.lightbox.querySelector("sakai-rubric-student");
+    await waitUntil(() => rubric.querySelector("h3 span"), "Preview rubric was not rendered");
+    expect(rubric.querySelector("h3 span").textContent).to.equal(data.rubric2.title);
+  });
+});

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
@@ -29,7 +29,7 @@ describe("sakai-rubric-student tests", () => {
 
   it ("renders a rubric student correctly", async () => {
 
-    let el = await fixture(html`
+    const el = await fixture(html`
       <sakai-rubric-student site-id="${data.siteId}"
           tool-id="${data.toolId}"
           entity-id="${data.entityId}"
@@ -45,13 +45,14 @@ describe("sakai-rubric-student tests", () => {
 
     await el.updateComplete;
     expect(el.querySelector("sakai-rubric-criterion-student")).to.exist;
+    expect(fetchMock.callHistory.calls(data.associationUrl)).to.have.length(1);
 
     await expect(el).to.be.accessible();
   });
 
   it ("rubric student preview renders correctly", async () => {
 
-    let el = await fixture(html`
+    const el = await fixture(html`
       <sakai-rubric-student site-id="${data.siteId}" rubric-id="1" preview="true"></sakai-rubric-student>
     `);
 
@@ -60,5 +61,76 @@ describe("sakai-rubric-student tests", () => {
     await expect(el).to.be.accessible();
 
     await waitUntil(() => el.querySelector("sakai-rubric-criterion-preview"), "No sakai-rubric-criterion-preview created");
+  });
+
+  it("ignores an obsolete association response after the entity changes", async () => {
+
+    const newEntityId = "entity2";
+    const newAssociationUrl = `/api/sites/${data.siteId}/rubric-associations/tools/${data.toolId}/items/${newEntityId}`;
+    const rubric2Url = `/api/sites/${data.siteId}/rubrics/${data.rubric2.id}`;
+    let resolveOldAssociation;
+    const oldAssociation = new Promise(resolve => resolveOldAssociation = resolve);
+
+    fetchMock.removeRoutes();
+    fetchMock
+      .get(data.i18nUrl, data.i18n)
+      .get(data.associationUrl, oldAssociation)
+      .get(newAssociationUrl, { ...data.association, rubricId: data.rubric2.id })
+      .get(data.rubric1Url, data.rubric1)
+      .get(rubric2Url, data.rubric2)
+      .get("*", 500);
+
+    const el = await fixture(html`
+      <sakai-rubric-student site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}">
+      </sakai-rubric-student>
+    `);
+
+    await waitUntil(() => fetchMock.callHistory.called(data.associationUrl), "Initial association was not requested");
+    el.setAttribute("entity-id", newEntityId);
+
+    await waitUntil(() => el.querySelector("h3 span")?.textContent === data.rubric2.title, "New rubric was not rendered");
+    resolveOldAssociation(data.association);
+    await fetchMock.callHistory.flush(true);
+    await elementUpdated(el);
+
+    expect(el.querySelector("h3 span").textContent).to.equal(data.rubric2.title);
+  });
+
+  it("shows a self-report result without granting instructor summary views", async () => {
+
+    const selfReportEntityId = "self-report";
+    const selfReportItemId = "self-report-item";
+    const selfReportOwnerId = "self-report-owner";
+    const associationUrl = `/api/sites/${data.siteId}/rubric-associations/tools/${data.toolId}/items/${selfReportEntityId}`;
+    const evaluationUrl = `/api/sites/${data.siteId}/rubric-evaluations/tools/${data.toolId}/items/${selfReportEntityId}/evaluations/${selfReportItemId}/owners/${selfReportOwnerId}?isPeer=true`;
+
+    fetchMock.removeRoutes();
+    fetchMock
+      .get(data.i18nUrl, data.i18n)
+      .get(associationUrl, {
+        ...data.association,
+        parameters: { hideStudentPreview: true },
+      })
+      .get(data.rubric1Url, data.rubric1)
+      .get(evaluationUrl, data.evaluation)
+      .get("*", 500);
+
+    const el = await fixture(html`
+      <sakai-rubric-student site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${selfReportEntityId}"
+          evaluated-item-id="${selfReportItemId}"
+          evaluated-item-owner-id="${selfReportOwnerId}"
+          student-self-report
+          is-peer-or-self>
+      </sakai-rubric-student>
+    `);
+
+    await waitUntil(() => el.querySelector("sakai-rubric-criterion-student"), "Self-report result was not rendered");
+
+    expect(el.hasAttribute("instructor")).to.be.false;
+    expect(el.querySelector("select")).to.not.exist;
   });
 });


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52800

Follow-up to #14827. This PR is independent and intentionally excludes the role propagation and modal utility changes from that focused fix.

## Summary

- Coalesce sequential custom-element attribute changes into one association/rubric load.
- Use load generations so late responses for a previous entity cannot overwrite current state.
- Clear stale launcher state when an association changes or becomes hidden.
- Keep Assignments student self-report results visible without treating the student as an instructor.
- Omit absent evaluated-item attributes instead of emitting the `"undefined"` sentinel.
- Add regression tests for request coalescing, stale responses, hidden-association transitions, and self-report visibility.

## Testing

- `npm test` in `packages/sakai-rubrics` — 30 tests passed in Chromium
- ESLint for the changed source and tests
- `npm run lint`
- `npm run analyze` — 0 problems in 130 files
- `npm run bundle`

A full Sakai Playwright scenario was not added because the demo fixture does not provide stable assignment self-report and gradebook rubric data; the browser component tests cover the relevant async and role-visible behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying student self-report rubric results without instructor-only controls.
  * Rubric buttons now appear only when associated submissions meet visibility requirements.

* **Bug Fixes**
  * Prevented invalid evaluation identifiers from appearing.
  * Improved rubric loading when information changes rapidly, preventing outdated results or stale buttons.
  * Improved handling when rubric information is unavailable or incomplete.

* **Tests**
  * Added coverage for self-report displays, hidden associations, request handling, and stale results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->