### PR TITLE
SAK-52721 Announcements stabilize reorder E2E navigation

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.microsoft.playwright.options.BoundingBox;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.assertions.LocatorAssertions;
 import java.util.List;
@@ -158,7 +159,11 @@ class AnnouncementTest extends SakaiUiTestBase {
             .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Reorder$", Pattern.CASE_INSENSITIVE))).first();
         assertThat(reorderLink).isVisible();
         reorderLink.click();
-        assertThat(page.locator("#reorder-list")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
+        page.waitForFunction(
+            "() => document.querySelector('#announcements-reorderer')?.updateComplete",
+            null,
+            new Page.WaitForFunctionOptions().setTimeout(20_000)
+        );
 
         Locator reorderedAnnouncements = page.locator("#reorder-list li").filter(new Locator.FilterOptions().setHasText(titlePrefix));
         assertThat(reorderedAnnouncements).hasCount(20);

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/AnnouncementTest.java
@@ -157,8 +157,8 @@ class AnnouncementTest extends SakaiUiTestBase {
         Locator reorderLink = page.locator(".navIntraTool a, .navIntraTool button, .navIntraTool [role=\"button\"]")
             .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Reorder$", Pattern.CASE_INSENSITIVE))).first();
         assertThat(reorderLink).isVisible();
-        reorderLink.click(new Locator.ClickOptions().setForce(true));
-        page.waitForLoadState();
+        reorderLink.click();
+        assertThat(page.locator("#reorder-list")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20_000));
 
         Locator reorderedAnnouncements = page.locator("#reorder-list li").filter(new Locator.FilterOptions().setHasText(titlePrefix));
         assertThat(reorderedAnnouncements).hasCount(20);


### PR DESCRIPTION
## Summary

- Let Playwright wait for the Reorder link to become actionable.
- Wait for the reorder list instead of a generic page load state.

## Root cause

The test force-clicked Reorder while the page could still be settling after a page-size change. The click could miss the link and leave the test on the View page.

## Validation

- `cd e2e-tests && mvn -DskipTests test-compile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved announcement reordering test reliability by waiting for the reorder interface to be ready before interacting with it.
  * Updated interaction and synchronization steps to better reflect normal user behavior and reduce timing-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->