### PR TITLE
SAK-52854 Messages make private-message FAQ publishing configurable

### DIFF
--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3942,6 +3942,11 @@
 # msgcntr.forums.showProfileInfo=true
 # msgcntr.messages.showProfileInfo=true
 
+# Enable publishing private messages to an automatically managed FAQ forum in Discussions.
+# Disabling this feature does not delete existing FAQ content.
+# DEFAULT: false
+# msgcntr.messages.publishToFaq.enabled=true
+
 # When creating topics in forums, this setting can default the permission section as collapsed to save screen space.
 # DEFAULT: false
 # mc.collapsePermissionPanel=true 

--- a/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/config/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -3944,8 +3944,8 @@
 
 # Enable publishing private messages to an automatically managed FAQ forum in Discussions.
 # Disabling this feature does not delete existing FAQ content.
-# DEFAULT: false
-# msgcntr.messages.publishToFaq.enabled=true
+# DEFAULT: true
+# msgcntr.messages.publishToFaq.enabled=false
 
 # When creating topics in forums, this setting can default the permission section as collapsed to save screen space.
 # DEFAULT: false

--- a/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsForumManager.java
+++ b/msgcntr/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsForumManager.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 
 public interface MessageForumsForumManager {
+
+    String PUBLISH_TO_FAQ_ENABLED_PROPERTY = "msgcntr.messages.publishToFaq.enabled";
  
 	public List getReceivedUuidByContextId(final List siteList);
 	
@@ -74,6 +76,11 @@ public interface MessageForumsForumManager {
      */
     public BaseForum getForumById(boolean open, Long forumId);
     public BaseForum getForumByUuid(String forumId);
+
+    /**
+     * Determine whether private messages can be published to an FAQ forum.
+     */
+    public boolean isPublishToFaqEnabled();
 
     /**
      * Retrieve FAQ Forum from a given area

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/MessageForumPublishToFaqBean.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/MessageForumPublishToFaqBean.java
@@ -115,6 +115,11 @@ public class MessageForumPublishToFaqBean extends SpringBeanAutowiringSupport im
         Objects.requireNonNull(siteService);
         Objects.requireNonNull(userDirectoryService);
 
+        if (!forumManager.isPublishToFaqEnabled()) {
+            canPost = canReply = Boolean.FALSE;
+            return;
+        }
+
         siteId = toolManager.getCurrentPlacement().getContext();
         userId = userDirectoryService.getCurrentUser().getId();
         discussionArea = areaManager.getDiscussionArea(siteId);
@@ -150,15 +155,20 @@ public class MessageForumPublishToFaqBean extends SpringBeanAutowiringSupport im
     }
 
     public void publishToFaq() {
-        DiscussionForum faqForum = forumManager.getOrCreateFaqForumForArea(discussionArea);
-        DiscussionTopic faqTopic = forumManager.getOrCreateFaqTopicForForum(faqForum);
-
-        log.debug("Creating question message for Forum [{}] and Topic [{}]", faqForum, faqTopic);
+        if (!forumManager.isPublishToFaqEnabled()) {
+            log.warn("Attempted to publish a private message to FAQ while the feature is disabled");
+            return;
+        }
 
         if (!Boolean.TRUE.equals(canPost)) {
             log.warn("User with id [{}] does not have permissions to create a new forum post", userId);
             return;
         }
+
+        DiscussionForum faqForum = forumManager.getOrCreateFaqForumForArea(discussionArea);
+        DiscussionTopic faqTopic = forumManager.getOrCreateFaqTopicForForum(faqForum);
+
+        log.debug("Creating question message for Forum [{}] and Topic [{}]", faqForum, faqTopic);
 
         String questionTitlePrefix = resourceBundle.getString("pvt_question_title_prefix");
         String answerTitlePrefix = resourceBundle.getString("pvt_answer_title_prefix");

--- a/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
+++ b/msgcntr/messageforums-app/src/java/org/sakaiproject/tool/messageforums/PrivateMessagesTool.java
@@ -4015,6 +4015,11 @@ public void processChangeSelectView(ValueChangeEvent eve)
   
   public String processPvtMsgPublishToFaq() {
     log.debug("processPvtMsgPublishToFaq()");
+    if (!forumManager.isPublishToFaqEnabled()) {
+      log.warn("Attempted to publish a private message to FAQ while the feature is disabled");
+      return SELECTED_MESSAGE_PG;
+    }
+
     MessageForumPublishToFaqBean publishToFaqBean =
         (MessageForumPublishToFaqBean) lookupBean(MessageForumPublishToFaqBean.NAME);
 
@@ -4036,6 +4041,11 @@ public void processChangeSelectView(ValueChangeEvent eve)
   public String processPvtMsgPublishToFaqEdit() {
     log.debug("processPvtMsgPublishToFaqEdit()");
     multiDeleteSuccess = false;
+
+    if (!forumManager.isPublishToFaqEnabled()) {
+      log.warn("Attempted to open private message FAQ publishing while the feature is disabled");
+      return SELECTED_MESSAGE_PG;
+    }
 
     MessageForumPublishToFaqBean publishToFaqBean =
         (MessageForumPublishToFaqBean) lookupBean(MessageForumPublishToFaqBean.NAME);
@@ -4627,6 +4637,10 @@ public void processChangeSelectView(ValueChangeEvent eve)
     }
 
     public boolean isDetailMessagePublishableToFaq() {
+        if (!forumManager.isPublishToFaqEnabled()) {
+          return false;
+        }
+
         String siteId = getSiteId();
 
         if (!StringUtils.equalsAny(getMsgNavMode(),

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
@@ -701,7 +701,7 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
     }
 
     public boolean isPublishToFaqEnabled() {
-        return serverConfigurationService.getBoolean(PUBLISH_TO_FAQ_ENABLED_PROPERTY, false);
+        return serverConfigurationService.getBoolean(PUBLISH_TO_FAQ_ENABLED_PROPERTY, true);
     }
 
     public DiscussionForum getFaqForumForArea(Area area) {

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
@@ -709,8 +709,7 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
             return query.list().stream().findAny().orElse(null);
         };
 
-        DiscussionForum existingFaqForum = getHibernateTemplate().execute(hibernateCallback);
-        return existingFaqForum != null ? existingFaqForum : createFaqForum(area);
+        return getHibernateTemplate().execute(hibernateCallback);
     }
 
     public DiscussionTopic getFaqTopicForForum(DiscussionForum faqForum) {

--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImpl.java
@@ -700,6 +700,10 @@ public class MessageForumsForumManagerImpl extends HibernateDaoSupport implement
         return forum;
     }
 
+    public boolean isPublishToFaqEnabled() {
+        return serverConfigurationService.getBoolean(PUBLISH_TO_FAQ_ENABLED_PROPERTY, false);
+    }
+
     public DiscussionForum getFaqForumForArea(Area area) {
         HibernateCallback<DiscussionForum> hibernateCallback = (session) -> {
             Query<DiscussionForum> query = session.getNamedQuery(QUERY_FAQ_FORUMS);

--- a/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImplTest.java
+++ b/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImplTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.component.app.messageforums;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sakaiproject.api.app.messageforums.Area;
+import org.sakaiproject.api.app.messageforums.MessageForumsForumManager;
+import org.sakaiproject.component.app.messageforums.dao.hibernate.AreaImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {MsgcntrTestConfiguration.class})
+public class MessageForumsForumManagerImplTest extends AbstractTransactionalJUnit4SpringContextTests {
+
+    @Autowired
+    @Qualifier("org.sakaiproject.api.app.messageforums.MessageForumsForumManager")
+    private MessageForumsForumManager forumManager;
+
+    @Test
+    public void getFaqForumForAreaReturnsNullWhenNoFaqForumExists() {
+        Area area = new AreaImpl();
+        area.setTypeUuid("discussionForum");
+        area.setContextId("site-without-faq-forum");
+
+        Assert.assertNull(forumManager.getFaqForumForArea(area));
+    }
+}

--- a/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImplTest.java
+++ b/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImplTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.AbstractTransactionalJUnit4Spring
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -50,16 +51,21 @@ public class MessageForumsForumManagerImplTest extends AbstractTransactionalJUni
     }
 
     @Test
-    public void publishToFaqIsDisabledByDefault() {
-        Assert.assertFalse(forumManager.isPublishToFaqEnabled());
-    }
-
-    @Test
-    public void publishToFaqCanBeEnabled() {
-        when(serverConfigurationService.getBoolean(MessageForumsForumManager.PUBLISH_TO_FAQ_ENABLED_PROPERTY, false))
+    public void publishToFaqIsEnabledByDefault() {
+        when(serverConfigurationService.getBoolean(MessageForumsForumManager.PUBLISH_TO_FAQ_ENABLED_PROPERTY, true))
                 .thenReturn(true);
 
         Assert.assertTrue(forumManager.isPublishToFaqEnabled());
+        verify(serverConfigurationService)
+                .getBoolean(MessageForumsForumManager.PUBLISH_TO_FAQ_ENABLED_PROPERTY, true);
+    }
+
+    @Test
+    public void publishToFaqCanBeDisabled() {
+        when(serverConfigurationService.getBoolean(MessageForumsForumManager.PUBLISH_TO_FAQ_ENABLED_PROPERTY, true))
+                .thenReturn(false);
+
+        Assert.assertFalse(forumManager.isPublishToFaqEnabled());
     }
 
     @Test

--- a/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImplTest.java
+++ b/msgcntr/messageforums-component-impl/src/test/java/org/sakaiproject/component/app/messageforums/MessageForumsForumManagerImplTest.java
@@ -16,16 +16,21 @@
 package org.sakaiproject.component.app.messageforums;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sakaiproject.api.app.messageforums.Area;
 import org.sakaiproject.api.app.messageforums.MessageForumsForumManager;
+import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.component.app.messageforums.dao.hibernate.AreaImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {MsgcntrTestConfiguration.class})
@@ -34,6 +39,28 @@ public class MessageForumsForumManagerImplTest extends AbstractTransactionalJUni
     @Autowired
     @Qualifier("org.sakaiproject.api.app.messageforums.MessageForumsForumManager")
     private MessageForumsForumManager forumManager;
+
+    @Autowired
+    @Qualifier("org.sakaiproject.component.api.ServerConfigurationService")
+    private ServerConfigurationService serverConfigurationService;
+
+    @Before
+    public void resetServerConfigurationService() {
+        reset(serverConfigurationService);
+    }
+
+    @Test
+    public void publishToFaqIsDisabledByDefault() {
+        Assert.assertFalse(forumManager.isPublishToFaqEnabled());
+    }
+
+    @Test
+    public void publishToFaqCanBeEnabled() {
+        when(serverConfigurationService.getBoolean(MessageForumsForumManager.PUBLISH_TO_FAQ_ENABLED_PROPERTY, false))
+                .thenReturn(true);
+
+        Assert.assertTrue(forumManager.isPublishToFaqEnabled());
+    }
 
     @Test
     public void getFaqForumForAreaReturnsNullWhenNoFaqForumExists() {


### PR DESCRIPTION
Jira: https://sakaiproject.atlassian.net/browse/SAK-52854

### Summary

- Add `msgcntr.messages.publishToFaq.enabled` as a configuration property. It defaults to `true` for backward compatibility; institutions can set it to `false` to opt out.
- Hide and reject the private-message **Post to FAQ Forum** workflow while the feature is disabled.
- Keep `getFaqForumForArea()` lookup-only so viewing a private message cannot create or recreate a deleted forum.
- When the feature is enabled, preserve the intended behavior: an authorized, explicit publish action creates the FAQ forum and topic when they do not exist.
- Check permissions before creating any FAQ records.

Disabling the feature does not delete existing FAQ content.

### Testing

`mvn -pl msgcntr/messageforums-app,msgcntr/messageforums-component-impl -am -Dtest=MessageForumsForumManagerImplTest -Dsurefire.failIfNoSpecifiedTests=false test`

Reactor build successful across 64 modules; 3 focused tests passed.
