### PR TITLE
SAK-52844 Discussions correct unread synoptic count

### DIFF
--- a/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/msgcntr/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -1222,18 +1222,20 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
         
         	
         	if (isMessageFromForums){
-        		if(!originalReadStatus && read){
+        		// status.setRead above negates read, so these transition checks intentionally use the opposite value.
+        		if(!originalReadStatus && !read){
         			//status is changing from Unread to Read, so decrement unread number for Synoptic Messages
         			decrementForumSynopticToolInfo(userId, context, SynopticMsgcntrManager.NUM_OF_ATTEMPTS);
-        		}else if(originalReadStatus && !read){
+        		}else if(originalReadStatus && read){
         			//status is changing from Read to Unread, so increment unread number for Synoptic Messages
         			incrementForumSynopticToolInfo(userId, context, SynopticMsgcntrManager.NUM_OF_ATTEMPTS);
         		}
         	}else{
-        		if(!originalReadStatus && read){
+        		// status.setRead above negates read, so these transition checks intentionally use the opposite value.
+        		if(!originalReadStatus && !read){
         			//status is changing from Unread to Read, so decrement unread number for Synoptic Messages
         			decrementMessagesSynopticToolInfo(userId, context, SynopticMsgcntrManager.NUM_OF_ATTEMPTS);
-        		}else if(originalReadStatus && !read){
+        		}else if(originalReadStatus && read){
         			//status is changing from Read to Unread, so increment unread number for Synoptic Messages
         			incrementMessagesSynopticToolInfo(userId, context, SynopticMsgcntrManager.NUM_OF_ATTEMPTS);
         		}


### PR DESCRIPTION
## Summary

- Correct the synoptic unread-count transition checks for forums and private messages.
- Keep Overview and Dashboard counts in sync when a message changes between unread and read.

## Reason

SAK-49440 automatically marks a message as read when the user views it. It also changed the manual action from Mark as read to Mark as unread.

The Discussions widget still used the old rules, so its unread count did not change. This fix makes the count go down when a message is read and go up when it is marked unread.

## Testing

- mvn test -Dtest=MessageForumsMessageManagerImplTest (5 tests)
- mvn test in msgcntr/messageforums-component-impl (8 tests)

## Jira

[SAK-52844](https://sakaiproject.atlassian.net/browse/SAK-52844)

[SAK-52844]: https://sakaiproject.atlassian.net/browse/SAK-52844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unread message counts in forum and message summary indicators when messages are marked as read or unread.
  * Summary counts now accurately reflect the message’s actual read-state transition.
  * Prevented summary indicators from being incorrectly incremented or decremented when a message’s read status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->