### PR TITLE
SAK-52840 Statistics Report title should be at the top, not the bottom

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -187,7 +187,8 @@ class SiteStatsTest extends SakaiUiTestBase {
         page.getByLabel(Pattern.compile("Presentation", Pattern.CASE_INSENSITIVE)).selectOption("how-presentation-both");
 
         page.locator("button:has-text(\"Generate report\"), input[type=\"submit\"][value*=\"Generate report\"]").first().click(new Locator.ClickOptions().setForce(true));
-        assertThat(page.getByText(REPORT_TITLE).first()).isVisible();
+        assertThat(page.getByRole(AriaRole.HEADING,
+            new Page.GetByRoleOptions().setName(REPORT_TITLE))).isVisible();
         Locator reportPanel = page.locator("sakai-sitestats-report-panel").first();
         assertThat(reportPanel).isVisible();
         assertThat(reportPanel).hasAttribute("endpoint", Pattern.compile("/api/sites/.*/sitestats/"));

--- a/sitestats/sitestats-bundle/src/resources/Messages.properties
+++ b/sitestats/sitestats-bundle/src/resources/Messages.properties
@@ -466,7 +466,6 @@ de_web_page=Page
 sitestats_report_title_required=A report title is required.
 sitestats_report_type_unavailable=The selected report type is not available for this site.
 sitestats_report_type=Report type
-sitestats_report_preview=Report preview
 sitestats_report_types_empty=No report types are available for this site.
 sitestats_reports_caption=Saved and predefined SiteStats reports
 sitestats_resource_ids=Resource IDs

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
@@ -153,10 +153,9 @@ public class SiteStatsController {
     @GetMapping("/reports/preview/{previewId}")
     public String preview(@PathVariable String previewId, @RequestParam(required = false) String siteId, Model model) {
         String authorizedSiteId = toolService.reportSite(siteId);
-        if (!toolService.canViewPreview(authorizedSiteId, previewId)) {
-            throw new IllegalArgumentException("The report preview expired or is unavailable");
-        }
+        ReportDef report = toolService.previewReportDefinition(authorizedSiteId, previewId);
         commonModel(model, authorizedSiteId, "reports");
+        model.addAttribute("report", report);
         model.addAttribute("reportEndpoint", SiteStatsApiUrls.previewReport(authorizedSiteId, previewId, reportRequest()));
         model.addAttribute("previewId", previewId);
         model.addAttribute("preview", true);

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
@@ -219,8 +219,10 @@ public class SiteStatsToolService {
         return new CopiedReport(saveReport(report.getSiteId(), form), report.getSiteId());
     }
 
-    public boolean canViewPreview(String requestedSiteId, String previewId) {
-        return reportExportService.canExportPreviewReport(reportSite(requestedSiteId), previewId);
+    public ReportDef previewReportDefinition(String requestedSiteId, String previewId) {
+        String siteId = reportSite(requestedSiteId);
+        ReportDef report = reportAccessService.previewReportDefinition(siteId, previewId);
+        return new ReportDef(report, siteId);
     }
 
     public ReportDef buildReport(String requestedSiteId, SiteStatsReportForm form) {

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/list.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/list.html
@@ -5,7 +5,7 @@
 <main class="portletBody container-fluid">
   <div th:replace="~{fragments/common :: menu('reports')}"></div>
   <div th:replace="~{fragments/common :: messages}"></div>
-  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3 mb-3">
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 my-3">
     <h1 class="h3 mb-0" th:text="#{menu_reports}">Reports</h1>
     <a class="btn btn-primary" th:href="@{/reports/new(siteId=${siteId})}" th:text="#{report_new}">Add report</a>
   </div>

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/view.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/view.html
@@ -5,8 +5,8 @@
 <main class="portletBody container-fluid">
   <div th:replace="~{fragments/common :: menu('reports')}"></div>
   <div th:replace="~{fragments/common :: messages}"></div>
-  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3">
-    <h1 class="h3 mb-0" th:text="${preview} ? #{sitestats_report_preview} : ${report.title}">Report</h1>
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 my-3">
+    <h1 class="h3 mb-0" th:text="${report.title}">Report</h1>
     <button id="print-report" type="button" class="btn btn-link noprint"
             th:text="#{report_print}">Print report</button>
   </div>

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
@@ -78,12 +78,6 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
         block-size: 100%;
       }
 
-      figcaption {
-        margin-block-start: 0.5rem;
-        color: var(--sakai-text-color-dimmed, #5f6773);
-        font-size: 0.9rem;
-      }
-
       .empty {
         border: 1px solid var(--sakai-border-color, #d8dde6);
         padding: 1rem;
@@ -140,10 +134,10 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
         <div class=${useDepthEffect(this.chart) ? "chart-frame depth" : "chart-frame"}>
           <canvas aria-label="${chartLabel}" role="img"></canvas>
         </div>
-        ${this.chart.title ? html`<figcaption>${this.chart.title}</figcaption>` : nothing}
+        ${this.chart.title ? html`<figcaption class="visually-hidden">${this.chart.title}</figcaption>` : nothing}
       </figure>
       ${this.renderTableFallback && this._fallbackTable
-        ? html`<sakai-sitestats-table class="visually-hidden" .hideCaption=${true} .table=${this._fallbackTable}></sakai-sitestats-table>`
+        ? html`<sakai-sitestats-table class="visually-hidden" .table=${this._fallbackTable}></sakai-sitestats-table>`
         : nothing}
     `;
   }

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsChart.js
@@ -79,7 +79,7 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
       }
 
       figcaption {
-        margin-block-end: 0.5rem;
+        margin-block-start: 0.5rem;
         color: var(--sakai-text-color-dimmed, #5f6773);
         font-size: 0.9rem;
       }
@@ -137,10 +137,10 @@ export class SakaiSiteStatsChart extends SakaiShadowElement {
 
     return html`
       <figure>
-        ${this.chart.title ? html`<figcaption>${this.chart.title}</figcaption>` : nothing}
         <div class=${useDepthEffect(this.chart) ? "chart-frame depth" : "chart-frame"}>
           <canvas aria-label="${chartLabel}" role="img"></canvas>
         </div>
+        ${this.chart.title ? html`<figcaption>${this.chart.title}</figcaption>` : nothing}
       </figure>
       ${this.renderTableFallback && this._fallbackTable
         ? html`<sakai-sitestats-table class="visually-hidden" .hideCaption=${true} .table=${this._fallbackTable}></sakai-sitestats-table>`

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsReportPanel.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsReportPanel.js
@@ -2,7 +2,6 @@ import { html, css, nothing } from "lit";
 import { SakaiShadowElement } from "@sakai-ui/sakai-element";
 import "../sakai-sitestats-chart.js";
 import "../sakai-sitestats-table.js";
-import { hasSiteStatsChartData } from "./site-stats-chart-adapter.js";
 
 export class SakaiSiteStatsReportPanel extends SakaiShadowElement {
 
@@ -104,9 +103,6 @@ export class SakaiSiteStatsReportPanel extends SakaiShadowElement {
     const presentationMode = this._report.presentationMode || "how-presentation-both";
     const showChart = this._report.chart && presentationMode !== "how-presentation-table";
     const showTable = this._report.table && presentationMode !== "how-presentation-chart";
-    const hideTableCaption = showChart && showTable
-      && hasSiteStatsChartData(this._report.chart)
-      && this._sameText(this._report.chart.title, this._report.table.caption);
 
     return html`
       <div class="panel">
@@ -118,10 +114,7 @@ export class SakaiSiteStatsReportPanel extends SakaiShadowElement {
           </sakai-sitestats-chart>
         ` : nothing}
         ${showTable ? html`
-          <sakai-sitestats-table
-              .hideCaption=${hideTableCaption}
-              .table=${this._report.table}>
-          </sakai-sitestats-table>
+          <sakai-sitestats-table .table=${this._report.table}></sakai-sitestats-table>
         ` : nothing}
       </div>
     `;
@@ -143,11 +136,6 @@ export class SakaiSiteStatsReportPanel extends SakaiShadowElement {
         `)}
       </dl>
     `;
-  }
-
-  _sameText(first, second) {
-
-    return Boolean(first && second && String(first).trim() === String(second).trim());
   }
 
   async _load() {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsTable.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/src/SakaiSiteStatsTable.js
@@ -8,7 +8,6 @@ export class SakaiSiteStatsTable extends SakaiShadowElement {
   static properties = {
     table: { type: Object },
     compact: { type: Boolean },
-    hideCaption: { type: Boolean, attribute: "hide-caption" },
   };
 
   static styles = [
@@ -29,12 +28,6 @@ export class SakaiSiteStatsTable extends SakaiShadowElement {
         inline-size: 100%;
         min-inline-size: 32rem;
         background: var(--sakai-background-color-1, #fff);
-      }
-
-      caption {
-        padding-block: 0.5rem;
-        text-align: start;
-        font-weight: 600;
       }
 
       th,
@@ -103,7 +96,7 @@ export class SakaiSiteStatsTable extends SakaiShadowElement {
     return html`
       <div class="table-wrap">
         <table>
-          ${this.table.caption ? html`<caption class=${this.hideCaption ? "visually-hidden" : nothing}>${this.table.caption}</caption>` : nothing}
+          ${this.table.caption ? html`<caption class="visually-hidden">${this.table.caption}</caption>` : nothing}
           <thead>
             <tr>
               ${repeat(this.table.columns, column => column.key, column => html`

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
@@ -53,7 +53,9 @@ describe("sakai-sitestats-chart tests", () => {
     expect(plugins.some(plugin => plugin.id === "sakai-sitestats-value-labels")).to.be.true;
     const fallbackTable = el.shadowRoot.querySelector("sakai-sitestats-table.visually-hidden");
     expect(fallbackTable).to.exist;
-    expect(fallbackTable.hideCaption).to.be.true;
+    const figcaption = el.shadowRoot.querySelector("figcaption");
+    expect(figcaption.textContent).to.equal("Visits");
+    expect(figcaption.classList.contains("visually-hidden")).to.be.true;
   });
 
   it("uses Sakai theme variables for chart colors", async () => {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-chart.test.js
@@ -47,8 +47,6 @@ describe("sakai-sitestats-chart tests", () => {
     const plugins = el._chartInstance.config.plugins || [];
 
     expect(el.shadowRoot.querySelector(".chart-frame.depth")).to.exist;
-    const figure = el.shadowRoot.querySelector("figure");
-    expect(figure.firstElementChild).to.equal(figure.querySelector("figcaption"));
     expect(dataset.backgroundColor).to.contain("0.26");
     expect(dataset.borderWidth).to.equal(3);
     expect(el._chartInstance.config.options.layout.padding.top).to.equal(18);

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-report-panel.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-report-panel.test.js
@@ -7,7 +7,6 @@ describe("sakai-sitestats-report-panel tests", () => {
 
   const endpoint = "/api/sites/site1/sitestats/widgets/visits/tabs/bydate?include=table,chart";
   const chartOnlyEndpoint = "/api/sites/site1/sitestats/widgets/visits/tabs/bydate?include=chart";
-  const tableOnlyEndpoint = "/api/sites/site1/sitestats/widgets/visits/tabs/bydate?include=table";
 
   beforeEach(() => {
     window.sessionStorage.clear();
@@ -80,7 +79,6 @@ describe("sakai-sitestats-report-panel tests", () => {
     await waitUntil(() => chartEl._i18n);
     await elementUpdated(chartEl);
     expect(chartEl.renderTableFallback).to.be.false;
-    expect(tableEl.hideCaption).to.be.true;
     expect(chartEl.shadowRoot.querySelector("sakai-sitestats-table.visually-hidden")).to.not.exist;
   });
 
@@ -126,52 +124,6 @@ describe("sakai-sitestats-report-panel tests", () => {
 
     expect(el.shadowRoot.querySelector("sakai-sitestats-table")).to.not.exist;
     expect(chartEl.renderTableFallback).to.be.true;
-  });
-
-  it("keeps table captions visible in table-only mode", async () => {
-
-    fetchMock.get(tableOnlyEndpoint, {
-      siteId: "site1",
-      presentationMode: "how-presentation-table",
-      table: {
-        caption: "Visits",
-        columns: [
-          { key: "date", label: "Date", type: "date" },
-          { key: "visits", label: "Visits", type: "number", align: "end" },
-        ],
-        rows: [
-          {
-            cells: {
-              date: { raw: "2026-06-17", display: "6/17/26" },
-              visits: { raw: 3, display: "3" },
-            },
-          },
-        ],
-      },
-      chart: {
-        title: "Visits",
-        type: "bar",
-        xKey: "date",
-        yKey: "visits",
-        datasets: [
-          {
-            key: "visits",
-            label: "Visits",
-            points: [{ x: "2026-06-17", label: "6/17/26", y: 3 }],
-          },
-        ],
-      },
-    });
-
-    const el = await fixture(html`<sakai-sitestats-report-panel endpoint="${tableOnlyEndpoint}"></sakai-sitestats-report-panel>`);
-    await waitUntil(() => el.shadowRoot.querySelector("sakai-sitestats-table"));
-    const tableEl = el.shadowRoot.querySelector("sakai-sitestats-table");
-    await waitUntil(() => tableEl.shadowRoot?.querySelector("caption"));
-
-    const caption = tableEl.shadowRoot.querySelector("caption");
-    expect(el.shadowRoot.querySelector("sakai-sitestats-chart")).to.not.exist;
-    expect(tableEl.hideCaption).to.be.false;
-    expect(caption.classList.contains("visually-hidden")).to.be.false;
   });
 
   it("renders an alert when the endpoint fails", async () => {

--- a/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-table.test.js
+++ b/webcomponents/tool/src/main/frontend/packages/sakai-sitestats/test/sakai-sitestats-table.test.js
@@ -16,7 +16,7 @@ describe("sakai-sitestats-table tests", () => {
     fetchMock.hardReset();
   });
 
-  it("renders table captions visibly by default", async () => {
+  it("keeps table captions available to assistive technology without rendering them visibly", async () => {
 
     const table = {
       caption: "Visits",
@@ -25,27 +25,6 @@ describe("sakai-sitestats-table tests", () => {
     };
 
     const el = await fixture(html`<sakai-sitestats-table .table=${table}></sakai-sitestats-table>`);
-    await waitUntil(() => el.shadowRoot.querySelector("caption"));
-
-    const caption = el.shadowRoot.querySelector("caption");
-    expect(caption.textContent).to.equal("Visits");
-    expect(caption.classList.contains("visually-hidden")).to.be.false;
-  });
-
-  it("can keep captions available to assistive technology without rendering them visibly", async () => {
-
-    const table = {
-      caption: "Visits",
-      columns: [{ key: "date", label: "Date", type: "date" }],
-      rows: [{ cells: { date: { raw: "2026-06-17", display: "6/17/26" } } }],
-    };
-
-    const el = await fixture(html`
-      <sakai-sitestats-table
-          .hideCaption=${true}
-          .table=${table}>
-      </sakai-sitestats-table>
-    `);
     await waitUntil(() => el.shadowRoot.querySelector("caption"));
 
     const caption = el.shadowRoot.querySelector("caption");


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Report and chart/table captions remain available to assistive technologies while being visually hidden where appropriate.
  * Report titles are now rendered consistently as headings.

* **Bug Fixes**
  * Improved report preview handling and validation.
  * Standardized spacing on report list and detail pages.

* **Tests**
  * Updated end-to-end and component tests to verify accessible headings and captions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->