### PR TITLE
SAK-52816 SCORM use EID as learner ID

### DIFF
--- a/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
+++ b/scormplayer/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
@@ -708,7 +708,7 @@ public class ScormApplicationServiceImpl implements ScormApplicationService {
 			{
 				// Initialize the learner id
 				element = CMI_LEARNER_ID;
-				DMInterface.processSetValue(element, learner.getId(), true, ioSCOData, validatorFactory);
+				DMInterface.processSetValue(element, learner.getDisplayId(), true, ioSCOData, validatorFactory);
 
 				// Initialize the learner name
 				element = CMI_LEARNER_NAME;


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52816

## What changed

Use the learner's Sakai display ID (EID) for the SCORM 2004 `cmi.learner_id` value instead of the internal Sakai user UUID.

## Why

The SCORM launch path passed `Learner.getId()`, which is Sakai's opaque internal user ID. `Learner.getDisplayId()` is already populated from `User.getDisplayId()` and provides the institutional identifier expected by SCO content, including personalized certificates and transcripts.

## Impact

SCO content now receives a recognizable institutional learner ID. No schema or data collection changes are required.

## Validation

- `git diff --check`
- Tests not run (not requested for this one-line value substitution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SCORM content now uses the learner’s display ID for `cmi.learner_id`, improving learner identification and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->