### PR TITLE
SAK-52799 SiteStats avoid duplicate report errors

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -85,6 +85,8 @@ class SiteStatsTest extends SakaiUiTestBase {
             new Page.GetByRoleOptions().setName(Pattern.compile("^Add$", Pattern.CASE_INSENSITIVE))).click();
         page.getByLabel("Title").fill(REPORT_TITLE);
         page.getByLabel("Period:").selectOption("when-custom");
+        page.locator("#when-from").fill("");
+        page.locator("#when-to").fill("");
 
         Locator validationError = page.locator(".sak-banner-error[role='alert']");
         for (String action : List.of("Save report", "Generate report")) {

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -79,6 +79,25 @@ class SiteStatsTest extends SakaiUiTestBase {
 
     @Test
     @Order(3)
+    void reportValidationDisplaysOneErrorBanner() {
+        openReportsAsInstructor();
+        page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions().setName(Pattern.compile("^Add$", Pattern.CASE_INSENSITIVE))).click();
+        page.getByLabel("Title").fill(REPORT_TITLE);
+        page.getByLabel("Period:").selectOption("when-custom");
+
+        Locator validationError = page.locator(".sak-banner-error[role='alert']");
+        for (String action : List.of("Save report", "Generate report")) {
+            page.getByRole(AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName(Pattern.compile("^" + action + "$", Pattern.CASE_INSENSITIVE)))
+                .click();
+            assertThat(validationError).hasCount(1);
+            assertThat(validationError).containsText("Custom time period not defined");
+        }
+    }
+
+    @Test
+    @Order(4)
     void createsReportViaReportsFlow() {
         sakai.login("instructor1");
         page.navigate(sakaiUrl);
@@ -156,7 +175,7 @@ class SiteStatsTest extends SakaiUiTestBase {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void savesEditsCopiesExportsAndDeletesReport() {
         openReportsAsInstructor();
         page.getByRole(AriaRole.LINK,
@@ -204,7 +223,7 @@ class SiteStatsTest extends SakaiUiTestBase {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void preferencesUseSpringForms() {
         sakai.login("instructor1");
         page.navigate(sakaiUrl);
@@ -233,7 +252,7 @@ class SiteStatsTest extends SakaiUiTestBase {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void studentOwnStatisticsViewDoesNotRenderInstructorNavigation() {
         sakai.login("admin");
         String siteId = sakai.siteIdFromUrl(sakaiUrl);
@@ -255,7 +274,7 @@ class SiteStatsTest extends SakaiUiTestBase {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void adminRegistrationRendersServerWideReports() {
         sakai.login("admin");
         sakai.gotoPath("/portal/site/!admin/tool/!admin-1225");

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/edit.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/edit.html
@@ -4,7 +4,6 @@
 <body>
 <main class="portletBody container-fluid">
   <div th:replace="~{fragments/common :: menu('reports')}"></div>
-  <div th:replace="~{fragments/common :: messages}"></div>
   <h1 class="h3 mt-3" th:text="${reportForm.id > 0} ? #{report_edit} : #{report_new}">Edit report</h1>
 
   <div class="sak-banner-error mb-3" role="alert" th:if="${#lists.isEmpty(editorOptions.availableReportTypes)}">


### PR DESCRIPTION
## Summary

- render report-editor validation errors only in the form-local alert
- preserve the alert referenced by invalid fields through `aria-describedby`
- cover invalid Save and Generate submissions with a Playwright regression test

## Root cause

The Thymeleaf report editor rendered the same `error` model attribute through both the shared page-message fragment and the form-local `#report-error` banner. A failed Save or Generate submission therefore displayed the same message twice.

## Impact

Statistics report validation failures now display one localized error banner while retaining the existing accessible relationship between invalid fields and the error message.

## Testing

- `mvn -f e2e-tests/pom.xml -DskipTests test-compile`
- `mvn -f sitestats/sitestats-tool/pom.xml -Dtest=SiteStatsControllerAdviceTest,SiteStatsReportFormValidatorTest test` (22 tests passed)
- `git diff --check upstream/master...HEAD`

The new Playwright flow was compiled but not executed locally because the isolated worktree was not deployed to a Sakai runtime.

[SAK-52799](https://sakaiproject.atlassian.net/browse/SAK-52799)


[SAK-52799]: https://sakaiproject.atlassian.net/browse/SAK-52799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report validation to clearly indicate when a custom time period is required before saving or generating a report.
  * Updated the report editor for a more consistent form experience while preserving existing fields, options, and actions.

* **Tests**
  * Added end-to-end coverage for custom time-period validation.
  * Added coverage for student statistics preferences and permissions, including verification of restricted instructor navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->