### PR TITLE
SAK-52810 Rubrics prevent duplicate scores in PDF exports

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
@@ -157,8 +157,8 @@ class AnnouncementTest extends SakaiUiTestBase {
         Locator reorderLink = page.locator(".navIntraTool a, .navIntraTool button, .navIntraTool [role=\"button\"]")
             .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Reorder$", Pattern.CASE_INSENSITIVE))).first();
         assertThat(reorderLink).isVisible();
-        reorderLink.click();
-        assertThat(page.locator("#reorder-list")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+        reorderLink.click(new Locator.ClickOptions().setForce(true));
+        page.waitForLoadState();
 
         Locator reorderedAnnouncements = page.locator("#reorder-list li").filter(new Locator.FilterOptions().setHasText(titlePrefix));
         assertThat(reorderedAnnouncements).hasCount(20);

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
@@ -157,8 +157,8 @@ class AnnouncementTest extends SakaiUiTestBase {
         Locator reorderLink = page.locator(".navIntraTool a, .navIntraTool button, .navIntraTool [role=\"button\"]")
             .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Reorder$", Pattern.CASE_INSENSITIVE))).first();
         assertThat(reorderLink).isVisible();
-        reorderLink.click(new Locator.ClickOptions().setForce(true));
-        page.waitForLoadState();
+        reorderLink.click();
+        assertThat(page.locator("#reorder-list")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
 
         Locator reorderedAnnouncements = page.locator("#reorder-list li").filter(new Locator.FilterOptions().setHasText(titlePrefix));
         assertThat(reorderedAnnouncements).hasCount(20);

--- a/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
+++ b/rubrics/impl/src/main/java/org/sakaiproject/rubrics/impl/RubricsServiceImpl.java
@@ -1503,13 +1503,11 @@ public class RubricsServiceImpl implements RubricsService, EntityTransferrer {
                     .filter(outcome -> cri.getId().equals(outcome.getCriterionId())).findAny();
 
                 if (evaluatedPoints.isPresent()) {
-                    if (optCriterionOutcome.isPresent() && optCriterionOutcome.get().getPointsAdjusted()) {
+                    if (adjustedScoreCell.isPresent()) {
 
                         //Get points of the selected rating (not altered) by maching selected rating id's and getting points from matched rating
                         Double selectedRatingOriginalPoints = optCriterionOutcome
-                                .flatMap(outcome -> cri.getRatings().stream()
-                                        .filter(rating -> rating.getId().equals(outcome.getSelectedRatingId())).findAny())
-                                .map(Rating::getPoints)
+                                .flatMap(outcome -> getSelectedRatingPoints(cri, outcome))
                                 .orElse(0D);
 
                         //Instrucor adjusted the rating point value on evaluation
@@ -1617,11 +1615,29 @@ public class RubricsServiceImpl implements RubricsService, EntityTransferrer {
             return Optional.empty();
         }
         for(CriterionOutcome outcome: evaluation.getCriterionOutcomes()){
-            if(outcome.getPointsAdjusted() && outcome.getCriterionId().equals(criterion.getId())){
+            if(Boolean.TRUE.equals(outcome.getPointsAdjusted()) && outcome.getCriterionId().equals(criterion.getId())
+                    && getSelectedRatingPoints(criterion, outcome)
+                            .map(points -> Double.compare(points, outcome.getPoints()) != 0)
+                            .orElse(true)) {
                 return Optional.of(outcome.getPoints());
             }
         }
         return Optional.empty();
+    }
+
+    private Optional<Double> getSelectedRatingPoints(Criterion criterion, CriterionOutcome outcome) {
+        if (criterion == null || outcome == null || outcome.getSelectedRatingId() == null) {
+            return Optional.empty();
+        }
+
+        return criterion.getRatings().stream()
+                .filter(rating -> rating.getId().equals(outcome.getSelectedRatingId()))
+                .map(Rating::getPoints)
+                .map(points -> criterion.getRubric().getWeighted()
+                        ? BigDecimal.valueOf(points * (criterion.getWeight() / 100.0D))
+                                .setScale(2, RoundingMode.HALF_UP).doubleValue()
+                        : points)
+                .findAny();
     }
 
     private Optional<String> getCriterionComment(Criterion criterion, Evaluation evaluation){

--- a/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
+++ b/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
@@ -788,7 +788,11 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
 
         pdfText = extractPdfText(rubricsService.createPdf(siteId, rubric.getId(), AssignmentConstants.TOOL_ID,
                 toolItemId, evaluation.getEvaluatedItemId()));
-        assertTrue(pdfText.contains("export_adjusted: 0.68"));
+        String weightedCriterionText = StringUtils.substringBetween(pdfText,
+                rubric.getCriteria().get(0).getTitle(), rubric.getCriteria().get(1).getTitle());
+        assertNotNull(weightedCriterionText);
+        assertTrue(weightedCriterionText.contains("0.67 0.68"));
+        assertTrue(weightedCriterionText.contains("export_adjusted: 0.68"));
     }
 
     @Test

--- a/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
+++ b/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
@@ -768,6 +768,27 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
         pdfText = extractPdfText(rubricsService.createPdf(siteId, rubric.getId(), AssignmentConstants.TOOL_ID,
                 toolItemId, evaluation.getEvaluatedItemId()));
         assertTrue(pdfText.contains("export_adjusted: 1.5"));
+
+        rubric.setWeighted(true);
+        rubric.getCriteria().get(0).setWeight(33.333F);
+        rubric = rubricsService.saveRubric(rubric);
+
+        outcome = evaluation.getCriterionOutcomes().get(0);
+        outcome.setPoints(0.67D);
+        outcome.setPointsAdjusted(true);
+        evaluation = rubricsService.saveEvaluation(evaluation, siteId);
+
+        pdfText = extractPdfText(rubricsService.createPdf(siteId, rubric.getId(), AssignmentConstants.TOOL_ID,
+                toolItemId, evaluation.getEvaluatedItemId()));
+        assertFalse(pdfText.contains("export_adjusted"));
+
+        outcome = evaluation.getCriterionOutcomes().get(0);
+        outcome.setPoints(0.68D);
+        evaluation = rubricsService.saveEvaluation(evaluation, siteId);
+
+        pdfText = extractPdfText(rubricsService.createPdf(siteId, rubric.getId(), AssignmentConstants.TOOL_ID,
+                toolItemId, evaluation.getEvaluatedItemId()));
+        assertTrue(pdfText.contains("export_adjusted: 0.68"));
     }
 
     @Test

--- a/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
+++ b/rubrics/impl/src/test/org/sakaiproject/rubrics/impl/test/RubricsServiceTests.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -38,12 +40,18 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
+import com.lowagie.text.pdf.PdfReader;
+import com.lowagie.text.pdf.parser.PdfTextExtractor;
+
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.sakaiproject.archive.api.ArchiveService;
+import org.sakaiproject.assignment.api.AssignmentConstants;
+import org.sakaiproject.assignment.api.AssignmentService;
+import org.sakaiproject.assignment.api.model.Assignment;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.rubrics.api.RubricsConstants;
 import org.sakaiproject.rubrics.api.RubricsService;
@@ -96,6 +104,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContextTests {
 
     @Autowired private AssociationRepository associationRepository;
+    @Autowired private AssignmentService assignmentService;
     @Autowired private CriterionRepository criterionRepository;
     @Autowired private EvaluationRepository evaluationRepository;
     @Autowired private ReturnedEvaluationRepository returnedEvaluationRepository;
@@ -722,6 +731,46 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
     }
 
     @Test
+    public void createPdfDisplaysOnlyActualPointAdjustments() throws Exception {
+
+        switchToInstructor();
+
+        String toolItemId = "pdf-item";
+        RubricTransferBean rubric = rubricsService.createDefaultRubric(siteId);
+        Map<String, String> rbcsParams = Map.of(RubricsConstants.RBCS_ASSOCIATE, "1",
+                RubricsConstants.RBCS_LIST, rubric.getId().toString());
+        ToolItemRubricAssociation association = rubricsService
+                .saveRubricAssociation(AssignmentConstants.TOOL_ID, toolItemId, rbcsParams)
+                .orElseThrow(() -> new IllegalStateException("Association not created"));
+
+        EvaluationTransferBean evaluation = buildEvaluation(association.getId(), rubric, toolItemId);
+        CriterionOutcomeTransferBean outcome = evaluation.getCriterionOutcomes().get(0);
+        RatingTransferBean selectedRating = rubric.getCriteria().get(0).getRatings().get(2);
+        outcome.setSelectedRatingId(selectedRating.getId());
+        outcome.setPoints(selectedRating.getPoints());
+        outcome.setPointsAdjusted(true);
+        evaluation = rubricsService.saveEvaluation(evaluation, siteId);
+
+        Assignment assignment = mock(Assignment.class);
+        when(assignment.getTitle()).thenReturn("PDF Assignment");
+        when(assignmentService.getAssignment(toolItemId)).thenReturn(assignment);
+        when(userDirectoryService.getUser(user2)).thenReturn(user2User);
+        configurePdfMessages();
+
+        String pdfText = extractPdfText(rubricsService.createPdf(siteId, rubric.getId(), AssignmentConstants.TOOL_ID,
+                toolItemId, evaluation.getEvaluatedItemId()));
+        assertFalse(pdfText.contains("export_adjusted"));
+
+        outcome = evaluation.getCriterionOutcomes().get(0);
+        outcome.setPoints(1.5D);
+        evaluation = rubricsService.saveEvaluation(evaluation, siteId);
+
+        pdfText = extractPdfText(rubricsService.createPdf(siteId, rubric.getId(), AssignmentConstants.TOOL_ID,
+                toolItemId, evaluation.getEvaluatedItemId()));
+        assertTrue(pdfText.contains("export_adjusted: 1.5"));
+    }
+
+    @Test
     public void saveEvaluationAsTeachingAssistant() {
 
         // Only users with a rubrics.editor role can create rubric and save rubric association
@@ -1105,6 +1154,25 @@ public class RubricsServiceTests extends AbstractTransactionalJUnit4SpringContex
         });
         etb.getCriterionOutcomes().addAll(criterionOutcomes);
         return etb;
+    }
+
+    private void configurePdfMessages() {
+        when(resourceLoader.getFormattedMessage(anyString(), any())).thenAnswer(invocation ->
+                invocation.getArgument(0) + ": " + invocation.getArgument(1));
+        when(resourceLoader.getFormattedMessage(anyString(), any(), any())).thenAnswer(invocation ->
+                invocation.getArgument(0) + ": " + invocation.getArgument(1) + " " + invocation.getArgument(2));
+        when(resourceLoader.getFormattedMessage(anyString(), any(), any(), any())).thenAnswer(invocation ->
+                invocation.getArgument(0) + ": " + invocation.getArgument(1) + " " + invocation.getArgument(2)
+                        + " " + invocation.getArgument(3));
+    }
+
+    private String extractPdfText(byte[] pdf) throws Exception {
+        PdfReader reader = new PdfReader(pdf);
+        try {
+            return new PdfTextExtractor(reader).getTextFromPage(1);
+        } finally {
+            reader.close();
+        }
     }
 
     private void setupStudentPermissions() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
@@ -340,11 +340,14 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
 
     const crit = criteria.map(c => {
 
+      const hasPointOverride = c.pointoverride !== "" && c.pointoverride !== null && c.pointoverride !== undefined;
+      const points = hasPointOverride ? parseFloat(c.pointoverride) : c.selectedvalue;
+
       return {
         criterionId: c.id,
-        points: (c.pointoverride !== "" && c.pointoverride !== null && c.pointoverride !== undefined) ? parseFloat(c.pointoverride) : c.selectedvalue,
+        points,
         comments: c.comments,
-        pointsAdjusted: c.pointoverride !== c.selectedvalue,
+        pointsAdjusted: hasPointOverride && points !== parseFloat(c.selectedvalue),
         selectedRatingId: c.selectedRatingId
       };
     });

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-grading.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-grading.test.js
@@ -85,6 +85,62 @@ describe("sakai-rubric-grading tests", () => {
     expect(totalPoints.value).to.equal("4.8");
   });
 
+  it ("only marks changed fine-tuned points as adjusted", async () => {
+
+    const saveUrl = `/api/sites/${data.siteId}/rubric-evaluations`;
+    fetchMock.get(data.rubric1Url, data.rubric1)
+      .get(data.associationUrl, data.association)
+      .get(data.evaluationUrl, data.evaluation)
+      .post(saveUrl, ({ options }) => JSON.parse(options.body));
+
+    const el = await fixture(html`
+      <sakai-rubric-grading
+          site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          evaluated-item-id="${data.evaluatedItemId}"
+          evaluated-item-owner-id="${data.evaluatedItemOwnerId}">
+      </sakai-rubric-grading>
+    `);
+
+    await waitUntil(() => el.querySelector("#rating-item-1"), "No rating rendered");
+
+    let saved = oneEvent(el, "rubric-ratings-changed");
+    el.querySelector("#rating-item-1").click();
+    await saved;
+
+    let request = JSON.parse(fetchMock.callHistory.lastCall(saveUrl).options.body);
+    expect(request.criterionOutcomes.every(outcome => !outcome.pointsAdjusted)).to.be.true;
+
+    const fineTuneInput = el.querySelector(".fine-tune-points");
+    fineTuneInput.value = "0";
+    saved = oneEvent(el, "rubric-ratings-changed");
+    fineTuneInput.dispatchEvent(new Event("input"));
+    await saved;
+
+    request = JSON.parse(fetchMock.callHistory.lastCall(saveUrl).options.body);
+    expect(request.criterionOutcomes[0].points).to.equal(0);
+    expect(request.criterionOutcomes[0].pointsAdjusted).to.be.true;
+
+    fineTuneInput.value = "1";
+    saved = oneEvent(el, "rubric-ratings-changed");
+    fineTuneInput.dispatchEvent(new Event("input"));
+    await saved;
+
+    request = JSON.parse(fetchMock.callHistory.lastCall(saveUrl).options.body);
+    expect(request.criterionOutcomes[0].points).to.equal(1);
+    expect(request.criterionOutcomes[0].pointsAdjusted).to.be.false;
+
+    fineTuneInput.value = "1.8";
+    saved = oneEvent(el, "rubric-ratings-changed");
+    fineTuneInput.dispatchEvent(new Event("input"));
+    await saved;
+
+    request = JSON.parse(fetchMock.callHistory.lastCall(saveUrl).options.body);
+    expect(request.criterionOutcomes[0].points).to.equal(1.8);
+    expect(request.criterionOutcomes[0].pointsAdjusted).to.be.true;
+  });
+
   it ("calculates percentage totals correctly", async () => {
 
     fetchMock.get(data.rubric1Url, data.rubric1)


### PR DESCRIPTION
## Summary

- treat a rubric score as adjusted only when a fine-tune value is present and differs from the selected rating
- preserve explicit zero-point overrides
- validate adjusted scores again during PDF generation so legacy evaluations with an incorrect flag do not render duplicate values
- compare and display the selected rating's weighted score for weighted rubrics

## Root cause

The grading component represented “no override” as an empty string, but compared that value directly with the numeric selected score. The type/value mismatch marked every normally selected rating as adjusted. PDF export trusted that flag and rendered the selected score struck through beside the same score.

## Tests

- `mvn -pl rubrics/impl -am -Dtest=RubricsServiceTests -Dsurefire.failIfNoSpecifiedTests=false test` (24 tests)
- `npm test --workspace=@sakai-ui/sakai-rubrics` (26 tests)
- `npx eslint packages/sakai-rubrics/src/SakaiRubricGrading.js --max-warnings=0`
- `npm run analyze` (130 files, 0 problems)

The component regression test covers normal selections, an explicit zero override, a numerically equal override, and a changed override. The service regression test generates and reads the PDF through the public Rubrics service API for both a legacy false-positive flag and a real adjustment.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rubric grading to accurately detect adjusted scores, including zero and decimal values.
  * PDF exports now show the originally selected rating points as struck through only when the saved score differs.
  * Improved handling of weighted ratings and missing rating data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->