### PR TITLE
SAK-52828 Preserve SameSite on non-HttpOnly cookies

### DIFF
--- a/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
+++ b/kernel/api/src/main/java/org/sakaiproject/util/RequestFilter.java
@@ -1456,21 +1456,19 @@ public class RequestFilter implements Filter
 	
 	protected void addCookie(HttpServletRequest req, HttpServletResponse res, Cookie cookie) {
 
-		if (!m_cookieHttpOnly) {
-			// Use the standard servlet mechanism for setting the cookie
+		if (!m_cookieHttpOnly && (m_cookieSameSite == null || m_cookieSameSite.isEmpty())) {
+			// Use the standard servlet mechanism when neither attribute is configured
 			res.addCookie(cookie);
-		} else {
-			// Set the cookie manually
-
-			StringBuffer sb = new StringBuffer();
-
-			ServerCookie.appendCookieValue(sb, cookie.getVersion(), cookie.getName(), cookie.getValue(),
-					cookie.getPath(), cookie.getDomain(), cookie.getComment(),
-					cookie.getMaxAge(), cookie.getSecure(), m_cookieHttpOnly, m_cookieSameSite, req.getHeader("user-agent"));
-
-			res.addHeader("Set-Cookie", sb.toString());
+			return;
 		}
-		return;
+
+		StringBuffer sb = new StringBuffer();
+
+		ServerCookie.appendCookieValue(sb, cookie.getVersion(), cookie.getName(), cookie.getValue(),
+				cookie.getPath(), cookie.getDomain(), cookie.getComment(),
+				cookie.getMaxAge(), cookie.getSecure(), m_cookieHttpOnly, m_cookieSameSite, req.getHeader("user-agent"));
+
+		res.addHeader("Set-Cookie", sb.toString());
 	}
 
 	/**

--- a/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
+++ b/kernel/api/src/test/java/org/sakaiproject/util/RequestFilterTest.java
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -43,6 +44,9 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RequestFilterTest {
+
+    private static final String MODERN_CHROME = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
 
     private MockedStatic<ComponentManager> componentManagerMock;
 
@@ -122,6 +126,50 @@ public class RequestFilterTest {
         Mockito.verify(sessionManager).getSession("principalSession");
         // principal authenticated sessions shouldn't set a cookie initially
         Mockito.verify(response, Mockito.never()).addCookie(Mockito.any(Cookie.class));
+        Mockito.verify(response, Mockito.never()).addHeader(Mockito.eq("Set-Cookie"), Mockito.anyString());
+    }
+
+    @Test
+    public void testAddCookieSameSiteWithoutHttpOnly() {
+        filter.m_cookieHttpOnly = false;
+        filter.m_cookieSameSite = "none";
+        Mockito.when(request.getHeader("user-agent")).thenReturn(MODERN_CHROME);
+
+        Cookie cookie = secureCookie();
+        filter.addCookie(request, response, cookie);
+
+        ArgumentCaptor<String> header = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(response).addHeader(Mockito.eq("Set-Cookie"), header.capture());
+        assertTrue(header.getValue().contains("SameSite=None"));
+        assertFalse(header.getValue().contains("HttpOnly"));
+        Mockito.verify(response, Mockito.never()).addCookie(Mockito.any(Cookie.class));
+    }
+
+    @Test
+    public void testAddCookieSameSiteWithHttpOnly() {
+        filter.m_cookieHttpOnly = true;
+        filter.m_cookieSameSite = "none";
+        Mockito.when(request.getHeader("user-agent")).thenReturn(MODERN_CHROME);
+
+        Cookie cookie = secureCookie();
+        filter.addCookie(request, response, cookie);
+
+        ArgumentCaptor<String> header = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(response).addHeader(Mockito.eq("Set-Cookie"), header.capture());
+        assertTrue(header.getValue().contains("SameSite=None"));
+        assertTrue(header.getValue().contains("HttpOnly"));
+        Mockito.verify(response, Mockito.never()).addCookie(Mockito.any(Cookie.class));
+    }
+
+    @Test
+    public void testAddCookieWithoutSameSiteOrHttpOnlyUsesServletContainer() {
+        filter.m_cookieHttpOnly = false;
+        filter.m_cookieSameSite = "";
+
+        Cookie cookie = secureCookie();
+        filter.addCookie(request, response, cookie);
+
+        Mockito.verify(response).addCookie(cookie);
         Mockito.verify(response, Mockito.never()).addHeader(Mockito.eq("Set-Cookie"), Mockito.anyString());
     }
 
@@ -228,6 +276,13 @@ public class RequestFilterTest {
         Mockito.when (cookie.getValue()).thenReturn("session1.server1");
         Mockito.when(request.getCookies()).thenReturn(new Cookie[]{cookie});
         Mockito.when (sessionManager.getSession("session1")).thenReturn(session);
+    }
+
+    private Cookie secureCookie() {
+        Cookie cookie = new Cookie("SAKAIID", "session.server1");
+        cookie.setPath("/");
+        cookie.setSecure(true);
+        return cookie;
     }
 
     private void setupPrincipal() {


### PR DESCRIPTION
## Summary

- Honor `sakai.cookieSameSite` when `sakai.cookieHttpOnly=false`.
- Preserve servlet-container handling when both attributes are disabled.
- Add regression coverage for both HttpOnly modes.

## Root cause

`RequestFilter` bypassed Sakai's SameSite-aware cookie serializer whenever HttpOnly was disabled, so `SAKAIID` omitted the configured SameSite attribute.

## Testing

`mvn -pl kernel/api test` — 106 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie handling to reliably preserve configured `SameSite` and `HttpOnly` security attributes.
  * Ensured cookies use standard servlet-container handling when no additional security attributes are configured.
* **Tests**
  * Added coverage for cookies with `SameSite`, `HttpOnly`, both attributes, and neither attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->