### PR TITLE
SAK-52840 SiteStats move report title above chart

### DIFF
--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
@@ -65,7 +65,7 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
       }
 
       figcaption {
-        margin-block-start: 0.5rem;
+        margin-block-end: 0.5rem;
         color: var(--sakai-text-color-dimmed, #5f6773);
         font-size: 0.9rem;
       }
@@ -123,10 +123,10 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
 
     return html`
       <figure>
+        ${this.chart.title ? html`<figcaption>${this.chart.title}</figcaption>` : nothing}
         <div class=${useDepthEffect(this.chart) ? "chart-frame depth" : "chart-frame"}>
           <canvas aria-label="${chartLabel}" role="img"></canvas>
         </div>
-        ${this.chart.title ? html`<figcaption>${this.chart.title}</figcaption>` : nothing}
       </figure>
       ${this.renderTableFallback && this._fallbackTable
         ? html`<sakai-sitestats-table class="visually-hidden" .hideCaption=${true} .table=${this._fallbackTable}></sakai-sitestats-table>`

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
@@ -47,6 +47,8 @@ describe("sakai-sitestats-chart tests", () => {
     const plugins = el._chartInstance.config.plugins || [];
 
     expect(el.shadowRoot.querySelector(".chart-frame.depth")).to.exist;
+    const figure = el.shadowRoot.querySelector("figure");
+    expect(figure.firstElementChild).to.equal(figure.querySelector("figcaption"));
     expect(dataset.backgroundColor).to.contain("0.26");
     expect(dataset.borderWidth).to.equal(3);
     expect(el._chartInstance.config.options.layout.padding.top).to.equal(18);


### PR DESCRIPTION
[Jira: SAK-52840](https://sakaiproject.atlassian.net/browse/SAK-52840)

## Why

The chart title is rendered after the chart, so it appears at the bottom in report and print views.

## What changed

- move the existing chart title above the chart
- update the title spacing
- test that the title stays above the chart

## Testing

- `npx wtr packages/sakai-sitestats/test/sakai-sitestats-chart.test.js --config web-test-runner.config.mjs`
- `npm run lint`
- `npm run analyze`
- `npm run bundle`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated SiteStats charts so titles appear above the chart visualization.
  * Adjusted title spacing for improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->