### PR TITLE
SAK-52808 Portal register tasks component

### DIFF
--- a/webcomponents/tool/src/main/frontend/bundle-entry-points/body-scripts.js
+++ b/webcomponents/tool/src/main/frontend/bundle-entry-points/body-scripts.js
@@ -2,6 +2,7 @@ import "@sakai-ui/sakai-permissions/sakai-permissions.js"
 import "@sakai-ui/sakai-search/sakai-search.js";
 import "@sakai-ui/sakai-calendar/sakai-calendar.js";
 import "@sakai-ui/sakai-grades/sakai-grades.js";
+import "@sakai-ui/sakai-tasks/sakai-tasks.js";
 import "get-browser-fingerprint";
 import { init as initJumpToTop } from "@sakai-ui/sakai-jump-to-top/sakai-jump-to-top.js";
 initJumpToTop();


### PR DESCRIPTION
## Summary

- Include the sakai-tasks component in the shared body-scripts bundle.
- Ensure the account menu task element is upgraded before portal.init.js calls loadData().

## Root cause

The 23.x account panel renders sakai-tasks, but the portal bundle imports only the calendar and grades component definitions. On pages that do not load tasks through another bundle, sakai-tasks remains an unupgraded HTML element and loadData is unavailable.

## Impact

Opening the account menu no longer raises the reported TypeError, and My Tasks can load as intended.

## Testing

- npm run lint
- npm run bundle

Jira: https://sakaiproject.atlassian.net/browse/SAK-52808