### PR TITLE
SAK-52766 SiteStats: consolidate activity by user

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -1148,9 +1149,6 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
                 Date fDate2 = c.getTime();
                 q.setParameter("fdate", fDate2, DateType.INSTANCE);
             }
-            if(columnMap.containsKey(StatsSqlBuilder.C_USER) && anonymousEvents != null && anonymousEvents.size() > 0) {
-                q.setParameterList("anonymousEvents", anonymousEvents);
-            }
             if(page != null){
                 q.setFirstResult(page.getFirst() - 1);
                 q.setMaxResults(page.getLast() - page.getFirst() + 1);
@@ -1289,26 +1287,6 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
                     results.add(c);
                 }
             }
-            // hack for hibernate-oracle bug producing duplicate lines
-            else if("oracle".equals(getDbVendor()) && totalsBy != null && totalsBy.contains(T_USER) && anonymousEvents != null && anonymousEvents.size() > 0) {
-                List<Stat> consolidated = new ArrayList<>();
-                for(Stat s : results) {
-                    EventStat es = (EventStat) s;
-                    boolean found = false;
-                    for(Stat c : consolidated) {
-                        EventStat esc = (EventStat) c;
-                        if(esc.equalExceptForCount((Object)es)) {
-                            esc.setCount(esc.getCount() + es.getCount());
-                            found = true;
-                            break;
-                        }
-                    }
-                    if(!found) {
-                        consolidated.add(es);
-                    }
-                }
-                results = consolidated;
-            }
             return results;
         };
 		return getHibernateTemplate().execute(hcb);
@@ -1367,9 +1345,6 @@ public class StatsManagerImpl extends HibernateDaoSupport implements StatsManage
                 c.add(Calendar.DAY_OF_YEAR, 1);
                 Date fDate2 = c.getTime();
                 q.setParameter("fdate", fDate2, DateType.INSTANCE);
-            }
-            if(columnMap.containsKey(StatsSqlBuilder.C_USER) && anonymousEvents != null && anonymousEvents.size() > 0){
-                q.setParameterList("anonymousEvents", anonymousEvents);
             }
             log.debug("getEventStatsRowCount(): " + q.getQueryString());
             Integer rowCount = q.list().size();
@@ -2209,9 +2184,6 @@ if (log.isDebugEnabled()) {
                 Date fDate2 = c.getTime();
                 q.setParameter("fdate", fDate2, DateType.INSTANCE);
             }
