### PR TITLE
SAK-52867 Statistics  User Activity Show More link error

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
@@ -478,7 +478,8 @@ public class SiteStatsToolService {
             events = detailedEventsManager.getDetailedEvents(tracking,
                     new PagingParams(offset, PAGE_SIZE), new SortingParams("eventDate", true)).stream()
                     .map(event -> new ActivityEvent(event.getId(), eventName(event.getEventId()), event.getEventRef(),
-                            event.getEventDate().toInstant().toString(), formatTimestamp(event.getEventDate())))
+                            event.getEventDate().toInstant().toString(), formatTimestamp(event.getEventDate()),
+                            detailedEventsManager.isResolvable(event.getEventId())))
                     .collect(Collectors.toList());
             statsManager.logEvent(new UserId(form.getUserId()), StatsManager.LOG_ACTION_TRACK, siteId, false);
         }
@@ -661,6 +662,7 @@ public class SiteStatsToolService {
         private final String reference;
         private final String timestamp;
         private final String displayTimestamp;
+        private final boolean resolvable;
     }
 
     @Getter

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/user-activity.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/user-activity.html
@@ -66,7 +66,8 @@
           <td th:text="${event.label}"></td>
           <td class="text-break" th:text="${event.reference}"></td>
           <td>
-            <a th:href="@{/useractivity/events/{id}(id=${event.id},siteId=${siteId})}"
+            <a th:if="${event.resolvable}"
+               th:href="@{/useractivity/events/{id}(id=${event.id},siteId=${siteId})}"
                th:text="#{de_resultsTable_detailsLink}">View details</a>
           </td>
         </tr>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User activity events now show the “View details” link only when detailed information is available.
  * Prevents users from opening unavailable or unresolvable event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->