### PR TITLE
SAK-52864 Portal allow superusers to use View Site As

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ViewSiteAsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ViewSiteAsTest.java
@@ -21,6 +21,7 @@ import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import com.microsoft.playwright.options.SelectOption;
+import java.net.URI;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,19 @@ class ViewSiteAsTest extends SakaiUiTestBase {
         String siteUrl = sakai.createProject("instructor1", List.of("sakai\\.announcements"));
 
         sakai.login("admin");
-        page.navigate(siteUrl);
+        // The test base URL can differ from the portal URL used in generated links.
+        Locator usernameInput = page.locator("input[name=\"eid\"], #eid").first();
+        if (usernameInput.isVisible()) {
+            usernameInput.fill("admin");
+            page.locator("input[name=\"pw\"], #pw").first().fill("admin");
+            page.locator("#submit, button[type=\"submit\"], input[type=\"submit\"]").first().click();
+            page.waitForLoadState();
+        }
+
+        URI portalUri = URI.create(page.url());
+        String configuredSiteUrl = portalUri.resolve(URI.create(siteUrl).getRawPath()).toString();
+        String adminSiteUrl = portalUri.resolve("/portal/site/!admin").toString();
+        page.navigate(configuredSiteUrl);
 
         Locator roleSwitcher = page.locator("#roleSwitch");
         assertThat(roleSwitcher).isVisible();
@@ -49,16 +62,16 @@ class ViewSiteAsTest extends SakaiUiTestBase {
 
         assertThat(page.locator("#roleSwitchAnchor.Mrphs-roleSwitch__exit")).isVisible();
 
-        page.navigate("/portal/site/!admin");
+        page.navigate(adminSiteUrl);
         assertThat(page.getByRole(AriaRole.LINK,
             new Page.GetByRoleOptions()
                 .setName(Pattern.compile("^Site Unavailable$", Pattern.CASE_INSENSITIVE))).first()).isVisible();
 
-        page.navigate(siteUrl);
+        page.navigate(configuredSiteUrl);
         page.locator("#roleSwitchAnchor.Mrphs-roleSwitch__exit").click();
         page.waitForLoadState();
 
-        page.navigate("/portal/site/!admin");
+        page.navigate(adminSiteUrl);
         assertThat(page.getByRole(AriaRole.LINK,
             new Page.GetByRoleOptions()
                 .setName(Pattern.compile("^Administration Workspace$", Pattern.CASE_INSENSITIVE))).first()).isVisible();

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ViewSiteAsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ViewSiteAsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.SelectOption;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.sakaiproject.e2e.support.SakaiUiTestBase;
+
+class ViewSiteAsTest extends SakaiUiTestBase {
+
+    @Test
+    void superuserCanViewSiteAsAnotherRole() {
+        sakai.login("instructor1");
+        String siteUrl = sakai.createProject("instructor1", List.of("sakai\\.announcements"));
+
+        sakai.login("admin");
+        page.navigate(siteUrl);
+
+        Locator roleSwitcher = page.locator("#roleSwitch");
+        assertThat(roleSwitcher).isVisible();
+
+        Locator roleSelect = roleSwitcher.locator("#roleSwitchSelect");
+        if (roleSelect.count() > 0 && roleSelect.isVisible()) {
+            roleSelect.selectOption(new SelectOption().setIndex(1));
+        } else {
+            roleSwitcher.locator("#roleSwitchAnchor").click();
+        }
+        page.waitForLoadState();
+
+        assertThat(page.locator("#roleSwitchAnchor.Mrphs-roleSwitch__exit")).isVisible();
+
+        page.navigate("/portal/site/!admin");
+        assertThat(page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions()
+                .setName(Pattern.compile("^Site Unavailable$", Pattern.CASE_INSENSITIVE))).first()).isVisible();
+
+        page.navigate(siteUrl);
+        page.locator("#roleSwitchAnchor.Mrphs-roleSwitch__exit").click();
+        page.waitForLoadState();
+
+        page.navigate("/portal/site/!admin");
+        assertThat(page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions()
+                .setName(Pattern.compile("^Administration Workspace$", Pattern.CASE_INSENSITIVE))).first()).isVisible();
+    }
+}

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/handlers/SiteHandler.java
@@ -846,7 +846,7 @@ public class SiteHandler extends WorksiteHandler
 			boolean roleswapcheck = false; // This variable will tell the UI if we will display any role swapping component; false by default
 			String roleswitchvalue = securityService.getUserEffectiveRole(); // checks the session for a role swap value
 			boolean roleswitchstate = securityService.isUserRoleSwapped(); // This variable determines if the site is in the switched state or not; false by default
-			boolean allowroleswap = siteService.allowRoleSwap(siteId) && !securityService.isSuperUser();
+			boolean allowroleswap = siteService.allowRoleSwap(siteId);
 
 			if (roleswitchvalue != null) {
 				String switchRoleUrl = serverConfigurationService.getPortalUrl()


### PR DESCRIPTION
## Summary

- expose the existing View Site As control to superusers who pass the normal `site.roleswap` check
- verify role view replaces the active admin identity with a limited synthetic role and restores admin on exit
- add focused Playwright coverage for the complete admin role-view flow

Jira: https://sakaiproject.atlassian.net/browse/SAK-52864

## Testing

- `mvn -pl :sakai-portal-impl -am -DskipTests -Dcheckstyle.skip=false test`
- `mvn -f portal/portal-impl/impl/pom.xml -Dtest=SiteHandlerTest test`
- `mvn -f e2e-tests/pom.xml -Dtest=ViewSiteAsTest test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Super users can now access the role-switching option in sites where it is enabled.
  * Added automated coverage for viewing a site as another role and returning to the administration workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->