### PR TITLE
SAK-52862 Statistics New Analytics Presence and access

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -78,6 +78,27 @@ class SiteStatsTest extends SakaiUiTestBase {
     }
 
     @Test
+    @Order(9)
+    void presenceAccessWidgetRendersThroughJsonPanel() {
+        sakai.login("instructor1");
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Statistics");
+
+        Locator presenceTab = page.locator(
+            ".sitestats-widget-tab[endpoint*='/widgets/presence-access/tabs/bydate']");
+        assertThat(presenceTab).hasCount(1);
+        presenceTab.locator("summary").click();
+
+        Locator reportPanel = presenceTab.locator("sakai-sitestats-report-panel");
+        assertThat(reportPanel).isVisible();
+        Locator lastVisitMetric = page.locator(".sitestats-widget")
+            .filter(new Locator.FilterOptions().setHas(presenceTab))
+            .locator(".sitestats-metric").first();
+        assertThat(lastVisitMetric).isVisible();
+        assertNoLegacyReportChartImages();
+    }
+
+    @Test
     @Order(3)
     void reportValidationDisplaysOneErrorBanner() {
         openReportsAsInstructor();
@@ -261,7 +282,8 @@ class SiteStatsTest extends SakaiUiTestBase {
         APIResponse permissionsResponse = page.request().post("/api/sites/" + siteId + "/permissions",
             RequestOptions.create().setForm(FormData.create()
                 .set("ref", "/site/" + siteId)
-                .set("Student:sitestats.view", "true")));
+                .set("Student:sitestats.view", "true")
+                .set("Student:sitestats.own", "true")));
         assertTrue(permissionsResponse.ok(),
             "Unable to grant student access to Statistics: HTTP " + permissionsResponse.status());
 
@@ -273,6 +295,10 @@ class SiteStatsTest extends SakaiUiTestBase {
             new Page.GetByRoleOptions().setName(Pattern.compile("^Overview$", Pattern.CASE_INSENSITIVE)))).isVisible();
         assertThat(page.getByRole(AriaRole.NAVIGATION,
             new Page.GetByRoleOptions().setName("SiteStats"))).hasCount(0);
+        assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/student-presence-access/']"))
+            .hasCount(1);
+        assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/presence-access/tabs/']"))
+            .hasCount(0);
     }
 
     @Test

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -74,6 +74,13 @@ class SiteStatsTest extends SakaiUiTestBase {
         Locator table = reportPanel.locator("sakai-sitestats-table table");
         assertThat(table).isVisible();
         assertThat(reportPanel.locator("sakai-sitestats-chart")).hasCount(1);
+        assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/visits/tabs/byrole']"))
+            .hasCount(1);
+        assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/member-adoption/tabs/']"))
+            .hasCount(0);
+        Locator visitsWidget = page.locator(".sitestats-widget")
+            .filter(new Locator.FilterOptions().setHas(widgetTab));
+        assertTrue(visitsWidget.locator("sakai-sitestats-highlights").count() <= 1);
         assertNoLegacyReportChartImages();
     }
 
@@ -298,6 +305,8 @@ class SiteStatsTest extends SakaiUiTestBase {
         assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/student-presence-access/']"))
             .hasCount(1);
         assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/presence-access/tabs/']"))
+            .hasCount(0);
+        assertThat(page.locator(".sitestats-widget-tab[endpoint*='/widgets/member-adoption/']"))
             .hasCount(0);
     }
 

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -216,7 +216,7 @@ class SiteStatsTest extends SakaiUiTestBase {
         page.getByRole(AriaRole.BUTTON,
             new Page.GetByRoleOptions().setName(Pattern.compile("^Save report$", Pattern.CASE_INSENSITIVE))).click();
 
-        assertThat(page.getByRole(AriaRole.STATUS)).containsText(
+        assertThat(page.locator(".sak-banner-success")).containsText(
             "Report '" + SAVED_REPORT_TITLE + "' saved successfully");
         assertThat(page.getByRole(AriaRole.HEADING,
             new Page.GetByRoleOptions().setName(SAVED_REPORT_TITLE))).isVisible();

--- a/library/src/skins/default/src/sass/modules/tool/sitestats/_sitestats.scss
+++ b/library/src/skins/default/src/sass/modules/tool/sitestats/_sitestats.scss
@@ -11,6 +11,7 @@
   }
 
   .sitestats-widget-title {
+    font-size: 1rem;
     margin: 0;
     padding: $standard-space-3x $standard-spacing;
   }
@@ -34,11 +35,12 @@
   }
 
   .sitestats-metric-primary {
-    font-size: 1.5rem;
     line-height: 1.25;
+    font-weight: 800;
   }
 
   .sitestats-metric-percentage {
+    font-size: 1rem;
     margin-inline-start: $standard-space;
     color: var(--sakai-text-color-dimmed);
   }

--- a/library/src/skins/default/src/sass/modules/tool/sitestats/_sitestats.scss
+++ b/library/src/skins/default/src/sass/modules/tool/sitestats/_sitestats.scss
@@ -45,6 +45,13 @@
     color: var(--sakai-text-color-dimmed);
   }
 
+  .sitestats-highlights {
+    display: block;
+    width: 100%;
+    padding: $standard-space-2x $standard-spacing;
+    border-block-end: 1px solid var(--sakai-border-color);
+  }
+
   .sitestats-widget-tab {
     + .sitestats-widget-tab {
       border-block-start: 1px solid var(--sakai-border-color);

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsChart.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsChart.java
@@ -28,5 +28,6 @@ public class SiteStatsChart implements Serializable {
 	private boolean threeDimensional;
 	private float transparency = 1.0f;
 	private boolean itemLabelsVisible = true;
+	private boolean compact;
 	private List<SiteStatsChartDataset> datasets = new ArrayList<SiteStatsChartDataset>();
 }

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsWidget.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsWidget.java
@@ -25,4 +25,5 @@ public class SiteStatsWidget implements Serializable {
 	private String audience;
 	private List<SiteStatsWidgetTab> tabs = new ArrayList<SiteStatsWidgetTab>();
 	private List<SiteStatsWidgetMetric> metrics = new ArrayList<SiteStatsWidgetMetric>();
+	private List<SiteStatsChart> highlights = new ArrayList<SiteStatsChart>();
 }

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsWidgetIds.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsWidgetIds.java
@@ -16,6 +16,8 @@ public final class SiteStatsWidgetIds {
 
 	public static final String WIDGET_VISITS = "visits";
 	public static final String WIDGET_STUDENT_VISITS = "student-visits";
+	public static final String WIDGET_PRESENCE_ACCESS = "presence-access";
+	public static final String WIDGET_STUDENT_PRESENCE_ACCESS = "student-presence-access";
 	public static final String WIDGET_ACTIVITY = "activity";
 	public static final String WIDGET_RESOURCES = "resources";
 	public static final String WIDGET_LESSONS = "lessons";
@@ -41,6 +43,18 @@ public final class SiteStatsWidgetIds {
 	public static final String METRIC_STUDENT_VISITS_TOTAL = "student-visits-total";
 	public static final String METRIC_STUDENT_VISITS_AVERAGE_PRESENCE = "student-visits-average-presence";
 	public static final String METRIC_STUDENT_VISITS_PRESENCE = "student-visits-presence";
+	public static final String METRIC_PRESENCE_LAST_VISIT = "presence-last-visit";
+	public static final String METRIC_PRESENCE_NEVER_VISITED = "presence-never-visited";
+	public static final String METRIC_PRESENCE_AVERAGE = "presence-average";
+	public static final String METRIC_PRESENCE_TOTAL_7D = "presence-total-7d";
+	public static final String METRIC_PRESENCE_TOTAL_30D = "presence-total-30d";
+	public static final String METRIC_PRESENCE_TOTAL_365D = "presence-total-365d";
+	public static final String METRIC_STUDENT_PRESENCE_LAST_VISIT = "student-presence-last-visit";
+	public static final String METRIC_STUDENT_PRESENCE_AVERAGE = "student-presence-average";
+	public static final String METRIC_STUDENT_PRESENCE_TOTAL = "student-presence-total";
+	public static final String METRIC_STUDENT_PRESENCE_TOTAL_7D = "student-presence-total-7d";
+	public static final String METRIC_STUDENT_PRESENCE_TOTAL_30D = "student-presence-total-30d";
+	public static final String METRIC_STUDENT_PRESENCE_TOTAL_365D = "student-presence-total-365d";
 	public static final String METRIC_ACTIVITY_EVENTS = "activity-events";
 	public static final String METRIC_ACTIVITY_MOST_ACTIVE_TOOL = "activity-most-active-tool";
 	public static final String METRIC_ACTIVITY_MOST_ACTIVE_USER = "activity-most-active-user";

--- a/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsWidgetIds.java
+++ b/sitestats/sitestats-api/src/java/org/sakaiproject/sitestats/api/view/SiteStatsWidgetIds.java
@@ -18,12 +18,14 @@ public final class SiteStatsWidgetIds {
 	public static final String WIDGET_STUDENT_VISITS = "student-visits";
 	public static final String WIDGET_PRESENCE_ACCESS = "presence-access";
 	public static final String WIDGET_STUDENT_PRESENCE_ACCESS = "student-presence-access";
+	public static final String WIDGET_MEMBER_ADOPTION = "member-adoption";
 	public static final String WIDGET_ACTIVITY = "activity";
 	public static final String WIDGET_RESOURCES = "resources";
 	public static final String WIDGET_LESSONS = "lessons";
 
 	public static final String TAB_BY_DATE = "bydate";
 	public static final String TAB_BY_USER = "byuser";
+	public static final String TAB_BY_ROLE = "byrole";
 	public static final String TAB_BY_TOOL = "bytool";
 	public static final String TAB_BY_RESOURCE = "byresource";
 	public static final String TAB_BY_PAGE = "bypage";
@@ -40,21 +42,26 @@ public final class SiteStatsWidgetIds {
 	public static final String METRIC_VISITS_USERS_WITH_VISITS = "visits-users-with-visits";
 	public static final String METRIC_VISITS_USERS_WITHOUT_VISITS = "visits-users-without-visits";
 	public static final String METRIC_VISITS_AVERAGE_PRESENCE = "visits-average-presence";
+	public static final String METRIC_VISITS_TRAFFIC_TREND = "visits-traffic-trend";
 	public static final String METRIC_STUDENT_VISITS_TOTAL = "student-visits-total";
+	public static final String METRIC_STUDENT_VISITS_TRAFFIC_TREND = "student-visits-traffic-trend";
 	public static final String METRIC_STUDENT_VISITS_AVERAGE_PRESENCE = "student-visits-average-presence";
 	public static final String METRIC_STUDENT_VISITS_PRESENCE = "student-visits-presence";
 	public static final String METRIC_PRESENCE_LAST_VISIT = "presence-last-visit";
 	public static final String METRIC_PRESENCE_NEVER_VISITED = "presence-never-visited";
 	public static final String METRIC_PRESENCE_AVERAGE = "presence-average";
+	public static final String METRIC_PRESENCE_BOUNCE_RATE = "presence-bounce-rate";
 	public static final String METRIC_PRESENCE_TOTAL_7D = "presence-total-7d";
 	public static final String METRIC_PRESENCE_TOTAL_30D = "presence-total-30d";
 	public static final String METRIC_PRESENCE_TOTAL_365D = "presence-total-365d";
 	public static final String METRIC_STUDENT_PRESENCE_LAST_VISIT = "student-presence-last-visit";
 	public static final String METRIC_STUDENT_PRESENCE_AVERAGE = "student-presence-average";
+	public static final String METRIC_STUDENT_PRESENCE_BOUNCE_RATE = "student-presence-bounce-rate";
 	public static final String METRIC_STUDENT_PRESENCE_TOTAL = "student-presence-total";
 	public static final String METRIC_STUDENT_PRESENCE_TOTAL_7D = "student-presence-total-7d";
 	public static final String METRIC_STUDENT_PRESENCE_TOTAL_30D = "student-presence-total-30d";
 	public static final String METRIC_STUDENT_PRESENCE_TOTAL_365D = "student-presence-total-365d";
+	public static final String METRIC_ADOPTION_ACTIVE = "adoption-active";
 	public static final String METRIC_ACTIVITY_EVENTS = "activity-events";
 	public static final String METRIC_ACTIVITY_MOST_ACTIVE_TOOL = "activity-most-active-tool";
 	public static final String METRIC_ACTIVITY_MOST_ACTIVE_USER = "activity-most-active-user";
@@ -66,4 +73,7 @@ public final class SiteStatsWidgetIds {
 	public static final String METRIC_LESSONS_READ_PAGES = "lessons-read-pages";
 	public static final String METRIC_LESSONS_MOST_READ_PAGE = "lessons-most-read-page";
 	public static final String METRIC_LESSONS_USER_READ_MORE_PAGES = "lessons-user-read-more-pages";
+
+	public static final String HIGHLIGHT_VISITS_LAST_30_DAYS = "visits-last-30-days";
+	public static final String HIGHLIGHT_PRESENCE_LAST_30_DAYS = "presence-last-30-days";
 }

--- a/sitestats/sitestats-bundle/src/resources/Messages.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages.properties
@@ -96,6 +96,14 @@ overview_title_enrolled_users_with_visits_sum=Members who have visited site
 overview_title_enrolled_users_without_visits_sum=Members who have not visited site
 overview_title_presence_time_avg=Average presence time per visit
 overview_title_presence_time=Total presence time
+# Overview::Presence and access
+overview_title_presence_access=Presence and access
+overview_title_last_visit=Most recent access
+overview_title_last_visit_own=Your last access
+overview_title_never_accessed=Members who have not accessed the site
+overview_title_presence_last7days=Presence (last 7 days)
+overview_title_presence_last30days=Presence (last 30 days)
+overview_title_presence_last365days=Presence (last 365 days)
 # Overview::Activity
 overview_title_activity=Activity
 overview_title_events_sum=Events

--- a/sitestats/sitestats-bundle/src/resources/Messages.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages.properties
@@ -103,8 +103,8 @@ overview_title_presence_time=Total presence time
 overview_title_bounce_rate=Bounce rate (visits under 5 min)
 # Overview::Presence and access
 overview_title_presence_access=Presence and Access
-overview_title_last_visit=Most recent access
-overview_title_last_visit_own=Your last access
+overview_title_last_visit=Last visit
+overview_title_last_student_visit=Last student visit
 overview_title_never_accessed=Members who have not accessed the site
 overview_title_presence_last7days=Presence (last 7 days)
 overview_title_presence_last30days=Presence (last 30 days)

--- a/sitestats/sitestats-bundle/src/resources/Messages.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages.properties
@@ -15,6 +15,7 @@ hours_abbr=hrs.
 minutes=Minutes
 minutes_abbr=min.
 seconds_abbr=sec.
+days_abbr=d
 statistics_loading=Statistics are loading. Please wait...
 
 # Menu/Title
@@ -79,6 +80,7 @@ overview_show_less=Show less
 overview_show_report=View complete report
 overview_tab_bydate=By date
 overview_tab_byuser=By user
+overview_tab_byrole=By role
 overview_tab_bytool=By tool
 overview_tab_byresource=By resource
 # Overview::Filter
@@ -89,15 +91,18 @@ overview_filter_tool_all=All tools
 overview_filter_resaction_all=All actions
 # Overview::Visits
 overview_title_visits=Visits
-overview_title_visits_sum=Visits
+overview_title_visits_sum=Total visits
 overview_title_unique_visits_sum=Users who have visited site
-overview_title_enrolled_users_sum=Site Members
-overview_title_enrolled_users_with_visits_sum=Members who have visited site
+overview_title_visits_last30days=Visits (last 30 days)
+overview_title_enrolled_users_sum=Site members
+overview_title_enrolled_users_with_visits_sum=Members who visited
 overview_title_enrolled_users_without_visits_sum=Members who have not visited site
-overview_title_presence_time_avg=Average presence time per visit
+overview_title_traffic_trend=Traffic trend (last 7 days)
+overview_title_presence_time_avg=Median time on site
 overview_title_presence_time=Total presence time
+overview_title_bounce_rate=Bounce rate (visits under 5 min)
 # Overview::Presence and access
-overview_title_presence_access=Presence and access
+overview_title_presence_access=Presence and Access
 overview_title_last_visit=Most recent access
 overview_title_last_visit_own=Your last access
 overview_title_never_accessed=Members who have not accessed the site

--- a/sitestats/sitestats-bundle/src/resources/Messages_es.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages_es.properties
@@ -15,6 +15,7 @@ hours_abbr=hrs.
 minutes=Minutos
 minutes_abbr=min.
 seconds_abbr=sec.
+days_abbr=d
 statistics_loading=Se estan cargando las estad\u00edsticas, espere por favor.
 
 # Menu/Title
@@ -76,6 +77,7 @@ overview_show_less=Mostrar menos
 overview_show_report=Ver informe completo
 overview_tab_bydate=Por fecha
 overview_tab_byuser=Por usuario
+overview_tab_byrole=Por rol
 overview_tab_bytool=Por herramienta
 overview_tab_byresource=Por recurso
 # Overview::Filter
@@ -86,13 +88,16 @@ overview_filter_tool_all=Todas las herramientas
 overview_filter_resaction_all=Todas las acciones
 # Overview::Visits
 overview_title_visits=Visitas
-overview_title_visits_sum=Visitas
+overview_title_visits_sum=Visitas totales
 overview_title_unique_visits_sum=Usuarios que han visitado el sitio
+overview_title_visits_last30days=Visitas (\u00faltimos 30 d\u00edas)
 overview_title_enrolled_users_sum=Usuarios matriculados
-overview_title_enrolled_users_with_visits_sum=Usuarios que han accedido al sitio
+overview_title_enrolled_users_with_visits_sum=Miembros que visitaron
 overview_title_enrolled_users_without_visits_sum=Usuarios que no han accedido al sitio
-overview_title_presence_time_avg=Tiempo medio de estancia por visita
+overview_title_traffic_trend=Tendencia de tr\u00e1fico (\u00faltimos 7 d\u00edas)
+overview_title_presence_time_avg=Tiempo mediano de permanencia
 overview_title_presence_time=Tiempo total de estancia
+overview_title_bounce_rate=Tasa de rebote (visitas < 5 min)
 # Overview::Presence and access
 overview_title_presence_access=Presencia y acceso
 overview_title_last_visit=\u00daltimo acceso

--- a/sitestats/sitestats-bundle/src/resources/Messages_es.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages_es.properties
@@ -93,6 +93,14 @@ overview_title_enrolled_users_with_visits_sum=Usuarios que han accedido al sitio
 overview_title_enrolled_users_without_visits_sum=Usuarios que no han accedido al sitio
 overview_title_presence_time_avg=Tiempo medio de estancia por visita
 overview_title_presence_time=Tiempo total de estancia
+# Overview::Presence and access
+overview_title_presence_access=Presencia y acceso
+overview_title_last_visit=\u00daltimo acceso
+overview_title_last_visit_own=Tu \u00faltimo acceso
+overview_title_never_accessed=Usuarios que no han accedido al sitio
+overview_title_presence_last7days=Presencia (\u00faltimos 7 d\u00edas)
+overview_title_presence_last30days=Presencia (\u00faltimos 30 d\u00edas)
+overview_title_presence_last365days=Presencia (\u00faltimos 365 d\u00edas)
 # Overview::Activity
 overview_title_activity=Actividad
 overview_title_events_sum=Eventos de la actividad

--- a/sitestats/sitestats-bundle/src/resources/Messages_es.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages_es.properties
@@ -100,8 +100,8 @@ overview_title_presence_time=Tiempo total de estancia
 overview_title_bounce_rate=Tasa de rebote (visitas < 5 min)
 # Overview::Presence and access
 overview_title_presence_access=Presencia y acceso
-overview_title_last_visit=\u00daltimo acceso
-overview_title_last_visit_own=Tu \u00faltimo acceso
+overview_title_last_visit=\u00daltima visita
+overview_title_last_student_visit=\u00daltima visita de un estudiante
 overview_title_never_accessed=Usuarios que no han accedido al sitio
 overview_title_presence_last7days=Presencia (\u00faltimos 7 d\u00edas)
 overview_title_presence_last30days=Presencia (\u00faltimos 30 d\u00edas)

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsManagerImpl.java
@@ -2812,10 +2812,10 @@ if (log.isDebugEnabled()) {
 				if(queryType == Q_TYPE_LESSON && sortBy.equals(T_PAGE_ACTION) && totalsBy.contains(T_PAGE_ACTION)) {
 					sortField = "s.pageAction";
 				}
-				if((sortBy.equals(T_DATE) || sortBy.equals(T_LASTDATE)) 
-						&& 
-						(totalsBy.contains(T_DATE) || totalsBy.contains(T_LASTDATE) )) {
+				if (sortBy.equals(T_DATE) && totalsBy.contains(T_DATE)) {
 					sortField = "s.date";
+				} else if ((sortBy.equals(T_DATE) || sortBy.equals(T_LASTDATE)) && totalsBy.contains(T_LASTDATE)) {
+					sortField = "max(s.date)";
 				}
 				if(sortBy.equals(T_DURATION)) {
 					sortField = "sum(s.duration)";

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/AbstractSiteStatsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/AbstractSiteStatsWidgetDefinition.java
@@ -12,6 +12,7 @@ import java.util.function.BooleanSupplier;
 
 import lombok.Setter;
 
+import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.event.EventRegistryService;
 import org.sakaiproject.sitestats.api.report.ReportManager;
@@ -36,6 +37,10 @@ abstract class AbstractSiteStatsWidgetDefinition implements SiteStatsWidgetDefin
 		return support.getEventRegistryService();
 	}
 
+	protected SiteService siteService() {
+		return support.getSiteService();
+	}
+
 	protected WidgetFilterCatalog filterCatalog() {
 		return support.getFilterCatalog();
 	}
@@ -50,7 +55,12 @@ abstract class AbstractSiteStatsWidgetDefinition implements SiteStatsWidgetDefin
 
 	protected WidgetSpec widgetSpec(String id, String titleKey, String icon, String audience, BooleanSupplier available,
 			List<WidgetTabSpec> tabs, List<WidgetMetricSpec> metrics) {
-		return new WidgetSpec(id, titleKey, icon, audience, available, tabs, metrics);
+		return widgetSpec(id, titleKey, icon, audience, available, tabs, metrics, Collections.emptyList());
+	}
+
+	protected WidgetSpec widgetSpec(String id, String titleKey, String icon, String audience, BooleanSupplier available,
+			List<WidgetTabSpec> tabs, List<WidgetMetricSpec> metrics, List<WidgetHighlightSpec> highlights) {
+		return new WidgetSpec(id, titleKey, icon, audience, available, tabs, metrics, highlights);
 	}
 
 	protected List<WidgetTabSpec> tabs(WidgetTabSpec... tabs) {
@@ -61,8 +71,25 @@ abstract class AbstractSiteStatsWidgetDefinition implements SiteStatsWidgetDefin
 		return Collections.unmodifiableList(Arrays.asList(metrics));
 	}
 
+	protected List<WidgetHighlightSpec> highlights(WidgetHighlightSpec... highlights) {
+		return Collections.unmodifiableList(Arrays.asList(highlights));
+	}
+
+	protected WidgetHighlightSpec highlightSpec(String id, String titleKey, WidgetHighlightFactory factory) {
+		return highlightSpec(id, titleKey, () -> true, factory);
+	}
+
+	protected WidgetHighlightSpec highlightSpec(String id, String titleKey, BooleanSupplier available,
+			WidgetHighlightFactory factory) {
+		return new WidgetHighlightSpec(id, titleKey, available, factory);
+	}
+
 	protected WidgetTabSpec tabSpec(String widgetId, String id, String titleKey, WidgetReportFactory reportFactory, String... filterIds) {
 		return new WidgetTabSpec(widgetId, id, titleKey, Arrays.asList(filterIds), reportFactory);
+	}
+
+	protected WidgetTabSpec viewTabSpec(String widgetId, String id, String titleKey, WidgetReportViewFactory viewFactory, String... filterIds) {
+		return new WidgetTabSpec(widgetId, id, titleKey, Arrays.asList(filterIds), null, viewFactory);
 	}
 
 	protected WidgetMetricSpec metricSpec(String widgetId, String id, String labelKey, String audience,

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/PresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/PresenceAccessWidgetDefinition.java
@@ -51,7 +51,7 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 								FILTER_DATE, FILTER_ROLE)),
 				metrics(
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_AVERAGE, "overview_title_presence_time_avg", AUDIENCE_ALL,
-								this::presencesEnabled, this::averagePresenceMetricDefinition, this::averagePresenceValue),
+								this::presencesEnabled, this::medianPresenceMetricDefinition, this::medianPresenceValue),
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_BOUNCE_RATE, "overview_title_bounce_rate", AUDIENCE_ALL,
 								this::presencesEnabled, this::bounceRateMetricDefinition, this::bounceRateValue),
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_7D, "overview_title_presence_last7days", AUDIENCE_ALL,
@@ -91,7 +91,7 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 				message("overview_title_presence_access"), chart, table);
 	}
 
-	private WidgetReportDefinition averagePresenceMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+	private WidgetReportDefinition medianPresenceMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
 		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
 		ReportParams params = reportDef.getReportParams();
 		params.setWhat(ReportManager.WHAT_PRESENCES);
@@ -149,8 +149,8 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 		return presenceRangeMetricDefinition(siteId, ReportManager.WHEN_LAST365DAYS, "overview_title_presence_last365days");
 	}
 
-	private WidgetMetricValue averagePresenceValue(String siteId, String userId) {
-		return metricSupport().averagePresencePerVisit(siteId);
+	private WidgetMetricValue medianPresenceValue(String siteId, String userId) {
+		return metricSupport().medianPresencePerVisit(siteId);
 	}
 
 	private WidgetMetricValue bounceRateValue(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/PresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/PresenceAccessWidgetDefinition.java
@@ -1,0 +1,216 @@
+/**********************************************************************************
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **********************************************************************************/
+
+package org.sakaiproject.sitestats.impl.view;
+
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_ALL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_ROLE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_AVERAGE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_LAST_VISIT;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_NEVER_VISITED;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_30D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_365D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_7D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_PRESENCE_ACCESS;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.sakaiproject.sitestats.api.StatsManager;
+import org.sakaiproject.sitestats.api.report.ReportDef;
+import org.sakaiproject.sitestats.api.report.ReportManager;
+import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
+
+public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
+
+	@Override
+	public WidgetSpec getSpec() {
+		return widgetSpec(WIDGET_PRESENCE_ACCESS, "overview_title_presence_access", "sakai-sitestats", AUDIENCE_ALL,
+				() -> true,
+				tabs(
+						tabSpec(WIDGET_PRESENCE_ACCESS, TAB_BY_DATE, "overview_tab_bydate", this::presenceByDateDefinition,
+								FILTER_DATE, FILTER_ROLE),
+						tabSpec(WIDGET_PRESENCE_ACCESS, TAB_BY_USER, "overview_tab_byuser", this::lastVisitByUserDefinition,
+								FILTER_DATE, FILTER_ROLE)),
+				metrics(
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_LAST_VISIT, "overview_title_last_visit", AUDIENCE_ALL,
+								this::lastVisitMetricDefinition, this::lastVisitValue),
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_NEVER_VISITED, "overview_title_never_accessed",
+								AUDIENCE_ALL, this::neverVisitedMetricDefinition, this::neverVisitedValue),
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_AVERAGE, "overview_title_presence_time_avg", AUDIENCE_ALL,
+								this::presencesEnabled, this::averagePresenceMetricDefinition, this::averagePresenceValue),
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_7D, "overview_title_presence_last7days", AUDIENCE_ALL,
+								this::presencesEnabled, this::presence7dMetricDefinition, this::presence7dValue),
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_30D, "overview_title_presence_last30days", AUDIENCE_ALL,
+								this::presencesEnabled, this::presence30dMetricDefinition, this::presence30dValue),
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_365D, "overview_title_presence_last365days", AUDIENCE_ALL,
+								this::presencesEnabled, this::presence365dMetricDefinition, this::presence365dValue)));
+	}
+
+	private WidgetReportDefinition presenceByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = reportFactory().presenceBase(siteId, request);
+		ReportParams params = reportDef.getReportParams();
+		params.setHowTotalsBy(reportFactory().dateTotals(request));
+		reportFactory().applyDateGrouping(params, request, true);
+		params.setHowChartType(StatsManager.CHARTTYPE_TIMESERIESBAR);
+		params.setHowChartSource(StatsManager.T_DATE);
+		params.setHowChartSeriesSource(StatsManager.T_NONE);
+		return new WidgetReportDefinition(message("overview_title_presence_access"), reportDef, reportDef);
+	}
+
+	private WidgetReportDefinition lastVisitByUserDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef table = lastVisitByUserReport(siteId, request);
+		ReportDef chart = reportFactory().presenceBase(siteId, request);
+		ReportParams chartParams = chart.getReportParams();
+		chartParams.setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
+		reportFactory().applyDateGrouping(chartParams, request, false);
+		chartParams.setHowSortBy(StatsManager.T_DURATION);
+		chartParams.setHowChartType(StatsManager.CHARTTYPE_PIE);
+		chartParams.setHowChartSource(StatsManager.T_USER);
+		chartParams.setHowPresentationMode(ReportManager.HOW_PRESENTATION_BOTH);
+		return new WidgetReportDefinition(message("overview_title_presence_access"),
+				message("overview_title_presence_access"), chart, table);
+	}
+
+	private ReportDef lastVisitByUserReport(String siteId, SiteStatsReportRequest request) {
+		ReportDef reportDef = reportFactory().baseReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_EVENTS);
+		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
+		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
+		reportFactory().applyRoleFilter(params, request);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER, StatsManager.T_LASTDATE));
+		params.setHowSortBy(StatsManager.T_LASTDATE);
+		params.setHowSortAscending(false);
+		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
+		return reportDef;
+	}
+
+	private WidgetReportDefinition lastVisitMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = lastVisitByUserReport(siteId, new SiteStatsReportRequest());
+		reportDef.getReportParams().setWhen(ReportManager.WHEN_ALL);
+		return new WidgetReportDefinition(message("overview_title_last_visit"), null, reportDef);
+	}
+
+	private WidgetReportDefinition neverVisitedMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_VISITS);
+		params.setWhen(ReportManager.WHEN_ALL);
+		params.setWho(ReportManager.WHO_NONE);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
+		params.setHowSort(false);
+		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
+		return new WidgetReportDefinition(message("overview_title_never_accessed"), null, reportDef);
+	}
+
+	private WidgetReportDefinition averagePresenceMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_PRESENCES);
+		params.setWhen(ReportManager.WHEN_ALL);
+		params.setWho(ReportManager.WHO_ALL);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE, StatsManager.T_USER));
+		params.setHowSortBy(StatsManager.T_DATE);
+		params.setHowSortAscending(false);
+		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_BOTH);
+		params.setHowChartType(StatsManager.CHARTTYPE_TIMESERIESBAR);
+		params.setHowChartSource(StatsManager.T_DATE);
+		params.setHowChartSeriesSource(StatsManager.T_NONE);
+		params.setHowChartSeriesPeriod(StatsManager.CHARTTIMESERIES_MONTH);
+		return new WidgetReportDefinition(message("overview_title_presence_time_avg"), reportDef, reportDef);
+	}
+
+	private WidgetReportDefinition presenceRangeMetricDefinition(String siteId, String when, String titleKey) {
+		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_PRESENCES);
+		params.setWhen(when);
+		params.setWho(ReportManager.WHO_ALL);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE, StatsManager.T_USER));
+		params.setHowSortBy(StatsManager.T_DATE);
+		params.setHowSortAscending(false);
+		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_BOTH);
+		params.setHowChartType(StatsManager.CHARTTYPE_TIMESERIESBAR);
+		params.setHowChartSource(StatsManager.T_DATE);
+		params.setHowChartSeriesSource(StatsManager.T_NONE);
+		return new WidgetReportDefinition(message(titleKey), reportDef, reportDef);
+	}
+
+	private WidgetReportDefinition presence7dMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		return presenceRangeMetricDefinition(siteId, ReportManager.WHEN_LAST7DAYS, "overview_title_presence_last7days");
+	}
+
+	private WidgetReportDefinition presence30dMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		return presenceRangeMetricDefinition(siteId, ReportManager.WHEN_LAST30DAYS, "overview_title_presence_last30days");
+	}
+
+	private WidgetReportDefinition presence365dMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		return presenceRangeMetricDefinition(siteId, ReportManager.WHEN_LAST365DAYS, "overview_title_presence_last365days");
+	}
+
+	private WidgetMetricValue lastVisitValue(String siteId, String userId) {
+		return metricSupport().lastVisitValue(siteId, null, true);
+	}
+
+	private WidgetMetricValue neverVisitedValue(String siteId, String userId) {
+		Set<String> siteUsers = siteUsers(siteId);
+		Set<String> usersWithVisits = usersWithVisits(siteId);
+		int count = 0;
+		for (String siteUser : siteUsers) {
+			if (!usersWithVisits.contains(siteUser)) {
+				count++;
+			}
+		}
+		return WidgetMetricValue.withPercentage(String.valueOf(count), (int) metricSupport().percent(count, siteUsers.size()));
+	}
+
+	private WidgetMetricValue averagePresenceValue(String siteId, String userId) {
+		return metricSupport().averagePresencePerVisit(siteId);
+	}
+
+	private WidgetMetricValue presence7dValue(String siteId, String userId) {
+		return metricSupport().presenceDurationValue(siteId, null, ReportManager.WHEN_LAST7DAYS);
+	}
+
+	private WidgetMetricValue presence30dValue(String siteId, String userId) {
+		return metricSupport().presenceDurationValue(siteId, null, ReportManager.WHEN_LAST30DAYS);
+	}
+
+	private WidgetMetricValue presence365dValue(String siteId, String userId) {
+		return metricSupport().presenceDurationValue(siteId, null, ReportManager.WHEN_LAST365DAYS);
+	}
+
+	private boolean presencesEnabled() {
+		return metricSupport().presencesEnabled();
+	}
+
+	private Set<String> siteUsers(String siteId) {
+		Set<String> users = statsManager().getSiteUsers(siteId);
+		return users == null ? Collections.<String>emptySet() : users;
+	}
+
+	private Set<String> usersWithVisits(String siteId) {
+		Set<String> users = statsManager().getUsersWithVisits(siteId);
+		return users == null ? new HashSet<String>() : users;
+	}
+}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/PresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/PresenceAccessWidgetDefinition.java
@@ -19,9 +19,9 @@ package org.sakaiproject.sitestats.impl.view;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_ALL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_ROLE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_PRESENCE_LAST_30_DAYS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_AVERAGE;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_LAST_VISIT;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_NEVER_VISITED;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_BOUNCE_RATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_30D;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_365D;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_7D;
@@ -30,14 +30,12 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_PRESENCE_ACCESS;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
 import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
 
 public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
