### PR TITLE
SAK-52850 Samigo validate Gradebook item before update

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/bundle/AssessmentSettingsMessages.properties
@@ -458,6 +458,7 @@ to_selected_gradebook=Grades sent to MANUALLY created gradebook (Gradebook > Add
 usedGradebookAssessment=associated with ''{0}''
 addtogradebook.previouslyAssoc = You are trying to associate this assessment with an already associated Gradebook item and scores might be overwritten. Do you want to continue?
 gbNotExistsError=The gradebook item that you are trying to associate does not exist anymore.
+gradebook_item_required=Select a Gradebook item.
 
 #S2U-8
 track_questions_title=Track questions

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -588,6 +588,13 @@ implements ActionListener
 		String siteId = assessmentSettings.getCurrentSiteId();
 		String defaultToGradebook = assessmentSettings.getToDefaultGradebook();
 
+		if (EvaluationModelIfc.TO_SELECTED_GRADEBOOK.toString().equals(defaultToGradebook)
+				&& StringUtils.isBlank(assessmentSettings.getGradebookName())) {
+			error = true;
+			String gradebookItemRequired = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "gradebook_item_required");
+			context.addMessage(null, new FacesMessage(gradebookItemRequired));
+		}
+
 		if (defaultToGradebook != null && isGradebookGroupEnabled) {
 			if (defaultToGradebook.equals(EvaluationModelIfc.TO_DEFAULT_GRADEBOOK.toString())) {
 				String categorySelected = assessmentSettings.getCategorySelected();
@@ -607,6 +614,10 @@ implements ActionListener
 				}
 			} else if (defaultToGradebook.equals(EvaluationModelIfc.TO_SELECTED_GRADEBOOK.toString())) {
 				String gradebookName = assessmentSettings.getGradebookName();
+				if (StringUtils.isBlank(gradebookName)) {
+					return error;
+				}
+
 				List<String> gradebookList = Arrays.asList(gradebookName.split(","));
 
 				boolean areItemsInGroups =
@@ -960,37 +971,24 @@ implements ActionListener
 
         if (toGradebook != null &&
                 !toGradebook.equals(EvaluationModelIfc.NOT_TO_GRADEBOOK.toString())) {
-            boolean existingItemHasBeenRemoved = false;
-
 			if (EvaluationModelIfc.TO_SELECTED_GRADEBOOK.toString().equals(toGradebook)) {
+				String gradebookItemString = assessment.getAssessmentToGradebookNameMetaData();
+				List<String> gradebookItemList = Arrays.asList(gradebookItemString.split(","));
+
+				if (gradebookItemList.contains(assessment.getPublishedAssessmentId().toString())) {
+					String gbNotExistsError = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "gbNotExistsError");
+					context.addMessage(null, new FacesMessage(gbNotExistsError));
+					return false;
+				}
+
 				/* SINCE THIS IS CASE 3, THE ITEMS ASSOCIATED WITH THIS EXAM ARE GENERATED IN THE GRADEBOOK
 					SO WE MUST ALWAYS DELETE ANY ITEM THAT IS ASSOCIATED WITH THE PUBLISHED EXAM ID
 					THIS IS BECAUSE ITEMS CAN BE CREATED IN EXAMS, BUT ONLY IF WE ARE IN CASE 2, SO
 					THESE ITEMS FROM CASE 2 WILL BE DELETED */
 				try {
-					// This variable is only true when the assessment has actually been removed!
-					existingItemHasBeenRemoved = gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingServiceApi);
+					gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessment.getPublishedAssessmentId().toString(), gradingServiceApi);
 				} catch (Exception e1) {
 					log.warn("Failed to remove gradebook item for published assessment {}", assessment.getPublishedAssessmentId(), e1);
-				}
-
-				if (existingItemHasBeenRemoved) {
-					String gradebookItemString = assessment.getAssessmentToGradebookNameMetaData();
-					List<String> gradebookItemList = new ArrayList<>();
-
-					if (gradebookItemString != null && !gradebookItemString.isBlank()) {
-						gradebookItemList = Arrays.asList(gradebookItemString.split(","));
-					} else {
-						String gbNotExistsError = "No se pueden crear exámenes sin ningún item asociado";
-						context.addMessage(null, new FacesMessage(gbNotExistsError));
-						return false;
-					}
-
-					if (gradebookItemList.contains(assessment.getPublishedAssessmentId().toString())) {
-						String gbNotExistsError = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "gbNotExistsError");
-						context.addMessage(null, new FacesMessage(gbNotExistsError));
-						return false;
-					}
 				}
 
 				gbsHelper.manageScoresToNewGradebook(new GradingService(), gradingServiceApi, assessment, evaluation);

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/SavePublishedSettingsListener.java
@@ -160,7 +160,7 @@ implements ActionListener
 		for (SelectItem item : existingGradebook) {
 			if (!item.getLabel().contains(assessmentSettings.getTitle()) &&
 				item.getLabel().split("\\(").length > 1 &&
-				assessmentSettings.getGradebookName().equals(item.getValue()) &&
+				Objects.equals(assessmentSettings.getGradebookName(), item.getValue()) &&
 				currentToolSession.getAttribute("NEW_ASSESSMENT_PREVIOUSLY_ASSOCIATED") == null) {
 					error = true;
 					String err = ContextUtil.getLocalizedString("org.sakaiproject.tool.assessment.bundle.AssessmentSettingsMessages", "addtogradebook.previouslyAssoc");


### PR DESCRIPTION
## Summary

- validate that a manually managed Gradebook item is selected before applying published assessment settings
- reject an invalid association before removing the assessment-owned Gradebook item
- replace the hard-coded Spanish error with a localized message

## Jira

[SAK-52850](https://sakaiproject.atlassian.net/browse/SAK-52850)

## Verification

- `mvn -pl samigo/samigo-app -am -DskipTests compile`
- `git diff --check`

No automated test was added because this regression depends on an integrated Samigo and Gradebook JSF workflow. The Jira issue contains the manual QA test plan.

[SAK-52850]: https://sakaiproject.atlassian.net/browse/SAK-52850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published assessments now require a Gradebook item when selected-gradebook mode is enabled.
  * Clear, localized validation messaging appears when no Gradebook item is selected.
  * Gradebook association checks now handle missing selections without errors.
  * Improved Gradebook synchronization prevents duplicate or stale assessment entries.
  * Validation errors are handled immediately, preventing additional checks from producing misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->