### PR TITLE
SAK-49369 Assignments-Peer Reviews-Rubrics Students are able to see how peers have graded them when they grade a peer review

### DIFF
--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_instructor_list_submissions.vm
@@ -587,7 +587,8 @@ function printView(url) {
 												evaluated-item-id="$!item.getId().getAssessorUserId()"
 												entity-id="$assignment.Id"
 												evaluated-item-owner-id="$!submitterId"
-												instructor="true">
+												instructor="true"
+												is-peer-or-self>
 											</sakai-rubric-student-button>
 											#end
 											#if($!item.getScoreDisplay().length() > 0 || ($!item.getComment() && $!item.getComment().trim().length() > 0))

--- a/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
+++ b/assignment/tool/src/webapp/vm/assignment/chef_assignments_student_view_grade.vm
@@ -301,7 +301,6 @@
         site-id="$assignment.context"
         tool-id="sakai.assignment.grades"
         entity-id="$assignment.Id"
-        instructor="true"
         is-peer-or-self="true"
         #if($!assignment.IsGroup)
             evaluated-item-id="$submission.GroupId"

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/sakai-rubrics-utils.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/sakai-rubrics-utils.js
@@ -48,7 +48,7 @@ window.top.rubrics.utils = window.top.rubrics.utils || {
     el.removeAttribute("evaluated-item-id");
     el.removeAttribute("instructor");
     el.removeAttribute("evaluated-item-owner-id");
-    el.removeAttribute("peer-or-self");
+    el.removeAttribute("is-peer-or-self");
   },
 
   showRubric(id, attributes, launchingElement) {
@@ -65,7 +65,7 @@ window.top.rubrics.utils = window.top.rubrics.utils || {
       el.removeAttribute("evaluated-item-id");
       el.removeAttribute("instructor");
       el.removeAttribute("evaluated-item-owner-id");
-      el.removeAttribute("peer-or-self");
+      el.removeAttribute("is-peer-or-self");
     } else {
       el.removeAttribute("rubric-id");
       if (attributes["force-preview"]) {
@@ -75,12 +75,12 @@ window.top.rubrics.utils = window.top.rubrics.utils || {
         // If a dropdown menu of views can be selected, initialize the view with the Grading Rubric
         el.displayGradingTab();
       }
+      el.toggleAttribute("instructor", attributes.instructor === true);
+      el.toggleAttribute("is-peer-or-self", attributes["is-peer-or-self"] === true);
+      el.setAttribute("evaluated-item-owner-id", attributes["evaluated-item-owner-id"]);
       el.setAttribute("tool-id", attributes["tool-id"]);
       el.setAttribute("entity-id", attributes["entity-id"]);
       el.setAttribute("evaluated-item-id", attributes["evaluated-item-id"]);
-      el.toggleAttribute("instructor", attributes.instructor === true);
-      el.setAttribute("evaluated-item-owner-id", attributes["evaluated-item-owner-id"]);
-      el.setAttribute("peer-or-self", attributes["peer-or-self"]);
     }
 
     bootstrap.Modal.getOrCreateInstance(this.lightbox).show();

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricGrading.js
@@ -111,6 +111,7 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
           ` : nothing }
         </h3>
 
+        ${!this.isPeerOrSelf ? html`
         <select @change=${this._viewSelected}
             aria-label="${this._i18n.rubric_view_selection_title}"
             title="${this._i18n.rubric_view_selection_title}" .value=${this._currentView}>
@@ -118,6 +119,7 @@ export class SakaiRubricGrading extends rubricsApiMixin(RubricsElement) {
           <option value="${STUDENT_SUMMARY}">${this._i18n.student_summary}</option>
           <option value="${CRITERIA_SUMMARY}">${this._i18n.criteria_summary}</option>
         </select>
+        ` : nothing}
 
         <div id="rubric-grading-or-preview-${this.instanceSalt}" class="rubric-tab-content rubrics-visible mt-1">
           ${this._evaluation && this._evaluation.status === "DRAFT" && !this.isPeerOrSelf ? html`

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
@@ -111,7 +111,7 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
           </h3>
         ` : nothing }
 
-        ${this.instructor ? html`
+        ${this.instructor && !this.isPeerOrSelf ? html`
           <select @change=${this._viewSelected} class="mb-3"
               aria-label="${this._i18n.rubric_view_selection_title}"
               title="${this._i18n.rubric_view_selection_title}" .value=${this._currentView}>

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudent.js
@@ -83,12 +83,12 @@ export class SakaiRubricStudent extends rubricsApiMixin(RubricsElement) {
   }
 
   shouldUpdate() {
-    // Render when loaded and either instructor is viewing, or student preview is allowed
-    // and the association is not dynamic (rbcs-associate != 2).
+    // Render when loaded and instructor is viewing, peer/self evaluation is shown,
+    // or student preview is allowed and the association is not dynamic (rbcs-associate != 2).
     return this.siteId
       && this._i18nLoaded
       && this._rubric
-      && (this.instructor || (!this.options.hideStudentPreview && Number(this.options?.["rbcs-associate"]) !== 2));
+      && (this.instructor || this.isPeerOrSelf || (!this.options.hideStudentPreview && Number(this.options?.["rbcs-associate"]) !== 2));
   }
 
   render() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/src/SakaiRubricStudentButton.js
@@ -14,6 +14,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     evaluatedItemOwnerId: { attribute: "evaluated-item-owner-id", type: String },
     forcePreview: { attribute: "force-preview", type: Boolean },
     instructor: { type: Boolean },
+    isPeerOrSelf: { attribute: "is-peer-or-self", type: Boolean },
   };
 
   constructor() {
@@ -70,7 +71,7 @@ export class SakaiRubricStudentButton extends rubricsApiMixin(RubricsElement) {
     if (this.forcePreview) {
       this.showRubricLightbox(this._rubricId);
     } else {
-      this.showRubricLightbox(this._rubricId, { "tool-id": this.toolId, "entity-id": this.entityId, "evaluated-item-id": this.evaluatedItemId, "evaluated-item-owner-id": this.evaluatedItemOwnerId, "instructor": this.instructor });
+      this.showRubricLightbox(this._rubricId, { "tool-id": this.toolId, "entity-id": this.entityId, "evaluated-item-id": this.evaluatedItemId, "evaluated-item-owner-id": this.evaluatedItemOwnerId, "instructor": this.instructor, "is-peer-or-self": this.isPeerOrSelf });
     }
   }
 

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-grading.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-grading.test.js
@@ -57,6 +57,7 @@ describe("sakai-rubric-grading tests", () => {
     // We need to wait until the evaluation data has been fetched, then count the rows.
     await waitUntil(() => el.querySelector(".criterion-row"), "No criterion rows rendered");
     expect(el.querySelectorAll(".criterion-row").length).to.equal(3);
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.exist;
 
     // Initially, with our test evaluation load, we have selected ratings worth 2 points for criterion1 and 3 points for criterion2
     const totalPoints = el.querySelector(`#rbcs-${data.evaluatedItemId}-${data.entityId}-totalpoints`);
@@ -234,5 +235,26 @@ describe("sakai-rubric-grading tests", () => {
     const criterion2Points = el.querySelector("#points-display-10");
     expect(criterion1Points.textContent.trim()).to.equal("1.2");
     expect(criterion2Points.textContent.trim()).to.equal("0.8");
+  });
+
+  it ("hides summary views for peer or self evaluation", async () => {
+
+    fetchMock.get(data.rubric1Url, data.rubric1)
+      .get(data.associationUrl, data.association)
+      .get(`${data.evaluationUrl}?isPeer=true`, data.evaluation);
+
+    const el = await fixture(html`
+      <sakai-rubric-grading
+          site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          evaluated-item-id="${data.evaluatedItemId}"
+          evaluated-item-owner-id="${data.evaluatedItemOwnerId}"
+          is-peer-or-self>
+      </sakai-rubric-grading>
+    `);
+
+    await waitUntil(() => el.querySelector(".criterion-row"), "No criterion rows rendered");
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.not.exist;
   });
 });

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
@@ -19,6 +19,7 @@ describe("sakai-rubric-student tests", () => {
       .get(data.rubric1Url, data.rubric1)
       .get(data.associationUrl, data.association)
       .get(data.evaluationUrl, data.evaluation)
+      .get(`${data.evaluationUrl}?isPeer=true`, data.evaluation)
       .get("*", 500);
   });
 
@@ -42,6 +43,7 @@ describe("sakai-rubric-student tests", () => {
 
     await waitUntil(() => el.querySelector(".rubric-details"), "No .rubric-details created");
     expect(el.querySelector("sakai-rubric-criterion-preview")).to.not.exist;
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.not.exist;
 
     await el.updateComplete;
     expect(el.querySelector("sakai-rubric-criterion-student")).to.exist;
@@ -60,5 +62,38 @@ describe("sakai-rubric-student tests", () => {
     await expect(el).to.be.accessible();
 
     await waitUntil(() => el.querySelector("sakai-rubric-criterion-preview"), "No sakai-rubric-criterion-preview created");
+  });
+
+  it ("shows summary views for instructors", async () => {
+
+    const el = await fixture(html`
+      <sakai-rubric-student site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          evaluated-item-id="${data.evaluatedItemId}"
+          evaluated-item-owner-id="${data.evaluatedItemOwnerId}"
+          instructor>
+      </sakai-rubric-student>
+    `);
+
+    await waitUntil(() => el.querySelector(".rubric-details"), "No .rubric-details created");
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.exist;
+  });
+
+  it ("hides summary views for peer or self evaluation even when instructor is set", async () => {
+
+    const el = await fixture(html`
+      <sakai-rubric-student site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          evaluated-item-id="${data.evaluatedItemId}"
+          evaluated-item-owner-id="${data.evaluatedItemOwnerId}"
+          instructor
+          is-peer-or-self>
+      </sakai-rubric-student>
+    `);
+
+    await waitUntil(() => el.querySelector(".rubric-details"), "No .rubric-details created");
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.not.exist;
   });
 });

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
@@ -25,6 +25,10 @@ describe("sakai-rubric-student tests", () => {
 
   afterEach(() => {
     fetchMock.hardReset();
+    document.getElementById("rubric-preview")?.remove();
+    if (window.top.rubrics?.utils) {
+      window.top.rubrics.utils.lightbox = null;
+    }
   });
 
 
@@ -95,5 +99,27 @@ describe("sakai-rubric-student tests", () => {
 
     await waitUntil(() => el.querySelector(".rubric-details"), "No .rubric-details created");
     expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.not.exist;
+    expect(fetchMock.callHistory.called(`${data.evaluationUrl}?isPeer=true`)).to.be.true;
+  });
+
+  it ("showRubric sets is-peer-or-self and hides summary views", async () => {
+
+    window.top.rubrics.utils.initLightbox({ preview_rubric: "Preview", close_dialog: "Close" }, data.siteId);
+
+    window.top.rubrics.utils.showRubric(data.rubric1.id, {
+      "tool-id": data.toolId,
+      "entity-id": data.entityId,
+      "evaluated-item-id": data.evaluatedItemId,
+      "evaluated-item-owner-id": data.evaluatedItemOwnerId,
+      instructor: true,
+      "is-peer-or-self": true,
+    });
+
+    const el = document.querySelector("sakai-rubric-student");
+    await waitUntil(() => el.querySelector(".rubric-details"), "No .rubric-details created");
+    expect(el.hasAttribute("is-peer-or-self")).to.be.true;
+    expect(el.isPeerOrSelf).to.be.true;
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.not.exist;
+    expect(fetchMock.callHistory.called(`${data.evaluationUrl}?isPeer=true`)).to.be.true;
   });
 });

--- a/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-rubrics/test/sakai-rubric-student.test.js
@@ -102,6 +102,44 @@ describe("sakai-rubric-student tests", () => {
     expect(fetchMock.callHistory.called(`${data.evaluationUrl}?isPeer=true`)).to.be.true;
   });
 
+  it ("renders completed self-assessment when student preview is hidden", async () => {
+
+    fetchMock.removeRoutes();
+    fetchMock
+      .get(data.i18nUrl, data.i18n)
+      .get(data.rubric1Url, data.rubric1)
+      .get(data.associationUrl, {
+        ...data.association,
+        parameters: {
+          ...data.association.parameters,
+          hideStudentPreview: 1,
+          studentSelfReport: 1,
+        },
+      })
+      .get(data.evaluationUrl, data.evaluation)
+      .get(`${data.evaluationUrl}?isPeer=true`, data.evaluation)
+      .get("*", 500);
+
+    const el = await fixture(html`
+      <sakai-rubric-student site-id="${data.siteId}"
+          tool-id="${data.toolId}"
+          entity-id="${data.entityId}"
+          evaluated-item-id="${data.evaluatedItemId}"
+          evaluated-item-owner-id="${data.evaluatedItemOwnerId}"
+          is-peer-or-self>
+      </sakai-rubric-student>
+    `);
+
+    await waitUntil(() => el.querySelector(".rubric-details"), "No .rubric-details created");
+    await waitUntil(() => el.querySelector("sakai-rubric-criterion-student"), "No sakai-rubric-criterion-student created");
+
+    const criterionStudent = el.querySelector("sakai-rubric-criterion-student");
+    await waitUntil(() => criterionStudent.querySelector(".criterion-row"), "No criteria rendered");
+
+    expect(el.querySelector(`select[aria-label="${el._i18n.rubric_view_selection_title}"]`)).to.not.exist;
+    expect(fetchMock.callHistory.called(`${data.evaluationUrl}?isPeer=true`)).to.be.true;
+  });
+
   it ("showRubric sets is-peer-or-self and hides summary views", async () => {
 
     window.top.rubrics.utils.initLightbox({ preview_rubric: "Preview", close_dialog: "Close" }, data.siteId);


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-49369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rubric view selectors are now hidden during peer and self assessments.
  - Instructor-only summary controls no longer appear during peer or self evaluations.
  - Student self-report and peer-review rubric views no longer display instructor controls.
  - Standard grading and instructor views retain their appropriate selection options.
  - Rubric previews now correctly reflect the selected evaluation context.

- **Tests**
  - Added coverage for selector visibility across grading, instructor, peer, self-assessment, and preview scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->