@@ -49,21 +47,21 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 				tabs(
 						tabSpec(WIDGET_PRESENCE_ACCESS, TAB_BY_DATE, "overview_tab_bydate", this::presenceByDateDefinition,
 								FILTER_DATE, FILTER_ROLE),
-						tabSpec(WIDGET_PRESENCE_ACCESS, TAB_BY_USER, "overview_tab_byuser", this::lastVisitByUserDefinition,
+						tabSpec(WIDGET_PRESENCE_ACCESS, TAB_BY_USER, "overview_tab_byuser", this::presenceByUserDefinition,
 								FILTER_DATE, FILTER_ROLE)),
 				metrics(
-						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_LAST_VISIT, "overview_title_last_visit", AUDIENCE_ALL,
-								this::lastVisitMetricDefinition, this::lastVisitValue),
-						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_NEVER_VISITED, "overview_title_never_accessed",
-								AUDIENCE_ALL, this::neverVisitedMetricDefinition, this::neverVisitedValue),
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_AVERAGE, "overview_title_presence_time_avg", AUDIENCE_ALL,
 								this::presencesEnabled, this::averagePresenceMetricDefinition, this::averagePresenceValue),
+						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_BOUNCE_RATE, "overview_title_bounce_rate", AUDIENCE_ALL,
+								this::presencesEnabled, this::bounceRateMetricDefinition, this::bounceRateValue),
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_7D, "overview_title_presence_last7days", AUDIENCE_ALL,
 								this::presencesEnabled, this::presence7dMetricDefinition, this::presence7dValue),
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_30D, "overview_title_presence_last30days", AUDIENCE_ALL,
 								this::presencesEnabled, this::presence30dMetricDefinition, this::presence30dValue),
 						metricSpec(WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_365D, "overview_title_presence_last365days", AUDIENCE_ALL,
-								this::presencesEnabled, this::presence365dMetricDefinition, this::presence365dValue)));
+								this::presencesEnabled, this::presence365dMetricDefinition, this::presence365dValue)),
+				highlights(highlightSpec(HIGHLIGHT_PRESENCE_LAST_30_DAYS, "overview_title_presence_last30days",
+						this::presencesEnabled, this::presenceLast30DaysChart)));
 	}
 
 	private WidgetReportDefinition presenceByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -77,50 +75,20 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 		return new WidgetReportDefinition(message("overview_title_presence_access"), reportDef, reportDef);
 	}
 
-	private WidgetReportDefinition lastVisitByUserDefinition(String siteId, SiteStatsReportRequest request, String userId) {
-		ReportDef table = lastVisitByUserReport(siteId, request);
+	private WidgetReportDefinition presenceByUserDefinition(String siteId, SiteStatsReportRequest request, String userId) {
 		ReportDef chart = reportFactory().presenceBase(siteId, request);
 		ReportParams chartParams = chart.getReportParams();
-		chartParams.setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
+		chartParams.setHowTotalsBy(reportFactory().dateTotals(request, StatsManager.T_USER));
 		reportFactory().applyDateGrouping(chartParams, request, false);
 		chartParams.setHowSortBy(StatsManager.T_DURATION);
 		chartParams.setHowChartType(StatsManager.CHARTTYPE_PIE);
 		chartParams.setHowChartSource(StatsManager.T_USER);
 		chartParams.setHowPresentationMode(ReportManager.HOW_PRESENTATION_BOTH);
+		ReportDef table = new ReportDef(chart, siteId);
+		table.getReportParams().setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
+		table.getReportParams().setHowSortBy(StatsManager.T_DURATION);
 		return new WidgetReportDefinition(message("overview_title_presence_access"),
 				message("overview_title_presence_access"), chart, table);
-	}
-
-	private ReportDef lastVisitByUserReport(String siteId, SiteStatsReportRequest request) {
-		ReportDef reportDef = reportFactory().baseReportDef(siteId);
-		ReportParams params = reportDef.getReportParams();
-		params.setWhat(ReportManager.WHAT_EVENTS);
-		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
-		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
-		reportFactory().applyRoleFilter(params, request);
-		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER, StatsManager.T_LASTDATE));
-		params.setHowSortBy(StatsManager.T_LASTDATE);
-		params.setHowSortAscending(false);
-		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
-		return reportDef;
-	}
-
-	private WidgetReportDefinition lastVisitMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
-		ReportDef reportDef = lastVisitByUserReport(siteId, new SiteStatsReportRequest());
-		reportDef.getReportParams().setWhen(ReportManager.WHEN_ALL);
-		return new WidgetReportDefinition(message("overview_title_last_visit"), null, reportDef);
-	}
-
-	private WidgetReportDefinition neverVisitedMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
-		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
-		ReportParams params = reportDef.getReportParams();
-		params.setWhat(ReportManager.WHAT_VISITS);
-		params.setWhen(ReportManager.WHEN_ALL);
-		params.setWho(ReportManager.WHO_NONE);
-		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
-		params.setHowSort(false);
-		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
-		return new WidgetReportDefinition(message("overview_title_never_accessed"), null, reportDef);
 	}
 
 	private WidgetReportDefinition averagePresenceMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -138,6 +106,19 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 		params.setHowChartSeriesSource(StatsManager.T_NONE);
 		params.setHowChartSeriesPeriod(StatsManager.CHARTTIMESERIES_MONTH);
 		return new WidgetReportDefinition(message("overview_title_presence_time_avg"), reportDef, reportDef);
+	}
+
+	private WidgetReportDefinition bounceRateMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_PRESENCES);
+		params.setWhen(ReportManager.WHEN_ALL);
+		params.setWho(ReportManager.WHO_ALL);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE, StatsManager.T_USER));
+		params.setHowSortBy(StatsManager.T_DURATION);
+		params.setHowSortAscending(true);
+		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
+		return new WidgetReportDefinition(message("overview_title_bounce_rate"), null, reportDef);
 	}
 
 	private WidgetReportDefinition presenceRangeMetricDefinition(String siteId, String when, String titleKey) {
@@ -168,24 +149,12 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 		return presenceRangeMetricDefinition(siteId, ReportManager.WHEN_LAST365DAYS, "overview_title_presence_last365days");
 	}
 
-	private WidgetMetricValue lastVisitValue(String siteId, String userId) {
-		return metricSupport().lastVisitValue(siteId, null, true);
-	}
-
-	private WidgetMetricValue neverVisitedValue(String siteId, String userId) {
-		Set<String> siteUsers = siteUsers(siteId);
-		Set<String> usersWithVisits = usersWithVisits(siteId);
-		int count = 0;
-		for (String siteUser : siteUsers) {
-			if (!usersWithVisits.contains(siteUser)) {
-				count++;
-			}
-		}
-		return WidgetMetricValue.withPercentage(String.valueOf(count), (int) metricSupport().percent(count, siteUsers.size()));
-	}
-
 	private WidgetMetricValue averagePresenceValue(String siteId, String userId) {
 		return metricSupport().averagePresencePerVisit(siteId);
+	}
+
+	private WidgetMetricValue bounceRateValue(String siteId, String userId) {
+		return metricSupport().bounceRateValue(siteId, null);
 	}
 
 	private WidgetMetricValue presence7dValue(String siteId, String userId) {
@@ -200,17 +169,11 @@ public class PresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefin
 		return metricSupport().presenceDurationValue(siteId, null, ReportManager.WHEN_LAST365DAYS);
 	}
 
