### PR TITLE
SAK-52801 Sitestats hide instructor navigation from students

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -18,10 +18,13 @@ package org.sakaiproject.e2e.tests;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.microsoft.playwright.APIResponse;
 import com.microsoft.playwright.Download;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.FormData;
+import com.microsoft.playwright.options.RequestOptions;
 import com.microsoft.playwright.options.SelectOption;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -232,6 +235,15 @@ class SiteStatsTest extends SakaiUiTestBase {
     @Test
     @Order(6)
     void studentOwnStatisticsViewDoesNotRenderInstructorNavigation() {
+        sakai.login("admin");
+        String siteId = sakai.siteIdFromUrl(sakaiUrl);
+        APIResponse permissionsResponse = page.request().post("/api/sites/" + siteId + "/permissions",
+            RequestOptions.create().setForm(FormData.create()
+                .set("ref", "/site/" + siteId)
+                .set("Student:sitestats.view", "true")));
+        assertTrue(permissionsResponse.ok(),
+            "Unable to grant student access to Statistics: HTTP " + permissionsResponse.status());
+
         sakai.login("student0011");
         page.navigate(sakaiUrl);
         sakai.toolClick("Statistics");

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -223,6 +223,7 @@ class SiteStatsTest extends SakaiUiTestBase {
         assertThat(activityEventOptions).isVisible();
         allTools.check();
         assertThat(activityEventOptions).isHidden();
+        page.getByLabel("Show their own statistics to students").check();
         page.getByRole(AriaRole.BUTTON,
             new Page.GetByRoleOptions().setName(Pattern.compile("^Update$", Pattern.CASE_INSENSITIVE))).click();
         assertThat(page.getByText("Preferences updated successfully.")).isVisible();
@@ -230,6 +231,19 @@ class SiteStatsTest extends SakaiUiTestBase {
 
     @Test
     @Order(6)
+    void studentOwnStatisticsViewDoesNotRenderInstructorNavigation() {
+        sakai.login("student0011");
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Statistics");
+
+        assertThat(page.getByRole(AriaRole.HEADING,
+            new Page.GetByRoleOptions().setName(Pattern.compile("^Overview$", Pattern.CASE_INSENSITIVE)))).isVisible();
+        assertThat(page.getByRole(AriaRole.NAVIGATION,
+            new Page.GetByRoleOptions().setName("SiteStats"))).hasCount(0);
+    }
+
+    @Test
+    @Order(7)
     void adminRegistrationRendersServerWideReports() {
         sakai.login("admin");
         sakai.gotoPath("/portal/site/!admin/tool/!admin-1225");

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
@@ -251,6 +251,7 @@ public class SiteStatsController {
         model.addAttribute("activeMenu", activeMenu);
         boolean adminTool = toolService.isAdminTool();
         model.addAttribute("adminTool", adminTool);
+        model.addAttribute("toolMenuAvailable", adminTool || toolService.canViewAllSiteStats(siteId));
         model.addAttribute("userActivityAvailable", !adminTool && toolService.canViewUserActivity(siteId));
     }
 

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolAuthorizationService.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolAuthorizationService.java
@@ -46,6 +46,10 @@ public class SiteStatsToolAuthorizationService {
         return statsManager.isDisplayDetailedEvents() && statsAuthz.canCurrentUserTrackInSite(siteId);
     }
 
+    public boolean canViewAllSiteStats(String siteId) {
+        return statsAuthz.isUserAbleToViewSiteStatsAll(siteId);
+    }
+
     private String authorizedSite(String requestedSiteId, AccessLevel accessLevel) {
         String siteId = StringUtils.defaultIfBlank(requestedSiteId, currentSiteId());
         String currentSiteId = currentSiteId();

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
@@ -488,6 +488,10 @@ public class SiteStatsToolService {
         return authorizationService.canViewUserActivity(siteId);
     }
 
+    public boolean canViewAllSiteStats(String siteId) {
+        return authorizationService.canViewAllSiteStats(siteId);
+    }
+
     private void assertCanViewUserActivity(String siteId) {
         if (!canViewUserActivity(siteId)) {
             throw new SecurityException("User Activity is not available");

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/fragments/common.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/fragments/common.html
@@ -9,7 +9,7 @@
   <script type="module" th:src="@{/js/sitestats-tool.js}"></script>
 </head>
 <body>
-  <nav th:fragment="menu(active)" class="navIntraTool actionToolBar navIntraToolMobile" aria-label="SiteStats">
+  <nav th:fragment="menu(active)" th:if="${toolMenuAvailable}" class="navIntraTool actionToolBar navIntraToolMobile" aria-label="SiteStats">
     <div class="dropdown-toggle dropdown-navIntraTool" th:text="#{menu_tooloptions}">Tool Options</div>
     <ul>
       <li th:if="${!adminTool}"><a th:classappend="${active == 'overview'} ? ' current'" th:attr="aria-current=${active == 'overview'} ? 'page' : null" th:href="@{/home(siteId=${siteId})}" th:text="#{menu_overview}">Overview</a></li>


### PR DESCRIPTION
## Summary

- hide the Sitestats intra-tool navigation from users who can only view their own statistics
- preserve the student Overview page while keeping Reports and Preferences out of the rendered UI
- add Playwright coverage for the student permission boundary

## Root cause

The SAK-52731 Thymeleaf migration did not carry over the Wicket menu's `sitestats.all` visibility check. The replacement template treated every non-admin user alike, so students with `sitestats.own` saw instructor-only links even though the corresponding endpoints remained protected.

This restores the previous behavior without changing server-side authorization.

Jira: [SAK-52801](https://sakaiproject.atlassian.net/browse/SAK-52801)

## Testing

- `mvn -pl sitestats/sitestats-tool -am test`
- `cd e2e-tests && mvn -DskipTests package`

The new Playwright scenario was compile-validated but not run because this worktree was not deployed to the local Sakai server.

[SAK-52801]: https://sakaiproject.atlassian.net/browse/SAK-52801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Students can view their own Statistics overview when enabled.
  * Site-wide Statistics navigation is available to administrators and authorized viewers.
* **Bug Fixes**
  * Statistics navigation now appears only when access is permitted.
  * Student views no longer display instructor-only navigation options.
* **Tests**
  * Added coverage for student Statistics access and navigation visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->