### PR TITLE
SAK-52839 SiteStats make report actions look like buttons

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -170,6 +170,7 @@ class SiteStatsTest extends SakaiUiTestBase {
         assertThat(reportPanel).hasAttribute("endpoint", Pattern.compile("/api/sites/.*/sitestats/"));
         assertReportSummaryRendered();
         assertReportTableRenderedWithData();
+        assertThat(page.locator("main > div.d-flex.noprint a.btn-link")).hasCount(4);
         assertThat(page.locator("sakai-sitestats-report-panel sakai-sitestats-chart canvas").first()).isVisible();
         page.waitForFunction(siteStatsCanvasHasPixelsScript());
         assertTrue(Boolean.TRUE.equals(page.evaluate(siteStatsCanvasHasPixelsScript())));

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -101,19 +101,14 @@ class SiteStatsTest extends SakaiUiTestBase {
     @Test
     @Order(4)
     void createsReportViaReportsFlow() {
-        sakai.login("instructor1");
-        page.navigate(sakaiUrl);
-        sakai.toolClick("Statistics");
-
-        page.locator(".navIntraTool a, .navIntraTool button, a, button")
-            .filter(new Locator.FilterOptions().setHasText(Pattern.compile("^Reports$", Pattern.CASE_INSENSITIVE))).first()
-            .click(new Locator.ClickOptions().setForce(true));
+        openReportsAsInstructor();
 
         Locator addReportLink = page.getByRole(AriaRole.LINK,
-            new Page.GetByRoleOptions().setName(Pattern.compile("^Add$", Pattern.CASE_INSENSITIVE))).first();
-        addReportLink.click(new Locator.ClickOptions().setForce(true));
+            new Page.GetByRoleOptions().setName(Pattern.compile("^Add$", Pattern.CASE_INSENSITIVE)));
+        addReportLink.click();
 
         Locator activity = page.getByLabel("Activity:");
+        assertThat(activity).isVisible();
         assertThat(activity.locator("option[value='what-resources']")).hasCount(0);
         assertThat(page.locator("#event-options")).isHidden();
         activity.selectOption("what-events");

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/view.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/view.html
@@ -13,27 +13,27 @@
   <sakai-sitestats-report-panel th:attr="endpoint=${reportEndpoint}">
   </sakai-sitestats-report-panel>
   <div class="d-flex flex-wrap gap-2 mt-3 noprint">
-    <a class="btn btn-outline-secondary" th:href="@{/reports(siteId=${siteId})}"
+    <a class="btn btn-link" th:href="@{/reports(siteId=${siteId})}"
        th:text="#{report_back}">Back to reports</a>
     <th:block th:if="${preview}">
-      <a class="btn btn-outline-secondary"
+      <a class="btn btn-link"
          th:href="@{/reports/preview/{id}/export/xls(id=${previewId},siteId=${siteId})}"
          th:text="#{bt_export_excel}">Export Excel</a>
-      <a class="btn btn-outline-secondary"
+      <a class="btn btn-link"
          th:href="@{/reports/preview/{id}/export/csv(id=${previewId},siteId=${siteId})}"
          th:text="#{bt_export_csv}">Export CSV</a>
-      <a class="btn btn-outline-secondary"
+      <a class="btn btn-link"
          th:href="@{/reports/preview/{id}/export/pdf(id=${previewId},siteId=${siteId})}"
          th:text="#{bt_export_pdf}">Export PDF</a>
     </th:block>
     <th:block th:unless="${preview}">
-      <a class="btn btn-outline-secondary"
+      <a class="btn btn-link"
          th:href="@{/reports/{id}/export/xls(id=${report.id},siteId=${siteId})}"
          th:text="#{bt_export_excel}">Export Excel</a>
-      <a class="btn btn-outline-secondary"
+      <a class="btn btn-link"
          th:href="@{/reports/{id}/export/csv(id=${report.id},siteId=${siteId})}"
          th:text="#{bt_export_csv}">Export CSV</a>
-      <a class="btn btn-outline-secondary"
+      <a class="btn btn-link"
          th:href="@{/reports/{id}/export/pdf(id=${report.id},siteId=${siteId})}"
          th:text="#{bt_export_pdf}">Export PDF</a>
     </th:block>


### PR DESCRIPTION
[Jira: SAK-52839](https://sakaiproject.atlassian.net/browse/SAK-52839)

## Why

The report action links use the wrong Sakai button class, so they look like plain text until hover.

## What changed

- use the standard secondary button style for the back and export links
- test that the preview actions use that style

## Testing

- `mvn -pl sitestats/sitestats-tool -am -DskipTests package`
- `mvn -f e2e-tests/pom.xml -DskipTests test-compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated report navigation and export options with a simpler link-style appearance across report views.

* **Tests**
  * Expanded report-flow coverage to verify that the Activity field is visible.
  * Added validation that generated report pages display all four expected action links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->