+	private SiteStatsChart presenceLast30DaysChart(String siteId, String userId) {
+		return metricSupport().last30DaysPresenceChart(siteId, null);
+	}
+
 	private boolean presencesEnabled() {
 		return metricSupport().presencesEnabled();
-	}
-
-	private Set<String> siteUsers(String siteId) {
-		Set<String> users = statsManager().getSiteUsers(siteId);
-		return users == null ? Collections.<String>emptySet() : users;
-	}
-
-	private Set<String> usersWithVisits(String siteId) {
-		Set<String> users = statsManager().getUsersWithVisits(siteId);
-		return users == null ? new HashSet<String>() : users;
 	}
 }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsViewServiceImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsViewServiceImpl.java
@@ -118,6 +118,12 @@ public class SiteStatsViewServiceImpl implements SiteStatsViewService {
 
 		SiteStatsReportRequest safeRequest = SiteStatsReportRequest.normalized(request);
 		String userId = siteStatsWidgetCatalog.isOwnOnlyWidget(widgetId) ? siteStatsReportAccess.currentUserId() : null;
+		SiteStatsReportView customView = siteStatsWidgetCatalog.getWidgetReportView(siteId, widgetId, tabId, safeRequest, userId);
+		if (customView != null) {
+			customView.setWidgetId(widgetId);
+			customView.setTabId(tabId);
+			return customView;
+		}
 		WidgetReportDefinition definition = siteStatsWidgetCatalog.getWidgetReportDefinition(siteId, widgetId, tabId, safeRequest, userId);
 		return buildWidgetReportView(siteId, definition, safeRequest, widgetId, tabId, null,
 				"Unknown SiteStats widget report: " + widgetId + "/" + tabId);

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsWidgetCatalog.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsWidgetCatalog.java
@@ -16,8 +16,10 @@ import java.util.Map;
 
 import lombok.Setter;
 
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
 import org.sakaiproject.sitestats.api.view.SiteStatsOverview;
 import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportView;
 import org.sakaiproject.sitestats.api.view.SiteStatsWidget;
 import org.sakaiproject.sitestats.api.view.SiteStatsWidgetMetric;
 import org.sakaiproject.sitestats.api.view.SiteStatsWidgetMetricSnapshot;
@@ -93,6 +95,15 @@ public class SiteStatsWidgetCatalog {
 		return spec.getReportFactory().build(siteId, SiteStatsReportRequest.normalized(request), userId);
 	}
 
+	public SiteStatsReportView getWidgetReportView(String siteId, String widgetId, String tabId,
+			SiteStatsReportRequest request, String userId) {
+		WidgetTabSpec spec = tabSpecs.get(key(widgetId, tabId));
+		if (spec == null || spec.getViewFactory() == null || !widgetAvailable(widgetId)) {
+			return null;
+		}
+		return spec.getViewFactory().build(siteId, SiteStatsReportRequest.normalized(request), userId);
+	}
+
 	public void init() {
 		buildRegistry();
 	}
@@ -153,6 +164,7 @@ public class SiteStatsWidgetCatalog {
 		}
 		widget.setTabs(tabs);
 		widget.setMetrics(toMetrics(siteId, spec, userId, true));
+		widget.setHighlights(toHighlights(siteId, spec, userId));
 		return widget;
 	}
 
@@ -176,6 +188,23 @@ public class SiteStatsWidgetCatalog {
 			}
 		}
 		return metrics;
+	}
+
+	private List<SiteStatsChart> toHighlights(String siteId, WidgetSpec spec, String userId) {
+		List<SiteStatsChart> charts = new ArrayList<SiteStatsChart>();
+		if (spec.getHighlights() == null) {
+			return charts;
+		}
+		for (WidgetHighlightSpec highlight : spec.getHighlights()) {
+			if (!highlight.isAvailable() || highlight.getFactory() == null) {
+				continue;
+			}
+			SiteStatsChart chart = highlight.getFactory().build(siteId, userId);
+			if (chart != null) {
+				charts.add(chart);
+			}
+		}
+		return charts;
 	}
 
 	private SiteStatsWidgetMetric toMetric(String siteId, WidgetSpec spec, WidgetMetricSpec metric, String userId, boolean includeValues) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsWidgetContext.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsWidgetContext.java
@@ -15,6 +15,7 @@ import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.event.EventRegistryService;
 import org.sakaiproject.sitestats.api.event.SiteStatsToolEventsService;
 import org.sakaiproject.sitestats.api.report.ReportManager;
+import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 
@@ -28,6 +29,7 @@ public class SiteStatsWidgetContext {
 	@Setter private SiteService siteService;
 	@Setter private ContentHostingService contentHostingService;
 	@Setter private UserDirectoryService userDirectoryService;
+	@Setter private UserTimeService userTimeService;
 
 	@Setter private ResourceLoader messages = new ResourceLoader("Messages");
 

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsWidgetDefinitionSupport.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/SiteStatsWidgetDefinitionSupport.java
@@ -7,6 +7,7 @@ package org.sakaiproject.sitestats.impl.view;
 
 import lombok.Setter;
 
+import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.event.EventRegistryService;
 import org.sakaiproject.sitestats.api.event.SiteStatsToolEventsService;
@@ -35,6 +36,10 @@ public class SiteStatsWidgetDefinitionSupport {
 		return context.getEventRegistryService();
 	}
 
+	public SiteService getSiteService() {
+		return context.getSiteService();
+	}
+
 	public WidgetFilterCatalog getFilterCatalog() {
 		return filterCatalog;
 	}
@@ -45,6 +50,10 @@ public class SiteStatsWidgetDefinitionSupport {
 
 	public WidgetMetricSupport getMetricSupport() {
 		return metricSupport;
+	}
+
+	public SiteStatsWidgetContext getContext() {
+		return context;
 	}
 
 	public String message(String key) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
@@ -30,7 +30,6 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_PRESENCE_LAST_30_DAYS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_AVERAGE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_BOUNCE_RATE;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_LAST_VISIT;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_30D;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_365D;
@@ -47,8 +46,6 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 				tabs(tabSpec(WIDGET_STUDENT_PRESENCE_ACCESS, TAB_BY_DATE, "overview_tab_bydate",
 						this::studentPresenceByDateDefinition, FILTER_DATE)),
 				metrics(
-						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT, "overview_title_last_visit_own",
-								AUDIENCE_OWN, null, this::studentLastVisitValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_AVERAGE, "overview_title_presence_time_avg",
 								AUDIENCE_OWN, this::presencesEnabled, null, this::studentMedianPresenceValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_BOUNCE_RATE, "overview_title_bounce_rate",
@@ -77,10 +74,6 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 		params.setHowChartSource(StatsManager.T_DATE);
 		params.setHowChartSeriesSource(StatsManager.T_NONE);
 		return new WidgetReportDefinition(message("overview_title_presence_access"), reportDef, reportDef);
-	}
-
-	private WidgetMetricValue studentLastVisitValue(String siteId, String userId) {
-		return metricSupport().lastVisitValue(siteId, userId, false);
 	}
 
 	private WidgetMetricValue studentMedianPresenceValue(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
@@ -1,0 +1,109 @@
+/**********************************************************************************
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **********************************************************************************/
+
+package org.sakaiproject.sitestats.impl.view;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.sitestats.api.StatsManager;
+import org.sakaiproject.sitestats.api.report.ReportDef;
+import org.sakaiproject.sitestats.api.report.ReportManager;
+import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_OWN;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_AVERAGE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_LAST_VISIT;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_30D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_365D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_7D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_STUDENT_PRESENCE_ACCESS;
+
+public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
+
+	@Override
+	public WidgetSpec getSpec() {
+		return widgetSpec(WIDGET_STUDENT_PRESENCE_ACCESS, "overview_title_presence_access", "sakai-sitestats", AUDIENCE_OWN,
+				() -> true,
+				tabs(tabSpec(WIDGET_STUDENT_PRESENCE_ACCESS, TAB_BY_DATE, "overview_tab_bydate",
+						this::studentPresenceByDateDefinition, FILTER_DATE)),
+				metrics(
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT, "overview_title_last_visit_own",
+								AUDIENCE_OWN, null, this::studentLastVisitValue),
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_AVERAGE, "overview_title_presence_time_avg",
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentAveragePresenceValue),
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL, "overview_title_presence_time",
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresenceTotalValue),
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_7D, "overview_title_presence_last7days",
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresence7dValue),
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_30D, "overview_title_presence_last30days",
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresence30dValue),
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_365D, "overview_title_presence_last365days",
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresence365dValue)));
+	}
+
+	private WidgetReportDefinition studentPresenceByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = reportFactory().baseReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_PRESENCES);
+		params.setWho(ReportManager.WHO_CUSTOM);
+		params.setWhoUserIds(Arrays.asList(userId));
+		reportFactory().applyDateGrouping(params, request, true);
+		params.setHowTotalsBy(reportFactory().dateTotals(request));
+		params.setHowChartType(StatsManager.CHARTTYPE_TIMESERIESBAR);
+		params.setHowChartSource(StatsManager.T_DATE);
+		params.setHowChartSeriesSource(StatsManager.T_NONE);
+		return new WidgetReportDefinition(message("overview_title_presence_access"), reportDef, reportDef);
+	}
+
+	private WidgetMetricValue studentLastVisitValue(String siteId, String userId) {
+		return metricSupport().lastVisitValue(siteId, userId, false);
+	}
+
+	private WidgetMetricValue studentAveragePresenceValue(String siteId, String userId) {
+		return metricSupport().averagePresencePerVisitForUser(siteId, userId);
+	}
+
+	private WidgetMetricValue studentPresenceTotalValue(String siteId, String userId) {
+		return studentPresenceValue(siteId, userId, ReportManager.WHEN_ALL);
+	}
+
+	private WidgetMetricValue studentPresence7dValue(String siteId, String userId) {
+		return studentPresenceValue(siteId, userId, ReportManager.WHEN_LAST7DAYS);
+	}
+
+	private WidgetMetricValue studentPresence30dValue(String siteId, String userId) {
+		return studentPresenceValue(siteId, userId, ReportManager.WHEN_LAST30DAYS);
+	}
+
+	private WidgetMetricValue studentPresence365dValue(String siteId, String userId) {
+		return studentPresenceValue(siteId, userId, ReportManager.WHEN_LAST365DAYS);
+	}
+
+	private WidgetMetricValue studentPresenceValue(String siteId, String userId, String when) {
+		if (StringUtils.isBlank(userId)) {
+			return WidgetMetricValue.of("-");
+		}
+		return metricSupport().presenceDurationValue(siteId, Arrays.asList(userId), when);
+	}
+
+	private boolean presencesEnabled() {
+		return metricSupport().presencesEnabled();
+	}
+}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
@@ -23,10 +23,13 @@ import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
 import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_OWN;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_PRESENCE_LAST_30_DAYS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_AVERAGE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_BOUNCE_RATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_LAST_VISIT;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_30D;
@@ -48,6 +51,8 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 								AUDIENCE_OWN, null, this::studentLastVisitValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_AVERAGE, "overview_title_presence_time_avg",
 								AUDIENCE_OWN, this::presencesEnabled, null, this::studentAveragePresenceValue),
+						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_BOUNCE_RATE, "overview_title_bounce_rate",
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentBounceRateValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL, "overview_title_presence_time",
 								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresenceTotalValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_7D, "overview_title_presence_last7days",
@@ -55,7 +60,9 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_30D, "overview_title_presence_last30days",
 								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresence30dValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_365D, "overview_title_presence_last365days",
-								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresence365dValue)));
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentPresence365dValue)),
+				highlights(highlightSpec(HIGHLIGHT_PRESENCE_LAST_30_DAYS, "overview_title_presence_last30days",
+						this::presencesEnabled, this::studentPresenceLast30DaysChart)));
 	}
 
 	private WidgetReportDefinition studentPresenceByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -80,6 +87,13 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 		return metricSupport().averagePresencePerVisitForUser(siteId, userId);
 	}
 
+	private WidgetMetricValue studentBounceRateValue(String siteId, String userId) {
+		if (StringUtils.isBlank(userId)) {
+			return WidgetMetricValue.of("-");
+		}
+		return metricSupport().bounceRateValue(siteId, Arrays.asList(userId));
+	}
+
 	private WidgetMetricValue studentPresenceTotalValue(String siteId, String userId) {
 		return studentPresenceValue(siteId, userId, ReportManager.WHEN_ALL);
 	}
@@ -101,6 +115,13 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 			return WidgetMetricValue.of("-");
 		}
 		return metricSupport().presenceDurationValue(siteId, Arrays.asList(userId), when);
+	}
+
+	private SiteStatsChart studentPresenceLast30DaysChart(String siteId, String userId) {
+		if (StringUtils.isBlank(userId)) {
+			return metricSupport().last30DaysPresenceChart(siteId, null);
+		}
+		return metricSupport().last30DaysPresenceChart(siteId, Arrays.asList(userId));
 	}
 
 	private boolean presencesEnabled() {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentPresenceAccessWidgetDefinition.java
@@ -50,7 +50,7 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT, "overview_title_last_visit_own",
 								AUDIENCE_OWN, null, this::studentLastVisitValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_AVERAGE, "overview_title_presence_time_avg",
-								AUDIENCE_OWN, this::presencesEnabled, null, this::studentAveragePresenceValue),
+								AUDIENCE_OWN, this::presencesEnabled, null, this::studentMedianPresenceValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_BOUNCE_RATE, "overview_title_bounce_rate",
 								AUDIENCE_OWN, this::presencesEnabled, null, this::studentBounceRateValue),
 						metricSpec(WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL, "overview_title_presence_time",
@@ -83,8 +83,8 @@ public class StudentPresenceAccessWidgetDefinition extends AbstractSiteStatsWidg
 		return metricSupport().lastVisitValue(siteId, userId, false);
 	}
 
-	private WidgetMetricValue studentAveragePresenceValue(String siteId, String userId) {
-		return metricSupport().averagePresencePerVisitForUser(siteId, userId);
+	private WidgetMetricValue studentMedianPresenceValue(String siteId, String userId) {
+		return metricSupport().medianPresencePerVisitForUser(siteId, userId);
 	}
 
 	private WidgetMetricValue studentBounceRateValue(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentVisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentVisitsWidgetDefinition.java
@@ -8,6 +8,7 @@ package org.sakaiproject.sitestats.impl.view;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_OWN;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_VISITS_LAST_30_DAYS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_LAST_VISIT;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TRAFFIC_TREND;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
@@ -32,6 +33,8 @@ public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefini
 				metrics(
 						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL, "overview_title_visits_sum", AUDIENCE_OWN,
 								this::studentVisitsByDateDefinition, this::studentVisitsTotalValue),
+						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_PRESENCE_LAST_VISIT, "overview_title_last_visit",
+								AUDIENCE_OWN, null, this::studentLastVisitValue),
 						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TRAFFIC_TREND, "overview_title_traffic_trend",
 								AUDIENCE_OWN, this::studentVisitsByDateDefinition, this::studentTrafficTrendValue)),
 				highlights(highlightSpec(HIGHLIGHT_VISITS_LAST_30_DAYS, "overview_title_visits_last30days",
@@ -56,6 +59,10 @@ public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefini
 
 	private WidgetMetricValue studentVisitsTotalValue(String siteId, String userId) {
 		return WidgetMetricValue.of(Long.toString(statsManager().getTotalSiteVisitsForUser(siteId, userId)));
+	}
+
+	private WidgetMetricValue studentLastVisitValue(String siteId, String userId) {
+		return metricSupport().lastVisitValue(siteId, userId, false);
 	}
 
 	private WidgetMetricValue studentTrafficTrendValue(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentVisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentVisitsWidgetDefinition.java
@@ -6,9 +6,11 @@
 package org.sakaiproject.sitestats.impl.view;
 
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_OWN;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_VISITS_LAST_30_DAYS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TRAFFIC_TREND;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_STUDENT_VISITS;
 
 import java.util.Arrays;
@@ -17,6 +19,7 @@ import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
 import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
 
 public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
@@ -26,8 +29,13 @@ public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefini
 		return widgetSpec(WIDGET_STUDENT_VISITS, "overview_title_visits", "sakai-singleuser", AUDIENCE_OWN, () -> true,
 				tabs(tabSpec(WIDGET_STUDENT_VISITS, TAB_BY_DATE, "overview_tab_bydate", this::studentVisitsByDateDefinition,
 						FILTER_DATE)),
-				metrics(metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL, "overview_title_visits_sum", AUDIENCE_OWN,
-						null, this::studentVisitsTotalValue)));
+				metrics(
+						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL, "overview_title_visits_sum", AUDIENCE_OWN,
+								this::studentVisitsByDateDefinition, this::studentVisitsTotalValue),
+						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TRAFFIC_TREND, "overview_title_traffic_trend",
+								AUDIENCE_OWN, this::studentVisitsByDateDefinition, this::studentTrafficTrendValue)),
+				highlights(highlightSpec(HIGHLIGHT_VISITS_LAST_30_DAYS, "overview_title_visits_last30days",
+						this::studentVisitsLast30DaysChart)));
 	}
 
 	private WidgetReportDefinition studentVisitsByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -48,5 +56,13 @@ public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefini
 
 	private WidgetMetricValue studentVisitsTotalValue(String siteId, String userId) {
 		return WidgetMetricValue.of(Long.toString(statsManager().getTotalSiteVisitsForUser(siteId, userId)));
+	}
+
+	private WidgetMetricValue studentTrafficTrendValue(String siteId, String userId) {
+		return metricSupport().trafficTrendValue(siteId, userId);
+	}
+
+	private SiteStatsChart studentVisitsLast30DaysChart(String siteId, String userId) {
+		return metricSupport().last30DaysVisitsChart(siteId, userId);
 	}
 }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentVisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/StudentVisitsWidgetDefinition.java
@@ -6,8 +6,6 @@
 package org.sakaiproject.sitestats.impl.view;
 
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_OWN;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_AVERAGE_PRESENCE;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_PRESENCE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
@@ -15,7 +13,6 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_STUD
 
 import java.util.Arrays;
 
-import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
@@ -29,13 +26,8 @@ public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefini
 		return widgetSpec(WIDGET_STUDENT_VISITS, "overview_title_visits", "sakai-singleuser", AUDIENCE_OWN, () -> true,
 				tabs(tabSpec(WIDGET_STUDENT_VISITS, TAB_BY_DATE, "overview_tab_bydate", this::studentVisitsByDateDefinition,
 						FILTER_DATE)),
-				metrics(
-						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL, "overview_title_visits_sum", AUDIENCE_OWN,
-								null, this::studentVisitsTotalValue),
-						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_AVERAGE_PRESENCE, "overview_title_presence_time_avg", AUDIENCE_OWN,
-								() -> Boolean.TRUE.equals(statsManager().getEnableSitePresences()), null, this::studentVisitsAveragePresenceValue),
-						metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_PRESENCE, "overview_title_presence_time", AUDIENCE_OWN,
-								() -> Boolean.TRUE.equals(statsManager().getEnableSitePresences()), null, this::studentVisitsPresenceValue)));
+				metrics(metricSpec(WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL, "overview_title_visits_sum", AUDIENCE_OWN,
+						null, this::studentVisitsTotalValue)));
 	}
 
 	private WidgetReportDefinition studentVisitsByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -56,19 +48,5 @@ public class StudentVisitsWidgetDefinition extends AbstractSiteStatsWidgetDefini
 
 	private WidgetMetricValue studentVisitsTotalValue(String siteId, String userId) {
 		return WidgetMetricValue.of(Long.toString(statsManager().getTotalSiteVisitsForUser(siteId, userId)));
-	}
-
-	private WidgetMetricValue studentVisitsAveragePresenceValue(String siteId, String userId) {
-		long visits = statsManager().getTotalSiteVisitsForUser(siteId, userId);
-		if (visits == 0 || StringUtils.isBlank(userId)) {
-			return WidgetMetricValue.of("0");
-		}
-		long duration = metricSupport().sitePresenceDuration(siteId, Arrays.asList(userId));
-		return WidgetMetricValue.of(metricSupport().msToString(duration / visits));
-	}
-
-	private WidgetMetricValue studentVisitsPresenceValue(String siteId, String userId) {
-		long duration = StringUtils.isBlank(userId) ? 0 : metricSupport().sitePresenceDuration(siteId, Arrays.asList(userId));
-		return WidgetMetricValue.of(metricSupport().msToString(duration));
 	}
 }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
@@ -48,7 +48,7 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 								this::visitsUniqueMetricDefinition, this::visitsUniqueValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS, "overview_title_enrolled_users_with_visits_sum", AUDIENCE_ALL,
 								this::visitsUsersWithVisitsMetricDefinition, this::visitsUsersWithVisitsValue),
-						metricSpec(WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT, "overview_title_last_visit", AUDIENCE_ALL,
+						metricSpec(WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT, "overview_title_last_student_visit", AUDIENCE_ALL,
 								this::lastVisitMetricDefinition, this::lastVisitValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_TRAFFIC_TREND, "overview_title_traffic_trend", AUDIENCE_ALL,
 								this::visitsTotalMetricDefinition, this::visitsTrafficTrendValue)),
