### PR TITLE
SAK-52868 Check authorization before saving Message tool configuration

### DIFF
--- a/message/message-tool/tool/src/java/org/sakaiproject/message/tool/SynopticMessageAction.java
+++ b/message/message-tool/tool/src/java/org/sakaiproject/message/tool/SynopticMessageAction.java
@@ -647,6 +647,15 @@ public class SynopticMessageAction extends VelocityPortletPaneledAction
 	 */
 	public void doUpdate(RunData data, Context context)
 	{
+		// ignore if not allowed - addOptionsMenu() only uses this to decide whether to
+		// show the "Options" link, so without this check here doUpdate() could be
+		// invoked directly (bypassing the UI) to change the tool's configuration
+		// regardless of permissions
+		if (!allowedToOptions())
+		{
+			return;
+		}
+
 		// access the portlet element id to find our state
 		String peid = ((JetspeedRunData) data).getJs_peid();
 		SessionState state = ((JetspeedRunData) data).getPortletSessionState(peid);


### PR DESCRIPTION
## Summary
- `SynopticMessageAction.doUpdate()` saved tool placement configuration without checking `allowedToOptions()` first — that check was only used to decide whether to show the "Options" link and before entering options mode, never before saving
- Adds the same guard already used for this purpose elsewhere in Sakai (e.g. `ResourcesAction.doDropboxOptions()`)
- Currently only affects `sakai.motd`, the only tool registered against this action that's actually placeable via Site Info

https://sakaiproject.atlassian.net/browse/SAK-52868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unauthorized direct requests from changing the tool’s configuration when the user lacks the required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->