### PR TITLE
SAK-52833 LTI Remove unnecessary check for userSubmission in assignment entity provider

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/entityproviders/AssignmentEntityProvider.java
@@ -1110,7 +1110,6 @@ public class AssignmentEntityProvider extends AbstractEntityProvider implements 
                 String contentItem = StringUtils.trimToEmpty((String) content.get(LTIService.LTI_CONTENTITEM));
 
                 for (Map<String, Object> submission : submissionMaps) {
-                    if (!submission.containsKey("userSubmission")) continue;
                     String ltiSubmissionLaunch = null;
 
                     try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gradable-submissions LTI launches are now generated for submissions without a `userSubmission` field.
  * Existing LTI submission launch values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->