@@ -144,13 +144,14 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
 		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
 		params.setWhen(ReportManager.WHEN_ALL);
-		params.setWho(ReportManager.WHO_ALL);
+		params.setWho(ReportManager.WHO_CUSTOM);
+		params.setWhoUserIds(metricSupport().learnersWithoutSiteUpdate(siteId));
 		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER, StatsManager.T_LASTDATE));
 		params.setHowSort(true);
 		params.setHowSortBy(StatsManager.T_LASTDATE);
 		params.setHowSortAscending(false);
 		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
-		return new WidgetReportDefinition(message("overview_title_last_visit"), null, reportDef);
+		return new WidgetReportDefinition(message("overview_title_last_student_visit"), null, reportDef);
 	}
 
 	private SiteStatsReportView visitsByRoleView(String siteId, SiteStatsReportRequest request, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
@@ -9,6 +9,7 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_AL
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_ROLE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_VISITS_LAST_30_DAYS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_LAST_VISIT;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TRAFFIC_TREND;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_UNIQUE;
@@ -47,6 +48,8 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 								this::visitsUniqueMetricDefinition, this::visitsUniqueValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS, "overview_title_enrolled_users_with_visits_sum", AUDIENCE_ALL,
 								this::visitsUsersWithVisitsMetricDefinition, this::visitsUsersWithVisitsValue),
+						metricSpec(WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT, "overview_title_last_visit", AUDIENCE_ALL,
+								this::lastVisitMetricDefinition, this::lastVisitValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_TRAFFIC_TREND, "overview_title_traffic_trend", AUDIENCE_ALL,
 								this::visitsTotalMetricDefinition, this::visitsTrafficTrendValue)),
 				highlights(highlightSpec(HIGHLIGHT_VISITS_LAST_30_DAYS, "overview_title_visits_last30days",
@@ -134,6 +137,22 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 		return new WidgetReportDefinition(message(titleKey), null, reportDef);
 	}
 
+	private WidgetReportDefinition lastVisitMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_EVENTS);
+		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
+		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
+		params.setWhen(ReportManager.WHEN_ALL);
+		params.setWho(ReportManager.WHO_ALL);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER, StatsManager.T_LASTDATE));
+		params.setHowSort(true);
+		params.setHowSortBy(StatsManager.T_LASTDATE);
+		params.setHowSortAscending(false);
+		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
+		return new WidgetReportDefinition(message("overview_title_last_visit"), null, reportDef);
+	}
+
 	private SiteStatsReportView visitsByRoleView(String siteId, SiteStatsReportRequest request, String userId) {
 		return metricSupport().visitsByRoleView(siteId, request);
 	}
@@ -148,6 +167,10 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 
 	private WidgetMetricValue visitsUsersWithVisitsValue(String siteId, String userId) {
 		return metricSupport().membersVisitedValue(siteId);
+	}
+
+	private WidgetMetricValue lastVisitValue(String siteId, String userId) {
+		return metricSupport().lastVisitValue(siteId, null, true);
 	}
 
 	private WidgetMetricValue visitsTrafficTrendValue(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
@@ -6,26 +6,27 @@
 package org.sakaiproject.sitestats.impl.view;
 
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_ALL;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_ENROLLED_USERS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_ROLE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.HIGHLIGHT_VISITS_LAST_30_DAYS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TRAFFIC_TREND;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_UNIQUE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_USERS_WITH_VISITS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_ROLE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_DATE;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.FILTER_ROLE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_VISITS;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
 import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportView;
 
 public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 
@@ -36,16 +37,20 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 						tabSpec(WIDGET_VISITS, TAB_BY_DATE, "overview_tab_bydate", this::visitsByDateDefinition,
 								FILTER_DATE, FILTER_ROLE),
 						tabSpec(WIDGET_VISITS, TAB_BY_USER, "overview_tab_byuser", this::visitsByUserDefinition,
-								FILTER_DATE, FILTER_ROLE)),
+								FILTER_DATE, FILTER_ROLE),
+						viewTabSpec(WIDGET_VISITS, TAB_BY_ROLE, "overview_tab_byrole", this::visitsByRoleView,
+								FILTER_DATE)),
 				metrics(
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_TOTAL, "overview_title_visits_sum", AUDIENCE_ALL,
 								this::visitsTotalMetricDefinition, this::visitsTotalValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_UNIQUE, "overview_title_unique_visits_sum", AUDIENCE_ALL,
-								this::visitsTotalMetricDefinition, this::visitsUniqueValue),
-						metricSpec(WIDGET_VISITS, METRIC_VISITS_ENROLLED_USERS, "overview_title_enrolled_users_sum", AUDIENCE_ALL,
-								null, this::visitsEnrolledUsersValue),
+								this::visitsUniqueMetricDefinition, this::visitsUniqueValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS, "overview_title_enrolled_users_with_visits_sum", AUDIENCE_ALL,
-								this::visitsUsersWithVisitsMetricDefinition, this::visitsUsersWithVisitsValue)));
+								this::visitsUsersWithVisitsMetricDefinition, this::visitsUsersWithVisitsValue),
+						metricSpec(WIDGET_VISITS, METRIC_VISITS_TRAFFIC_TREND, "overview_title_traffic_trend", AUDIENCE_ALL,
+								this::visitsTotalMetricDefinition, this::visitsTrafficTrendValue)),
+				highlights(highlightSpec(HIGHLIGHT_VISITS_LAST_30_DAYS, "overview_title_visits_last30days",
+						this::visitsLast30DaysChart)));
 	}
 
 	private WidgetReportDefinition visitsByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -110,6 +115,14 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 	}
 
 	private WidgetReportDefinition visitsUsersWithVisitsMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		return visitsByUserTableDefinition(siteId, "overview_title_enrolled_users_with_visits_sum");
+	}
+
+	private WidgetReportDefinition visitsUniqueMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
+		return visitsByUserTableDefinition(siteId, "overview_title_unique_visits_sum");
+	}
+
+	private WidgetReportDefinition visitsByUserTableDefinition(String siteId, String titleKey) {
 		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
 		ReportParams params = reportDef.getReportParams();
 		params.setWhat(ReportManager.WHAT_VISITS);
@@ -118,7 +131,11 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
 		params.setHowSort(false);
 		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
-		return new WidgetReportDefinition(message("overview_title_enrolled_users_with_visits_sum"), null, reportDef);
+		return new WidgetReportDefinition(message(titleKey), null, reportDef);
+	}
+
+	private SiteStatsReportView visitsByRoleView(String siteId, SiteStatsReportRequest request, String userId) {
+		return metricSupport().visitsByRoleView(siteId, request);
 	}
 
 	private WidgetMetricValue visitsTotalValue(String siteId, String userId) {
@@ -126,32 +143,18 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 	}
 
 	private WidgetMetricValue visitsUniqueValue(String siteId, String userId) {
-		return WidgetMetricValue.of(Long.toString(statsManager().getTotalSiteUniqueVisits(siteId)));
-	}
-
-	private WidgetMetricValue visitsEnrolledUsersValue(String siteId, String userId) {
-		return WidgetMetricValue.of(Long.toString(statsManager().getTotalSiteUsers(siteId)));
+		return metricSupport().uniqueVisitsValue(siteId);
 	}
 
 	private WidgetMetricValue visitsUsersWithVisitsValue(String siteId, String userId) {
-		Set<String> siteUsers = siteUsers(siteId);
-		Set<String> usersWithVisits = usersWithVisits(siteId);
-		int count = 0;
-		for (String siteUser : siteUsers) {
-			if (usersWithVisits.contains(siteUser)) {
-				count++;
-			}
-		}
-		return WidgetMetricValue.withPercentage(String.valueOf(count), (int) metricSupport().percent(count, siteUsers.size()));
+		return metricSupport().membersVisitedValue(siteId);
 	}
 
-	private Set<String> siteUsers(String siteId) {
-		Set<String> users = statsManager().getSiteUsers(siteId);
-		return users == null ? Collections.<String>emptySet() : users;
+	private WidgetMetricValue visitsTrafficTrendValue(String siteId, String userId) {
+		return metricSupport().trafficTrendValue(siteId, null);
 	}
 
-	private Set<String> usersWithVisits(String siteId) {
-		Set<String> users = statsManager().getUsersWithVisits(siteId);
-		return users == null ? new HashSet<String>() : users;
+	private SiteStatsChart visitsLast30DaysChart(String siteId, String userId) {
+		return metricSupport().last30DaysVisitsChart(siteId, null);
 	}
 }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/VisitsWidgetDefinition.java
@@ -6,11 +6,9 @@
 package org.sakaiproject.sitestats.impl.view;
 
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_ALL;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_AVERAGE_PRESENCE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_ENROLLED_USERS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TOTAL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_UNIQUE;
-import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_USERS_WITHOUT_VISITS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_USERS_WITH_VISITS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER;
@@ -20,12 +18,10 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_VISI
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.sakaiproject.sitestats.api.StatsManager;
-import org.sakaiproject.sitestats.api.Util;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
@@ -49,12 +45,7 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_ENROLLED_USERS, "overview_title_enrolled_users_sum", AUDIENCE_ALL,
 								null, this::visitsEnrolledUsersValue),
 						metricSpec(WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS, "overview_title_enrolled_users_with_visits_sum", AUDIENCE_ALL,
-								this::visitsUsersWithVisitsMetricDefinition, this::visitsUsersWithVisitsValue),
-						metricSpec(WIDGET_VISITS, METRIC_VISITS_USERS_WITHOUT_VISITS, "overview_title_enrolled_users_without_visits_sum", AUDIENCE_ALL,
-								this::visitsUsersWithoutVisitsMetricDefinition, this::visitsUsersWithoutVisitsValue),
-						metricSpec(WIDGET_VISITS, METRIC_VISITS_AVERAGE_PRESENCE, "overview_title_presence_time_avg", AUDIENCE_ALL,
-								() -> Boolean.TRUE.equals(statsManager().getEnableSitePresences()), this::visitsAveragePresenceMetricDefinition,
-								this::visitsAveragePresenceValue)));
+								this::visitsUsersWithVisitsMetricDefinition, this::visitsUsersWithVisitsValue)));
 	}
 
 	private WidgetReportDefinition visitsByDateDefinition(String siteId, SiteStatsReportRequest request, String userId) {
@@ -130,35 +121,6 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 		return new WidgetReportDefinition(message("overview_title_enrolled_users_with_visits_sum"), null, reportDef);
 	}
 
-	private WidgetReportDefinition visitsUsersWithoutVisitsMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
-		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
-		ReportParams params = reportDef.getReportParams();
-		params.setWhat(ReportManager.WHAT_VISITS);
-		params.setWhen(ReportManager.WHEN_ALL);
-		params.setWho(ReportManager.WHO_NONE);
-		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER));
-		params.setHowSort(false);
-		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_TABLE);
-		return new WidgetReportDefinition(message("overview_title_enrolled_users_without_visits_sum"), null, reportDef);
-	}
-
-	private WidgetReportDefinition visitsAveragePresenceMetricDefinition(String siteId, SiteStatsReportRequest request, String userId) {
-		ReportDef reportDef = reportFactory().baseMetricReportDef(siteId);
-		ReportParams params = reportDef.getReportParams();
-		params.setWhat(ReportManager.WHAT_PRESENCES);
-		params.setWhen(ReportManager.WHEN_ALL);
-		params.setWho(ReportManager.WHO_ALL);
-		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE, StatsManager.T_USER));
-		params.setHowSortBy(StatsManager.T_DATE);
-		params.setHowSortAscending(false);
-		params.setHowPresentationMode(ReportManager.HOW_PRESENTATION_BOTH);
-		params.setHowChartType(StatsManager.CHARTTYPE_TIMESERIESBAR);
-		params.setHowChartSource(StatsManager.T_DATE);
-		params.setHowChartSeriesSource(StatsManager.T_NONE);
-		params.setHowChartSeriesPeriod(StatsManager.CHARTTIMESERIES_MONTH);
-		return new WidgetReportDefinition(message("overview_title_presence_time_avg"), reportDef, reportDef);
-	}
-
 	private WidgetMetricValue visitsTotalValue(String siteId, String userId) {
 		return WidgetMetricValue.of(Long.toString(statsManager().getTotalSiteVisits(siteId)));
 	}
