### PR TITLE
SAK-52847 Assignments preserve submission time in Grader history

### DIFF
--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7558,10 +7558,7 @@ public class AssignmentAction extends PagedResourceActionII {
                         // keep the history of assignment feed back text
                         String prevSubmittedDate = previousSubmissionDate == null
                                 ? prevGradedDate
-                                : DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)
-                                        .withLocale(localeService.getLocaleForCurrentSiteAndUser())
-                                        .withZone(userTimeService.getLocalTimeZone().toZoneId())
-                                        .format(previousSubmissionDate);
+                                : userTimeService.dateTimeFormat(previousSubmissionDate, FormatStyle.LONG, FormatStyle.LONG);
                         String feedbackTextHistory = StringUtils.trimToEmpty(properties.get(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT));
                         feedbackTextHistory = "<h4>" + prevSubmittedDate + "</h4>" + "<div style=\"margin:0;padding:0\">" + submission.getFeedbackText() + "</div>" + feedbackTextHistory;
                         properties.put(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT, feedbackTextHistory);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7558,7 +7558,10 @@ public class AssignmentAction extends PagedResourceActionII {
                         // keep the history of assignment feed back text
                         String prevSubmittedDate = previousSubmissionDate == null
                                 ? prevGradedDate
-                                : DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG).withZone(ZoneId.systemDefault()).format(previousSubmissionDate);
+                                : DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)
+                                        .withLocale(localeService.getLocaleForCurrentSiteAndUser())
+                                        .withZone(userTimeService.getLocalTimeZone().toZoneId())
+                                        .format(previousSubmissionDate);
                         String feedbackTextHistory = StringUtils.trimToEmpty(properties.get(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT));
                         feedbackTextHistory = "<h4>" + prevSubmittedDate + "</h4>" + "<div style=\"margin:0;padding:0\">" + submission.getFeedbackText() + "</div>" + feedbackTextHistory;
                         properties.put(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT, feedbackTextHistory);

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -7482,6 +7482,9 @@ public class AssignmentAction extends PagedResourceActionII {
                         setResubmissionProperties(a, submission);
                     }
 
+                    // Preserve the student submission time before replacing it with the resubmission time below.
+                    Instant previousSubmissionDate = submission.getDateSubmitted();
+
                     // update submission info after resubmission which prevents updating resubmission count for the first submission
                     submission.setUserSubmission(true);
                     submission.setSubmittedText(text);
@@ -7553,8 +7556,11 @@ public class AssignmentAction extends PagedResourceActionII {
                     // following involves content, not grading, so always do on resubmit, not just if graded
                     if (StringUtils.isNotBlank(submission.getFeedbackText())) {
                         // keep the history of assignment feed back text
+                        String prevSubmittedDate = previousSubmissionDate == null
+                                ? prevGradedDate
+                                : DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG).withZone(ZoneId.systemDefault()).format(previousSubmissionDate);
                         String feedbackTextHistory = StringUtils.trimToEmpty(properties.get(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT));
-                        feedbackTextHistory = "<h4>" + prevGradedDate + "</h4>" + "<div style=\"margin:0;padding:0\">" + submission.getFeedbackText() + "</div>" + feedbackTextHistory;
+                        feedbackTextHistory = "<h4>" + prevSubmittedDate + "</h4>" + "<div style=\"margin:0;padding:0\">" + submission.getFeedbackText() + "</div>" + feedbackTextHistory;
                         properties.put(ResourceProperties.PROP_SUBMISSION_PREVIOUS_FEEDBACK_TEXT, feedbackTextHistory);
                     }
 


### PR DESCRIPTION
## Why

Sakai Grader showed the instructor grading time for a previous student submission.

## What

Use the student submission time for previous submissions. Previous grades still show the grading time.

## Testing

- `mvn -pl assignment/tool -am -DskipTests install`
- `mvn -pl assignment/tool -Dtest=AssignmentActionTest test`

No E2E test was added because this is a server-side timestamp selection change in the legacy Assignments submission flow.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resubmissions now retain the prior submission timestamp when recording feedback history.
  - Feedback history falls back to the existing graded date when the prior submission timestamp is unavailable.
  - Prior submission timestamps are formatted consistently using the applicable date and time settings.
  - These updates improve the accuracy and consistency of submission timelines displayed in feedback history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->