### PR TITLE
SAK-52819 LTI add logic to disable Add Site Link checkbox for deep linking tools

### DIFF
--- a/lti/lti-impl/src/bundle/ltiservice.properties
+++ b/lti/lti-impl/src/bundle/ltiservice.properties
@@ -140,6 +140,7 @@ error.need.key.secret = This tool will not function without a key and secret.
 error.placement.not.removed = Unable to remove tool placement
 error.transfer.bad.tools=You must have access to the source and destination tools to transfer
 error.tool.not.available = Tool is not available in this site
+error.deeplink.nav.denied = Tools that only support Deep Linking cannot be added to site navigation
 tool.added.by.insert.content = Added deployment while inserting content (admin)
 
 #export fields

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -330,6 +330,25 @@ public abstract class BaseLTIService implements LTIService {
 
 
 	private Object updateTool(Long key, Object newProps, String siteId) {
+		if (newProps instanceof Properties) {
+			Properties props = (Properties) newProps;
+			if (!props.containsKey(LTIService.LTI_MT_LAUNCH)) {
+				props.setProperty(LTIService.LTI_MT_LAUNCH, "0");
+			}
+			if (!props.containsKey(LTIService.LTI_MT_LINKSELECTION)) {
+				props.setProperty(LTIService.LTI_MT_LINKSELECTION, "0");
+			}
+		} else if (newProps instanceof Map) {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> props = (Map<String, Object>) newProps;
+			if (!props.containsKey(LTIService.LTI_MT_LAUNCH)) {
+				props.put(LTIService.LTI_MT_LAUNCH, "0");
+			}
+			if (!props.containsKey(LTIService.LTI_MT_LINKSELECTION)) {
+				props.put(LTIService.LTI_MT_LINKSELECTION, "0");
+			}
+		}
+
 		return updateToolDao(key, newProps, siteId, isAdmin(siteId), isMaintain(siteId));
 	}
 

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -913,6 +913,13 @@ public abstract class BaseLTIService implements LTIService {
 			return retval;
 		}
 
+		Long allowLaunch = LTIUtil.toLongNull(ltiTool.get(LTIService.LTI_MT_LAUNCH));
+		Long allowLinkSelection = LTIUtil.toLongNull(ltiTool.get(LTIService.LTI_MT_LINKSELECTION));
+		if (allowLaunch != null && allowLaunch < 1 && allowLinkSelection != null && allowLinkSelection > 0) {
+			retval = "0" + rb.getString("error.deeplink.nav.denied");
+			return retval;
+		}
+
 		String contentSite = (String) content.get(LTI_SITE_ID);
 		try
 		{

--- a/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/lti/lti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -915,7 +915,7 @@ public abstract class BaseLTIService implements LTIService {
 
 		Long allowLaunch = LTIUtil.toLongNull(ltiTool.get(LTIService.LTI_MT_LAUNCH));
 		Long allowLinkSelection = LTIUtil.toLongNull(ltiTool.get(LTIService.LTI_MT_LINKSELECTION));
-		if (allowLaunch != null && allowLaunch < 1 && allowLinkSelection != null && allowLinkSelection > 0) {
+		if ((allowLaunch == null || allowLaunch < 1) && allowLinkSelection != null && allowLinkSelection > 0) {
 			retval = "0" + rb.getString("error.deeplink.nav.denied");
 			return retval;
 		}

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -1689,6 +1689,13 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			reqProps.remove(LTIService.LTI_SECRET);
 		}
 
+		if (!reqProps.containsKey(LTIService.LTI_MT_LAUNCH)) {
+			reqProps.setProperty(LTIService.LTI_MT_LAUNCH, "0");
+		}
+		if (!reqProps.containsKey(LTIService.LTI_MT_LINKSELECTION)) {
+			reqProps.setProperty(LTIService.LTI_MT_LINKSELECTION, "0");
+		}
+
 		// Retrieve the tool
 		String id = data.getParameters().getString(LTIService.LTI_ID);
 		if (id.isEmpty()) {
@@ -1951,6 +1958,10 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 			context.put("tool_description", tool.get(LTIService.LTI_DESCRIPTION));
 			Long visible = LTIUtil.toLong(tool.get(LTIService.LTI_VISIBLE));
 			context.put("tool_visible", visible);
+
+			Long allowLaunch = LTIUtil.toLong(tool.get(LTIService.LTI_MT_LAUNCH));
+			Long allowLinkSelection = LTIUtil.toLong(tool.get(LTIService.LTI_MT_LINKSELECTION));
+			context.put("disableSiteLink", allowLaunch < 1 && allowLinkSelection > 0);
 		}
 
 		String flow = data.getParameters().getString(FLOW_PARAMETER);

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -1689,13 +1689,6 @@ public class LTIAdminTool extends VelocityPortletPaneledAction {
 			reqProps.remove(LTIService.LTI_SECRET);
 		}
 
-		if (!reqProps.containsKey(LTIService.LTI_MT_LAUNCH)) {
-			reqProps.setProperty(LTIService.LTI_MT_LAUNCH, "0");
-		}
-		if (!reqProps.containsKey(LTIService.LTI_MT_LINKSELECTION)) {
-			reqProps.setProperty(LTIService.LTI_MT_LINKSELECTION, "0");
-		}
-
 		// Retrieve the tool
 		String id = data.getParameters().getString(LTIService.LTI_ID);
 		if (id.isEmpty()) {

--- a/lti/lti-tool/src/webapp/vm/lti_content_insert.vm
+++ b/lti/lti-tool/src/webapp/vm/lti_content_insert.vm
@@ -46,7 +46,7 @@
 #if ( $formInput )
 		$formInput
 <div id="input-add-site-link">
-<input #if($placement) disabled="disabled" checked="checked" #end type="checkbox" name="add_site_link"/> $tlang.getString("bl_addlink")
+<input #if($placement) disabled="disabled" checked="checked" #elseif($disableSiteLink) disabled="disabled" #end type="checkbox" name="add_site_link"/> $tlang.getString("bl_addlink")
 </div>
 #else
 #if ( $oldContentId )


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52819

@csev

**Changes Made**

1. Added logic in buildContentPutPanelContext to check the tool's message types. If a tool supports Deep Linking (allowLinkSelection > 0) but does not support Resource Link (allowLaunch < 1), a disableSiteLink flag is set to true. Updated lti_content_insert.vm to use this flag to disable the checkbox, preventing admins from adding deep link only tools to the site navigation.

2. While testing the new logic, I found that LTI_MT_LAUNCH was returning 1 for LTI 1.1 tools regardless of whether the "The tool URL supports a single LTI tool (Resource Link launch)" checkbox was checked when the tool was configured. This seems to happen because HTML checkboxes do not send a parameter when unchecked, causing the database update to ignore the field. So I added explicit checks in doToolEdit for missing LTI_MT_LAUNCH and LTI_MT_LINKSELECTION parameters, setting them to "0" to ensure the database accurately reflects the admin's selections during tool configuration. This also ensures the new UI logic works correctly for LTI 1.1 tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LTI content configuration when launch or link-selection options are omitted.
  * Disabled site-link selection when launching is unavailable but link selection remains enabled.
  * Prevented Deep Linking-only tools from being added to site navigation.
  * Added a clear error message when site navigation placement is not allowed.
  * Preserved existing behavior for placements where site-link selection is already disabled and selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->