### PR TITLE
SAK-52826: Lessons: append class for non sakai local items instead of replacing already present classes

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -2317,7 +2317,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 									.decorate(new UIFreeAttributeDecorator("src", itemUrl))
 									.decorate(new UIFreeAttributeDecorator("allow", ServerConfigurationService.getBrowserFeatureAllowString()));
 						    if (!IframeUrlUtil.isLocalToSakai(itemUrl, ServerConfigurationService.getServerUrl())) {
-								item.decorate(new UIFreeAttributeDecorator("class", "sakai-iframe-force-light"));
+								item.decorate(new UIStyleDecorator("sakai-iframe-force-light"));
 						    }
 						    // if user specifies auto, use Javascript to resize the
 						    // iframe when the


### PR DESCRIPTION
Use UIStyleDecorator instead, which appends to the existing class list rather than replacing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated external multimedia iframe styling to consistently use the light-theme presentation.
  * Local Sakai iframe behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->