@@ -172,31 +134,15 @@ public class VisitsWidgetDefinition extends AbstractSiteStatsWidgetDefinition {
 	}
 
 	private WidgetMetricValue visitsUsersWithVisitsValue(String siteId, String userId) {
-		return enrolledUsersVisitMetric(siteId, true);
-	}
-
-	private WidgetMetricValue visitsUsersWithoutVisitsValue(String siteId, String userId) {
-		return enrolledUsersVisitMetric(siteId, false);
-	}
-
-	private WidgetMetricValue enrolledUsersVisitMetric(String siteId, boolean withVisits) {
 		Set<String> siteUsers = siteUsers(siteId);
 		Set<String> usersWithVisits = usersWithVisits(siteId);
 		int count = 0;
 		for (String siteUser : siteUsers) {
-			if (usersWithVisits.contains(siteUser) == withVisits) {
+			if (usersWithVisits.contains(siteUser)) {
 				count++;
 			}
 		}
 		return WidgetMetricValue.withPercentage(String.valueOf(count), (int) metricSupport().percent(count, siteUsers.size()));
-	}
-
-	private WidgetMetricValue visitsAveragePresenceValue(String siteId, String userId) {
-		long durationInMs = metricSupport().sitePresenceDuration(siteId, null);
-		Date firstPresenceDate = metricSupport().firstPresenceDate(siteId);
-		long totalVisits = statsManager().getTotalSiteVisits(siteId, firstPresenceDate, null);
-		double durationInMin = durationInMs == 0 || totalVisits == 0 ? 0 : Util.round((durationInMs / (double) totalVisits) / 1000 / 60, 1);
-		return WidgetMetricValue.of(durationInMin + " " + message("minutes_abbr"));
 	}
 
 	private Set<String> siteUsers(String siteId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetHighlightFactory.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetHighlightFactory.java
@@ -1,0 +1,24 @@
+/**********************************************************************************
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing the License.
+ **********************************************************************************/
+
+package org.sakaiproject.sitestats.impl.view;
+
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
+
+@FunctionalInterface
+interface WidgetHighlightFactory {
+
+	SiteStatsChart build(String siteId, String userId);
+}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetHighlightSpec.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetHighlightSpec.java
@@ -1,0 +1,36 @@
+/**********************************************************************************
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing the License.
+ **********************************************************************************/
+
+package org.sakaiproject.sitestats.impl.view;
+
+import java.util.function.BooleanSupplier;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class WidgetHighlightSpec {
+
+	private final String id;
+	private final String titleKey;
+	private final BooleanSupplier available;
+	private final WidgetHighlightFactory factory;
+
+	boolean isAvailable() {
+		return available.getAsBoolean();
+	}
+}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
@@ -85,24 +85,21 @@ public class WidgetMetricSupport {
 		String hoursAbbr = context.message("hours_abbr");
 		String minsAbbr = context.message("minutes_abbr");
 		String secsAbbr = context.message("seconds_abbr");
+		List<String> parts = new ArrayList<>();
 		if (hours >= 48) {
-			long days = hours / 24;
-			long remainingHours = hours % 24;
-			if (remainingHours == 0) {
-				return days + " " + daysAbbr;
-			}
-			return days + " " + daysAbbr + " " + remainingHours + " " + hoursAbbr;
+			parts.add((hours / 24) + " " + daysAbbr);
+			hours = hours % 24;
 		}
 		if (hours > 0) {
-			if (mins == 0) {
-				return hours + " " + hoursAbbr;
-			}
-			return hours + " " + hoursAbbr + " " + mins + " " + minsAbbr;
+			parts.add(hours + " " + hoursAbbr);
 		}
 		if (mins > 0) {
-			return mins + " " + minsAbbr;
+			parts.add(mins + " " + minsAbbr);
 		}
-		return secs + " " + secsAbbr;
+		if (secs > 0 || parts.isEmpty()) {
+			parts.add(secs + " " + secsAbbr);
+		}
+		return String.join(" ", parts);
 	}
 
 	String userDisplayId(String userId) {
@@ -213,7 +210,10 @@ public class WidgetMetricSupport {
 		List<LocalDate> days = sparklineDays(zone);
 		Map<LocalDate, Long> values = new HashMap<LocalDate, Long>();
 		for (SitePresence row : presenceRows(siteId, userIds, ReportManager.WHEN_LAST30DAYS)) {
-			addDayValue(values, toLocalDate(row.getDate(), zone), Math.max(0L, row.getDuration() / 60000L));
+			addDayValue(values, toLocalDate(row.getDate(), zone), Math.max(0L, row.getDuration()));
+		}
+		for (Map.Entry<LocalDate, Long> entry : values.entrySet()) {
+			entry.setValue(Long.valueOf(entry.getValue().longValue() / 60000L));
 		}
 		return compactDailyChart(context.message("overview_title_presence_last30days"), StatsManager.T_DURATION,
 				context.message("overview_title_presence_time"), days, values, zone);
@@ -357,11 +357,11 @@ public class WidgetMetricSupport {
 		return WidgetMetricValue.of(msToString(sitePresenceDuration(siteId, userIds, when)));
 	}
 
-	WidgetMetricValue averagePresencePerVisit(String siteId) {
+	WidgetMetricValue medianPresencePerVisit(String siteId) {
 		return medianPresenceValue(siteId, null);
 	}
 
-	WidgetMetricValue averagePresencePerVisitForUser(String siteId, String userId) {
+	WidgetMetricValue medianPresencePerVisitForUser(String siteId, String userId) {
 		if (StringUtils.isBlank(userId)) {
 			return WidgetMetricValue.of("-");
 		}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.TimeZone;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -38,6 +39,7 @@ import org.sakaiproject.sitestats.api.report.Report;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 
 @Slf4j
@@ -172,7 +174,18 @@ public class WidgetMetricSupport {
 			locale = Locale.getDefault();
 		}
 		return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
-				.format(Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate());
+				.format(Instant.ofEpochMilli(date.getTime()).atZone(localZoneId()).toLocalDate());
+	}
+
+	private ZoneId localZoneId() {
+		UserTimeService userTimeService = context.getUserTimeService();
+		if (userTimeService != null) {
+			TimeZone timeZone = userTimeService.getLocalTimeZone();
+			if (timeZone != null) {
+				return timeZone.toZoneId();
+			}
+		}
+		return ZoneId.systemDefault();
 	}
 
 	private LastVisit findLastVisit(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
@@ -5,16 +5,23 @@
  */
 package org.sakaiproject.sitestats.impl.view;
 
+import java.text.NumberFormat;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.StringJoiner;
+import java.util.Set;
 import java.util.TimeZone;
 
 import lombok.Getter;
@@ -22,16 +29,17 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.TypeException;
-import org.sakaiproject.javax.PagingPosition;
 import org.sakaiproject.sitestats.api.EventStat;
 import org.sakaiproject.sitestats.api.ResourceStat;
 import org.sakaiproject.sitestats.api.SitePresence;
 import org.sakaiproject.sitestats.api.SitePresenceTotal;
+import org.sakaiproject.sitestats.api.SiteVisits;
 import org.sakaiproject.sitestats.api.Stat;
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.Util;
@@ -39,11 +47,26 @@ import org.sakaiproject.sitestats.api.report.Report;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsChart;
+import org.sakaiproject.sitestats.api.view.SiteStatsChartDataset;
+import org.sakaiproject.sitestats.api.view.SiteStatsChartPoint;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportView;
+import org.sakaiproject.sitestats.api.view.SiteStatsTable;
+import org.sakaiproject.sitestats.api.view.SiteStatsTableCell;
+import org.sakaiproject.sitestats.api.view.SiteStatsTableColumn;
+import org.sakaiproject.sitestats.api.view.SiteStatsTableRow;
+import org.sakaiproject.site.api.Site;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 
 @Slf4j
 public class WidgetMetricSupport {
+
+	private static final String ROLE_COLUMN = "role";
+	private static final int SPARKLINE_DAYS = 30;
+
+	static final long BOUNCE_THRESHOLD_MS = 5L * 60L * 1000L;
 
 	@Setter private SiteStatsWidgetContext context;
 	@Setter private WidgetReportDefFactory reportFactory;
@@ -53,24 +76,33 @@ public class WidgetMetricSupport {
 	}
 
 	String msToString(long ms) {
-		StringJoiner time = new StringJoiner(" ");
-		String hoursAbbr = context.message("hours_abbr");
-		String minsAbbr = context.message("minutes_abbr");
-		String secsAbbr = context.message("seconds_abbr");
-		long totalSecs = ms / 1000;
+		long safeMs = Math.max(0L, ms);
+		long totalSecs = safeMs / 1000;
 		long hours = totalSecs / 3600;
 		long mins = (totalSecs / 60) % 60;
 		long secs = totalSecs % 60;
-		String minsString = mins == 0 ? "0" : Long.toString(mins);
-		String secsString = secs == 0 ? "0" : Long.toString(secs);
-		if (hours > 0) {
-			time.add(Long.toString(hours)).add(hoursAbbr).add(minsString).add(minsAbbr).add(secsString).add(secsAbbr);
-		} else if (mins > 0) {
-			time.add(Long.toString(mins)).add(minsAbbr).add(secsString).add(secsAbbr);
-		} else {
-			time.add(secsString).add(secsAbbr);
+		String daysAbbr = context.message("days_abbr");
+		String hoursAbbr = context.message("hours_abbr");
+		String minsAbbr = context.message("minutes_abbr");
+		String secsAbbr = context.message("seconds_abbr");
+		if (hours >= 48) {
+			long days = hours / 24;
+			long remainingHours = hours % 24;
+			if (remainingHours == 0) {
+				return days + " " + daysAbbr;
+			}
+			return days + " " + daysAbbr + " " + remainingHours + " " + hoursAbbr;
 		}
-		return time.toString();
+		if (hours > 0) {
+			if (mins == 0) {
+				return hours + " " + hoursAbbr;
+			}
+			return hours + " " + hoursAbbr + " " + mins + " " + minsAbbr;
+		}
+		if (mins > 0) {
+			return mins + " " + minsAbbr;
+		}
+		return secs + " " + secsAbbr;
 	}
 
 	String userDisplayId(String userId) {
@@ -122,6 +154,190 @@ public class WidgetMetricSupport {
 		return Boolean.TRUE.equals(context.getStatsManager().getEnableSitePresences());
 	}
 
+	Set<String> siteUsers(String siteId) {
+		Set<String> users = context.getStatsManager().getSiteUsers(siteId);
+		return users == null ? Collections.<String>emptySet() : users;
+	}
+
+	Set<String> usersWithVisits(String siteId) {
+		Set<String> users = context.getStatsManager().getUsersWithVisits(siteId);
+		return users == null ? new HashSet<String>() : users;
+	}
+
+	int membersWhoVisitedCount(String siteId) {
+		Set<String> siteUsers = siteUsers(siteId);
+		Set<String> visited = usersWithVisits(siteId);
+		int count = 0;
+		for (String siteUser : siteUsers) {
+			if (visited.contains(siteUser)) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	WidgetMetricValue membersVisitedValue(String siteId) {
+		Set<String> enrolled = siteUsers(siteId);
+		int visited = membersWhoVisitedCount(siteId);
+		return WidgetMetricValue.withPercentage(visited + " / " + enrolled.size(), (int) percent(visited, enrolled.size()));
+	}
+
+	WidgetMetricValue uniqueVisitsValue(String siteId) {
+		return WidgetMetricValue.of(Long.toString(context.getStatsManager().getTotalSiteUniqueVisits(siteId)));
+	}
+
+	SiteStatsChart last30DaysVisitsChart(String siteId, String userId) {
+		ZoneId zone = localZoneId();
+		List<LocalDate> days = sparklineDays(zone);
+		Map<LocalDate, Long> values = new HashMap<LocalDate, Long>();
+		if (StringUtils.isNotBlank(userId)) {
+			for (Stat stat : visitRows(siteId, Arrays.asList(userId), ReportManager.WHEN_LAST30DAYS)) {
+				addDayValue(values, toLocalDate(stat.getDate(), zone), stat.getCount());
+			}
+		} else {
+			Date from = startOfDay(days.get(0), zone);
+			Date to = startOfDay(days.get(days.size() - 1), zone);
+			List<SiteVisits> visits = context.getStatsManager().getSiteVisits(siteId, from, to);
+			if (visits != null) {
+				for (SiteVisits dayVisits : visits) {
+					addDayValue(values, toLocalDate(dayVisits.getDate(), zone), dayVisits.getTotalVisits());
+				}
+			}
+		}
+		return compactDailyChart(context.message("overview_title_visits_last30days"), StatsManager.T_VISITS,
+				context.message("overview_title_visits"), days, values, zone);
+	}
+
+	SiteStatsChart last30DaysPresenceChart(String siteId, List<String> userIds) {
+		ZoneId zone = localZoneId();
+		List<LocalDate> days = sparklineDays(zone);
+		Map<LocalDate, Long> values = new HashMap<LocalDate, Long>();
+		for (SitePresence row : presenceRows(siteId, userIds, ReportManager.WHEN_LAST30DAYS)) {
+			addDayValue(values, toLocalDate(row.getDate(), zone), Math.max(0L, row.getDuration() / 60000L));
+		}
+		return compactDailyChart(context.message("overview_title_presence_last30days"), StatsManager.T_DURATION,
+				context.message("overview_title_presence_time"), days, values, zone);
+	}
+
+	SiteStatsReportView visitsByRoleView(String siteId, SiteStatsReportRequest request) {
+		SiteStatsReportRequest safeRequest = SiteStatsReportRequest.normalized(request);
+		String title = context.message("overview_title_visits");
+		List<RoleVisitCount> counts = visitsByRole(siteId, dateFilter(safeRequest));
+
+		SiteStatsReportView view = new SiteStatsReportView();
+		view.setSiteId(siteId);
+		view.setTitle(title);
+		view.setPresentationMode(ReportManager.HOW_PRESENTATION_BOTH);
+		if (safeRequest.isIncludeChart()) {
+			view.setChart(visitsByRoleChart(title, counts));
+		}
+		if (safeRequest.isIncludeTable()) {
+			view.setTable(visitsByRoleTable(title, counts, safeRequest));
+		}
+		return view;
+	}
+
+	WidgetMetricValue trafficTrendValue(String siteId, String userId) {
+		ZoneId zone = localZoneId();
+		LocalDate today = LocalDate.now(zone);
+		Date currentFrom = startOfDay(today.minusDays(6), zone);
+		Date currentTo = startOfDay(today, zone);
+		Date previousFrom = startOfDay(today.minusDays(13), zone);
+		Date previousTo = startOfDay(today.minusDays(7), zone);
+		long current = visitCount(siteId, userId, currentFrom, currentTo);
+		long previous = visitCount(siteId, userId, previousFrom, previousTo);
+		String primary = Long.toString(current);
+		if (previous == 0) {
+			return current == 0 ? WidgetMetricValue.withPercentage(primary, 0) : WidgetMetricValue.of(primary);
+		}
+		int change = (int) Math.round(100d * (current - previous) / previous);
+		return WidgetMetricValue.withPercentage(primary, change);
+	}
+
+	long visitCountForRole(String siteId, String roleId, String when) {
+		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_EVENTS);
+		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
+		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
+		params.setWho(ReportManager.WHO_ROLE);
+		params.setWhoRoleId(roleId);
+		params.setWhen(StringUtils.defaultIfBlank(when, ReportManager.WHEN_ALL));
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_SITE));
+		return sumCounts(context.getReportManager().getReport(reportDef, true));
+	}
+
+	WidgetMetricValue bounceRateValue(String siteId, List<String> userIds) {
+		if (!presencesEnabled()) {
+			return WidgetMetricValue.of("-");
+		}
+		List<SitePresence> rows = presenceRows(siteId, userIds, ReportManager.WHEN_ALL);
+		int bounce = 0;
+		for (SitePresence row : rows) {
+			if (row.getDuration() < BOUNCE_THRESHOLD_MS) {
+				bounce++;
+			}
+		}
+		return WidgetMetricValue.withPercentage(bounce + " / " + rows.size(), (int) percent(bounce, rows.size()));
+	}
+
+	List<SitePresence> presenceRows(String siteId, List<String> userIds, String when) {
+		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_PRESENCES);
+		params.setWhen(StringUtils.defaultIfBlank(when, ReportManager.WHEN_ALL));
+		params.setWho(userIds == null ? ReportManager.WHO_ALL : ReportManager.WHO_CUSTOM);
+		if (userIds != null) {
+			params.setWhoUserIds(userIds);
+		}
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE, StatsManager.T_USER));
+		Report report = context.getReportManager().getReport(reportDef, true);
+		List<SitePresence> rows = new ArrayList<SitePresence>();
+		for (Stat stat : report.getReportData()) {
+			if (stat instanceof SitePresence) {
+				rows.add((SitePresence) stat);
+			}
+		}
+		return rows;
+	}
+
+	private long visitCount(String siteId, String userId, Date from, Date to) {
+		if (StringUtils.isNotBlank(userId)) {
+			return eventVisitCount(siteId, Arrays.asList(userId), from, to);
+		}
+		return context.getStatsManager().getTotalSiteVisits(siteId, from, to);
+	}
+
+	private long eventVisitCount(String siteId, List<String> userIds, Date from, Date to) {
+		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_EVENTS);
+		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
+		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
+		params.setWho(ReportManager.WHO_CUSTOM);
+		params.setWhoUserIds(userIds);
+		params.setWhen(ReportManager.WHEN_CUSTOM);
+		params.setWhenFrom(from);
+		params.setWhenTo(to);
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_SITE));
+		return sumCounts(context.getReportManager().getReport(reportDef, true));
+	}
+
+	private long sumCounts(Report report) {
+		long total = 0;
+		if (report == null || report.getReportData() == null) {
+			return total;
+		}
+		for (Stat stat : report.getReportData()) {
+			total += stat.getCount();
+		}
+		return total;
+	}
+
+	private Date startOfDay(LocalDate date, ZoneId zone) {
+		return Date.from(date.atStartOfDay(zone).toInstant());
+	}
+
 	WidgetMetricValue lastVisitValue(String siteId, String userId, boolean includeUserDetail) {
 		LastVisit visit = findLastVisit(siteId, userId);
 		if (visit == null) {
@@ -142,27 +358,37 @@ public class WidgetMetricSupport {
 	}
 
 	WidgetMetricValue averagePresencePerVisit(String siteId) {
-		if (!presencesEnabled()) {
-			return WidgetMetricValue.of("-");
-		}
-		long durationInMs = sitePresenceDuration(siteId, null);
-		Date firstPresenceDate = firstPresenceDate(siteId);
-		long totalVisits = context.getStatsManager().getTotalSiteVisits(siteId, firstPresenceDate, null);
-		double durationInMin = durationInMs == 0 || totalVisits == 0 ? 0
-				: Util.round((durationInMs / (double) totalVisits) / 1000 / 60, 1);
-		return WidgetMetricValue.of(durationInMin + " " + context.message("minutes_abbr"));
+		return medianPresenceValue(siteId, null);
 	}
 
 	WidgetMetricValue averagePresencePerVisitForUser(String siteId, String userId) {
-		if (!presencesEnabled() || StringUtils.isBlank(userId)) {
+		if (StringUtils.isBlank(userId)) {
 			return WidgetMetricValue.of("-");
 		}
-		long visits = context.getStatsManager().getTotalSiteVisitsForUser(siteId, userId);
-		if (visits == 0) {
-			return WidgetMetricValue.of("0");
+		return medianPresenceValue(siteId, Arrays.asList(userId));
+	}
+
+	private WidgetMetricValue medianPresenceValue(String siteId, List<String> userIds) {
+		if (!presencesEnabled()) {
+			return WidgetMetricValue.of("-");
 		}
-		long duration = sitePresenceDuration(siteId, Arrays.asList(userId));
-		return WidgetMetricValue.of(msToString(duration / visits));
+		return WidgetMetricValue.of(msToString(medianDuration(presenceRows(siteId, userIds, ReportManager.WHEN_ALL))));
+	}
+
+	private long medianDuration(List<SitePresence> rows) {
+		if (rows == null || rows.isEmpty()) {
+			return 0;
+		}
+		long[] durations = new long[rows.size()];
+		for (int i = 0; i < rows.size(); i++) {
+			durations[i] = rows.get(i).getDuration();
+		}
+		Arrays.sort(durations);
+		int middle = durations.length / 2;
+		if (durations.length % 2 == 0) {
+			return (durations[middle - 1] + durations[middle]) / 2;
+		}
+		return durations[middle];
 	}
 
 	String formatDate(Date date) {
@@ -258,23 +484,6 @@ public class WidgetMetricSupport {
 		}
 	}
 
-	Date firstPresenceDate(String siteId) {
-		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
-		ReportParams params = reportDef.getReportParams();
-		params.setWhat(ReportManager.WHAT_PRESENCES);
-		params.setWho(ReportManager.WHO_ALL);
-		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE));
-		params.setHowSort(true);
-		params.setHowSortAscending(true);
-		params.setHowSortBy(StatsManager.T_DATE);
-		PagingPosition paging = new PagingPosition();
-		Report report = context.getReportManager().getReport(reportDef, true, paging, false);
-		if (report.getReportData().isEmpty()) {
-			return new Date();
-		}
-		return ((SitePresence) report.getReportData().get(0)).getDate();
-	}
-
 	int countExistingResources(Report report) {
 		int total = 0;
 		ContentHostingService contentHostingService = context.getContentHostingService();
@@ -298,5 +507,184 @@ public class WidgetMetricSupport {
 			}
 		}
 		return total;
+	}
+
+	private List<Stat> visitRows(String siteId, List<String> userIds, String when) {
+		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_EVENTS);
+		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
+		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
+		params.setWhen(StringUtils.defaultIfBlank(when, ReportManager.WHEN_ALL));
+		params.setWho(userIds == null ? ReportManager.WHO_ALL : ReportManager.WHO_CUSTOM);
+		if (userIds != null) {
+			params.setWhoUserIds(userIds);
+		}
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_DATE));
+		Report report = context.getReportManager().getReport(reportDef, true);
+		return report.getReportData() == null ? Collections.<Stat>emptyList() : report.getReportData();
+	}
+
+	private List<RoleVisitCount> visitsByRole(String siteId, String when) {
+		List<RoleVisitCount> counts = new ArrayList<RoleVisitCount>();
+		try {
+			Site site = context.getSiteService().getSite(siteId);
+			Set<Role> roles = site.getRoles();
+			if (roles == null) {
+				return counts;
+			}
+			for (Role role : roles) {
+				if (role == null || role.getId() == null) {
+					continue;
+				}
+				counts.add(new RoleVisitCount(role.getId(), visitCountForRole(siteId, role.getId(), when)));
+			}
+		} catch (IdUnusedException e) {
+			return counts;
+		}
+		Collections.sort(counts, Comparator.comparingLong(RoleVisitCount::getVisits).reversed());
+		return counts;
+	}
+
+	private SiteStatsChart visitsByRoleChart(String title, List<RoleVisitCount> counts) {
+		SiteStatsChart chart = new SiteStatsChart();
+		chart.setTitle(title);
+		chart.setType(StatsManager.CHARTTYPE_PIE);
+		chart.setXKey(ROLE_COLUMN);
+		chart.setYKey(StatsManager.T_TOTAL);
+		chart.setEmptyMessage(context.message("no_data"));
+		SiteStatsChartDataset dataset = new SiteStatsChartDataset();
+		dataset.setKey(ROLE_COLUMN);
+		dataset.setLabel(context.message("overview_title_visits"));
+		for (RoleVisitCount count : counts) {
+			SiteStatsChartPoint point = new SiteStatsChartPoint();
+			point.setX(count.getRoleId());
+			point.setLabel(count.getRoleId());
+			point.setY(Long.valueOf(count.getVisits()));
+			dataset.getPoints().add(point);
+		}
+		chart.getDatasets().add(dataset);
+		return chart;
+	}
+
+	private SiteStatsTable visitsByRoleTable(String title, List<RoleVisitCount> counts, SiteStatsReportRequest request) {
+		NumberFormat numberFormat = NumberFormat.getNumberInstance(currentLocale());
+		SiteStatsTable table = new SiteStatsTable();
+		table.setCaption(title);
+		table.setPage(request.getPage());
+		table.setPageSize(request.getPageSize());
+		table.setTotalRows(counts.size());
+		table.getColumns().add(column(ROLE_COLUMN, context.message("report_who_role"), "text", "start"));
+		table.getColumns().add(column(StatsManager.T_TOTAL, context.message("th_visits"), "number", "end"));
+		int fromIndex = Math.min((request.getPage() - 1) * request.getPageSize(), counts.size());
+		int toIndex = Math.min(fromIndex + request.getPageSize(), counts.size());
+		for (RoleVisitCount count : counts.subList(fromIndex, toIndex)) {
+			SiteStatsTableRow row = new SiteStatsTableRow();
+			row.getCells().put(ROLE_COLUMN, cell(count.getRoleId(), count.getRoleId()));
+			row.getCells().put(StatsManager.T_TOTAL, cell(Long.valueOf(count.getVisits()), numberFormat.format(count.getVisits())));
+			table.getRows().add(row);
+		}
+		return table;
+	}
+
+	private SiteStatsChart compactDailyChart(String title, String yKey, String datasetLabel, List<LocalDate> days,
+			Map<LocalDate, Long> values, ZoneId zone) {
+		if (!hasSparklineData(values)) {
+			return null;
+		}
+		DateTimeFormatter labels = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).withLocale(currentLocale()).withZone(zone);
+		SiteStatsChart chart = new SiteStatsChart();
+		chart.setTitle(title);
+		chart.setType(StatsManager.CHARTTYPE_BAR);
+		chart.setXKey(StatsManager.T_DATE);
+		chart.setYKey(yKey);
+		chart.setEmptyMessage(context.message("no_data"));
+		chart.setItemLabelsVisible(false);
+		chart.setCompact(true);
+		SiteStatsChartDataset dataset = new SiteStatsChartDataset();
+		dataset.setKey(yKey);
+		dataset.setLabel(datasetLabel);
+		for (LocalDate day : days) {
+			Long value = values.get(day);
+			SiteStatsChartPoint point = new SiteStatsChartPoint();
+			point.setX(day.toString());
+			point.setLabel(labels.format(day.atStartOfDay(zone)));
+			point.setY(value == null ? Long.valueOf(0L) : value);
+			dataset.getPoints().add(point);
+		}
+		chart.getDatasets().add(dataset);
+		return chart;
+	}
+
+	private boolean hasSparklineData(Map<LocalDate, Long> values) {
+		for (Long value : values.values()) {
+			if (value != null && value.longValue() > 0L) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private List<LocalDate> sparklineDays(ZoneId zone) {
+		List<LocalDate> days = new ArrayList<LocalDate>();
+		LocalDate today = LocalDate.now(zone);
+		for (int i = SPARKLINE_DAYS - 1; i >= 0; i--) {
+			days.add(today.minusDays(i));
+		}
+		return days;
+	}
+
+	private void addDayValue(Map<LocalDate, Long> values, LocalDate day, long amount) {
+		if (day == null) {
+			return;
+		}
+		Long current = values.get(day);
+		values.put(day, Long.valueOf((current == null ? 0L : current.longValue()) + amount));
+	}
+
+	private LocalDate toLocalDate(Date date, ZoneId zone) {
+		if (date == null) {
+			return null;
+		}
+		return Instant.ofEpochMilli(date.getTime()).atZone(zone).toLocalDate();
+	}
+
+	private String dateFilter(SiteStatsReportRequest request) {
+		return StringUtils.defaultIfBlank(request.getDate(), ReportManager.WHEN_ALL);
+	}
+
+	private SiteStatsTableColumn column(String key, String label, String type, String align) {
+		SiteStatsTableColumn column = new SiteStatsTableColumn();
+		column.setKey(key);
+		column.setLabel(label);
+		column.setType(type);
+		column.setAlign(align);
+		return column;
+	}
+
+	private SiteStatsTableCell cell(Object raw, String display) {
+		SiteStatsTableCell cell = new SiteStatsTableCell();
+		cell.setRaw(raw);
+		cell.setSort(raw);
+		cell.setDisplay(display);
+		return cell;
+	}
+
+	private Locale currentLocale() {
+		if (context.getMessages() != null && context.getMessages().getLocale() != null) {
+			return context.getMessages().getLocale();
+		}
+		return Locale.getDefault();
+	}
+
+	@Getter
+	private static class RoleVisitCount {
+		private final String roleId;
+		private final long visits;
+
+		RoleVisitCount(String roleId, long visits) {
+			this.roleId = roleId;
+			this.visits = visits;
+		}
 	}
 }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
@@ -57,6 +57,7 @@ import org.sakaiproject.sitestats.api.view.SiteStatsTableCell;
 import org.sakaiproject.sitestats.api.view.SiteStatsTableColumn;
 import org.sakaiproject.sitestats.api.view.SiteStatsTableRow;
 import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.user.api.UserNotDefinedException;
 
@@ -415,49 +416,72 @@ public class WidgetMetricSupport {
 	}
 
 	private LastVisit findLastVisit(String siteId, String userId) {
-		LastVisit fromTotals = lastVisitFromPresenceTotals(siteId, userId);
+		if (StringUtils.isNotBlank(userId)) {
+			LastVisit fromTotals = lastVisitFromPresenceTotals(siteId, Collections.singleton(userId));
+			if (fromTotals != null) {
+				return fromTotals;
+			}
+			return lastVisitFromEvents(siteId, Arrays.asList(userId));
+		}
+		List<String> learners = learnersWithoutSiteUpdate(siteId);
+		if (learners.isEmpty()) {
+			return null;
+		}
+		LastVisit fromTotals = lastVisitFromPresenceTotals(siteId, new HashSet<String>(learners));
 		if (fromTotals != null) {
 			return fromTotals;
 		}
-		return lastVisitFromEvents(siteId, userId);
+		return lastVisitFromEvents(siteId, learners);
 	}
 
-	private LastVisit lastVisitFromPresenceTotals(String siteId, String userId) {
+	List<String> learnersWithoutSiteUpdate(String siteId) {
+		try {
+			Site site = context.getSiteService().getSite(siteId);
+			Set<String> members = site.getUsers();
+			if (members == null || members.isEmpty()) {
+				return Collections.emptyList();
+			}
+			Set<String> learners = new HashSet<String>(members);
+			Set<String> updaters = site.getUsersIsAllowed(SiteService.SECURE_UPDATE_SITE);
+			if (updaters != null) {
+				learners.removeAll(updaters);
+			}
+			return new ArrayList<String>(learners);
+		} catch (IdUnusedException e) {
+			log.debug("Cannot resolve site members without update permission for {}", siteId, e);
+			return Collections.emptyList();
+		}
+	}
+
+	private LastVisit lastVisitFromPresenceTotals(String siteId, Set<String> userIds) {
 		Map<String, SitePresenceTotal> totals = context.getStatsManager().getPresenceTotalsForSite(siteId);
-		if (totals == null || totals.isEmpty()) {
+		if (totals == null || totals.isEmpty() || userIds == null || userIds.isEmpty()) {
 			return null;
 		}
-		if (StringUtils.isNotBlank(userId)) {
-			SitePresenceTotal total = totals.get(userId);
-			if (total == null || total.getLastVisitTime() == null) {
-				return null;
-			}
-			return new LastVisit(userId, total.getLastVisitTime());
-		}
 		LastVisit latest = null;
-		for (SitePresenceTotal total : totals.values()) {
-			if (total.getLastVisitTime() == null) {
+		for (String id : userIds) {
+			SitePresenceTotal total = totals.get(id);
+			if (total == null || total.getLastVisitTime() == null) {
 				continue;
 			}
 			if (latest == null || total.getLastVisitTime().after(latest.getDate())) {
-				latest = new LastVisit(total.getUserId(), total.getLastVisitTime());
+				latest = new LastVisit(id, total.getLastVisitTime());
 			}
 		}
 		return latest;
 	}
 
-	private LastVisit lastVisitFromEvents(String siteId, String userId) {
+	private LastVisit lastVisitFromEvents(String siteId, List<String> userIds) {
+		if (userIds == null || userIds.isEmpty()) {
+			return null;
+		}
 		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
 		ReportParams params = reportDef.getReportParams();
 		params.setWhat(ReportManager.WHAT_EVENTS);
 		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
 		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
-		if (StringUtils.isNotBlank(userId)) {
-			params.setWho(ReportManager.WHO_CUSTOM);
-			params.setWhoUserIds(Arrays.asList(userId));
-		} else {
-			params.setWho(ReportManager.WHO_ALL);
-		}
+		params.setWho(ReportManager.WHO_CUSTOM);
+		params.setWhoUserIds(userIds);
 		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER, StatsManager.T_LASTDATE));
 		params.setHowSort(true);
 		params.setHowSortBy(StatsManager.T_LASTDATE);

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetMetricSupport.java
@@ -5,22 +5,32 @@
  */
 package org.sakaiproject.sitestats.impl.view;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.StringJoiner;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.TypeException;
 import org.sakaiproject.javax.PagingPosition;
+import org.sakaiproject.sitestats.api.EventStat;
 import org.sakaiproject.sitestats.api.ResourceStat;
 import org.sakaiproject.sitestats.api.SitePresence;
+import org.sakaiproject.sitestats.api.SitePresenceTotal;
 import org.sakaiproject.sitestats.api.Stat;
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.Util;
@@ -86,9 +96,14 @@ public class WidgetMetricSupport {
 	}
 
 	long sitePresenceDuration(String siteId, List<String> userIds) {
+		return sitePresenceDuration(siteId, userIds, ReportManager.WHEN_ALL);
+	}
+
+	long sitePresenceDuration(String siteId, List<String> userIds, String when) {
 		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
 		ReportParams params = reportDef.getReportParams();
 		params.setWhat(ReportManager.WHAT_PRESENCES);
+		params.setWhen(StringUtils.defaultIfBlank(when, ReportManager.WHEN_ALL));
 		params.setWho(userIds == null ? ReportManager.WHO_ALL : ReportManager.WHO_CUSTOM);
 		if (userIds != null) {
 			params.setWhoUserIds(userIds);
@@ -99,6 +114,135 @@ public class WidgetMetricSupport {
 			return 0;
 		}
 		return ((SitePresence) report.getReportData().get(0)).getDuration();
+	}
+
+	boolean presencesEnabled() {
+		return Boolean.TRUE.equals(context.getStatsManager().getEnableSitePresences());
+	}
+
+	WidgetMetricValue lastVisitValue(String siteId, String userId, boolean includeUserDetail) {
+		LastVisit visit = findLastVisit(siteId, userId);
+		if (visit == null) {
+			return WidgetMetricValue.of("-");
+		}
+		String primary = formatDate(visit.getDate());
+		if (includeUserDetail) {
+			return WidgetMetricValue.withDetail(primary, userTooltip(visit.getUserId()));
+		}
+		return WidgetMetricValue.of(primary);
+	}
+
+	WidgetMetricValue presenceDurationValue(String siteId, List<String> userIds, String when) {
+		if (!presencesEnabled()) {
+			return WidgetMetricValue.of("-");
+		}
+		return WidgetMetricValue.of(msToString(sitePresenceDuration(siteId, userIds, when)));
+	}
+
+	WidgetMetricValue averagePresencePerVisit(String siteId) {
+		if (!presencesEnabled()) {
+			return WidgetMetricValue.of("-");
+		}
+		long durationInMs = sitePresenceDuration(siteId, null);
+		Date firstPresenceDate = firstPresenceDate(siteId);
+		long totalVisits = context.getStatsManager().getTotalSiteVisits(siteId, firstPresenceDate, null);
+		double durationInMin = durationInMs == 0 || totalVisits == 0 ? 0
+				: Util.round((durationInMs / (double) totalVisits) / 1000 / 60, 1);
+		return WidgetMetricValue.of(durationInMin + " " + context.message("minutes_abbr"));
+	}
+
+	WidgetMetricValue averagePresencePerVisitForUser(String siteId, String userId) {
+		if (!presencesEnabled() || StringUtils.isBlank(userId)) {
+			return WidgetMetricValue.of("-");
+		}
+		long visits = context.getStatsManager().getTotalSiteVisitsForUser(siteId, userId);
+		if (visits == 0) {
+			return WidgetMetricValue.of("0");
+		}
+		long duration = sitePresenceDuration(siteId, Arrays.asList(userId));
+		return WidgetMetricValue.of(msToString(duration / visits));
+	}
+
+	String formatDate(Date date) {
+		if (date == null) {
+			return "-";
+		}
+		Locale locale = context.getMessages() == null ? Locale.getDefault() : context.getMessages().getLocale();
+		if (locale == null) {
+			locale = Locale.getDefault();
+		}
+		return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale)
+				.format(Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate());
+	}
+
+	private LastVisit findLastVisit(String siteId, String userId) {
+		LastVisit fromTotals = lastVisitFromPresenceTotals(siteId, userId);
+		if (fromTotals != null) {
+			return fromTotals;
+		}
+		return lastVisitFromEvents(siteId, userId);
+	}
+
+	private LastVisit lastVisitFromPresenceTotals(String siteId, String userId) {
+		Map<String, SitePresenceTotal> totals = context.getStatsManager().getPresenceTotalsForSite(siteId);
+		if (totals == null || totals.isEmpty()) {
+			return null;
+		}
+		if (StringUtils.isNotBlank(userId)) {
+			SitePresenceTotal total = totals.get(userId);
+			if (total == null || total.getLastVisitTime() == null) {
+				return null;
+			}
+			return new LastVisit(userId, total.getLastVisitTime());
+		}
+		LastVisit latest = null;
+		for (SitePresenceTotal total : totals.values()) {
+			if (total.getLastVisitTime() == null) {
+				continue;
+			}
+			if (latest == null || total.getLastVisitTime().after(latest.getDate())) {
+				latest = new LastVisit(total.getUserId(), total.getLastVisitTime());
+			}
+		}
+		return latest;
+	}
+
+	private LastVisit lastVisitFromEvents(String siteId, String userId) {
+		ReportDef reportDef = reportFactory.baseMetricReportDef(siteId);
+		ReportParams params = reportDef.getReportParams();
+		params.setWhat(ReportManager.WHAT_EVENTS);
+		params.setWhatEventSelType(ReportManager.WHAT_EVENTS_BYEVENTS);
+		params.setWhatEventIds(Arrays.asList(StatsManager.SITEVISIT_EVENTID));
+		if (StringUtils.isNotBlank(userId)) {
+			params.setWho(ReportManager.WHO_CUSTOM);
+			params.setWhoUserIds(Arrays.asList(userId));
+		} else {
+			params.setWho(ReportManager.WHO_ALL);
+		}
+		params.setHowTotalsBy(Arrays.asList(StatsManager.T_USER, StatsManager.T_LASTDATE));
+		params.setHowSort(true);
+		params.setHowSortBy(StatsManager.T_LASTDATE);
+		params.setHowSortAscending(false);
+		Report report = context.getReportManager().getReport(reportDef, true);
+		if (report.getReportData().isEmpty()) {
+			return null;
+		}
+		EventStat stat = (EventStat) report.getReportData().get(0);
+		if (stat.getDate() == null) {
+			return null;
+		}
+		return new LastVisit(stat.getUserId(), stat.getDate());
+	}
+
+	@Getter
+	private static class LastVisit {
+		private final String userId;
+		private final Date date;
+
+		LastVisit(String userId, Date date) {
+			this.userId = userId;
+			this.date = date;
+		}
 	}
 
 	Date firstPresenceDate(String siteId) {

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetReportDefFactory.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetReportDefFactory.java
@@ -53,6 +53,13 @@ public class WidgetReportDefFactory {
 		return reportDef;
 	}
 
+	ReportDef presenceBase(String siteId, SiteStatsReportRequest request) {
+		ReportDef reportDef = baseReportDef(siteId);
+		reportDef.getReportParams().setWhat(ReportManager.WHAT_PRESENCES);
+		applyRoleFilter(reportDef.getReportParams(), request);
+		return reportDef;
+	}
+
 	ReportDef activityMetricBase(String siteId) {
 		ReportDef reportDef = baseMetricReportDef(siteId);
 		ReportParams params = reportDef.getReportParams();

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetReportViewFactory.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetReportViewFactory.java
@@ -1,0 +1,25 @@
+/**********************************************************************************
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **********************************************************************************/
+
+package org.sakaiproject.sitestats.impl.view;
+
+import org.sakaiproject.sitestats.api.view.SiteStatsReportRequest;
+import org.sakaiproject.sitestats.api.view.SiteStatsReportView;
+
+interface WidgetReportViewFactory {
+
+	SiteStatsReportView build(String siteId, SiteStatsReportRequest request, String userId);
+}

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetSpec.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetSpec.java
@@ -23,6 +23,7 @@ class WidgetSpec {
 	private final BooleanSupplier available;
 	private final List<WidgetTabSpec> tabs;
 	private final List<WidgetMetricSpec> metrics;
+	private final List<WidgetHighlightSpec> highlights;
 
 	boolean isAvailable() {
 		return available.getAsBoolean();

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetTabSpec.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/view/WidgetTabSpec.java
@@ -19,12 +19,19 @@ class WidgetTabSpec {
 	private final String titleKey;
 	private final List<String> filterIds;
 	private final WidgetReportFactory reportFactory;
+	private final WidgetReportViewFactory viewFactory;
 
 	WidgetTabSpec(String widgetId, String id, String titleKey, List<String> filterIds, WidgetReportFactory reportFactory) {
+		this(widgetId, id, titleKey, filterIds, reportFactory, null);
+	}
+
+	WidgetTabSpec(String widgetId, String id, String titleKey, List<String> filterIds, WidgetReportFactory reportFactory,
+			WidgetReportViewFactory viewFactory) {
 		this.widgetId = widgetId;
 		this.id = id;
 		this.titleKey = titleKey;
 		this.filterIds = Collections.unmodifiableList(new ArrayList<String>(filterIds));
 		this.reportFactory = reportFactory;
+		this.viewFactory = viewFactory;
 	}
 }

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsTestConfiguration.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsTestConfiguration.java
@@ -364,7 +364,9 @@ public class SiteStatsTestConfiguration {
 
     @Bean(name = "org.sakaiproject.time.api.UserTimeService")
     public UserTimeService userTimeService() {
-        return mock(UserTimeService.class);
+        UserTimeService userTimeService = mock(UserTimeService.class);
+        when(userTimeService.getLocalTimeZone()).thenReturn(java.util.TimeZone.getTimeZone("America/New_York"));
+        return userTimeService;
     }
 
 }

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsTestFixtures.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsTestFixtures.java
@@ -15,6 +15,8 @@ import java.util.LinkedHashSet;
 import org.sakaiproject.authz.api.Role;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.sitestats.api.EventStat;
+import org.sakaiproject.sitestats.api.SitePresence;
+import org.sakaiproject.sitestats.api.SitePresenceTotal;
 import org.sakaiproject.sitestats.api.SiteVisits;
 import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.event.EventInfo;
@@ -23,6 +25,8 @@ import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
 import org.sakaiproject.sitestats.impl.EventStatImpl;
+import org.sakaiproject.sitestats.impl.SitePresenceImpl;
+import org.sakaiproject.sitestats.impl.SitePresenceTotalImpl;
 import org.sakaiproject.sitestats.impl.SiteVisitsImpl;
 
 final class SiteStatsTestFixtures {
@@ -74,6 +78,26 @@ final class SiteStatsTestFixtures {
 		EventStat stat = new EventStatImpl(0, siteId, userId, eventId, count, date);
 		stat.setToolId(toolId);
 		return stat;
+	}
+
+	static SitePresence presenceStat(String siteId, String userId, java.util.Date date, long durationMs) {
+		return SitePresenceImpl.builder()
+				.siteId(siteId)
+				.userId(userId)
+				.date(date)
+				.duration(durationMs)
+				.lastVisitStartTime(date)
+				.currentOpenSessions(Integer.valueOf(0))
+				.build();
+	}
+
+	static SitePresenceTotal presenceTotal(String siteId, String userId, java.util.Date lastVisit, int visits) {
+		SitePresenceTotalImpl total = new SitePresenceTotalImpl();
+		total.setSiteId(siteId);
+		total.setUserId(userId);
+		total.setLastVisitTime(lastVisit);
+		total.setTotalVisits(visits);
+		return total;
 	}
 
 	static ReportDef visitReport(String siteId, String userId) {

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
@@ -72,6 +72,7 @@ import org.sakaiproject.sitestats.api.StatsManager;
 import org.sakaiproject.sitestats.api.report.ReportDef;
 import org.sakaiproject.sitestats.api.report.ReportManager;
 import org.sakaiproject.sitestats.api.report.ReportParams;
+import org.sakaiproject.sitestats.api.view.SiteStatsChartPoint;
 import org.sakaiproject.sitestats.api.view.SiteStatsFilter;
 import org.sakaiproject.sitestats.api.view.SiteStatsOverview;
 import org.sakaiproject.sitestats.api.view.SiteStatsReportPreviewService;
@@ -309,6 +310,50 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 	}
 
 	@Test
+	public void presenceMedianIgnoresOutlierDurations() {
+		db.insertObject(presenceStat(SITE_ID, USER_ID, Date.valueOf("2026-06-15"), 60000L));
+		db.insertObject(presenceStat(SITE_ID, USER_ID, Date.valueOf("2026-06-16"), 60000L));
+		db.insertObject(presenceStat(SITE_ID, USER_ID, Date.valueOf("2026-06-17"), 420000L));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertEquals("1 minutes_abbr",
+				metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_AVERAGE).getSnapshot().getPrimary());
+	}
+
+	@Test
+	public void presenceDurationIncludesEveryNonzeroRemainingUnit() {
+		long durationMs = ((2L * 24L + 1L) * 3600L + 5L * 60L + 3L) * 1000L;
+		db.insertObject(presenceStat(SITE_ID, USER_ID, new java.util.Date(), durationMs));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertEquals("2 days_abbr 1 hours_abbr 5 minutes_abbr 3 seconds_abbr",
+				metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_7D).getSnapshot().getPrimary());
+	}
+
+	@Test
+	public void presenceSparklineSumsRawDurationsBeforeConvertingToMinutes() {
+		Date today = Date.valueOf(java.time.LocalDate.now());
+		db.insertObject(presenceStat(SITE_ID, USER_ID, today, 90000L));
+		db.insertObject(presenceStat(SITE_ID, OTHER_USER_ID, today, 90000L));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertEquals(1, widget(overview, WIDGET_PRESENCE_ACCESS).getHighlights().size());
+		List<SiteStatsChartPoint> points = widget(overview, WIDGET_PRESENCE_ACCESS)
+				.getHighlights().get(0).getDatasets().get(0).getPoints();
+		assertEquals(30, points.size());
+		long totalMinutes = 0L;
+		for (SiteStatsChartPoint point : points) {
+			if (point.getY() != null) {
+				totalMinutes += point.getY().longValue();
+			}
+		}
+		assertEquals(3L, totalMinutes);
+	}
+
+	@Test
 	public void trafficWidgetReportsUniqueVisitorsAndVisitsByRole() {
 		Date lastVisit = Date.valueOf("2026-06-17");
 		db.insertObject(eventStat(SITE_ID, USER_ID, FakeData.TOOL_CHAT, StatsManager.SITEVISIT_EVENTID,
@@ -320,6 +365,8 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		assertEquals("1 / 2", metric(overview, WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS).getSnapshot().getPrimary());
 		assertEquals(Integer.valueOf(50),
 				metric(overview, WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS).getSnapshot().getPercentage());
+		assertTrue(metric(overview, WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getPrimary().contains("2026"));
+		assertEquals("User A", metric(overview, WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getDetail());
 		assertTrue(widget(overview, WIDGET_VISITS).getHighlights().isEmpty());
 
 		db.insertObject(visitStat(SITE_ID, Date.valueOf(java.time.LocalDate.now()), 2, 1));
@@ -339,6 +386,11 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		assertEquals(Long.valueOf(3), byRole.getChart().getDatasets().get(0).getPoints().get(0).getY());
 		assertEquals(1, byRole.getTable().getTotalRows());
 		assertEquals("Instructor", byRole.getTable().getRows().get(0).getCells().get("role").getDisplay());
+
+		SiteStatsReportView lastVisitReport = service.getWidgetMetricReport(SITE_ID, WIDGET_VISITS,
+				METRIC_PRESENCE_LAST_VISIT, new SiteStatsReportRequest());
+		assertNotNull(lastVisitReport.getTable());
+		assertTrue(lastVisitReport.getTable().getTotalRows() >= 1);
 	}
 
 	@Test
@@ -368,43 +420,15 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		List<SiteStatsWidgetMetric> metrics = service.getWidgetMetrics(SITE_ID, WIDGET_VISITS);
 
 		assertEquals(METRIC_VISITS_TOTAL, metrics.get(0).getId());
-		assertEquals(4, metrics.size());
+		assertEquals(5, metrics.size());
 		assertEquals(AUDIENCE_ALL, metrics.get(0).getAudience());
 		assertNotNull(metrics.get(0).getWidgetTitle());
 		assertFalse(metrics.get(0).getWidgetTitle().isEmpty());
 		assertTrue(metrics.get(0).isReportable());
+		assertEquals(METRIC_PRESENCE_LAST_VISIT, metrics.get(3).getId());
+		assertTrue(metrics.get(3).isReportable());
 	}
 
-	@Test
-	public void visitAndPresenceWidgetsDoNotDuplicateVisitOrPresenceMetrics() {
-		List<String> visitIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_VISITS));
-		assertTrue(visitIds.contains(METRIC_VISITS_TRAFFIC_TREND));
-		assertTrue(visitIds.contains(METRIC_VISITS_UNIQUE));
-		assertTrue(visitIds.contains(METRIC_VISITS_USERS_WITH_VISITS));
-		assertFalse(visitIds.contains(METRIC_VISITS_USERS_WITHOUT_VISITS));
-		assertFalse(visitIds.contains(METRIC_VISITS_AVERAGE_PRESENCE));
-		assertFalse(visitIds.contains(METRIC_PRESENCE_LAST_VISIT));
-		assertFalse(visitIds.contains(METRIC_PRESENCE_AVERAGE));
-		assertFalse(visitIds.contains(METRIC_VISITS_ENROLLED_USERS));
-
-		List<String> presenceIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_PRESENCE_ACCESS));
-		assertTrue(presenceIds.contains(METRIC_PRESENCE_AVERAGE));
-		assertTrue(presenceIds.contains(METRIC_PRESENCE_BOUNCE_RATE));
-		assertFalse(presenceIds.contains(METRIC_PRESENCE_LAST_VISIT));
-		assertFalse(presenceIds.contains(METRIC_PRESENCE_NEVER_VISITED));
-		assertFalse(presenceIds.contains(METRIC_VISITS_TOTAL));
-
-		when(securityService.unlock(StatsAuthz.PERMISSION_SITESTATS_ALL, SITE_REF)).thenReturn(false);
-
-		List<String> studentVisitIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_STUDENT_VISITS));
-		assertEquals(Arrays.asList(METRIC_STUDENT_VISITS_TOTAL, METRIC_STUDENT_VISITS_TRAFFIC_TREND), studentVisitIds);
-		assertFalse(studentVisitIds.contains(METRIC_STUDENT_VISITS_AVERAGE_PRESENCE));
-		assertFalse(studentVisitIds.contains(METRIC_STUDENT_VISITS_PRESENCE));
-
-		List<String> studentPresenceIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_STUDENT_PRESENCE_ACCESS));
-		assertTrue(studentPresenceIds.contains(METRIC_STUDENT_PRESENCE_LAST_VISIT));
-		assertFalse(studentPresenceIds.contains(METRIC_STUDENT_VISITS_TOTAL));
-	}
 
 	@Test
 	public void lessonMetricsAreExplicitlyNonReportable() {

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -18,6 +19,7 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_AL
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_ACTIVITY_MOST_ACTIVE_TOOL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_LESSONS_PAGES;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_AVERAGE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_BOUNCE_RATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_LAST_VISIT;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_NEVER_VISITED;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_7D;
@@ -26,10 +28,16 @@ import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUD
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_AVERAGE_PRESENCE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_PRESENCE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TRAFFIC_TREND;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_AVERAGE_PRESENCE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_ENROLLED_USERS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TRAFFIC_TREND;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_UNIQUE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_USERS_WITHOUT_VISITS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_USERS_WITH_VISITS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_ROLE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_ACTIVITY;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_LESSONS;
@@ -54,6 +62,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sakaiproject.authz.api.Member;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.site.api.Site;
 import org.sakaiproject.site.api.SiteService;
@@ -119,6 +128,13 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 
 		Site site = site(SITE_ID, "Site A", "Instructor");
 		when(site.getUsers()).thenReturn(new HashSet<String>(Arrays.asList(USER_ID, OTHER_USER_ID)));
+		when(site.getMembers()).thenReturn(new HashSet<Member>(Arrays.asList(mock(Member.class), mock(Member.class))));
+		when(site.getUsersHasRole(anyString())).thenAnswer(invocation -> {
+			if ("Instructor".equals(invocation.getArgument(0))) {
+				return new HashSet<String>(Arrays.asList(USER_ID));
+			}
+			return new HashSet<String>();
+		});
 		when(siteService.siteReference(SITE_ID)).thenReturn(SITE_REF);
 		when(siteService.getSite(SITE_ID)).thenReturn(site);
 		when(siteService.isUserSite(SITE_ID)).thenReturn(false);
@@ -263,7 +279,7 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 	}
 
 	@Test
-	public void presenceAccessWidgetReportsLastVisitAndPresenceTotals() {
+	public void presenceAccessWidgetReportsEngagementMetrics() {
 		Date lastVisit = Date.valueOf("2026-06-17");
 		db.insertObject(presenceTotal(SITE_ID, USER_ID, lastVisit, 3));
 		db.insertObject(presenceStat(SITE_ID, USER_ID, new java.util.Date(), 120000L));
@@ -272,11 +288,13 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 
 		SiteStatsOverview overview = service.getOverview(SITE_ID);
 
-		assertTrue(metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getPrimary()
-				.contains("2026"));
-		assertEquals("1", metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_NEVER_VISITED).getSnapshot().getPrimary());
-		assertEquals("2 minutes_abbr 0 seconds_abbr",
+		assertEquals("2 minutes_abbr",
 				metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_7D).getSnapshot().getPrimary());
+		assertEquals("2 minutes_abbr",
+				metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_AVERAGE).getSnapshot().getPrimary());
+		assertEquals("1 / 1", metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_BOUNCE_RATE).getSnapshot().getPrimary());
+		assertEquals(Integer.valueOf(100),
+				metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_BOUNCE_RATE).getSnapshot().getPercentage());
 
 		SiteStatsReportRequest request = new SiteStatsReportRequest();
 		request.setDate(ReportManager.WHEN_ALL);
@@ -291,6 +309,39 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 	}
 
 	@Test
