### PR TITLE
SAK-52853 Portal fix narrow site navigation scrolling

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/PortalNavigationTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/PortalNavigationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+class PortalNavigationTest extends SakaiUiTestBase {
+
+    @BeforeEach
+    void loginAndOpenPortalInNarrowView() {
+        sakai.login("instructor1");
+        page.setViewportSize(767, 600);
+        page.navigate("/portal");
+    }
+
+    @Test
+    void mobileSiteNavigationScrollsWithMouseWheel() {
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
+            .setName(Pattern.compile("site navigation", Pattern.CASE_INSENSITIVE))).click();
+
+        Locator sidebar = page.locator("#portal-nav-sidebar");
+        Locator navigation = sidebar.locator("#toolMenu");
+        assertThat(sidebar).isVisible();
+
+        Boolean navigationFitsAboveFooter = (Boolean) sidebar.evaluate("sidebar => {"
+            + "const navigation = sidebar.querySelector('#toolMenu');"
+            + "const footer = sidebar.querySelector('.sticky-footer');"
+            + "return navigation.getBoundingClientRect().bottom <= footer.getBoundingClientRect().top;"
+            + "}");
+        assertTrue(navigationFitsAboveFooter);
+
+        Boolean navigationOverflows = (Boolean) navigation.evaluate(
+            "navigation => navigation.scrollHeight > navigation.clientHeight");
+        assertTrue(navigationOverflows);
+
+        navigation.hover();
+        page.mouse().wheel(0, 1000);
+
+        Number scrollTop = (Number) navigation.evaluate("navigation => navigation.scrollTop");
+        assertTrue(scrollTop.doubleValue() > 0);
+    }
+}

--- a/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
+++ b/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
@@ -539,6 +539,7 @@
   }
 
   .sakai-sitesAndToolsNav {
+    height: 100%;
     padding-bottom: 96px;
     overflow-y: scroll;
     position: sticky;
@@ -649,10 +650,19 @@
   }
 
   #portal-nav-sidebar .sakai-sitesAndToolsNav {
+    // keep the scroll container between the offcanvas header and footer
+    flex: 1 1 auto;
+    height: auto;
+    min-height: 0;
+    overflow-y: auto;
     padding-right: calc(var(--bs-offcanvas-padding-x) - 1rem);
     padding-left: calc(var(--bs-offcanvas-padding-x) - 1rem);
     padding-top: calc(var(--bs-offcanvas-padding-y) - 1rem);
     padding-bottom: calc(var(--bs-offcanvas-padding-y) - 1rem);
+  }
+
+  #portal-nav-sidebar .sticky-footer {
+    flex: 0 0 auto;
   }
 }
 

--- a/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
+++ b/library/src/skins/default/src/sass/modules/tool/portal/_portal.scss
@@ -649,6 +649,11 @@
     margin: 0px;
   }
 
+  #portal-nav-sidebar {
+    display: flex;
+    flex-direction: column;
+  }
+
   #portal-nav-sidebar .sakai-sitesAndToolsNav {
     // keep the scroll container between the offcanvas header and footer
     flex: 1 1 auto;

--- a/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
+++ b/portal/portal-render-engine-impl/impl/src/webapp/vm/morpheus/includeSiteNav.vm
@@ -143,7 +143,7 @@
         <h2 class="offcanvas-title">${rloader.sitenav_title}</h2>
         <button type="button" class="btn-close text-reset ms-auto" data-bs-dismiss="offcanvas" aria-label="Close the sites sidebar"></button>
     </div>
-    <nav id="toolMenu" role="navigation" aria-label="${rloader.sit_toolshead}" class="Mrphs-toolsNav__menu sakai-sitesAndToolsNav h-100 d-flex flex-column">
+    <nav id="toolMenu" role="navigation" aria-label="${rloader.sit_toolshead}" class="Mrphs-toolsNav__menu sakai-sitesAndToolsNav d-flex flex-column">
         <h2 class="visually-hidden d-none d-md-block" id="totoolmenu">${rloader.sitenav_title}</h2>
         #if (${userIsLoggedIn})
             <div id="sites-section-first" class="sites-section">


### PR DESCRIPTION
[Jira: SAK-52853](https://sakaiproject.atlassian.net/browse/SAK-52853)

## Summary

- size the narrow-view site navigation as the flex area between the offcanvas header and footer
- keep the course tool list independently scrollable with mouse, trackpad, and scrollbar input
- preserve the existing full-height desktop sidebar behavior
- add Playwright coverage for the responsive breakpoint and mouse-wheel scrolling

## Testing

- `npm run css-compile`
- `mvn -f e2e-tests/pom.xml -Dtest=PortalNavigationTest test`
- `PLAYWRIGHT_BROWSER=firefox mvn -f e2e-tests/pom.xml -Dtest=PortalNavigationTest test`
- `PLAYWRIGHT_BROWSER=webkit mvn -f e2e-tests/pom.xml -Dtest=PortalNavigationTest test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile portal navigation so the sidebar uses available space and scrolls independently.
  - Kept the navigation footer fixed while allowing the menu content to scroll.
  - Adjusted navigation height behavior for a more reliable mobile layout.

- **Tests**
  - Added end-to-end coverage for mobile navigation visibility, scrolling, and changing scroll position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->