### PR TITLE
SAK-52752 Polls accept em dashes in bulk CSV imports

### DIFF
--- a/polls/tool/src/main/java/org/sakaiproject/poll/tool/mvc/PollImportController.java
+++ b/polls/tool/src/main/java/org/sakaiproject/poll/tool/mvc/PollImportController.java
@@ -17,8 +17,10 @@
 package org.sakaiproject.poll.tool.mvc;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,6 +60,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PollImportController {
 
     private static final long MAX_IMPORT_FILE_BYTES = 1024 * 1024;
+    private static final Charset WINDOWS_1252 = Charset.forName("windows-1252");
 
     private final MessageSource messageSource;
     private final ToolManager toolManager;
@@ -190,14 +193,17 @@ public class PollImportController {
             throw new IllegalArgumentException(messageSource.getMessage("poll_import_error_file", null, locale));
         }
 
-        try (Reader reader = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8)) {
-            StringBuilder builder = new StringBuilder();
-            char[] buffer = new char[4096];
-            int count;
-            while ((count = reader.read(buffer)) != -1) {
-                builder.append(buffer, 0, count);
+        try {
+            byte[] contents = file.getBytes();
+            try {
+                return StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT)
+                        .decode(ByteBuffer.wrap(contents))
+                        .toString();
+            } catch (CharacterCodingException e) {
+                return new String(contents, WINDOWS_1252);
             }
-            return builder.toString();
         } catch (IOException e) {
             log.warn("Unable to read imported poll file {}", file.getOriginalFilename(), e);
             throw new IllegalArgumentException(messageSource.getMessage("poll_import_error_file", null, locale), e);

--- a/polls/tool/src/test/java/org/sakaiproject/poll/tool/mvc/PollImportControllerTest.java
+++ b/polls/tool/src/test/java/org/sakaiproject/poll/tool/mvc/PollImportControllerTest.java
@@ -1,0 +1,101 @@
+/**********************************************************************************
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **********************************************************************************/
+
+package org.sakaiproject.poll.tool.mvc;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.sakaiproject.poll.api.service.PollsService;
+import org.sakaiproject.tool.api.Placement;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.tool.api.ToolManager;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.springframework.context.MessageSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PollImportControllerTest {
+
+    private static final Charset WINDOWS_1252 = Charset.forName("windows-1252");
+    private static final String SITE_ID = "site-id";
+    private static final String USER_ID = "user-id";
+
+    private PollsService pollsService;
+    private PollImportController controller;
+
+    @Before
+    public void setUp() {
+        MessageSource messageSource = mock(MessageSource.class);
+        ToolManager toolManager = mock(ToolManager.class);
+        SessionManager sessionManager = mock(SessionManager.class);
+        pollsService = mock(PollsService.class);
+        UserDirectoryService userDirectoryService = mock(UserDirectoryService.class);
+        Placement placement = mock(Placement.class);
+
+        when(toolManager.getCurrentPlacement()).thenReturn(placement);
+        when(placement.getContext()).thenReturn(SITE_ID);
+        when(sessionManager.getCurrentSessionUserId()).thenReturn(USER_ID);
+        when(pollsService.isAllowedPollAdd(SITE_ID)).thenReturn(true);
+
+        controller = new PollImportController(
+                messageSource,
+                toolManager,
+                sessionManager,
+                pollsService,
+                userDirectoryService);
+    }
+
+    @Test
+    public void importPollsPreservesUtf8EmDash() {
+        verifyImportedCsv(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void importPollsPreservesWindows1252EmDash() {
+        verifyImportedCsv(WINDOWS_1252);
+    }
+
+    private void verifyImportedCsv(Charset charset) {
+        String csv = "Question,Option 1,Option 2\nQuestion?,Yes — definitely,No\n";
+        MockMultipartFile file = new MockMultipartFile(
+                "pollUploadFile",
+                "polls.csv",
+                "text/csv",
+                csv.getBytes(charset));
+
+        String view = controller.importPolls(
+                null,
+                file,
+                new RedirectAttributesModelMap(),
+                Locale.ENGLISH,
+                new ExtendedModelMap());
+
+        Assert.assertEquals("redirect:/votePolls", view);
+        verify(pollsService).importPollsFromCsv(eq(List.of(csv)), eq(SITE_ID), eq(USER_ID));
+    }
+}


### PR DESCRIPTION
## Summary

- preserve valid UTF-8 bulk poll CSV uploads
- fall back to Windows-1252 for spreadsheet-generated CSV files containing punctuation such as em dashes
- cover UTF-8 and Windows-1252 multipart imports with controller regression tests

## Root cause

The bulk import path decoded every uploaded file as UTF-8 using the decoder's replacement behavior. A Windows-1252 em dash is byte `0x97`, which is invalid UTF-8 and was therefore replaced with `�` before CSV parsing.

## User impact

Poll options imported from common spreadsheet CSV exports retain em dashes instead of displaying replacement characters.

## Testing

- `mvn -pl tool -am test -Dtest=PollImportControllerTest -Dsurefire.failIfNoSpecifiedTests=false` (2 tests, 0 failures)
- `mvn test` from `polls` was also attempted; the reactor stopped in unchanged `polls-impl` because `sakai-kernel-storage-util:27-SNAPSHOT` is unavailable locally

[SAK-52752](https://sakaiproject.atlassian.net/browse/SAK-52752)


[SAK-52752]: https://sakaiproject.atlassian.net/browse/SAK-52752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll CSV imports by correctly handling both UTF-8 and Windows-1252 encoded files.
  * Prevented character corruption when imported poll content includes special characters, such as em dashes.

* **Tests**
  * Added coverage for poll imports using UTF-8 and Windows-1252 encoded CSV files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->