### PR TITLE
docs: fix typo implmentation -> implementation

### DIFF
--- a/jobscheduler/scheduler-component-shared/README.configurablejobs.txt
+++ b/jobscheduler/scheduler-component-shared/README.configurablejobs.txt
@@ -147,7 +147,7 @@ method runJob() instead.
 
 IV. Example
 
-An example implmentation of the above configurable job framework is available under the jobscheduler module and is
+An example implementation of the above configurable job framework is available under the jobscheduler module and is
 implemented in two sub-modules:
 
    scheduler-configurable-job-test-component


### PR DESCRIPTION
Corrects a single misspelling of `implmentation` in `jobscheduler/scheduler-component-shared/README.configurablejobs.txt`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the configurable jobs documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->