### PR TITLE
SAK-52838 Prevent Lessons from creating /blti/null items

### DIFF
--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -2535,9 +2535,9 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 					failures.add(rb.getString("error.contentitem.content.insert"));
 					continue;
 				}
-				contentKey = (Long) retval;
+				Long insertedContentKey = (Long) retval;
 				String contentUrl = null;
-				Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
+				Map<String, Object> content = ltiService.getContent(insertedContentKey, getSiteId(state));
 				if (content != null) {
 					contentUrl = ltiService.getContentLaunch(content);
 					if (contentUrl != null && contentUrl.startsWith("/")) {
@@ -2545,11 +2545,12 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 					}
 				}
 				if (contentUrl == null) {
-					log.error("Unable to get launch url from contentitem content={}", contentKey);
+					log.error("Unable to get launch url from contentitem content={}", insertedContentKey);
 					log.debug("{}", item);
 					failures.add(rb.getString("error.contentitem.content.launch"));
 					continue;
 				}
+				contentKey = insertedContentKey;
 				item.put("launch", contentUrl);
 
 				JSONObject lineItem = getObject(item, DeepLinkResponse.LINEITEM);
@@ -2633,9 +2634,9 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 					failures.add(rb.getString("error.contentitem.content.insert"));
 					continue;
 				}
-				contentKey = (Long) retval;
+				Long insertedContentKey = (Long) retval;
 				String contentUrl = null;
-				Map<String, Object> content = ltiService.getContent(contentKey, getSiteId(state));
+				Map<String, Object> content = ltiService.getContent(insertedContentKey, getSiteId(state));
 				if (content != null) {
 					contentUrl = ltiService.getContentLaunch(content);
 					if (contentUrl != null && contentUrl.startsWith("/")) {
@@ -2643,11 +2644,12 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 					}
 				}
 				if (contentUrl == null) {
-					log.error("Unable to get launch url from contentitem content={}", contentKey);
+					log.error("Unable to get launch url from contentitem content={}", insertedContentKey);
 					log.debug("{}", item);
 					failures.add(rb.getString("error.contentitem.content.launch"));
 					continue;
 				}
+				contentKey = insertedContentKey;
 				item.put("launch", contentUrl);
 
 				// Extract the lineItem material
@@ -2683,7 +2685,8 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		String forward;
 		if ( flow.equals(FLOW_PARAMETER_LESSONS) ) {
 			if  (contentKey == null ) {
-				log.warn("Deep Link response did not contain a usable LTI resource link for Lessons");
+				log.warn("Deep Link response did not contain a usable LTI resource link for Lessons, toolKey={} siteId={}",
+					toolKey, getSiteId(state));
 				addAlert(state, rb.getString("error.deeplink.no.ltilink"));
 				switchPanel(state, errorPanel);
 				return;

--- a/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
+++ b/lti/lti-tool/src/java/org/sakaiproject/lti/tool/LTIAdminTool.java
@@ -2683,7 +2683,10 @@ public List<LtiToolBean> getAvailableToolsAsBeans(String ourSite, String context
 		String forward;
 		if ( flow.equals(FLOW_PARAMETER_LESSONS) ) {
 			if  (contentKey == null ) {
-				log.warn("Returning content item to Lessons, but contentKey={}", contentKey);
+				log.warn("Deep Link response did not contain a usable LTI resource link for Lessons");
+				addAlert(state, rb.getString("error.deeplink.no.ltilink"));
+				switchPanel(state, errorPanel);
+				return;
 			}
 			if (returnUrl.indexOf("?") > 0) {
 			   returnUrl += "&ltiItemId=/blti/" + contentKey;


### PR DESCRIPTION
## Summary

- stop the Lessons LTI callback when Deep Linking produces no content key
- show the existing missing-resource-link error instead of returning `/blti/null`

## Root cause

The Lessons callback logged a null `contentKey` but continued building the return URL. Lessons then persisted `/blti/null` as an LTI reference, and the missing LTI title could prevent the affected page from rendering.

## Impact

Invalid Deep Linking responses no longer create malformed Lessons items that require database repair.

## Validation

- `git diff --check`
- No automated test added or run for this targeted guard, as requested.

[SAK-52838](https://sakaiproject.atlassian.net/browse/SAK-52838)


[SAK-52838]: https://sakaiproject.atlassian.net/browse/SAK-52838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or unusable content links across content insertion flows.
  * Users now receive a clear error message and are directed to the error panel instead of being redirected with an invalid link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->