+	public void trafficWidgetReportsUniqueVisitorsAndVisitsByRole() {
+		Date lastVisit = Date.valueOf("2026-06-17");
+		db.insertObject(eventStat(SITE_ID, USER_ID, FakeData.TOOL_CHAT, StatsManager.SITEVISIT_EVENTID,
+				lastVisit, 3));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertEquals("1", metric(overview, WIDGET_VISITS, METRIC_VISITS_UNIQUE).getSnapshot().getPrimary());
+		assertEquals("1 / 2", metric(overview, WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS).getSnapshot().getPrimary());
+		assertEquals(Integer.valueOf(50),
+				metric(overview, WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS).getSnapshot().getPercentage());
+		assertTrue(widget(overview, WIDGET_VISITS).getHighlights().isEmpty());
+
+		db.insertObject(visitStat(SITE_ID, Date.valueOf(java.time.LocalDate.now()), 2, 1));
+		overview = service.getOverview(SITE_ID);
+		assertEquals(1, widget(overview, WIDGET_VISITS).getHighlights().size());
+		assertEquals(30, widget(overview, WIDGET_VISITS).getHighlights().get(0).getDatasets().get(0).getPoints().size());
+		assertTrue(widget(overview, WIDGET_VISITS).getHighlights().get(0).isCompact());
+
+		SiteStatsReportRequest request = new SiteStatsReportRequest();
+		request.setDate(ReportManager.WHEN_ALL);
+		SiteStatsReportView byRole = service.getWidgetReport(SITE_ID, WIDGET_VISITS, TAB_BY_ROLE, request);
+		assertEquals(WIDGET_VISITS, byRole.getWidgetId());
+		assertEquals(TAB_BY_ROLE, byRole.getTabId());
+		assertNotNull(byRole.getChart());
+		assertFalse(byRole.getChart().getDatasets().isEmpty());
+		assertEquals("Instructor", byRole.getChart().getDatasets().get(0).getPoints().get(0).getLabel());
+		assertEquals(Long.valueOf(3), byRole.getChart().getDatasets().get(0).getPoints().get(0).getY());
+		assertEquals(1, byRole.getTable().getTotalRows());
+		assertEquals("Instructor", byRole.getTable().getRows().get(0).getCells().get("role").getDisplay());
+	}
+
+	@Test
 	public void studentPresenceAccessWidgetUsesCurrentUserLastVisit() {
 		when(securityService.unlock(StatsAuthz.PERMISSION_SITESTATS_ALL, SITE_REF)).thenReturn(false);
 		Date lastVisit = Date.valueOf("2026-06-17");
@@ -301,7 +352,7 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 
 		assertTrue(metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT)
 				.getSnapshot().getPrimary().contains("2026"));
