### PR TITLE
SAK-52848 Date Manager preserve Gradebook due date

### DIFF
--- a/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -822,7 +822,8 @@ public class DateManagerServiceImpl implements DateManagerService {
 						} else {
 							date = LocalDate.parse(dueDateRaw, inputDateFormatter);
 						}
-						ZoneId zone = userTimeService.getLocalTimeZone().toZoneId();
+						// Gradebook treats due dates as date-only values in the server timezone.
+						ZoneId zone = ZoneId.systemDefault();
 						dueDate = date.atStartOfDay(zone).toInstant();
 					} catch (DateTimeParseException e) {
 						log.warn("Could not parse due date [{}], {}", dueDateRaw, e);

--- a/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
+++ b/site-manage/datemanager/impl/src/main/java/org/sakaiproject/datemanager/impl/DateManagerServiceImpl.java
@@ -289,6 +289,16 @@ public class DateManagerServiceImpl implements DateManagerService {
         return userDate.format(outputDatePickerFormat);
 	}
 
+	private ZoneId getGradebookZoneId() {
+		// Gradebook treats due dates as date-only values in the server timezone.
+		return ZoneId.systemDefault();
+	}
+
+	private String formatToGradebookDateFormat(Date date) {
+		if (date == null) return "";
+		return date.toInstant().atZone(getGradebookZoneId()).format(outputDatePickerFormat);
+	}
+
 	@Override
 	public JSONArray getAssignmentsForContext(String siteId) {
 		JSONArray jsonAssignments = new JSONArray();
@@ -772,7 +782,7 @@ public class DateManagerServiceImpl implements DateManagerService {
 					JSONObject gobj = new JSONObject();
 					gobj.put(DateManagerConstants.JSON_ID_PARAM_NAME, gbitem.getId());
 					gobj.put(DateManagerConstants.JSON_TITLE_PARAM_NAME, gbitem.getName());
-					gobj.put(DateManagerConstants.JSON_DUEDATE_PARAM_NAME, formatToUserDateFormat(gbitem.getDueDate()));
+					gobj.put(DateManagerConstants.JSON_DUEDATE_PARAM_NAME, formatToGradebookDateFormat(gbitem.getDueDate()));
 					gobj.put(DateManagerConstants.JSON_TOOLTITLE_PARAM_NAME, toolTitle);
 					gobj.put(DateManagerConstants.JSON_URL_PARAM_NAME, url);
 					gobj.put(DateManagerConstants.JSON_EXTRAINFO_PARAM_NAME, "false");
@@ -822,8 +832,7 @@ public class DateManagerServiceImpl implements DateManagerService {
 						} else {
 							date = LocalDate.parse(dueDateRaw, inputDateFormatter);
 						}
-						// Gradebook treats due dates as date-only values in the server timezone.
-						ZoneId zone = ZoneId.systemDefault();
+						ZoneId zone = getGradebookZoneId();
 						dueDate = date.atStartOfDay(zone).toInstant();
 					} catch (DateTimeParseException e) {
 						log.warn("Could not parse due date [{}], {}", dueDateRaw, e);
@@ -2083,7 +2092,7 @@ public class DateManagerServiceImpl implements DateManagerService {
 						date = LocalDate.parse(columns[2], inputDateFormatter);
 					}
 					columns[2] = date.format(outputDateFormatter);
-					ZoneId zone = userTimeService.getLocalTimeZone().toZoneId();
+					ZoneId zone = getGradebookZoneId();
 					if (gbitem.getDueDate() != null) {
 						changed = !gbitem.getDueDate().toInstant().atZone(zone).toLocalDate().equals(date);
 					} else {

--- a/site-manage/datemanager/impl/src/test/java/org/sakaiproject/datemanager/test/DateManagerServiceTest.java
+++ b/site-manage/datemanager/impl/src/test/java/org/sakaiproject/datemanager/test/DateManagerServiceTest.java
@@ -18,6 +18,7 @@ package org.sakaiproject.datemanager.test;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -58,6 +59,7 @@ import org.sakaiproject.datemanager.impl.DateManagerServiceImpl;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.grading.api.Assignment;
 import org.sakaiproject.grading.api.GradingService;
+import org.sakaiproject.grading.api.SortType;
 import org.sakaiproject.lessonbuildertool.model.SimplePageToolDao;
 import org.sakaiproject.signup.api.SignupMeetingService;
 import org.sakaiproject.signup.api.model.SignupMeeting;
@@ -185,10 +187,10 @@ public class DateManagerServiceTest {
         String siteId = toolSession.getAttribute(DateManagerService.STATE_SITE_ID).toString();
 
         when(gradingService.currentUserHasEditPerm(siteId)).thenReturn(true);
-        // Use a different user timezone to verify Gradebook's date-only server timezone.
+        LocalDate expectedDate = LocalDate.parse("2025-05-16");
         ZoneId serverZone = ZoneId.systemDefault();
-        ZoneId userZone = LocalDate.parse("2025-05-16").atStartOfDay(serverZone).getOffset().equals(ZoneOffset.UTC)
-                ? ZoneId.of("America/New_York") : ZoneOffset.UTC;
+        Instant expectedInstant = expectedDate.atStartOfDay(serverZone).toInstant();
+        ZoneId userZone = getZoneWithDifferentLocalDate(expectedInstant, expectedDate);
         when(userTimeService.getLocalTimeZone()).thenReturn(TimeZone.getTimeZone(userZone));
 
         Assignment assignment = Mockito.mock(Assignment.class);
@@ -199,7 +201,7 @@ public class DateManagerServiceTest {
             Assert.assertEquals(0, validation.getErrors().size());
             Assert.assertEquals(1, validation.getUpdates().size());
             DateManagerUpdate update = validation.getUpdates().get(0);
-            Assert.assertEquals(LocalDateTime.parse("2025-05-16T00:00:00").atZone(serverZone).toInstant(), update.getDueDate());
+            Assert.assertEquals(expectedInstant, update.getDueDate());
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -214,17 +216,44 @@ public class DateManagerServiceTest {
             Assert.assertEquals(0, validation.getErrors().size());
             Assert.assertEquals(1, validation.getUpdates().size());
             DateManagerUpdate update = validation.getUpdates().get(0);
-            Assert.assertEquals(LocalDate.parse("2025-05-16").atStartOfDay(serverZone).toInstant(), update.getDueDate());
+            Assert.assertEquals(expectedInstant, update.getDueDate());
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
     }
 
     @Test
+    public void testGetGradebookItemsForContextUsesServerTimeZone() {
+        String siteId = toolSession.getAttribute(DateManagerService.STATE_SITE_ID).toString();
+        LocalDate expectedDate = LocalDate.parse("2025-05-16");
+        Instant dueDate = expectedDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        ZoneId userZone = getZoneWithDifferentLocalDate(dueDate, expectedDate);
+        when(userTimeService.getLocalTimeZone()).thenReturn(TimeZone.getTimeZone(userZone));
+        when(gradingService.currentUserHasEditPerm(siteId)).thenReturn(true);
+
+        Assignment assignment = Mockito.mock(Assignment.class);
+        when(assignment.getId()).thenReturn(78L);
+        when(assignment.getName()).thenReturn("Participation");
+        when(assignment.getDueDate()).thenReturn(Date.from(dueDate));
+        when(gradingService.getAssignments(siteId, siteId, SortType.SORT_BY_NONE)).thenReturn(List.of(assignment));
+
+        JSONArray items = dateManagerService.getGradebookItemsForContext(siteId);
+
+        Assert.assertEquals(1, items.size());
+        JSONObject item = (JSONObject) items.get(0);
+        Assert.assertEquals("2025-05-16T00:00:00", item.get(DateManagerConstants.JSON_DUEDATE_PARAM_NAME));
+    }
+
+    @Test
     public void testIsChangedForGradebook() {
         String siteId = toolSession.getAttribute(DateManagerService.STATE_SITE_ID).toString();
+        LocalDate expectedDate = LocalDate.parse("2025-05-16");
+        Instant dueDateInstant = expectedDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        ZoneId userZone = getZoneWithDifferentLocalDate(dueDateInstant, expectedDate);
+        when(userTimeService.getLocalTimeZone()).thenReturn(TimeZone.getTimeZone(userZone));
+
         Assignment assignment = Mockito.mock(Assignment.class);
-        Date dueDate = Date.from(LocalDate.parse("2025-05-16").atStartOfDay(ZoneOffset.systemDefault()).toInstant());
+        Date dueDate = Date.from(dueDateInstant);
         when(assignment.getDueDate()).thenReturn(dueDate);
         when(gradingService.getAssignment(siteId, siteId, 78L)).thenReturn(assignment);
 
@@ -547,6 +576,20 @@ public class DateManagerServiceTest {
             log.warn("Failed to read file [{}], {}", filePath, e.toString());
         }
         return "";
+    }
+
+    private static ZoneId getZoneWithDifferentLocalDate(Instant instant, LocalDate date) {
+        ZoneId zone = ZoneOffset.ofHours(-12);
+        if (!instant.atZone(zone).toLocalDate().equals(date)) {
+            return zone;
+        }
+
+        zone = ZoneOffset.ofHours(14);
+        if (!instant.atZone(zone).toLocalDate().equals(date)) {
+            return zone;
+        }
+
+        throw new IllegalStateException("Could not find a timezone with a different local date");
     }
 
 }

--- a/site-manage/datemanager/impl/src/test/java/org/sakaiproject/datemanager/test/DateManagerServiceTest.java
+++ b/site-manage/datemanager/impl/src/test/java/org/sakaiproject/datemanager/test/DateManagerServiceTest.java
@@ -185,7 +185,11 @@ public class DateManagerServiceTest {
         String siteId = toolSession.getAttribute(DateManagerService.STATE_SITE_ID).toString();
 
         when(gradingService.currentUserHasEditPerm(siteId)).thenReturn(true);
-        when(userTimeService.getLocalTimeZone()).thenReturn(TimeZone.getDefault());
+        // Use a different user timezone to verify Gradebook's date-only server timezone.
+        ZoneId serverZone = ZoneId.systemDefault();
+        ZoneId userZone = LocalDate.parse("2025-05-16").atStartOfDay(serverZone).getOffset().equals(ZoneOffset.UTC)
+                ? ZoneId.of("America/New_York") : ZoneOffset.UTC;
+        when(userTimeService.getLocalTimeZone()).thenReturn(TimeZone.getTimeZone(userZone));
 
         Assignment assignment = Mockito.mock(Assignment.class);
         when(gradingService.getAssignment(siteId, siteId, 78L)).thenReturn(assignment);
@@ -195,7 +199,7 @@ public class DateManagerServiceTest {
             Assert.assertEquals(0, validation.getErrors().size());
             Assert.assertEquals(1, validation.getUpdates().size());
             DateManagerUpdate update = validation.getUpdates().get(0);
-            Assert.assertEquals(LocalDateTime.parse("2025-05-16T00:00:00").atZone(ZoneId.systemDefault()).toInstant(), update.getDueDate());
+            Assert.assertEquals(LocalDateTime.parse("2025-05-16T00:00:00").atZone(serverZone).toInstant(), update.getDueDate());
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -210,7 +214,7 @@ public class DateManagerServiceTest {
             Assert.assertEquals(0, validation.getErrors().size());
             Assert.assertEquals(1, validation.getUpdates().size());
             DateManagerUpdate update = validation.getUpdates().get(0);
-            Assert.assertEquals(LocalDate.parse("2025-05-16").atStartOfDay(ZoneOffset.systemDefault()).toInstant(), update.getDueDate());
+            Assert.assertEquals(LocalDate.parse("2025-05-16").atStartOfDay(serverZone).toInstant(), update.getDueDate());
         } catch (Exception e) {
             Assert.fail(e.toString());
         }


### PR DESCRIPTION
## Why

Date Manager saved Gradebook due dates in the user timezone, while Gradebook reads them in the server timezone. When those timezones differ, Gradebook can show the previous day.

## What changed

Date Manager now saves Gradebook due dates in the same timezone Gradebook uses.

## Testing

- `mvn -pl site-manage/datemanager/impl -am -Dtest=DateManagerServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`

The service test uses different user and server timezones and verifies both supported Gradebook date formats. A Playwright test is not included because reproducing this in the UI requires changing both the Sakai user timezone and the running server timezone.

Jira: [SAK-52848](https://sakaiproject.atlassian.net/browse/SAK-52848)

[SAK-52848]: https://sakaiproject.atlassian.net/browse/SAK-52848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Gradebook due-date handling so date-only values consistently use the server’s timezone, preventing discrepancies caused by individual user timezone settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->