### PR TITLE
NOJIRA Update README documentation references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+The canonical reference is @AGENTS.md.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The other branches are currently or previously supported releases. See below for
 
 ## Building
 
-[![Build Status](https://travis-ci.org/sakaiproject/sakai.svg?branch=master)](https://travis-ci.org/sakaiproject/sakai)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c68908d6bc044e95b453bae7ddcbad4a)](https://www.codacy.com/app/sakaiproject/sakai?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sakaiproject/sakai&amp;utm_campaign=Badge_Grade)
 
 This is the "Mini Quick Start" for more complete steps to get Sakai configured please look at [this guide on the wiki](https://github.com/sakaiproject/sakai/wiki/Quick-Start-from-Source).
@@ -139,5 +138,4 @@ Other languages have been declared legacy in Sakai 19 and have been moved to [Sa
 
 ## Community (contrib) tools
 A number of institutions have written additional tools for Sakai that they use in their local installations, but are not yet in an official release of Sakai. These are being collected at https://github.com/sakaicontrib where you will find information about each one. You might find just the thing you are after!
-
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For full history of supported releases please see our [release information on co
 - *Sakai 23.6* is the current development release of Sakai 23. It is expected to release Q4 2026.
 
 ## Accessibility
-[The Sakai Accessibility Working Group](https://confluence.sakaiproject.org/display/2ACC/Accessibility+Working+Group) is responsible for ensuring that the Sakai framework and its tools are accessible to persons with disabilities. [The Sakai Ra11y plan](https://confluence.sakaiproject.org/display/2ACC/rA11y+Plan) is working towards a VPAT and/or a WCAG2 certification.
+[The Sakai Accessibility Working Group](https://confluence.sakaiproject.org/display/2ACC/Accessibility+Working+Group) is responsible for ensuring that the Sakai framework and its tools are accessible to persons with disabilities. Sakai's [Voluntary Product Accessibility Template (VPAT) reports](https://www.sakailms.org/accessibility/vpat) document its accessibility conformance.
 
 CKSource has created a GPL licensed open source version of their [Accessibility Checker](https://cksource.com/ckeditor/services#accessibility-checker) that lets you inspect the accessibility level of content created in CKEditor and immediately solve any accessibility issues that are found. CKEditor is the open source rich text editor used throughout Sakai. While the Accessibility Checker, due to the GPL license, can not be bundled with Sakai, it can be used with Sakai and the A11y group has created [instructions](https://confluence.sakaiproject.org/display/2ACC/CKEditor+Accessibility+Checker) to help you.
 
@@ -138,4 +138,5 @@ Other languages have been declared legacy in Sakai 19 and have been moved to [Sa
 
 ## Community (contrib) tools
 A number of institutions have written additional tools for Sakai that they use in their local installations, but are not yet in an official release of Sakai. These are being collected at https://github.com/sakaicontrib where you will find information about each one. You might find just the thing you are after!
+
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ The other branches are currently or previously supported releases. See below for
 
 ## Building
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/c68908d6bc044e95b453bae7ddcbad4a)](https://www.codacy.com/app/sakaiproject/sakai?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sakaiproject/sakai&amp;utm_campaign=Badge_Grade)
-
 This is the "Mini Quick Start" for more complete steps to get Sakai configured please look at [this guide on the wiki](https://github.com/sakaiproject/sakai/wiki/Quick-Start-from-Source).
 
 To build Sakai you need Java 1.8. Once you have, clone a copy of this repository you can


### PR DESCRIPTION
## Summary
- remove obsolete Travis CI and Codacy badges from README.md
- replace outdated VPAT-in-progress wording with a link to the existing Sakai VPAT reports
- add CLAUDE.md pointing to the canonical AGENTS.md guidance

## Testing
- not run (documentation-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a canonical reference for contributor guidance.
  * Removed outdated build and code-quality badges from the README.
  * Updated accessibility information to link directly to Sakai’s VPAT reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->