-		assertEquals("1 minutes_abbr 0 seconds_abbr",
+		assertEquals("1 minutes_abbr",
 				metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_7D)
 						.getSnapshot().getPrimary());
 
@@ -327,21 +378,26 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 	@Test
 	public void visitAndPresenceWidgetsDoNotDuplicateVisitOrPresenceMetrics() {
 		List<String> visitIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_VISITS));
+		assertTrue(visitIds.contains(METRIC_VISITS_TRAFFIC_TREND));
+		assertTrue(visitIds.contains(METRIC_VISITS_UNIQUE));
+		assertTrue(visitIds.contains(METRIC_VISITS_USERS_WITH_VISITS));
 		assertFalse(visitIds.contains(METRIC_VISITS_USERS_WITHOUT_VISITS));
 		assertFalse(visitIds.contains(METRIC_VISITS_AVERAGE_PRESENCE));
 		assertFalse(visitIds.contains(METRIC_PRESENCE_LAST_VISIT));
 		assertFalse(visitIds.contains(METRIC_PRESENCE_AVERAGE));
+		assertFalse(visitIds.contains(METRIC_VISITS_ENROLLED_USERS));
 
 		List<String> presenceIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_PRESENCE_ACCESS));
-		assertTrue(presenceIds.contains(METRIC_PRESENCE_LAST_VISIT));
-		assertTrue(presenceIds.contains(METRIC_PRESENCE_NEVER_VISITED));
 		assertTrue(presenceIds.contains(METRIC_PRESENCE_AVERAGE));
+		assertTrue(presenceIds.contains(METRIC_PRESENCE_BOUNCE_RATE));
+		assertFalse(presenceIds.contains(METRIC_PRESENCE_LAST_VISIT));
+		assertFalse(presenceIds.contains(METRIC_PRESENCE_NEVER_VISITED));
 		assertFalse(presenceIds.contains(METRIC_VISITS_TOTAL));
 
 		when(securityService.unlock(StatsAuthz.PERMISSION_SITESTATS_ALL, SITE_REF)).thenReturn(false);
 
 		List<String> studentVisitIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_STUDENT_VISITS));
-		assertEquals(Arrays.asList(METRIC_STUDENT_VISITS_TOTAL), studentVisitIds);
+		assertEquals(Arrays.asList(METRIC_STUDENT_VISITS_TOTAL, METRIC_STUDENT_VISITS_TRAFFIC_TREND), studentVisitIds);
 		assertFalse(studentVisitIds.contains(METRIC_STUDENT_VISITS_AVERAGE_PRESENCE));
 		assertFalse(studentVisitIds.contains(METRIC_STUDENT_VISITS_PRESENCE));
 
@@ -463,6 +519,15 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 			}
 		}
 		throw new AssertionError("Missing filter " + widgetId + "/" + tabId + "/" + filterId);
+	}
+
+	private SiteStatsWidget widget(SiteStatsOverview overview, String widgetId) {
+		for (SiteStatsWidget widget : overview.getWidgets()) {
+			if (widgetId.equals(widget.getId())) {
+				return widget;
+			}
+		}
+		throw new AssertionError("Missing widget " + widgetId);
 	}
 
 	private SiteStatsWidgetMetric metric(SiteStatsOverview overview, String widgetId, String metricId) {

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
@@ -126,10 +126,17 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		when(user.getDisplayName()).thenReturn("User A");
 		when(user.getSortName()).thenReturn("User A");
 		when(userDirectoryService.getUser(USER_ID)).thenReturn(user);
+		User otherUser = mock(User.class);
+		when(otherUser.getDisplayId()).thenReturn(OTHER_USER_ID);
+		when(otherUser.getDisplayName()).thenReturn("User B");
+		when(otherUser.getSortName()).thenReturn("User B");
+		when(userDirectoryService.getUser(OTHER_USER_ID)).thenReturn(otherUser);
 
 		Site site = site(SITE_ID, "Site A", "Instructor");
 		when(site.getUsers()).thenReturn(new HashSet<String>(Arrays.asList(USER_ID, OTHER_USER_ID)));
 		when(site.getMembers()).thenReturn(new HashSet<Member>(Arrays.asList(mock(Member.class), mock(Member.class))));
+		when(site.getUsersIsAllowed(SiteService.SECURE_UPDATE_SITE))
+				.thenReturn(new HashSet<String>(Arrays.asList(USER_ID)));
 		when(site.getUsersHasRole(anyString())).thenAnswer(invocation -> {
 			if ("Instructor".equals(invocation.getArgument(0))) {
 				return new HashSet<String>(Arrays.asList(USER_ID));
@@ -183,7 +190,7 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		assertFalse(hasWidget(overview, WIDGET_VISITS));
 		assertFalse(hasWidget(overview, WIDGET_PRESENCE_ACCESS));
 		assertNotNull(metric(overview, WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL).getSnapshot());
-		assertNotNull(metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT).getSnapshot());
+		assertNotNull(metric(overview, WIDGET_STUDENT_VISITS, METRIC_STUDENT_PRESENCE_LAST_VISIT).getSnapshot());
 	}
 
 	@Test
@@ -365,8 +372,6 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		assertEquals("1 / 2", metric(overview, WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS).getSnapshot().getPrimary());
 		assertEquals(Integer.valueOf(50),
 				metric(overview, WIDGET_VISITS, METRIC_VISITS_USERS_WITH_VISITS).getSnapshot().getPercentage());
-		assertTrue(metric(overview, WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getPrimary().contains("2026"));
-		assertEquals("User A", metric(overview, WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getDetail());
 		assertTrue(widget(overview, WIDGET_VISITS).getHighlights().isEmpty());
 
 		db.insertObject(visitStat(SITE_ID, Date.valueOf(java.time.LocalDate.now()), 2, 1));
@@ -386,11 +391,24 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		assertEquals(Long.valueOf(3), byRole.getChart().getDatasets().get(0).getPoints().get(0).getY());
 		assertEquals(1, byRole.getTable().getTotalRows());
 		assertEquals("Instructor", byRole.getTable().getRows().get(0).getCells().get("role").getDisplay());
+	}
+
+	@Test
+	public void lastVisitMetricIgnoresUsersWhoCanUpdateTheSite() {
+		db.insertObject(eventStat(SITE_ID, USER_ID, FakeData.TOOL_CHAT, StatsManager.SITEVISIT_EVENTID,
+				Date.valueOf("2026-06-20"), 2));
+		db.insertObject(eventStat(SITE_ID, OTHER_USER_ID, FakeData.TOOL_CHAT, StatsManager.SITEVISIT_EVENTID,
+				Date.valueOf("2026-06-17"), 1));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertTrue(metric(overview, WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getPrimary().contains("2026"));
+		assertEquals("User B", metric(overview, WIDGET_VISITS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getDetail());
 
 		SiteStatsReportView lastVisitReport = service.getWidgetMetricReport(SITE_ID, WIDGET_VISITS,
 				METRIC_PRESENCE_LAST_VISIT, new SiteStatsReportRequest());
 		assertNotNull(lastVisitReport.getTable());
-		assertTrue(lastVisitReport.getTable().getTotalRows() >= 1);
+		assertEquals(1, lastVisitReport.getTable().getTotalRows());
 	}
 
 	@Test
@@ -402,7 +420,7 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 
 		SiteStatsOverview overview = service.getOverview(SITE_ID);
 
-		assertTrue(metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT)
+		assertTrue(metric(overview, WIDGET_STUDENT_VISITS, METRIC_STUDENT_PRESENCE_LAST_VISIT)
 				.getSnapshot().getPrimary().contains("2026"));
 		assertEquals("1 minutes_abbr",
 				metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_7D)

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/SiteStatsViewServiceTest.java
@@ -17,15 +17,29 @@ import static org.mockito.Mockito.when;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.AUDIENCE_ALL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_ACTIVITY_MOST_ACTIVE_TOOL;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_LESSONS_PAGES;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_AVERAGE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_LAST_VISIT;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_NEVER_VISITED;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_PRESENCE_TOTAL_7D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_LAST_VISIT;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_PRESENCE_TOTAL_7D;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_AVERAGE_PRESENCE;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_PRESENCE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_STUDENT_VISITS_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_AVERAGE_PRESENCE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_TOTAL;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.METRIC_VISITS_USERS_WITHOUT_VISITS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_DATE;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.TAB_BY_USER;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_ACTIVITY;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_LESSONS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_PRESENCE_ACCESS;
+import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_STUDENT_PRESENCE_ACCESS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_STUDENT_VISITS;
 import static org.sakaiproject.sitestats.api.view.SiteStatsWidgetIds.WIDGET_VISITS;
 import static org.sakaiproject.sitestats.test.SiteStatsTestFixtures.eventStat;
+import static org.sakaiproject.sitestats.test.SiteStatsTestFixtures.presenceStat;
+import static org.sakaiproject.sitestats.test.SiteStatsTestFixtures.presenceTotal;
 import static org.sakaiproject.sitestats.test.SiteStatsTestFixtures.site;
 import static org.sakaiproject.sitestats.test.SiteStatsTestFixtures.tool;
 import static org.sakaiproject.sitestats.test.SiteStatsTestFixtures.visitReport;
@@ -138,7 +152,9 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		SiteStatsOverview overview = service.getOverview(SITE_ID);
 
 		assertEquals("3", metric(overview, WIDGET_VISITS, METRIC_VISITS_TOTAL).getSnapshot().getPrimary());
+		assertTrue(hasWidget(overview, WIDGET_PRESENCE_ACCESS));
 		assertFalse(hasWidget(overview, WIDGET_STUDENT_VISITS));
+		assertFalse(hasWidget(overview, WIDGET_STUDENT_PRESENCE_ACCESS));
 	}
 
 	@Test
@@ -148,7 +164,9 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 		SiteStatsOverview overview = service.getOverview(SITE_ID);
 
 		assertFalse(hasWidget(overview, WIDGET_VISITS));
+		assertFalse(hasWidget(overview, WIDGET_PRESENCE_ACCESS));
 		assertNotNull(metric(overview, WIDGET_STUDENT_VISITS, METRIC_STUDENT_VISITS_TOTAL).getSnapshot());
+		assertNotNull(metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT).getSnapshot());
 	}
 
 	@Test
@@ -245,14 +263,91 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 	}
 
 	@Test
+	public void presenceAccessWidgetReportsLastVisitAndPresenceTotals() {
+		Date lastVisit = Date.valueOf("2026-06-17");
+		db.insertObject(presenceTotal(SITE_ID, USER_ID, lastVisit, 3));
+		db.insertObject(presenceStat(SITE_ID, USER_ID, new java.util.Date(), 120000L));
+		db.insertObject(eventStat(SITE_ID, USER_ID, FakeData.TOOL_CHAT, StatsManager.SITEVISIT_EVENTID,
+				lastVisit, 3));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertTrue(metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_LAST_VISIT).getSnapshot().getPrimary()
+				.contains("2026"));
+		assertEquals("1", metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_NEVER_VISITED).getSnapshot().getPrimary());
+		assertEquals("2 minutes_abbr 0 seconds_abbr",
+				metric(overview, WIDGET_PRESENCE_ACCESS, METRIC_PRESENCE_TOTAL_7D).getSnapshot().getPrimary());
+
+		SiteStatsReportRequest request = new SiteStatsReportRequest();
+		request.setDate(ReportManager.WHEN_ALL);
+		SiteStatsReportView byDate = service.getWidgetReport(SITE_ID, WIDGET_PRESENCE_ACCESS, TAB_BY_DATE, request);
+		assertEquals(WIDGET_PRESENCE_ACCESS, byDate.getWidgetId());
+		assertNotNull(byDate.getTable());
+		assertNotNull(byDate.getChart());
+
+		SiteStatsReportView byUser = service.getWidgetReport(SITE_ID, WIDGET_PRESENCE_ACCESS, TAB_BY_USER, request);
+		assertNotNull(byUser.getTable());
+		assertTrue(byUser.getTable().getTotalRows() >= 1);
+	}
+
+	@Test
+	public void studentPresenceAccessWidgetUsesCurrentUserLastVisit() {
+		when(securityService.unlock(StatsAuthz.PERMISSION_SITESTATS_ALL, SITE_REF)).thenReturn(false);
+		Date lastVisit = Date.valueOf("2026-06-17");
+		db.insertObject(presenceTotal(SITE_ID, USER_ID, lastVisit, 1));
+		db.insertObject(presenceStat(SITE_ID, USER_ID, new java.util.Date(), 60000L));
+
+		SiteStatsOverview overview = service.getOverview(SITE_ID);
+
+		assertTrue(metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_LAST_VISIT)
+				.getSnapshot().getPrimary().contains("2026"));
+		assertEquals("1 minutes_abbr 0 seconds_abbr",
+				metric(overview, WIDGET_STUDENT_PRESENCE_ACCESS, METRIC_STUDENT_PRESENCE_TOTAL_7D)
+						.getSnapshot().getPrimary());
+
+		SiteStatsReportRequest request = new SiteStatsReportRequest();
+		request.setDate(ReportManager.WHEN_ALL);
+		SiteStatsReportView view = service.getWidgetReport(SITE_ID, WIDGET_STUDENT_PRESENCE_ACCESS, TAB_BY_DATE, request);
+		assertEquals(WIDGET_STUDENT_PRESENCE_ACCESS, view.getWidgetId());
+		assertNotNull(view.getTable());
+	}
+
+	@Test
 	public void getWidgetMetricsReturnsStableMetricMetadata() {
 		List<SiteStatsWidgetMetric> metrics = service.getWidgetMetrics(SITE_ID, WIDGET_VISITS);
 
 		assertEquals(METRIC_VISITS_TOTAL, metrics.get(0).getId());
+		assertEquals(4, metrics.size());
 		assertEquals(AUDIENCE_ALL, metrics.get(0).getAudience());
 		assertNotNull(metrics.get(0).getWidgetTitle());
 		assertFalse(metrics.get(0).getWidgetTitle().isEmpty());
 		assertTrue(metrics.get(0).isReportable());
+	}
+
+	@Test
+	public void visitAndPresenceWidgetsDoNotDuplicateVisitOrPresenceMetrics() {
+		List<String> visitIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_VISITS));
+		assertFalse(visitIds.contains(METRIC_VISITS_USERS_WITHOUT_VISITS));
+		assertFalse(visitIds.contains(METRIC_VISITS_AVERAGE_PRESENCE));
+		assertFalse(visitIds.contains(METRIC_PRESENCE_LAST_VISIT));
+		assertFalse(visitIds.contains(METRIC_PRESENCE_AVERAGE));
+
+		List<String> presenceIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_PRESENCE_ACCESS));
+		assertTrue(presenceIds.contains(METRIC_PRESENCE_LAST_VISIT));
+		assertTrue(presenceIds.contains(METRIC_PRESENCE_NEVER_VISITED));
+		assertTrue(presenceIds.contains(METRIC_PRESENCE_AVERAGE));
+		assertFalse(presenceIds.contains(METRIC_VISITS_TOTAL));
+
+		when(securityService.unlock(StatsAuthz.PERMISSION_SITESTATS_ALL, SITE_REF)).thenReturn(false);
+
+		List<String> studentVisitIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_STUDENT_VISITS));
+		assertEquals(Arrays.asList(METRIC_STUDENT_VISITS_TOTAL), studentVisitIds);
+		assertFalse(studentVisitIds.contains(METRIC_STUDENT_VISITS_AVERAGE_PRESENCE));
+		assertFalse(studentVisitIds.contains(METRIC_STUDENT_VISITS_PRESENCE));
+
+		List<String> studentPresenceIds = metricIds(service.getWidgetMetrics(SITE_ID, WIDGET_STUDENT_PRESENCE_ACCESS));
+		assertTrue(studentPresenceIds.contains(METRIC_STUDENT_PRESENCE_LAST_VISIT));
+		assertFalse(studentPresenceIds.contains(METRIC_STUDENT_VISITS_TOTAL));
 	}
 
 	@Test