-            if(columnMap.containsKey(StatsSqlBuilder.C_USER) && anonymousEvents != null && anonymousEvents.size() > 0) {
-                q.setParameterList("anonymousEvents", anonymousEvents);
-            }
             if(page != null){
                 q.setFirstResult(page.getFirst() - 1);
                 q.setMaxResults(page.getLast() - page.getFirst() + 1);
@@ -2449,11 +2421,7 @@ if (log.isDebugEnabled()) {
 				}
 				// user
 				if(totalsBy.contains(T_USER)) {
-					if(queryType == Q_TYPE_EVENT && anonymousEvents != null && anonymousEvents.size() > 0) {
-						selectFields.add("(CASE WHEN s.eventId not in (:anonymousEvents) THEN s.userId ELSE '-' END) as user");						
-					}else{
-						selectFields.add("s.userId as user");
-					}
+					selectFields.add(getUserField() + " as user");
 					columnMap.put(C_USER, columnIndex++);
 				}
 				// event
@@ -2545,11 +2513,7 @@ if (log.isDebugEnabled()) {
 				
 			// inverse query (users not matching conditions)
 			}else{
-				if(queryType == Q_TYPE_EVENT && anonymousEvents != null && anonymousEvents.size() > 0) {
-					selectFields.add("distinct(case when s.eventId not in (:anonymousEvents) then s.userId else '-' end) as user");
-				}else{
-					selectFields.add("distinct s.userId as user");
-				}
+				selectFields.add("distinct " + getUserField() + " as user");
 				columnMap.put(C_USER, columnIndex++);
 			}
 			
@@ -2713,17 +2677,7 @@ if (log.isDebugEnabled()) {
 			}
 			// User: new approach		
 			if(totalsBy.contains(T_USER)) {
-				if(queryType == Q_TYPE_EVENT && anonymousEvents != null && anonymousEvents.size() > 0) {
-						// unfortunately, this produces results different from the expected:
-						//	- hibernate-oracle bug (sometimes) producing duplicate lines
-						//	- hack fix in getEventStats() method
-						groupFields.add("s.eventId");
-						groupFields.add("s.userId");
-						// it should be: ( but doesn't work in Hibernate :( )
-						//groupFields.add("(CASE WHEN s.eventId not in (:anonymousEvents) THEN s.userId ELSE '-' END)");
-				} else {
-					groupFields.add("s.userId");
-				}
+				groupFields.add(getUserField());
 			}			
 			if((queryType == Q_TYPE_EVENT || queryType == Q_TYPE_ACTIVITYTOTALS)
 					&& (
@@ -2784,6 +2738,22 @@ if (log.isDebugEnabled()) {
 			
 			return _hql.toString();
 		}
+
+		private boolean hasAnonymousUserField() {
+			return queryType == Q_TYPE_EVENT && totalsBy.contains(T_USER)
+					&& anonymousEvents != null && !anonymousEvents.isEmpty();
+		}
+
+		private String getUserField() {
+			if(!hasAnonymousUserField()) {
+				return "s.userId";
+			}
+			String anonymousEventIds = anonymousEvents.stream()
+					.sorted()
+					.map(eventId -> "'" + eventId.replace("'", "''") + "'")
+					.collect(Collectors.joining(", "));
+			return "(CASE WHEN s.eventId not in (" + anonymousEventIds + ") THEN s.userId ELSE '-' END)";
+		}
 		
 		private String getSortByClause() {
 			if(sortBy != null){
@@ -2794,7 +2764,7 @@ if (log.isDebugEnabled()) {
 					sortField = "s.siteId";
 				}
 				if(sortBy.equals(T_USER) && totalsBy.contains(T_USER)) {
-					sortField = "s.userId";
+					sortField = getUserField();
 				}
 				if((queryType == Q_TYPE_EVENT || queryType == Q_TYPE_ACTIVITYTOTALS) 
 					&& (sortBy.equals(T_EVENT) || sortBy.equals(T_TOOL)) && (totalsBy.contains(T_EVENT) || totalsBy.contains(T_TOOL))) {

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsManagerTest.java
@@ -765,6 +765,50 @@ public class StatsManagerTest extends AbstractTransactionalJUnit4SpringContextTe
 	}
 	
 	@Test
+	public void testEventStatsByUserGroupsAnonymousAndRegularEvents() {
+		Date today = new Date();
+		statsUpdateManager.collectEvents(Arrays.asList(
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_CHATNEW, "/chat/msg/" + FakeData.SITE_A_ID, FakeData.SITE_A_ID, FakeData.USER_A_ID, FakeData.SESSION_A_ID),
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_CHATNEW, "/chat/msg/" + FakeData.SITE_A_ID, FakeData.SITE_A_ID, FakeData.USER_A_ID, FakeData.SESSION_A_ID),
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_CONTENTNEW, "/content/group/" + FakeData.SITE_A_ID + "/resource-a", FakeData.SITE_A_ID, FakeData.USER_A_ID, FakeData.SESSION_A_ID),
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_CHATNEW, "/chat/msg/" + FakeData.SITE_A_ID, FakeData.SITE_A_ID, FakeData.USER_B_ID, FakeData.SESSION_B_ID),
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_POLLVOTE, "/poll/" + FakeData.SITE_A_ID + "/poll-a", FakeData.SITE_A_ID, FakeData.USER_A_ID, FakeData.SESSION_A_ID),
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_POLLVOTE, "/poll/" + FakeData.SITE_A_ID + "/poll-a", FakeData.SITE_A_ID, FakeData.USER_A_ID, FakeData.SESSION_A_ID),
+				statsUpdateManager.buildEvent(today, FakeData.EVENT_POLLVOTE, "/poll/" + FakeData.SITE_A_ID + "/poll-a", FakeData.SITE_A_ID, FakeData.USER_B_ID, FakeData.SESSION_B_ID)));
+
+		List<String> events = Arrays.asList(FakeData.EVENT_CHATNEW, FakeData.EVENT_CONTENTNEW, FakeData.EVENT_POLLVOTE);
+		List<String> totalsBy = Arrays.asList(StatsManager.T_USER);
+		List<Stat> stats = statsManager.getEventStats(FakeData.SITE_A_ID, events,
+				null, null, null, false, null, totalsBy, StatsManager.T_USER, true, 0);
+
+		assertEquals(3, stats.size());
+		assertEquals(3L, countForUser(stats, "-"));
+		assertEquals(3L, countForUser(stats, FakeData.USER_A_ID));
+		assertEquals(1L, countForUser(stats, FakeData.USER_B_ID));
+		assertEquals(3, statsManager.getEventStatsRowCount(FakeData.SITE_A_ID, events,
+				null, null, null, false, totalsBy));
+
+		List<Stat> firstPage = statsManager.getEventStats(FakeData.SITE_A_ID, events,
+				null, null, null, false, new PagingPosition(1, 2), totalsBy, StatsManager.T_USER, true, 0);
+		assertEquals(2, firstPage.size());
+		assertEquals("-", firstPage.get(0).getUserId());
+		assertEquals(FakeData.USER_A_ID, firstPage.get(1).getUserId());
+
+		List<Stat> secondPage = statsManager.getEventStats(FakeData.SITE_A_ID, events,
+				null, null, null, false, new PagingPosition(3, 3), totalsBy, StatsManager.T_USER, true, 0);
+		assertEquals(1, secondPage.size());
+		assertEquals(FakeData.USER_B_ID, secondPage.get(0).getUserId());
+	}
+
+	private long countForUser(List<Stat> stats, String userId) {
+		return stats.stream()
+				.filter(stat -> userId.equals(stat.getUserId()))
+				.mapToLong(Stat::getCount)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("No statistics found for user " + userId));
+	}
+
+	@Test
 	@Ignore		// TODO JUNIT test is not working on hsqldb need to look into
 	public void testEventStats() {
 		statsUpdateManager.collectEvents(getSampleData());

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/data/FakeData.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/data/FakeData.java
@@ -60,6 +60,7 @@ public class FakeData {
 	public final static String					EVENT_CHATNEW		= "chat.new";
 	public final static String					EVENT_CONTENTNEW	= "content.new";
 	public final static String					EVENT_CONTENTREV	= "content.revise";
+	public final static String					EVENT_POLLVOTE		= "poll.vote";
 	public final static String					EVENT_CONTENTREAD	= "content.read";
 	// anonymous events
 	public final static String					EVENT_CONTENTDEL	= "content.delete";


### PR DESCRIPTION
## Summary

- Group SiteStats event activity by the same anonymized-user expression used in the report output on every supported database dialect.
- Remove the Hibernate 3-era Oracle fallback and its post-query Java consolidation.
- Keep row counts, sorting, and pagination aligned with the rows users actually see.
- Add regression coverage for reports containing named activity and identity-protected `poll.vote` activity.

## Problem

`poll.vote` is configured as an anonymous event. The old query selected those events under the protected-user key (`-`) but grouped by the raw event and user IDs. It then merged duplicate Oracle results in Java. Besides preserving an unverified workaround from 2009, that repair happened after database pagination and did not repair row counts or ordering.

The query now uses one identical, literalized `CASE` expression for selection, grouping, and user sorting. A select alias is not a viable substitute: Hibernate 5.6 rewrites the selected alias while leaving the HQL alias unchanged in `GROUP BY`, producing invalid SQL.

## Database compatibility

The exact Hibernate 5.6 query path was verified against:

- HSQLDB 2.7.4
- MySQL 8 with `ONLY_FULL_GROUP_BY`
- Oracle AI Database Free 23.26.2 using Hibernate 5.6.15's `Oracle12cDialect` and Oracle JDBC 23.26.1

Each database returned the same three grouped results: protected user `-` with count 3, `user-a` with count 3, and `user-b` with count 1.

Oracle's [21c `SELECT` documentation](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/SELECT.html) permits expressions in `GROUP BY` (other than scalar subqueries) and requires a selected grouped expression to be identical to the grouping expression. The implementation follows that rule directly.

## Testing

- `mvn test` in `sitestats/sitestats-impl` after rebasing onto current `master` — 114 tests, 0 failures, 0 errors, 4 skipped
- The new Spring/Hibernate integration test exercises the public `StatsManager` API and verifies grouped values, row count, sort order, and two pages of results.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52766


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event statistics grouping for anonymous and identified users.
  * Ensured anonymous event entries appear consistently in sorting, grouping, and result counts.
  * Improved paging order and accuracy for user-based event statistics.

* **Tests**
  * Added coverage for event statistics containing both anonymous and regular user activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->