### PR TITLE
SAK-52855 Samigo remove stale Gradebook items during replace

### DIFF
--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemoveAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemoveAssessmentListener.java
@@ -47,7 +47,6 @@ import org.sakaiproject.samigo.util.SamigoConstants;
 import org.sakaiproject.site.api.Group;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
-import org.sakaiproject.spring.SpringBeanLocator;
 import org.sakaiproject.tasks.api.Task;
 import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.tool.api.ToolManager;
@@ -55,11 +54,9 @@ import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
 import org.sakaiproject.tool.assessment.facade.AssessmentFacade;
-import org.sakaiproject.tool.assessment.facade.GradebookFacade;
 import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
 import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.CalendarServiceHelper;
-import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceHelper;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentEntityProducer;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentService;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
@@ -76,8 +73,6 @@ import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 @Slf4j
 public class RemoveAssessmentListener implements ActionListener
 {
-    private static final GradebookServiceHelper gbsHelper = IntegrationContextFactory.getInstance().getGradebookServiceHelper();
-    private static final boolean integrated = IntegrationContextFactory.getInstance().isIntegrated();
     private CalendarServiceHelper calendarService = IntegrationContextFactory.getInstance().getCalendarServiceHelper();
     private SamigoAvailableNotificationService samigoAvailableNotificationService = ComponentManager.get(SamigoAvailableNotificationService.class);
     private SiteService siteService = ComponentManager.get(SiteService.class);
@@ -185,9 +180,8 @@ public class RemoveAssessmentListener implements ActionListener
                 log.debug("assessmentId = {}", assessmentId);
 
                 try {
-                    publishedAssessmentService.removeAssessment(assessmentId, "remove");
+                    publishedAssessmentService.removeAssessmentAndExternalGradebookItem(assessmentId, siteId);
                     removedPublishedAssessmentIds.add(assessmentId);
-                    removeFromGradebook(assessmentId);
                 } catch (Exception e) {
                     log.error("Failed to remove published assessment {}", assessmentId, e);
                     continue;
@@ -273,22 +267,6 @@ public class RemoveAssessmentListener implements ActionListener
         }
 
         return true;
-    }
-
-    private void removeFromGradebook(String assessmentId) {
-        org.sakaiproject.grading.api.GradingService g = null;
-        if (integrated)
-        {
-            g = (org.sakaiproject.grading.api.GradingService) SpringBeanLocator.getInstance().
-            getBean("org.sakaiproject.grading.api.GradingService");
-        }
-        try {
-            if (!gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessmentId, g)) {
-                log.debug("Published assessment {} was not linked to the gradebook, nothing to remove", assessmentId);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to remove gradebook item for published assessment {}", assessmentId, e);
-        }
     }
 
     private void collectGroupLockRemovals(String assessmentId, Set<String> selectedGroupIds, Map<String, Set<String>> assessmentIdsByGroupId) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemovePublishedAssessmentListener.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/listener/author/RemovePublishedAssessmentListener.java
@@ -36,16 +36,13 @@ import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.event.cover.EventTrackingService;
 import org.sakaiproject.samigo.api.SamigoAvailableNotificationService;
 import org.sakaiproject.samigo.util.SamigoConstants;
-import org.sakaiproject.spring.SpringBeanLocator;
 import org.sakaiproject.tasks.api.Task;
 import org.sakaiproject.tasks.api.TaskService;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentMetaDataIfc;
 import org.sakaiproject.tool.assessment.facade.AgentFacade;
-import org.sakaiproject.tool.assessment.facade.GradebookFacade;
 import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacade;
 import org.sakaiproject.tool.assessment.integration.context.IntegrationContextFactory;
 import org.sakaiproject.tool.assessment.integration.helper.ifc.CalendarServiceHelper;
-import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceHelper;
 import org.sakaiproject.tool.assessment.services.assessment.AssessmentEntityProducer;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.tool.assessment.ui.bean.author.AuthorBean;
@@ -62,8 +59,6 @@ import org.sakaiproject.tool.assessment.ui.listener.util.ContextUtil;
 public class RemovePublishedAssessmentListener
     implements ActionListener
 {
-  private static final GradebookServiceHelper gbsHelper = IntegrationContextFactory.getInstance().getGradebookServiceHelper();
-  private static final boolean integrated = IntegrationContextFactory.getInstance().isIntegrated();
   private CalendarServiceHelper calendarService = IntegrationContextFactory.getInstance().getCalendarServiceHelper();
   private TaskService taskService;
   private SamigoAvailableNotificationService samigoAvailableNotificationService;
@@ -93,8 +88,7 @@ public class RemovePublishedAssessmentListener
         throw new IllegalArgumentException("User does not have permission to delete assessmentId " + assessmentId);
       }
 
-      assessmentService.removeAssessment(assessmentId, "remove");
-      removeFromGradebook(assessmentId);
+      assessmentService.removeAssessmentAndExternalGradebookItem(assessmentId, AgentFacade.getCurrentSiteId());
       
       String calendarDueDateEventId = assessment.getAssessmentMetaDataByLabel(AssessmentMetaDataIfc.CALENDAR_DUE_DATE_EVENT_ID);
       if(calendarDueDateEventId != null){
@@ -150,19 +144,4 @@ public class RemovePublishedAssessmentListener
     }
   }
   