@@ -385,6 +480,14 @@ public class SiteStatsViewServiceTest extends AbstractTransactionalJUnit4SpringC
 
 	private boolean hasWidget(SiteStatsOverview overview, String widgetId) {
 		return overview.getWidgets().stream().anyMatch(widget -> widgetId.equals(widget.getId()));
+	}
+
+	private List<String> metricIds(List<SiteStatsWidgetMetric> metrics) {
+		List<String> ids = new ArrayList<String>();
+		for (SiteStatsWidgetMetric metric : metrics) {
+			ids.add(metric.getId());
+		}
+		return ids;
 	}
 
 }

--- a/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
+++ b/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
@@ -260,6 +260,7 @@
 		<property name="siteService" ref="org.sakaiproject.site.api.SiteService"/>
 		<property name="contentHostingService" ref="org.sakaiproject.content.api.ContentHostingService"/>
 		<property name="userDirectoryService" ref="org.sakaiproject.user.api.UserDirectoryService"/>
+		<property name="userTimeService" ref="org.sakaiproject.time.api.UserTimeService"/>
 	</bean>
 
 	<bean id="org.sakaiproject.sitestats.impl.view.WidgetFilterCatalog"

--- a/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
+++ b/sitestats/sitestats-impl/src/webapp/WEB-INF/components.xml
@@ -290,8 +290,12 @@
 
 	<bean id="org.sakaiproject.sitestats.impl.view.VisitsWidgetDefinition"
 		  class="org.sakaiproject.sitestats.impl.view.VisitsWidgetDefinition"/>
+	<bean id="org.sakaiproject.sitestats.impl.view.PresenceAccessWidgetDefinition"
+		  class="org.sakaiproject.sitestats.impl.view.PresenceAccessWidgetDefinition"/>
 	<bean id="org.sakaiproject.sitestats.impl.view.StudentVisitsWidgetDefinition"
 		  class="org.sakaiproject.sitestats.impl.view.StudentVisitsWidgetDefinition"/>
+	<bean id="org.sakaiproject.sitestats.impl.view.StudentPresenceAccessWidgetDefinition"
+		  class="org.sakaiproject.sitestats.impl.view.StudentPresenceAccessWidgetDefinition"/>
 	<bean id="org.sakaiproject.sitestats.impl.view.ActivityWidgetDefinition"
 		  class="org.sakaiproject.sitestats.impl.view.ActivityWidgetDefinition"/>
 	<bean id="org.sakaiproject.sitestats.impl.view.ResourcesWidgetDefinition"
@@ -306,7 +310,9 @@
 		<property name="widgetDefinitions">
 			<list>
 				<ref bean="org.sakaiproject.sitestats.impl.view.VisitsWidgetDefinition"/>
+				<ref bean="org.sakaiproject.sitestats.impl.view.PresenceAccessWidgetDefinition"/>
 				<ref bean="org.sakaiproject.sitestats.impl.view.StudentVisitsWidgetDefinition"/>
+				<ref bean="org.sakaiproject.sitestats.impl.view.StudentPresenceAccessWidgetDefinition"/>
 				<ref bean="org.sakaiproject.sitestats.impl.view.ActivityWidgetDefinition"/>
 				<ref bean="org.sakaiproject.sitestats.impl.view.ResourcesWidgetDefinition"/>
 				<ref bean="org.sakaiproject.sitestats.impl.view.LessonsWidgetDefinition"/>

--- a/sitestats/sitestats-tool/pom.xml
+++ b/sitestats/sitestats-tool/pom.xml
@@ -79,6 +79,10 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+    </dependency>
     
     <!-- Servlet -->  
     <dependency>

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
@@ -68,6 +68,7 @@ public class SiteStatsController {
         commonModel(model, result.getOverview().getSiteId(), "overview");
         model.addAttribute("overview", result.getOverview());
         model.addAttribute("widgetEndpoints", result.getWidgetEndpoints());
+        model.addAttribute("widgetHighlightsJson", result.getWidgetHighlightsJson());
         return "overview";
     }
 

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
@@ -73,6 +73,7 @@ import org.sakaiproject.sitestats.api.view.SiteStatsViewService;
 import org.sakaiproject.sitestats.api.view.SiteStatsWidget;
 import org.sakaiproject.sitestats.api.view.SiteStatsWidgetTab;
 import org.sakaiproject.sitestats.tool.transformers.ResolvedRefTransformer;
+import org.sakaiproject.serialization.MapperFactory;
 import org.sakaiproject.time.api.UserTimeService;
 import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
@@ -80,6 +81,9 @@ import org.sakaiproject.user.api.UserNotDefinedException;
 import org.sakaiproject.util.api.LocaleService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 @Slf4j
@@ -160,18 +164,27 @@ public class SiteStatsToolService {
     public OverviewResult overviewWithEndpoints(String requestedSiteId) {
         SiteStatsOverview overview = overview(requestedSiteId);
         Map<String, String> widgetEndpoints = new LinkedHashMap<String, String>();
+        Map<String, String> widgetHighlightsJson = new LinkedHashMap<String, String>();
         SiteStatsReportRequest reportRequest = new SiteStatsReportRequest();
         reportRequest.setIncludeTable(true);
         reportRequest.setIncludeChart(true);
+        ObjectMapper objectMapper = MapperFactory.createDefaultJsonMapper();
         for (SiteStatsWidget widget : overview.getWidgets()) {
             if (widget.isVisible()) {
                 for (SiteStatsWidgetTab tab : widget.getTabs()) {
                     widgetEndpoints.put(widget.getId() + ":" + tab.getId(), SiteStatsApiUrls.widgetReport(
                             overview.getSiteId(), widget.getId(), tab.getId(), reportRequest));
                 }
+                if (widget.getHighlights() != null && !widget.getHighlights().isEmpty()) {
+                    try {
+                        widgetHighlightsJson.put(widget.getId(), objectMapper.writeValueAsString(widget.getHighlights()));
+                    } catch (JsonProcessingException e) {
+                        log.warn("Unable to serialize SiteStats widget highlights for {}", widget.getId(), e);
+                    }
+                }
             }
         }
-        return new OverviewResult(overview, widgetEndpoints);
+        return new OverviewResult(overview, widgetEndpoints, widgetHighlightsJson);
     }
 
     public List<SiteStatsReportSummary> reports(String requestedSiteId) {
@@ -602,6 +615,7 @@ public class SiteStatsToolService {
     public static class OverviewResult {
         private final SiteStatsOverview overview;
         private final Map<String, String> widgetEndpoints;
+        private final Map<String, String> widgetHighlightsJson;
     }
 
     @Getter

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/overview.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/overview.html
@@ -28,6 +28,10 @@
           </dd>
         </div>
       </dl>
+      <sakai-sitestats-highlights class="sitestats-highlights"
+                                  th:if="${widgetHighlightsJson.containsKey(widget.id)}"
+                                  th:attr="charts=${widgetHighlightsJson.get(widget.id)}">
+      </sakai-sitestats-highlights>
       <sakai-sitestats-widget-tab class="sitestats-widget-tab"
                                   th:each="tab : ${widget.tabs}"
                                   th:attr="endpoint=${widgetEndpoints.get(widget.id + ':' + tab.id)},

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/overview.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/overview.html
@@ -12,7 +12,7 @@
   </div>
   <div class="sitestats-widgets" th:if="${!#lists.isEmpty(overview.widgets)}">
     <section class="sitestats-widget" th:each="widget : ${overview.widgets}" th:if="${widget.visible}">
-      <h2 class="h4 sitestats-widget-title" th:text="${widget.title}">Report</h2>
+      <h2 class="sitestats-widget-title" th:text="${widget.title}">Report</h2>
       <dl class="sitestats-metrics" th:if="${!#lists.isEmpty(widget.metrics)}">
         <div class="sitestats-metric" th:each="metric : ${widget.metrics}"
              th:title="${metric.snapshot.detail != metric.snapshot.primary ? metric.snapshot.detail : null}">

--- a/webcomponents/tool/src/main/frontend/bundle-entry-points/sitestats.js
+++ b/webcomponents/tool/src/main/frontend/bundle-entry-points/sitestats.js
@@ -1,4 +1,5 @@
 import "@sakai-ui/sakai-sitestats/sakai-sitestats-report-panel.js";
 import "@sakai-ui/sakai-sitestats/sakai-sitestats-widget-tab.js";
+import "@sakai-ui/sakai-sitestats/sakai-sitestats-highlights.js";
 import "@sakai-ui/sakai-sitestats/sakai-sitestats-chart.js";
 import "@sakai-ui/sakai-sitestats/sakai-sitestats-table.js";

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/index.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/index.js
@@ -1,4 +1,5 @@
 export { SakaiSiteStatsReportPanel } from "./src/SakaiSiteStatsReportPanel.js";
 export { SakaiSiteStatsWidgetTab } from "./src/SakaiSiteStatsWidgetTab.js";
+export { SakaiSiteStatsHighlights } from "./src/SakaiSiteStatsHighlights.js";
 export { SakaiSiteStatsChart } from "./src/SakaiSiteStatsChart.js";
 export { SakaiSiteStatsTable } from "./src/SakaiSiteStatsTable.js";

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/package.json
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/package.json
@@ -20,6 +20,7 @@
     ".": "./index.js",
     "./sakai-sitestats-report-panel.js": "./sakai-sitestats-report-panel.js",
     "./sakai-sitestats-widget-tab.js": "./sakai-sitestats-widget-tab.js",
+    "./sakai-sitestats-highlights.js": "./sakai-sitestats-highlights.js",
     "./sakai-sitestats-chart.js": "./sakai-sitestats-chart.js",
     "./sakai-sitestats-table.js": "./sakai-sitestats-table.js"
   },

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/sakai-sitestats-highlights.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/sakai-sitestats-highlights.js
@@ -1,0 +1,3 @@
+import { SakaiSiteStatsHighlights } from "./src/SakaiSiteStatsHighlights.js";
+
+customElements.define("sakai-sitestats-highlights", SakaiSiteStatsHighlights);

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
@@ -17,6 +17,7 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
 
   static properties = {
     chart: { type: Object },
+    compact: { type: Boolean, reflect: true },
     renderTableFallback: { type: Boolean, attribute: "render-table-fallback" },
     _fallbackTable: { state: true },
   };
@@ -57,6 +58,19 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
 
       .chart-frame.depth {
         box-shadow: inset 0 -0.45rem 0 rgba(0, 0, 0, 0.08);
+      }
+
+      :host([compact]) .chart-frame {
+        block-size: 5rem;
+        min-block-size: 5rem;
+        padding: 0.25rem 0.35rem;
+        border: 0;
+        background: transparent;
+      }
+
+      :host([compact]) figcaption {
+        margin-block-start: 0.35rem;
+        font-size: 0.8rem;
       }
 
       canvas {
@@ -103,7 +117,7 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
 
   updated(changedProperties) {
 
-    if (changedProperties.has("chart") || changedProperties.has("_i18n")) {
+    if (changedProperties.has("chart") || changedProperties.has("compact") || changedProperties.has("_i18n")) {
       this._fallbackTable = siteStatsFallbackTable(this.chart, this._i18n);
       this.updateComplete.then(() => this._renderChart());
     }
@@ -146,11 +160,12 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
     const theme = siteStatsChartTheme(this);
     this._themeSignature = siteStatsChartThemeSignature(theme);
     const showItemLabels = this._showItemLabels();
+    const compact = this._isCompact();
 
     this._chartInstance = new Chart(canvas, {
       type: siteStatsChartType(this.chart),
       data: siteStatsChartData(this.chart, theme),
-      options: siteStatsChartOptions(this.chart, theme, showItemLabels),
+      options: siteStatsChartOptions(this.chart, theme, showItemLabels, compact),
       plugins: showItemLabels ? [ this._valueLabelsPlugin(theme) ] : [],
     });
 
@@ -190,9 +205,14 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
     this._scheduleOncePerFrame("_resizeHandle", () => this._chartInstance?.resize());
   }
 
+  _isCompact() {
+
+    return this.compact === true || this.chart?.compact === true;
+  }
+
   _showItemLabels() {
 
-    return this.chart?.itemLabelsVisible !== false;
+    return !this._isCompact() && this.chart?.itemLabelsVisible !== false;
   }
 
   _valueLabelsPlugin(theme) {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsHighlights.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsHighlights.js
@@ -1,0 +1,61 @@
+import { css, html, nothing } from "lit";
+import { SakaiShadowElement } from "@sakai-ui/sakai-element";
+import "../sakai-sitestats-chart.js";
+
+export class SakaiSiteStatsHighlights extends SakaiShadowElement {
+
+  static properties = {
+    charts: { type: Array },
+  };
+
+  static styles = [
+    ...SakaiShadowElement.styles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+      }
+
+      .highlight {
+        display: block;
+        width: 100%;
+      }
+
+      .highlight + .highlight {
+        margin-block-start: 0.75rem;
+      }
+    `,
+  ];
+
+  constructor() {
+
+    super();
+    this.charts = [];
+  }
+
+  render() {
+
+    const charts = (Array.isArray(this.charts) ? this.charts : []).filter(chart => this._hasData(chart));
+    if (!charts.length) {
+      return nothing;
+    }
+
+    return html`
+      ${charts.map(chart => html`
+        <sakai-sitestats-chart
+            class="highlight"
+            compact
+            .chart=${chart}
+            .renderTableFallback=${false}>
+        </sakai-sitestats-chart>
+      `)}
+    `;
+  }
+
+  _hasData(chart) {
+
+    return Array.isArray(chart?.datasets)
+      && chart.datasets.some(dataset => Array.isArray(dataset.points)
+        && dataset.points.some(point => Number(point?.y) > 0));
+  }
+}

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsTable.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsTable.js
@@ -47,8 +47,8 @@ export class SakaiSiteStatsTable extends SakaiShadowElement {
 
       th {
         background: var(--sakai-background-color-2, #f5f7f9);
-        font-weight: 600;
         white-space: nowrap;
+        font-size: 0.9125rem;
       }
 
       td[data-align="end"],
@@ -70,8 +70,9 @@ export class SakaiSiteStatsTable extends SakaiShadowElement {
       }
 
       .empty {
+        font-size: 0.9125rem;
         border: 1px solid var(--sakai-border-color, #d8dde6);
-        padding: 1rem;
+        padding: 0.45rem 0.6rem;
         background: var(--sakai-background-color-2, #f8f9fb);
       }
 

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/site-stats-chart-adapter.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/site-stats-chart-adapter.js
@@ -57,21 +57,22 @@ export function siteStatsChartData(chart, theme = SITE_STATS_CHART_FALLBACK_THEM
   };
 }
 
-export function siteStatsChartOptions(chart, theme = SITE_STATS_CHART_FALLBACK_THEME, showItemLabels = true) {
+export function siteStatsChartOptions(chart, theme = SITE_STATS_CHART_FALLBACK_THEME, showItemLabels = true, compact = false) {
 
   const chartType = siteStatsChartType(chart);
+  const compactChart = compact || chart?.compact === true;
 
   return {
     responsive: true,
     maintainAspectRatio: false,
     layout: {
       padding: {
-        top: showItemLabels && chartType !== "pie" ? 18 : 0,
+        top: showItemLabels && !compactChart && chartType !== "pie" ? 18 : 0,
       },
     },
     plugins: {
       legend: {
-        display: chart.datasets.length > 1 || chartType === "pie",
+        display: !compactChart && (chart.datasets.length > 1 || chartType === "pie"),
         labels: {
           color: theme.textColor,
         },
@@ -84,7 +85,7 @@ export function siteStatsChartOptions(chart, theme = SITE_STATS_CHART_FALLBACK_T
     elements: {
       bar: {
         borderSkipped: false,
-        borderRadius: useDepthEffect(chart) ? 2 : 0,
+        borderRadius: compactChart ? 1 : (useDepthEffect(chart) ? 2 : 0),
       },
       line: {
         borderColor: theme.borderColor,
@@ -95,21 +96,33 @@ export function siteStatsChartOptions(chart, theme = SITE_STATS_CHART_FALLBACK_T
     },
     scales: chartType === "pie" ? {} : {
       x: {
+        border: {
+          color: theme.borderColor,
+        },
         grid: {
+          display: !compactChart,
           color: theme.gridColor,
         },
         ticks: {
+          display: !compactChart,
           autoSkip: true,
+          maxTicksLimit: compactChart ? 8 : undefined,
           color: theme.mutedTextColor,
           maxRotation: 0,
+          font: compactChart ? { size: 10 } : undefined,
         },
       },
       y: {
         beginAtZero: true,
+        border: {
+          color: theme.borderColor,
+        },
         grid: {
+          display: !compactChart,
           color: theme.gridColor,
         },
         ticks: {
+          display: !compactChart,
           color: theme.mutedTextColor,
         },
       },

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
@@ -95,9 +95,7 @@ describe("sakai-sitestats-chart tests", () => {
     expect(el.hasAttribute("compact")).to.be.true;
     expect((el._chartInstance.config.plugins || []).some(plugin => plugin.id === "sakai-sitestats-value-labels")).to.be.false;
     expect(options.plugins.legend.display).to.be.false;
-    expect(options.scales.x.display).to.be.false;
-    expect(options.scales.x.border.display).to.be.false;
-    expect(options.scales.y.border.display).to.be.false;
+    expect(options.scales.x.ticks.display).to.be.false;
     expect(options.scales.y.ticks.display).to.be.false;
     expect(el.shadowRoot.querySelector("sakai-sitestats-table.visually-hidden")).to.not.exist;
   });

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
@@ -80,7 +80,26 @@ describe("sakai-sitestats-chart tests", () => {
     expect(el._chartInstance.data.datasets[0].backgroundColor).to.contain("rgba(10, 20, 30, 0.26)");
     expect(options.plugins.legend.labels.color).to.equal("rgb(220, 230, 240)");
     expect(options.scales.x.ticks.color).to.equal("rgb(150, 160, 170)");
+    expect(options.scales.x.border.color).to.equal("rgb(70, 80, 90)");
+    expect(options.scales.y.border.color).to.equal("rgb(70, 80, 90)");
     expect(options.scales.x.grid.color).to.equal("rgba(70, 80, 90, 0.55)");
+  });
+
+  it("renders a short chart without value labels in compact mode", async () => {
+
+    const compactChart = { ...chart, compact: true, itemLabelsVisible: false };
+    const el = await fixture(html`<sakai-sitestats-chart compact .chart=${compactChart} .renderTableFallback=${false}></sakai-sitestats-chart>`);
+    await waitUntil(() => el._chartInstance);
+
+    const options = siteStatsChartOptions(compactChart, siteStatsChartTheme(el), false, true);
+    expect(el.hasAttribute("compact")).to.be.true;
+    expect((el._chartInstance.config.plugins || []).some(plugin => plugin.id === "sakai-sitestats-value-labels")).to.be.false;
+    expect(options.plugins.legend.display).to.be.false;
+    expect(options.scales.x.display).to.be.false;
+    expect(options.scales.x.border.display).to.be.false;
+    expect(options.scales.y.border.display).to.be.false;
+    expect(options.scales.y.ticks.display).to.be.false;
+    expect(el.shadowRoot.querySelector("sakai-sitestats-table.visually-hidden")).to.not.exist;
   });
 
   it("resolves chart theme aliases through browser CSS", async () => {


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52862

<img width="908" height="565" alt="image" src="https://github.com/user-attachments/assets/44226bcd-017c-4724-be2e-deb3af7ddd28" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Presence and Access widgets, including student-specific views.
- Added traffic trends, by-role visit reporting, and 30-day visit and presence highlights.
- Added median presence, bounce-rate, and presence-duration metrics.
- Added Spanish translations for updated statistics.

## Bug Fixes
- Improved last-visit report sorting, duration formatting, presence calculations, and local-time handling.

## Style
- Refined charts, widget typography, table headers, and empty-state spacing.
- Added compact chart layouts and responsive highlight displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->