### PR TITLE
SAK-52818 SiteInfo DateManager display correct Gradebook weekdays across DST

### DIFF
--- a/library/src/webapp/js/lang-datepicker/lang-datepicker.js
+++ b/library/src/webapp/js/lang-datepicker/lang-datepicker.js
@@ -164,8 +164,9 @@ const defaults = {
       const minutes = DateHelper.pad(date.getMinutes());
       const seconds = DateHelper.pad(date.getSeconds());
       
-      // Always use local timezone offset
-      const offset = -new Date().getTimezoneOffset();
+      // Use the offset in effect at the selected date and time, since it may
+      // differ from today's offset across daylight saving time transitions.
+      const offset = -date.getTimezoneOffset();
       const offsetSign = offset >= 0 ? '+' : '-';
       const offsetHours = DateHelper.pad(Math.floor(Math.abs(offset) / 60));
       const offsetMinutes = DateHelper.pad(Math.abs(offset) % 60);


### PR DESCRIPTION
Fix Date Manager's Gradebook weekday display across daylight-saving transitions.

The datepicker previously serialized every selected value using the browser's current timezone offset. When the selected date was in a different DST phase, parsing the hidden ISO value could shift a midnight date into the previous day and display the wrong weekday.

Use the offset in effect for the selected `Date` instead.

Tests:
- Date Manager JavaScript suite in UTC and `Europe/Stockholm`
- Targeted `America/New_York` verification: winter `-05:00`, summer `-04:00`
- `node --check library/src/webapp/js/lang-datepicker/lang-datepicker.js`

Jira: [SAK-52818](https://sakaiproject.atlassian.net/browse/SAK-52818)

[SAK-52818]: https://sakaiproject.atlassian.net/browse/SAK-52818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