-  private void removeFromGradebook(String assessmentId) {
-	  org.sakaiproject.grading.api.GradingService g = null;
-	  if (integrated)
-	  {
-		  g = (org.sakaiproject.grading.api.GradingService) SpringBeanLocator.getInstance().
-		  getBean("org.sakaiproject.grading.api.GradingService");
-	  }
-	  try {
-		  if (!gbsHelper.removeExternalAssessment(GradebookFacade.getGradebookUId(), assessmentId, g)) {
-			  log.debug("Published assessment {} was not linked to the gradebook, nothing to remove", assessmentId);
-		  }
-	  } catch (Exception e) {
-		  log.warn("Failed to remove gradebook item for published assessment {}", assessmentId, e);
-	  }
-  }
 }

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/AssessmentEntityProducer.java
@@ -448,7 +448,8 @@ public class AssessmentEntityProducer implements EntityTransferrer, EntityProduc
                 log.debug("found {} published assessments in site: {}", publishedAssessmentList.size(), toContext);
                 for (PublishedAssessmentData publishedAssessment : publishedAssessmentList) {
                     log.debug("removing published assessment id = {}", publishedAssessment.getPublishedAssessmentId());
-                    publishedAssessmentService.removeAssessment(publishedAssessment.getPublishedAssessmentId().toString(), "remove");
+                    publishedAssessmentService.removeAssessmentAndExternalGradebookItem(
+                            publishedAssessment.getPublishedAssessmentId().toString(), toContext);
                 }
 			}
 		} catch (Exception e) {

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/assessment/PublishedAssessmentService.java
@@ -264,6 +264,38 @@ public class PublishedAssessmentService extends AssessmentService{
 	    PersistenceService.getInstance().getPublishedAssessmentFacadeQueries().
 	        removeAssessment(new Long(assessmentId), action);
   }
+
+  /**
+   * Move a published assessment to Trash and remove its externally maintained Gradebook item.
+   * Gradebook cleanup is best effort so an unavailable Gradebook does not prevent the assessment
+   * from being removed.
+   *
+   * @param assessmentId the published assessment id
+   * @param gradebookUid the root Gradebook uid for the assessment's site
+   */
+  public void removeAssessmentAndExternalGradebookItem(String assessmentId, String gradebookUid) {
+    removeAssessment(assessmentId, "remove");
+
+    try {
+      IntegrationContextFactory integrationContext = IntegrationContextFactory.getInstance();
+      if (integrationContext == null || !integrationContext.isIntegrated()) {
+        return;
+      }
+
+      org.sakaiproject.grading.api.GradingService gradingService
+          = (org.sakaiproject.grading.api.GradingService) SpringBeanLocator.getInstance().getBean(
+              "org.sakaiproject.grading.api.GradingService");
+      GradebookServiceHelper gradebookServiceHelper = integrationContext.getGradebookServiceHelper();
+
+      if (!gradebookServiceHelper.removeExternalAssessment(gradebookUid, assessmentId, gradingService)) {
+        log.debug("Published assessment {} was not linked to gradebook {}, nothing to remove",
+            assessmentId, gradebookUid);
+      }
+    } catch (Exception e) {
+      log.warn("Failed to remove gradebook item for published assessment {} from gradebook {}",
+          assessmentId, gradebookUid, e);
+    }
+  }
   
   public List<PublishedAssessmentFacade> getBasicInfoOfAllActivePublishedAssessments(String orderBy,boolean ascending) {
     String siteAgentId = AgentFacade.getCurrentSiteId();


### PR DESCRIPTION
[SAK-52855](https://sakaiproject.atlassian.net/browse/SAK-52855)

## Problem

Site Info's **Replace My Data** cleanup moved existing published Samigo assessments to Trash without removing their externally maintained Gradebook items. Those stale items could then block replacement assessments from creating same-titled Gradebook items.

## Solution

Add a service-level published-assessment removal operation that:

- moves the assessment to Trash;
- removes its external Gradebook item using the root site Gradebook UID;
- reuses the existing root/group-aware Samigo Gradebook helper; and
- treats Gradebook cleanup as best effort, preserving the existing deletion behavior if Gradebook is unavailable.

The replace-import entity producer and both normal published-assessment deletion listeners now use the same operation.

## Verification

- mvn -pl samigo/samigo-services,samigo/samigo-app test — 137 tests passed.
- mvn -pl samigo/samigo-services,samigo/samigo-app -am -DskipTests install — 62-module reactor succeeded.
- The Jira contains a numbered manual QA Test Plan covering stale-item cleanup, preservation of manual Gradebook items, same-title replacement publishing, and score delivery.


[SAK-52855]: https://sakaiproject.atlassian.net/browse/SAK-52855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved published assessment deletion by removing associated external Gradebook items in the same operation.
  * Assessment removal now completes even when Gradebook integration is unavailable or cleanup encounters an error.
  * Updated site-transfer cleanup to use the improved deletion process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->