### PR TITLE
SAK-52768 SiteStats correct by-user chart labels

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/ActivityWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/ActivityWidgetDefinition.java
@@ -70,7 +70,8 @@ public class ActivityWidgetDefinition extends AbstractSiteStatsWidgetDefinition 
 		ReportDef table = new ReportDef(chart, siteId);
 		table.getReportParams().setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
 		table.getReportParams().setHowSortBy(StatsManager.T_TOTAL);
-		return new WidgetReportDefinition(message("overview_title_activity"), chart, table);
+		String title = message("overview_title_activity");
+		return new WidgetReportDefinition(title, title, chart, table);
 	}
 
 	private WidgetReportDefinition activityByToolDefinition(String siteId, SiteStatsReportRequest request, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsChartMapper.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsChartMapper.java
@@ -39,6 +39,10 @@ public class SiteStatsChartMapper {
 	@Setter private ResourceLoader messages = new ResourceLoader("Messages");
 
 	public SiteStatsChart mapChart(Report report, PrefsData prefsData, String title) {
+		return mapChart(report, prefsData, title, null);
+	}
+
+	public SiteStatsChart mapChart(Report report, PrefsData prefsData, String title, String datasetLabel) {
 		ReportParams params = report.getReportDefinition().getReportParams();
 		PrefsData safePrefsData = prefsData == null ? new PrefsData() : prefsData;
 		SiteStatsChart chart = new SiteStatsChart();
@@ -58,7 +62,7 @@ public class SiteStatsChartMapper {
 		}
 
 		try {
-			mapChartDatasets(chart, report, reportData, chartSource);
+			mapChartDatasets(chart, report, reportData, chartSource, datasetLabel);
 		} catch (IllegalArgumentException e) {
 			chart.getDatasets().clear();
 			String unsupportedReason = message("sitestats_chart_unsupported",
@@ -71,10 +75,11 @@ public class SiteStatsChartMapper {
 		return chart;
 	}
 
-	private void mapChartDatasets(SiteStatsChart chart, Report report, List<Stat> reportData, String chartSource) {
+	private void mapChartDatasets(SiteStatsChart chart, Report report, List<Stat> reportData, String chartSource,
+			String datasetLabel) {
 		String chartType = chart.getType();
 		if (StatsManager.CHARTTYPE_PIE.equals(chartType)) {
-			mapPieChartDatasets(chart, report, reportData, chartSource);
+			mapPieChartDatasets(chart, report, reportData, chartSource, datasetLabel);
 			return;
 		}
 		if (StatsManager.CHARTTYPE_TIMESERIES.equals(chartType) || StatsManager.CHARTTYPE_TIMESERIESBAR.equals(chartType)) {
@@ -88,11 +93,13 @@ public class SiteStatsChartMapper {
 		throw new IllegalArgumentException("Unsupported chart type: " + chartType);
 	}
 
-	private void mapPieChartDatasets(SiteStatsChart chart, Report report, List<Stat> reportData, String chartSource) {
+	private void mapPieChartDatasets(SiteStatsChart chart, Report report, List<Stat> reportData, String chartSource,
+			String datasetLabel) {
 		SiteStatsChartDataset dataset = new SiteStatsChartDataset();
 		String valueKey = chartSingleValueKey(report);
 		dataset.setKey(chartSource);
-		dataset.setLabel(siteStatsTableMapper.getColumn(valueKey, false).getLabel());
+		dataset.setLabel(StringUtils.defaultIfBlank(datasetLabel,
+				siteStatsTableMapper.getColumn(valueKey, false).getLabel()));
 		ChartDatasetAccumulator accumulator = new ChartDatasetAccumulator(dataset.getKey(), dataset.getLabel());
 		for (Stat stat : reportData) {
 			addPoint(accumulator, siteStatsTableMapper.getCell(stat, chartSource), siteStatsTableMapper.getNumericValue(stat, valueKey));

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsReportViewMapper.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsReportViewMapper.java
@@ -106,6 +106,10 @@ public class SiteStatsReportViewMapper {
 		return siteStatsChartMapper.mapChart(report, prefsData, title);
 	}
 
+	public SiteStatsChart mapChart(Report report, PrefsData prefsData, String title, String datasetLabel) {
+		return siteStatsChartMapper.mapChart(report, prefsData, title, datasetLabel);
+	}
+
 	public String localizedReportTitle(ReportDef reportDef) {
 		if (reportDef.getTitle() == null) {
 			return message("reportres_title");

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsViewServiceImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsViewServiceImpl.java
@@ -172,7 +172,8 @@ public class SiteStatsViewServiceImpl implements SiteStatsViewService {
 		}
 		view.setTitle(definition.getTitle());
 		if (chartReport != null) {
-			view.setChart(siteStatsReportViewMapper.mapChart(chartReport, prefsData, definition.getTitle()));
+			view.setChart(siteStatsReportViewMapper.mapChart(chartReport, prefsData, definition.getTitle(),
+					definition.getChartDatasetLabel()));
 		}
 		if (tableReport != null) {
 			view.setTable(siteStatsReportViewMapper.mapTable(tableReport, safeRequest, definition.getTitle()));

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
@@ -82,7 +82,8 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 		ReportDef table = new ReportDef(chart, siteId);
 		table.getReportParams().setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
 		table.getReportParams().setHowSortBy(StatsManager.T_TOTAL);
-		return new WidgetReportDefinition(message("overview_title_visits"), chart, table);
+		String title = message("overview_title_visits");
+		return new WidgetReportDefinition(title, title, chart, table);
 	}
 
 	private ReportDef visitsByUserChart(String siteId, SiteStatsReportRequest request) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetReportDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetReportDefinition.java
@@ -5,17 +5,26 @@
  */
 package org.sakaiproject.sitestats.impl.view;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import org.sakaiproject.sitestats.api.report.ReportDef;
 
-@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
 class WidgetReportDefinition {
 
 	private final String title;
+	private final String chartDatasetLabel;
 	private final ReportDef chartReportDef;
 	private final ReportDef tableReportDef;
+
+	WidgetReportDefinition(String title, ReportDef chartReportDef, ReportDef tableReportDef) {
+		this(title, null, chartReportDef, tableReportDef);
+	}
+
+	WidgetReportDefinition(String title, String chartDatasetLabel, ReportDef chartReportDef, ReportDef tableReportDef) {
+		this.title = title;
+		this.chartDatasetLabel = chartDatasetLabel;
+		this.chartReportDef = chartReportDef;
+		this.tableReportDef = tableReportDef;
+	}
 }

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
@@ -20,6 +20,7 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_LESS
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_ACTIVITY;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_LESSONS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_STUDENT_VISITS;
@@ -214,6 +215,33 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		SiteStatsReportView view = service.getReport(SITE_ID, reportDef.getId(), new SiteStatsReportRequest());
 
 		assertEquals("Visits", view.getChart().getDatasets().get(0).getLabel());
+	}
+
+	@Test
+	public void activityByUserPieChartUsesTheLocalizedWidgetTitleForCounts() {
+		db.insertObject(eventStat(SITE_ID, USER_ID, FakeData.TOOL_CHAT,
+				FakeData.EVENT_CHATNEW, Date.valueOf("2026-06-17"), 4));
+		SiteStatsReportRequest request = new SiteStatsReportRequest();
+		request.setDate(ReportManager.WHEN_ALL);
+		SiteStatsReportView view = service.getWidgetReport(SITE_ID, WIDGET_ACTIVITY, TAB_BY_USER, request);
+
+		assertFalse(view.getChart().getDatasets().isEmpty());
+		assertEquals("overview_title_activity", view.getTitle());
+		assertEquals(view.getTitle(), view.getChart().getDatasets().get(0).getLabel());
+	}
+
+	@Test
+	public void visitsByUserPieChartUsesTheLocalizedWidgetTitleForCounts() {
+		db.insertObject(eventStat(SITE_ID, USER_ID, FakeData.TOOL_CHAT,
+				StatsManager.SITEVISIT_EVENTID, Date.valueOf("2026-06-17"), 3));
+		SiteStatsReportRequest request = new SiteStatsReportRequest();
+		request.setDate(ReportManager.WHEN_ALL);
+
+		SiteStatsReportView view = service.getWidgetReport(SITE_ID, WIDGET_VISITS, TAB_BY_USER, request);
+
+		assertFalse(view.getChart().getDatasets().isEmpty());
+		assertEquals("overview_title_visits", view.getTitle());
+		assertEquals(view.getTitle(), view.getChart().getDatasets().get(0).getLabel());
 	}
 
 	@Test


### PR DESCRIPTION
## What changed

- Added an optional localized dataset label to SiteStats widget report metadata.
- Applied the widget titles to the Activity and Visits **By user** pie-chart datasets.
- Added regression coverage through the Spring-wired `SiteStatsViewService` endpoints for both affected charts while preserving generic chart-label tests.

## Why

Pie-chart tooltip labels were inferred from generic report column metadata. That describes the grouping or storage shape rather than the metric shown to instructors, which produced **Name** in the reported UI and can otherwise fall back to the vague **Total** label. The affected widgets now explicitly identify their values as **Activity** and **Visits**.

This fixes [SAK-52768](https://sakaiproject.atlassian.net/browse/SAK-52768).

## Impact

Instructors hovering over the Overview **By user** pie charts now see localized, metric-specific tooltip labels. Saved reports and other chart mappings retain their existing behavior.

## Validation

- `mvn -q -pl sitestats/sitestats-impl -am test -Dtest=SiteStatsViewServiceTest -Dsurefire.failIfNoSpecifiedTests=false`
- 19 tests passed, 0 failures
- `git diff --check`

Browser QA was not available because the local `https://sakai.example` demo returned HTTP 502. The regression tests verify the same serialized dataset label consumed by the Chart.js component through the production service contract.

[SAK-52768]: https://sakaiproject.atlassian.net/browse/SAK-52768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity and visit charts grouped by user with clearer, localized dataset labels.
  * Ensured chart legends display the appropriate widget title instead of a generic table-column label.

* **Tests**
  * Added coverage verifying that user-based activity and visit pie charts contain non-empty, correctly labeled datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->