### PR TITLE
SAK-52860 Date Manager Cancel button does not return user to Site Info main page

### DIFF
--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -214,10 +214,10 @@ DTMN.initCancelRevert = function() {
     // Clicking Cancel is already an explicit discard, so don't let the unsaved-changes guard
     // second-guess the navigation away.
     DTMN.suppressUnsavedGuard = true;
-    const marker = "/sakai.datemanager.helper";
-    const href = window.location.href.replace(/#.*$/, "");
-    const idx = href.indexOf(marker);
-    window.location = idx === -1 ? href : href.substring(0, idx);
+    // The helper is mounted one path segment below the tool placement; dropping that segment
+    // returns to the host tool (Site Info).
+    const path = window.location.pathname.replace(/\/$/, "");
+    window.location = path.substring(0, path.lastIndexOf("/"));
   }, false);
 
   let reverted = false;

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -204,18 +204,13 @@ DTMN.initUnsavedGuard = function() {
   });
 };
 
-// Cancel abandons the staged edits and returns to the Site Info main page. Staged edits live
-// only in the page, so leaving the helper discards them; dropping the helper segment from the
-// URL hands control back to the host tool (Site Info).
+// Cancel discards the staged edits (they live only in the page) and returns to Site Info by
+// dropping the helper path segment below the tool placement.
 DTMN.initCancelRevert = function() {
   const cancelButton = document.getElementById("datemanager-cancel");
   cancelButton && cancelButton.addEventListener("click", function(e) {
     e.preventDefault();
-    // Clicking Cancel is already an explicit discard, so don't let the unsaved-changes guard
-    // second-guess the navigation away.
     DTMN.suppressUnsavedGuard = true;
-    // The helper is mounted one path segment below the tool placement; dropping that segment
-    // returns to the host tool (Site Info).
     const path = window.location.pathname.replace(/\/$/, "");
     window.location = path.substring(0, path.lastIndexOf("/"));
   }, false);

--- a/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
+++ b/site-manage/datemanager/tool/src/main/resources/static/js/initDatePicker.js
@@ -204,18 +204,20 @@ DTMN.initUnsavedGuard = function() {
   });
 };
 
-// Cancel discards staged edits by reloading the tool from saved state — the page stays in
-// Date Manager rather than bouncing back to Site Info. A sessionStorage flag survives the
-// reload so the fresh page can briefly confirm that the changes were discarded.
+// Cancel abandons the staged edits and returns to the Site Info main page. Staged edits live
+// only in the page, so leaving the helper discards them; dropping the helper segment from the
+// URL hands control back to the host tool (Site Info).
 DTMN.initCancelRevert = function() {
   const cancelButton = document.getElementById("datemanager-cancel");
   cancelButton && cancelButton.addEventListener("click", function(e) {
     e.preventDefault();
+    // Clicking Cancel is already an explicit discard, so don't let the unsaved-changes guard
+    // second-guess the navigation away.
     DTMN.suppressUnsavedGuard = true;
-    if (DTMN.hasUnsavedChanges()) {
-      try { window.sessionStorage.setItem("dm-cancel-reverted", "1"); } catch (err) { /* storage unavailable */ }
-    }
-    window.location.reload();
+    const marker = "/sakai.datemanager.helper";
+    const href = window.location.href.replace(/#.*$/, "");
+    const idx = href.indexOf(marker);
+    window.location = idx === -1 ? href : href.substring(0, idx);
   }, false);
 
   let reverted = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Date Manager **Cancel** action to return users to the host tool instead of reloading saved Date Manager state.
  * Improved cancellation navigation so users return to the correct host-tool location, including when the page URL contains trailing slashes or additional path segments.
  * Prevented the obsolete reverted-state banner from appearing when cancellation is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->