### PR TITLE
SAK-52873 T&Q PDF download issues with Hot Spot (Answer Key)

### DIFF
--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/pdf/model/AssessmentPdfQuestionModel.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/pdf/model/AssessmentPdfQuestionModel.java
@@ -48,6 +48,7 @@ public final class AssessmentPdfQuestionModel implements Serializable {
     private final List<AssessmentPdfValueTypes.AssessmentPdfEmiPromptModel> emiPrompts;
     private final String imageMapSrc;
     private final List<String> imageMapItemTexts;
+    private final List<String> imageMapRegionJsons;
     private final List<AssessmentPdfValueTypes.AssessmentPdfPrintChoiceModel> printChoices;
     private final String sequence;
     private final String text;
@@ -102,6 +103,7 @@ public final class AssessmentPdfQuestionModel implements Serializable {
         this.emiPrompts = copy(builder.emiPrompts);
         this.imageMapSrc = builder.imageMapSrc;
         this.imageMapItemTexts = copy(builder.imageMapItemTexts);
+        this.imageMapRegionJsons = copy(builder.imageMapRegionJsons);
         this.printChoices = copy(builder.printChoices);
         this.sequence = builder.sequence;
         this.text = builder.text;
@@ -219,6 +221,10 @@ public final class AssessmentPdfQuestionModel implements Serializable {
 
     public List<String> getImageMapItemTexts() {
         return imageMapItemTexts;
+    }
+
+    public List<String> getImageMapRegionJsons() {
+        return imageMapRegionJsons;
     }
 
     public List<AssessmentPdfValueTypes.AssessmentPdfPrintChoiceModel> getPrintChoices() {
@@ -373,6 +379,7 @@ public final class AssessmentPdfQuestionModel implements Serializable {
         private List<AssessmentPdfValueTypes.AssessmentPdfEmiPromptModel> emiPrompts;
         private String imageMapSrc;
         private List<String> imageMapItemTexts;
+        private List<String> imageMapRegionJsons;
         private List<AssessmentPdfValueTypes.AssessmentPdfPrintChoiceModel> printChoices;
         private String sequence;
         private String text;
@@ -499,6 +506,11 @@ public final class AssessmentPdfQuestionModel implements Serializable {
 
         public Builder imageMapItemTexts(List<String> imageMapItemTexts) {
             this.imageMapItemTexts = imageMapItemTexts;
+            return this;
+        }
+
+        public Builder imageMapRegionJsons(List<String> imageMapRegionJsons) {
+            this.imageMapRegionJsons = imageMapRegionJsons;
             return this;
         }
 

--- a/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/pdf/model/AssessmentPdfValueTypes.java
+++ b/samigo/samigo-api/src/java/org/sakaiproject/samigo/api/pdf/model/AssessmentPdfValueTypes.java
@@ -340,10 +340,16 @@ public final class AssessmentPdfValueTypes {
 
         private final String answerText;
         private final Long publishedItemTextId;
+        private final Integer sequence;
 
         public AssessmentPdfItemGradingModel(String answerText, Long publishedItemTextId) {
+            this(answerText, publishedItemTextId, null);
+        }
+
+        public AssessmentPdfItemGradingModel(String answerText, Long publishedItemTextId, Integer sequence) {
             this.answerText = answerText;
             this.publishedItemTextId = publishedItemTextId;
+            this.sequence = sequence;
         }
 
         public String getAnswerText() {
@@ -352,6 +358,10 @@ public final class AssessmentPdfValueTypes {
 
         public Long getPublishedItemTextId() {
             return publishedItemTextId;
+        }
+
+        public Integer getSequence() {
+            return sequence;
         }
     }
 

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilder.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilder.java
@@ -277,7 +277,6 @@ public final class AssessmentPdfSnapshotBuilder {
                 .duration(itemData.getDuration())
                 .triesAllowed(itemData.getTriesAllowed())
                 .itemScore(itemData.getScore())
-                .itemAnswerKey(itemData.getAnswerKey())
                 .generalItemFeedback(itemData.getGeneralItemFeedback())
                 .correctItemFeedback(itemData.getCorrectItemFeedback())
                 .incorrectItemFeedback(itemData.getInCorrectItemFeedback())
@@ -288,9 +287,15 @@ public final class AssessmentPdfSnapshotBuilder {
                 .emiAnswerOptionsRichText(itemData.getEmiAnswerOptionsRichText())
                 .emiAnswerOptions(toEmiAnswerOptions(itemData))
                 .emiPrompts(toEmiPrompts(itemData))
-                .imageMapSrc(itemData.getItemMetaDataByLabel("IMAGE_MAP_SRC"))
-                .imageMapItemTexts(toImageMapItemTexts(itemData))
-                .printChoices(toPrintChoices(itemData));
+                .imageMapSrc(itemData.getImageMapSrc())
+                .imageMapItemTexts(toImageMapItemTexts(itemData));
+        if (TypeIfc.IMAGEMAP_QUESTION.equals(itemData.getTypeId())) {
+            builder.itemAnswerKey(null)
+                    .imageMapRegionJsons(toImageMapRegionJsons(itemData));
+        } else {
+            builder.itemAnswerKey(itemData.getAnswerKey())
+                    .printChoices(toPrintChoices(itemData));
+        }
     }
 
     private List<AssessmentPdfPrintChoiceModel> toPrintChoices(ItemDataIfc itemData) {
@@ -363,6 +368,33 @@ public final class AssessmentPdfSnapshotBuilder {
             }
         }
         return texts;
+    }
+
+    private List<String> toImageMapRegionJsons(ItemDataIfc itemData) {
+        List<String> regions = new ArrayList<>();
+        List itemTexts = itemData.getItemTextArraySorted();
+        if (itemTexts == null) {
+            return regions;
+        }
+        for (Object itemTextObject : itemTexts) {
+            if (!(itemTextObject instanceof ItemTextIfc)) {
+                continue;
+            }
+            List answers = ((ItemTextIfc) itemTextObject).getAnswerArraySorted();
+            if (answers == null) {
+                continue;
+            }
+            for (Object answerObject : answers) {
+                if (!(answerObject instanceof AnswerIfc)) {
+                    continue;
+                }
+                String regionJson = ((AnswerIfc) answerObject).getText();
+                if (StringUtils.isNotBlank(regionJson)) {
+                    regions.add(regionJson);
+                }
+            }
+        }
+        return regions;
     }
 
     private String calculatedQuestionText(ItemContentsBean item) {

--- a/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilder.java
+++ b/samigo/samigo-app/src/java/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilder.java
@@ -17,8 +17,10 @@ package org.sakaiproject.tool.assessment.ui.bean.print;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.faces.model.SelectItem;
 
@@ -262,7 +264,7 @@ public final class AssessmentPdfSnapshotBuilder {
                 .matrixAddComment(item.getAddComment())
                 .matrixCommentField(item.getCommentField())
                 .mediaItems(toMediaItems(item.getMediaArray()))
-                .itemGradingData(toItemGradingData(item.getItemGradingDataArray()))
+                .itemGradingData(toItemGradingData(item))
                 .matchingResponses(matchingResponses);
         applyItemDataSnapshot(builder, item.getItemData());
         return builder.build();
@@ -563,19 +565,40 @@ public final class AssessmentPdfSnapshotBuilder {
         return items;
     }
 
-    private List<AssessmentPdfItemGradingModel> toItemGradingData(List itemGradingDataArray) {
-        if (itemGradingDataArray == null) {
+    private List<AssessmentPdfItemGradingModel> toItemGradingData(ItemContentsBean item) {
+        if (item == null || item.getItemGradingDataArray() == null) {
             return Collections.emptyList();
         }
+        Map<Long, Integer> sequenceByItemTextId = itemTextSequenceById(item.getItemData());
         List<AssessmentPdfItemGradingModel> items = new ArrayList<>();
-        for (Object gradingObject : itemGradingDataArray) {
+        for (Object gradingObject : item.getItemGradingDataArray()) {
             if (!(gradingObject instanceof ItemGradingData)) {
                 continue;
             }
             ItemGradingData itemGradingData = (ItemGradingData) gradingObject;
-            items.add(new AssessmentPdfItemGradingModel(itemGradingData.getAnswerText(), itemGradingData.getPublishedItemTextId()));
+            Long publishedItemTextId = itemGradingData.getPublishedItemTextId();
+            Integer sequence = publishedItemTextId == null ? null : sequenceByItemTextId.get(publishedItemTextId);
+            items.add(new AssessmentPdfItemGradingModel(itemGradingData.getAnswerText(), publishedItemTextId, sequence));
         }
         return items;
+    }
+
+    private Map<Long, Integer> itemTextSequenceById(ItemDataIfc itemData) {
+        Map<Long, Integer> sequences = new HashMap<>();
+        if (itemData == null || itemData.getItemTextArraySorted() == null) {
+            return sequences;
+        }
+        for (Object itemTextObject : itemData.getItemTextArraySorted()) {
+            if (!(itemTextObject instanceof ItemTextIfc)) {
+                continue;
+            }
+            ItemTextIfc itemText = (ItemTextIfc) itemTextObject;
+            if (itemText.getId() == null || itemText.getSequence() == null) {
+                continue;
+            }
+            sequences.put(itemText.getId(), itemText.getSequence().intValue());
+        }
+        return sequences;
     }
 
     private AssessmentPdfPrintSettingsModel toPrintSettings(PrintSettingsBean printSettings) {

--- a/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilderTest.java
+++ b/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilderTest.java
@@ -37,6 +37,7 @@ import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.ContentsDeliveryBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.DeliveryBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.FinBean;
+import org.sakaiproject.tool.assessment.ui.bean.delivery.ImageMapQuestionBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.ItemContentsBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.MatchingBean;
 import org.sakaiproject.tool.assessment.ui.bean.delivery.SectionContentsBean;
@@ -244,8 +245,94 @@ public class AssessmentPdfSnapshotBuilderTest {
         assertTrue(selection.isSelected());
     }
 
+    @Test
+    public void buildPrintModelCapturesImageMapRegionsAndOmitsTextKey() {
+        String regionJson = "{\"x1\":10,\"y1\":20,\"x2\":40,\"y2\":50}";
+        ItemContentsBean item = imageMapQuestionItem("/group/site/hotspot.png", "Heart", regionJson, null);
+
+        SectionContentsBean section = mock(SectionContentsBean.class);
+        when(section.getItemContents()).thenReturn(List.of(item));
+        when(section.getAttachmentList()).thenReturn(Collections.emptyList());
+        when(section.getTitle()).thenReturn("Part 1");
+        when(section.getDescription()).thenReturn("");
+
+        DeliveryBean deliveryBean = mock(DeliveryBean.class);
+        when(deliveryBean.getAssessmentTitle()).thenReturn("Sample Quiz");
+        when(deliveryBean.getIsMathJaxEnabled()).thenReturn(Boolean.FALSE);
+
+        PrintSettingsBean printSettings = new PrintSettingsBean();
+        printSettings.setShowKeys(Boolean.TRUE);
+
+        AssessmentPrintPdfModel model = snapshotBuilder()
+                .deliveryBean(deliveryBean)
+                .deliveryParts(List.of(section))
+                .printSettings(printSettings)
+                .buildPrintModel();
+
+        AssessmentPdfQuestionModel question = model.getParts().get(0).getQuestions().get(0);
+        assertNull(question.getItemAnswerKey());
+        assertTrue(question.getPrintChoices().isEmpty());
+        assertEquals("/group/site/hotspot.png", question.getImageMapSrc());
+        assertEquals(List.of("Heart"), question.getImageMapItemTexts());
+        assertEquals(List.of(regionJson), question.getImageMapRegionJsons());
+    }
+
+    @Test
+    public void buildStudentReportModelMapsImageMapRowsAfterRegionSnapshot() {
+        String regionJson = "{\"x1\":5,\"y1\":5,\"x2\":15,\"y2\":15}";
+        ImageMapQuestionBean imageMapBean = new ImageMapQuestionBean();
+        imageMapBean.setText("1. Heart");
+        imageMapBean.setIsCorrect(Boolean.TRUE);
+
+        ItemContentsBean item = imageMapQuestionItem("/group/site/hotspot.png", "Heart", regionJson, imageMapBean);
+        item.setImageSrc("/group/site/hotspot.png");
+
+        DeliveryBean deliveryBean = studentReportDeliveryBean(item);
+        StudentScoresBean studentScoresBean = studentReportScoresBean(null);
+
+        AssessmentStudentReportPdfModel model = snapshotBuilder()
+                .deliveryBean(deliveryBean)
+                .studentScores(studentScoresBean)
+                .buildStudentReportModel();
+        AssessmentPdfQuestionModel question = model.getParts().get(0).getQuestions().get(0);
+
+        assertEquals("/group/site/hotspot.png", question.getImageSrc());
+        assertEquals(List.of(regionJson), question.getImageMapRegionJsons());
+        assertEquals(1, question.getImageMapRows().size());
+        assertEquals("1. Heart", question.getImageMapRows().get(0).getText());
+        assertEquals(Boolean.TRUE, question.getImageMapRows().get(0).getCorrect());
+    }
+
     private static AssessmentPdfSnapshotBuilder snapshotBuilder() {
         return new AssessmentPdfSnapshotBuilder(mock(FormattedText.class), mock(ResourceLoader.class));
+    }
+
+    private static ItemContentsBean imageMapQuestionItem(String imageMapSrc, String itemText, String regionJson,
+            ImageMapQuestionBean imageMapRow) {
+        AnswerIfc answer = mock(AnswerIfc.class);
+        when(answer.getText()).thenReturn(regionJson);
+        when(answer.getLabel()).thenReturn("A");
+        when(answer.getIsCorrect()).thenReturn(Boolean.TRUE);
+
+        ItemTextIfc itemTextIfc = mock(ItemTextIfc.class);
+        when(itemTextIfc.getText()).thenReturn(itemText);
+        when(itemTextIfc.getAnswerArraySorted()).thenReturn(List.of(answer));
+
+        ItemDataIfc itemData = mock(ItemDataIfc.class);
+        when(itemData.getTypeId()).thenReturn(TypeIfc.IMAGEMAP_QUESTION);
+        when(itemData.getItemId()).thenReturn(1L);
+        when(itemData.getImageMapSrc()).thenReturn(imageMapSrc);
+        when(itemData.getAnswerKey()).thenReturn("A");
+        when(itemData.getItemTextArraySorted()).thenReturn(List.of(itemTextIfc));
+
+        ItemContentsBean item = new ItemContentsBean();
+        item.setItemData(itemData);
+        item.setSequence("1");
+        item.setItemGradingDataArray(new java.util.ArrayList<>());
+        if (imageMapRow != null) {
+            item.setMatchingArray(new java.util.ArrayList<>(List.of(imageMapRow)));
+        }
+        return item;
     }
 
     private static ItemContentsBean matchingQuestionItem() {

--- a/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilderTest.java
+++ b/samigo/samigo-app/src/test/org/sakaiproject/tool/assessment/ui/bean/print/AssessmentPdfSnapshotBuilderTest.java
@@ -26,10 +26,12 @@ import org.junit.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfQuestionModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfItemGradingModel;
 import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfMatchingRowModel;
 import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfSelectionAnswerModel;
 import org.sakaiproject.samigo.api.pdf.model.AssessmentPrintPdfModel;
 import org.sakaiproject.samigo.api.pdf.model.AssessmentStudentReportPdfModel;
+import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemDataIfc;
 import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
@@ -301,6 +303,35 @@ public class AssessmentPdfSnapshotBuilderTest {
         assertEquals(1, question.getImageMapRows().size());
         assertEquals("1. Heart", question.getImageMapRows().get(0).getText());
         assertEquals(Boolean.TRUE, question.getImageMapRows().get(0).getCorrect());
+    }
+
+    @Test
+    public void buildStudentReportModelSnapshotsImageMapClickSequenceFromItemText() {
+        String regionJson = "{\"x1\":5,\"y1\":5,\"x2\":15,\"y2\":15}";
+        ImageMapQuestionBean imageMapBean = new ImageMapQuestionBean();
+        imageMapBean.setText("1. Heart");
+        imageMapBean.setIsCorrect(Boolean.TRUE);
+
+        ItemContentsBean item = imageMapQuestionItem("/group/site/hotspot.png", "Heart", regionJson, imageMapBean);
+        item.setImageSrc("/group/site/hotspot.png");
+        ItemTextIfc itemText = (ItemTextIfc) item.getItemData().getItemTextArraySorted().get(0);
+        when(itemText.getId()).thenReturn(9001L);
+        when(itemText.getSequence()).thenReturn(1L);
+
+        ItemGradingData grading = new ItemGradingData();
+        grading.setAnswerText("{\"x\":10,\"y\":20}");
+        grading.setPublishedItemTextId(9001L);
+        item.setItemGradingDataArray(new java.util.ArrayList<>(List.of(grading)));
+
+        AssessmentStudentReportPdfModel model = snapshotBuilder()
+                .deliveryBean(studentReportDeliveryBean(item))
+                .studentScores(studentReportScoresBean(null))
+                .buildStudentReportModel();
+        AssessmentPdfItemGradingModel click = model.getParts().get(0).getQuestions().get(0).getItemGradingData().get(0);
+
+        assertEquals("{\"x\":10,\"y\":20}", click.getAnswerText());
+        assertEquals(Long.valueOf(9001L), click.getPublishedItemTextId());
+        assertEquals(Integer.valueOf(1), click.getSequence());
     }
 
     private static AssessmentPdfSnapshotBuilder snapshotBuilder() {

--- a/samigo/samigo-impl/pom.xml
+++ b/samigo/samigo-impl/pom.xml
@@ -154,6 +154,11 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfCellEvents.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfCellEvents.java
@@ -137,6 +137,14 @@ public final class AssessmentPdfCellEvents {
             this.drawnHeight = drawnHeight;
         }
 
+        public List<Rectangle> getAnswerRectangles() {
+            return answerRectangles;
+        }
+
+        public List<ImageMapCircle> getAnswerCircles() {
+            return answerCircles;
+        }
+
         @Override
         public void cellLayout(PdfPCell cell, Rectangle position, PdfContentByte[] canvases) {
             if (originalWidth <= 0f || originalHeight <= 0f) {
@@ -168,22 +176,20 @@ public final class AssessmentPdfCellEvents {
             canvas.fill();
 
             float radius = 3f;
-            int smallestValue = answerCircles.size() > 0 ? answerCircles.get(0).getPublishedItemId() + 1 : 0;
             for (ImageMapCircle answerCircle : answerCircles) {
                 PdfGState transparentState = new PdfGState();
                 transparentState.setFillOpacity(0.3f);
                 transparentState.setStrokeOpacity(0.8f);
-                float transformedX = x + answerCircle.getX() * scaleX;
-                float transformedY = y + drawnHeight - answerCircle.getY() * scaleY;
+                float imageX = studentMarkerHotspotX(answerCircle.getX());
+                float imageY = studentMarkerHotspotY(answerCircle.getY());
+                float transformedX = x + imageX * scaleX;
+                float transformedY = y + drawnHeight - imageY * scaleY;
                 if (answerCircle.getX() != 0 && answerCircle.getY() != 0) {
                     canvas.circle(transformedX, transformedY, radius);
                     canvas.setGState(transparentState);
                     canvas.circle(transformedX, transformedY, 0.3f);
                     canvas.setColorFill(Color.YELLOW);
                     canvas.setColorStroke(Color.YELLOW);
-                }
-                if (answerCircle.getPublishedItemId() < smallestValue) {
-                    smallestValue = answerCircle.getPublishedItemId();
                 }
             }
             canvas.fillStroke();
@@ -210,17 +216,17 @@ public final class AssessmentPdfCellEvents {
                 }
             }
 
-            int toReduce = smallestValue;
             for (ImageMapCircle answerCircle : answerCircles) {
-                float transformedX = x + answerCircle.getX() * scaleX;
-                float transformedY = y + drawnHeight - answerCircle.getY() * scaleY;
+                float imageX = studentMarkerHotspotX(answerCircle.getX());
+                float imageY = studentMarkerHotspotY(answerCircle.getY());
+                float transformedX = x + imageX * scaleX;
+                float transformedY = y + drawnHeight - imageY * scaleY;
                 if (answerCircle.getX() != 0 && answerCircle.getY() != 0) {
                     try {
-                        int answerIndex = answerCircles.size() - (answerCircle.getPublishedItemId() - toReduce);
                         canvas.beginText();
                         canvas.setColorFill(Color.YELLOW);
                         canvas.setFontAndSize(BaseFont.createFont(), 9);
-                        canvas.showTextAligned(Element.ALIGN_LEFT, String.valueOf(answerIndex), transformedX + 4, transformedY - 3, 0);
+                        canvas.showTextAligned(Element.ALIGN_LEFT, String.valueOf(answerCircle.getSequence()), transformedX + 4, transformedY - 3, 0);
                         canvas.endText();
                         canvas.fill();
                     } catch (Exception ex) {
@@ -289,12 +295,36 @@ public final class AssessmentPdfCellEvents {
     public static class ImageMapCircle {
         private float x;
         private float y;
-        private int publishedItemId;
+        private int sequence;
 
-        public ImageMapCircle(float x, float y, int publishedItemId) {
+        public ImageMapCircle(float x, float y, int sequence) {
             this.x = x;
             this.y = y;
-            this.publishedItemId = publishedItemId;
+            this.sequence = sequence;
         }
+    }
+
+    /**
+     * Compensates for delivery storing the marker top-left, not the click
+     * ({@code selection.student.js} uses {@code click - (width/2, height/2)}).
+     * These deltas match the current 18×16 crosshair box in imageQuestion.student.css;
+     * they are not a live CSS contract.
+     *
+     * TODO: Stored image-map JSON is the .pointerClass top-left, so this PDF (and grading)
+     * must guess the click. Changing height/padding-left in imageQuestion.student.css
+     * desyncs the yellow dots (small regions look missed even when the on-screen marker
+     * sits on the target). 9 and 8 are half of that 18×16 box, an approximation of the
+     * crosshair center, not the live div (width includes the item number). Drop this
+     * offset once item grading stores the image click; then draw and score {x,y} as-is.
+     */
+    static final float STUDENT_MARKER_OFFSET_X = 9f;
+    static final float STUDENT_MARKER_OFFSET_Y = 8f;
+
+    static float studentMarkerHotspotX(float storedX) {
+        return storedX + STUDENT_MARKER_OFFSET_X;
+    }
+
+    static float studentMarkerHotspotY(float storedY) {
+        return storedY + STUDENT_MARKER_OFFSET_Y;
     }
 }

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfImageMapCoords.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfImageMapCoords.java
@@ -123,7 +123,7 @@ final class AssessmentPdfImageMapCoords {
             return OptionalDouble.empty();
         }
         double value = node.asDouble();
-        if (!Double.isFinite(value)) {
+        if (!Double.isFinite(value) || value > Float.MAX_VALUE || value < -Float.MAX_VALUE) {
             return OptionalDouble.empty();
         }
         return OptionalDouble.of(value);

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfImageMapCoords.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfImageMapCoords.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.impl.pdf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalDouble;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfItemGradingModel;
+import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapCircle;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lowagie.text.Rectangle;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Parses authored image-map regions and student click markers from stored JSON.
+ */
+@Slf4j
+final class AssessmentPdfImageMapCoords {
+
+    private final ObjectMapper jsonMapper;
+
+    AssessmentPdfImageMapCoords(ObjectMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
+    }
+
+    List<Rectangle> parseRectangles(List<String> regionJsons) {
+        List<Rectangle> answerRectangles = new ArrayList<>();
+        if (regionJsons == null) {
+            return answerRectangles;
+        }
+        for (String regionJson : regionJsons) {
+            String json = extractJsonObject(regionJson);
+            if (json == null) {
+                continue;
+            }
+            try {
+                JsonNode jsonNode = jsonMapper.readTree(json);
+                OptionalDouble x1 = finiteNumber(jsonNode, "x1");
+                OptionalDouble y1 = finiteNumber(jsonNode, "y1");
+                OptionalDouble x2 = finiteNumber(jsonNode, "x2");
+                OptionalDouble y2 = finiteNumber(jsonNode, "y2");
+                if (x1.isEmpty() || y1.isEmpty() || x2.isEmpty() || y2.isEmpty()) {
+                    continue;
+                }
+                answerRectangles.add(new Rectangle((float) x1.getAsDouble(), (float) y1.getAsDouble(),
+                        (float) x2.getAsDouble(), (float) y2.getAsDouble()));
+            } catch (JsonProcessingException e) {
+                log.warn("Skipping unparseable image map answer rectangle [{}], {}", regionJson, e.toString());
+            }
+        }
+        return answerRectangles;
+    }
+
+    List<ImageMapCircle> parseCircles(List<AssessmentPdfItemGradingModel> itemsGrading) {
+        List<ImageMapCircle> answerCircles = new ArrayList<>();
+        if (itemsGrading == null) {
+            return answerCircles;
+        }
+        int fallbackSequence = 1;
+        for (AssessmentPdfItemGradingModel itemGrading : itemsGrading) {
+            Long publishedItemTextId = itemGrading.getPublishedItemTextId();
+            String json = extractJsonObject(itemGrading.getAnswerText());
+            if (publishedItemTextId == null || json == null) {
+                continue;
+            }
+            try {
+                JsonNode jsonNode = jsonMapper.readTree(json);
+                OptionalDouble x = finiteNumber(jsonNode, "x");
+                OptionalDouble y = finiteNumber(jsonNode, "y");
+                if (x.isEmpty() || y.isEmpty()) {
+                    continue;
+                }
+                Integer sequence = itemGrading.getSequence();
+                int markerSequence = sequence != null ? sequence.intValue() : fallbackSequence;
+                answerCircles.add(new ImageMapCircle((float) x.getAsDouble(), (float) y.getAsDouble(), markerSequence));
+                fallbackSequence++;
+            } catch (JsonProcessingException e) {
+                log.warn("Skipping unparseable image map response for published item text {} [{}], {}", publishedItemTextId,
+                        itemGrading.getAnswerText(), e.toString());
+            }
+        }
+        return answerCircles;
+    }
+
+    static String extractJsonObject(String raw) {
+        if (StringUtils.isBlank(raw) || Strings.CI.equals(raw, "undefined")) {
+            return null;
+        }
+        int start = raw.indexOf('{');
+        int end = raw.lastIndexOf('}');
+        if (start < 0 || end <= start) {
+            return null;
+        }
+        return raw.substring(start, end + 1);
+    }
+
+    static OptionalDouble finiteNumber(JsonNode parent, String field) {
+        if (parent == null || StringUtils.isBlank(field)) {
+            return OptionalDouble.empty();
+        }
+        JsonNode node = parent.get(field);
+        if (node == null || node.isMissingNode() || node.isNull() || !node.isNumber()) {
+            return OptionalDouble.empty();
+        }
+        double value = node.asDouble();
+        if (!Double.isFinite(value)) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of(value);
+    }
+}

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRenderer.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRenderer.java
@@ -91,7 +91,8 @@ public class AssessmentPdfQuestionRenderer {
     private static final Set<Long> PRINT_NO_KEY_TYPES = Set.of(
             TypeIfc.MULTIPLE_CHOICE_SURVEY,
             TypeIfc.AUDIO_RECORDING,
-            TypeIfc.FILE_UPLOAD);
+            TypeIfc.FILE_UPLOAD,
+            TypeIfc.IMAGEMAP_QUESTION);
 
     private static final Set<Long> PRINT_FEEDBACK_TYPES = Set.of(
             TypeIfc.MULTIPLE_CORRECT,
@@ -218,7 +219,7 @@ public class AssessmentPdfQuestionRenderer {
         } else if (Objects.equals(questionType, TypeIfc.EXTENDED_MATCHING_ITEMS)) {
             renderPrintExtendedMatching(document, context, question);
         } else if (Objects.equals(questionType, TypeIfc.IMAGEMAP_QUESTION)) {
-            renderPrintImageMapOptions(document, context, question);
+            renderPrintImageMapOptions(document, context, question, printSettings);
         }
     }
 
@@ -396,30 +397,21 @@ public class AssessmentPdfQuestionRenderer {
         }
     }
 
-    private void renderPrintImageMapOptions(Document document, QuestionRenderContext context, AssessmentPdfQuestionModel question) throws Exception {
+    private void renderPrintImageMapOptions(Document document, QuestionRenderContext context, AssessmentPdfQuestionModel question, AssessmentPdfPrintSettingsModel printSettings) throws Exception {
         List<String> itemTexts = question.getImageMapItemTexts();
         for (int k = 0; k < itemTexts.size(); k++) {
             document.add(new Paragraph((k + 1) + ". " + itemTexts.get(k), fontWithColor(context.bodyFont(), TEXT_PRIMARY)));
         }
 
-        String imsrc = question.getImageMapSrc();
-        if (StringUtils.isBlank(imsrc)) {
-            return;
+        boolean showKeys = printSettings != null && Boolean.TRUE.equals(printSettings.getShowKeys());
+        if (showKeys) {
+            Paragraph keyLabel = new Paragraph(AssessmentPdfBundle.getPrintString("answer_key") + ":",
+                    fontWithColor(context.smallBoldFont(), SECONDARY_COLOR));
+            keyLabel.setSpacingBefore(AssessmentPdfStyle.ELEMENT_SPACING);
+            document.add(keyLabel);
         }
-        Optional<Image> loadedImage = contentHelper.loadContentImage(AssessmentPdfContentHelper.resolveContentResourceId(imsrc));
-        if (loadedImage.isEmpty()) {
-            log.warn("Could not load image map image [{}] for the printable assessment", imsrc);
-            return;
-        }
-        Image image = loadedImage.get();
-        contentHelper.scaleImageForPage(image);
-        PdfPTable imageTable = new PdfPTable(1);
-        imageTable.setWidthPercentage(100f);
-        contentHelper.configureSplittableTable(imageTable);
-        PdfPCell imageCell = new PdfPCell(image);
-        imageCell.setBorder(Rectangle.NO_BORDER);
-        imageTable.addCell(imageCell);
-        document.add(imageTable);
+        List<Rectangle> answerRectangles = showKeys ? parseImageMapRectangles(imageMapRegionJsons(question)) : List.of();
+        renderImageMapImage(document, imageMapSource(question), answerRectangles, List.of(), "the printable assessment");
     }
 
     private void renderPrintAnswerKey(Document document, QuestionRenderContext context, AssessmentPdfQuestionModel question, Long questionType, AssessmentPdfPrintSettingsModel printSettings) throws Exception {
@@ -662,69 +654,128 @@ public class AssessmentPdfQuestionRenderer {
 
     private void renderReportImageMap(Document document, AssessmentPdfQuestionModel question, Long questionType)
             throws Exception {
-        if (!Objects.equals(questionType, TypeIfc.IMAGEMAP_QUESTION) || StringUtils.isBlank(question.getImageSrc())) {
+        if (!Objects.equals(questionType, TypeIfc.IMAGEMAP_QUESTION)) {
+            return;
+        }
+        Paragraph keyLabel = new Paragraph(AssessmentPdfBundle.getEvaluationString("ans_key") + ":",
+                fontWithColor(AssessmentPdfStyle.SMALL_BOLD_FONT, SECONDARY_COLOR));
+        keyLabel.setSpacingBefore(AssessmentPdfStyle.ELEMENT_SPACING);
+        document.add(keyLabel);
+        renderImageMapImage(document, imageMapSource(question), parseImageMapRectangles(imageMapRegionJsons(question)),
+                parseImageMapCircles(question.getItemGradingData()), "the student report");
+    }
+
+    private void renderImageMapImage(Document document, String imageSrc, List<Rectangle> answerRectangles,
+            List<ImageMapCircle> answerCircles, String warnContext) throws Exception {
+        if (StringUtils.isBlank(imageSrc)) {
             return;
         }
         // Read the image straight out of content hosting rather than fetching our own server over
         // HTTP: a self request has no session, so a non-public image would come back denied.
-        Optional<Image> loadedImage = contentHelper.loadContentImage(AssessmentPdfContentHelper.resolveContentResourceId(question.getImageSrc()));
+        Optional<Image> loadedImage = contentHelper.loadContentImage(AssessmentPdfContentHelper.resolveContentResourceId(imageSrc));
         if (loadedImage.isEmpty()) {
-            log.warn("Could not load image map image [{}] for the student report", question.getImageSrc());
+            log.warn("Could not load image map image [{}] for {}", imageSrc, warnContext);
             return;
         }
         Image image = loadedImage.get();
         contentHelper.scaleImageForPage(image);
-        PdfPTable tableImage = new PdfPTable(1);
-        tableImage.setWidthPercentage(100f);
-        contentHelper.configureSplittableTable(tableImage);
-        PdfPCell cellImage = new PdfPCell();
-        cellImage.setBorderWidth(0);
-        cellImage.setPadding(0);
-        cellImage.addElement(image);
+        PdfPTable imageTable = new PdfPTable(1);
+        imageTable.setWidthPercentage(100f);
+        imageTable.setKeepTogether(true);
+        PdfPCell imageCell = new PdfPCell(image);
+        imageCell.setBorder(Rectangle.NO_BORDER);
+        imageCell.setPadding(0);
+        if (!answerRectangles.isEmpty() || !answerCircles.isEmpty()) {
+            // getWidth/getHeight are the intrinsic size the answer coordinates are stored against;
+            // getScaledWidth/Height are what scaleImageForPage left the image occupying on the page.
+            imageCell.setCellEvent(new ImageMapQuestionCellEvent(answerCircles, answerRectangles,
+                    image.getWidth(), image.getHeight(), image.getScaledWidth(), image.getScaledHeight()));
+        }
+        imageTable.addCell(imageCell);
+        document.add(imageTable);
+    }
 
-        List<Rectangle> answerRectangles = new ArrayList<>();
+    private static String imageMapSource(AssessmentPdfQuestionModel question) {
+        if (StringUtils.isNotBlank(question.getImageSrc())) {
+            return question.getImageSrc();
+        }
+        return question.getImageMapSrc();
+    }
+
+    private List<String> imageMapRegionJsons(AssessmentPdfQuestionModel question) {
+        List<String> regionJsons = question.getImageMapRegionJsons();
+        if (regionJsons != null && !regionJsons.isEmpty()) {
+            return regionJsons;
+        }
+        List<String> fromSelectionAnswers = new ArrayList<>();
         for (AssessmentPdfSelectionAnswerModel answer : question.getSelectionAnswers()) {
-            String plainTextAnswer = answer.getPlainTextAnswer();
-            if (StringUtils.isBlank(plainTextAnswer) || Strings.CI.equals(plainTextAnswer, "undefined")) {
+            if (StringUtils.isNotBlank(answer.getPlainTextAnswer())) {
+                fromSelectionAnswers.add(answer.getPlainTextAnswer());
+            }
+        }
+        return fromSelectionAnswers;
+    }
+
+    private List<Rectangle> parseImageMapRectangles(List<String> regionJsons) {
+        List<Rectangle> answerRectangles = new ArrayList<>();
+        if (regionJsons == null) {
+            return answerRectangles;
+        }
+        for (String regionJson : regionJsons) {
+            String json = extractJsonObject(regionJson);
+            if (json == null) {
                 continue;
             }
             try {
-                JsonNode jsonNode = jsonMapper.readTree(plainTextAnswer);
-                // path() rather than get() so an absent coordinate is a MissingNode rather than a
-                // null that would abort the whole report, and asDouble so a numeric string coerces
-                // instead of silently collapsing the region to the origin
+                JsonNode jsonNode = jsonMapper.readTree(json);
+                if (!jsonNode.has("x1") || !jsonNode.has("y1") || !jsonNode.has("x2") || !jsonNode.has("y2")) {
+                    continue;
+                }
                 answerRectangles.add(new Rectangle((float) jsonNode.path("x1").asDouble(), (float) jsonNode.path("y1").asDouble(),
                         (float) jsonNode.path("x2").asDouble(), (float) jsonNode.path("y2").asDouble()));
             } catch (JsonProcessingException e) {
-                log.warn("Skipping unparseable image map answer rectangle [{}], {}", plainTextAnswer, e.toString());
+                log.warn("Skipping unparseable image map answer rectangle [{}], {}", regionJson, e.toString());
             }
         }
+        return answerRectangles;
+    }
 
-        List<AssessmentPdfItemGradingModel> itemsGrading = question.getItemGradingData();
+    private List<ImageMapCircle> parseImageMapCircles(List<AssessmentPdfItemGradingModel> itemsGrading) {
         List<ImageMapCircle> answerCircles = new ArrayList<>();
+        if (itemsGrading == null) {
+            return answerCircles;
+        }
         for (AssessmentPdfItemGradingModel itemGrading : itemsGrading) {
-            String answerText = itemGrading.getAnswerText();
             Long publishedItemTextId = itemGrading.getPublishedItemTextId();
-            if (publishedItemTextId != null && StringUtils.isNotBlank(itemGrading.getAnswerText())) {
-                try {
-                    JsonNode jsonNode = jsonMapper.readTree(answerText);
-                    // asDouble coerces a numeric string and yields 0 for anything absent or
-                    // non-numeric, which is the origin fallback these coordinates already wanted
-                    float x = (float) jsonNode.path("x").asDouble();
-                    float y = (float) jsonNode.path("y").asDouble();
-                    answerCircles.add(new ImageMapCircle(x, y, publishedItemTextId.intValue()));
-                } catch (JsonProcessingException e) {
-                    log.warn("Skipping unparseable image map response for published item text {} [{}], {}", publishedItemTextId, answerText, e.toString());
+            String json = extractJsonObject(itemGrading.getAnswerText());
+            if (publishedItemTextId == null || json == null) {
+                continue;
+            }
+            try {
+                JsonNode jsonNode = jsonMapper.readTree(json);
+                if (!jsonNode.has("x") || !jsonNode.has("y")) {
+                    continue;
                 }
+                answerCircles.add(new ImageMapCircle((float) jsonNode.path("x").asDouble(),
+                        (float) jsonNode.path("y").asDouble(), publishedItemTextId.intValue()));
+            } catch (JsonProcessingException e) {
+                log.warn("Skipping unparseable image map response for published item text {} [{}], {}", publishedItemTextId,
+                        itemGrading.getAnswerText(), e.toString());
             }
         }
-        // getWidth/getHeight are the intrinsic size the answer coordinates are stored against;
-        // getScaledWidth/Height are what scaleImageForPage left the image occupying on the page.
-        cellImage.setCellEvent(new ImageMapQuestionCellEvent(answerCircles, answerRectangles,
-                image.getWidth(), image.getHeight(), image.getScaledWidth(), image.getScaledHeight()));
-        contentHelper.configureSplittableCell(cellImage);
-        tableImage.addCell(cellImage);
-        document.add(tableImage);
+        return answerCircles;
+    }
+
+    static String extractJsonObject(String raw) {
+        if (StringUtils.isBlank(raw) || Strings.CI.equals(raw, "undefined")) {
+            return null;
+        }
+        int start = raw.indexOf('{');
+        int end = raw.lastIndexOf('}');
+        if (start < 0 || end <= start) {
+            return null;
+        }
+        return raw.substring(start, end + 1);
     }
 
     private void renderReportChoiceAnswers(Document document, QuestionRenderContext context, AssessmentPdfQuestionModel question, Long questionType) throws Exception {
@@ -796,6 +847,7 @@ public class AssessmentPdfQuestionRenderer {
         int cellsAdded = 0;
 
         if (Objects.equals(questionType, TypeIfc.IMAGEMAP_QUESTION)) {
+            matchingTable.setSpacingBefore(AssessmentPdfStyle.ELEMENT_SPACING);
             for (AssessmentPdfImageMapRowModel imageMapRow : question.getImageMapRows()) {
                 if (StringUtils.isBlank(imageMapRow.getText())) {
                     continue;

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRenderer.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRenderer.java
@@ -36,7 +36,6 @@ import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.CheckboxCellEven
 import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.CircleCellEvent;
 import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapCircle;
 import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapQuestionCellEvent;
-import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfItemGradingModel;
 import org.sakaiproject.serialization.MapperFactory;
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
 import static org.sakaiproject.samigo.impl.pdf.AssessmentPdfStyle.BACKGROUND_GRAY;
@@ -54,9 +53,6 @@ import static org.sakaiproject.samigo.impl.pdf.AssessmentPdfStyle.WARNING_BG;
 import static org.sakaiproject.samigo.impl.pdf.AssessmentPdfStyle.WARNING_COLOR;
 import static org.sakaiproject.samigo.impl.pdf.AssessmentPdfStyle.fontWithColor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lowagie.text.Chunk;
 import com.lowagie.text.Document;
 import com.lowagie.text.Element;
@@ -66,7 +62,6 @@ import com.lowagie.text.Phrase;
 import com.lowagie.text.Rectangle;
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
-import org.apache.commons.lang3.Strings;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -106,11 +101,11 @@ public class AssessmentPdfQuestionRenderer {
             TypeIfc.IMAGEMAP_QUESTION);
 
     private final AssessmentPdfContentHelper contentHelper;
-    private final ObjectMapper jsonMapper;
+    private final AssessmentPdfImageMapCoords imageMapCoords;
 
     public AssessmentPdfQuestionRenderer(AssessmentPdfContentHelper contentHelper) {
         this.contentHelper = contentHelper;
-        this.jsonMapper = MapperFactory.createDefaultJsonMapper();
+        this.imageMapCoords = new AssessmentPdfImageMapCoords(MapperFactory.createDefaultJsonMapper());
     }
 
     public void render(Document document, QuestionRenderContext context) throws Exception {
@@ -410,7 +405,7 @@ public class AssessmentPdfQuestionRenderer {
             keyLabel.setSpacingBefore(AssessmentPdfStyle.ELEMENT_SPACING);
             document.add(keyLabel);
         }
-        List<Rectangle> answerRectangles = showKeys ? parseImageMapRectangles(imageMapRegionJsons(question)) : List.of();
+        List<Rectangle> answerRectangles = showKeys ? imageMapCoords.parseRectangles(imageMapRegionJsons(question)) : List.of();
         renderImageMapImage(document, imageMapSource(question), answerRectangles, List.of(), "the printable assessment");
     }
 
@@ -661,8 +656,8 @@ public class AssessmentPdfQuestionRenderer {
                 fontWithColor(AssessmentPdfStyle.SMALL_BOLD_FONT, SECONDARY_COLOR));
         keyLabel.setSpacingBefore(AssessmentPdfStyle.ELEMENT_SPACING);
         document.add(keyLabel);
-        renderImageMapImage(document, imageMapSource(question), parseImageMapRectangles(imageMapRegionJsons(question)),
-                parseImageMapCircles(question.getItemGradingData()), "the student report");
+        renderImageMapImage(document, imageMapSource(question), imageMapCoords.parseRectangles(imageMapRegionJsons(question)),
+                imageMapCoords.parseCircles(question.getItemGradingData()), "the student report");
     }
 
     private void renderImageMapImage(Document document, String imageSrc, List<Rectangle> answerRectangles,
@@ -714,68 +709,6 @@ public class AssessmentPdfQuestionRenderer {
             }
         }
         return fromSelectionAnswers;
-    }
-
-    private List<Rectangle> parseImageMapRectangles(List<String> regionJsons) {
-        List<Rectangle> answerRectangles = new ArrayList<>();
-        if (regionJsons == null) {
-            return answerRectangles;
-        }
-        for (String regionJson : regionJsons) {
-            String json = extractJsonObject(regionJson);
-            if (json == null) {
-                continue;
-            }
-            try {
-                JsonNode jsonNode = jsonMapper.readTree(json);
-                if (!jsonNode.has("x1") || !jsonNode.has("y1") || !jsonNode.has("x2") || !jsonNode.has("y2")) {
-                    continue;
-                }
-                answerRectangles.add(new Rectangle((float) jsonNode.path("x1").asDouble(), (float) jsonNode.path("y1").asDouble(),
-                        (float) jsonNode.path("x2").asDouble(), (float) jsonNode.path("y2").asDouble()));
-            } catch (JsonProcessingException e) {
-                log.warn("Skipping unparseable image map answer rectangle [{}], {}", regionJson, e.toString());
-            }
-        }
-        return answerRectangles;
-    }
-
-    private List<ImageMapCircle> parseImageMapCircles(List<AssessmentPdfItemGradingModel> itemsGrading) {
-        List<ImageMapCircle> answerCircles = new ArrayList<>();
-        if (itemsGrading == null) {
-            return answerCircles;
-        }
-        for (AssessmentPdfItemGradingModel itemGrading : itemsGrading) {
-            Long publishedItemTextId = itemGrading.getPublishedItemTextId();
-            String json = extractJsonObject(itemGrading.getAnswerText());
-            if (publishedItemTextId == null || json == null) {
-                continue;
-            }
-            try {
-                JsonNode jsonNode = jsonMapper.readTree(json);
-                if (!jsonNode.has("x") || !jsonNode.has("y")) {
-                    continue;
-                }
-                answerCircles.add(new ImageMapCircle((float) jsonNode.path("x").asDouble(),
-                        (float) jsonNode.path("y").asDouble(), publishedItemTextId.intValue()));
-            } catch (JsonProcessingException e) {
-                log.warn("Skipping unparseable image map response for published item text {} [{}], {}", publishedItemTextId,
-                        itemGrading.getAnswerText(), e.toString());
-            }
-        }
-        return answerCircles;
-    }
-
-    static String extractJsonObject(String raw) {
-        if (StringUtils.isBlank(raw) || Strings.CI.equals(raw, "undefined")) {
-            return null;
-        }
-        int start = raw.indexOf('{');
-        int end = raw.lastIndexOf('}');
-        if (start < 0 || end <= start) {
-            return null;
-        }
-        return raw.substring(start, end + 1);
     }
 
     private void renderReportChoiceAnswers(Document document, QuestionRenderContext context, AssessmentPdfQuestionModel question, Long questionType) throws Exception {

--- a/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRendererTest.java
+++ b/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRendererTest.java
@@ -15,18 +15,261 @@
  */
 package org.sakaiproject.samigo.impl.pdf;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.sakaiproject.content.api.ContentHostingService;
+import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfPartModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfQuestionModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfImageMapRowModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfItemGradingModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfPrintSettingsModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentPrintPdfModel;
+import org.sakaiproject.samigo.api.pdf.model.AssessmentStudentReportPdfModel;
+import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapCircle;
+import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapQuestionCellEvent;
+import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Element;
+import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPRow;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
 
 public class AssessmentPdfQuestionRendererTest {
+
+    private static final byte[] TEST_PNG = createPng();
+    private static final String MAP_RESOURCE = "/group/site/map.png";
+    private static final String STUDENT_RESOURCE = "/group/site/student.png";
+    private static final String VALID_REGION = "{\"x1\":17,\"y1\":19,\"x2\":181,\"y2\":283}";
+    private static final String STUDENT_CLICK = "{\"x\":555,\"y\":666}";
 
     @Test
     public void extractJsonObjectStripsPrefixAndUndefined() {
         assertEquals("{\"x1\":1,\"y1\":2,\"x2\":3,\"y2\":4}",
-                AssessmentPdfQuestionRenderer.extractJsonObject("prefix {\"x1\":1,\"y1\":2,\"x2\":3,\"y2\":4}"));
-        assertNull(AssessmentPdfQuestionRenderer.extractJsonObject("undefined"));
-        assertNull(AssessmentPdfQuestionRenderer.extractJsonObject("no-json"));
-        assertNull(AssessmentPdfQuestionRenderer.extractJsonObject(null));
+                AssessmentPdfImageMapCoords.extractJsonObject("prefix {\"x1\":1,\"y1\":2,\"x2\":3,\"y2\":4}"));
+        assertNull(AssessmentPdfImageMapCoords.extractJsonObject("undefined"));
+        assertNull(AssessmentPdfImageMapCoords.extractJsonObject("no-json"));
+        assertNull(AssessmentPdfImageMapCoords.extractJsonObject(null));
+    }
+
+    @Test
+    public void finiteNumberRejectsNullTextAndNonFiniteCoordinates() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        assertTrue(AssessmentPdfImageMapCoords.finiteNumber(mapper.readTree("{\"x1\":17}"), "x1").isPresent());
+        assertTrue(AssessmentPdfImageMapCoords.finiteNumber(mapper.readTree("{\"x1\":null}"), "x1").isEmpty());
+        assertTrue(AssessmentPdfImageMapCoords.finiteNumber(mapper.readTree("{\"x1\":\"17\"}"), "x1").isEmpty());
+        assertTrue(AssessmentPdfImageMapCoords.finiteNumber(mapper.readTree("{}"), "x1").isEmpty());
+        JsonNode overflow = mapper.readTree("{\"x1\":1e309}");
+        assertTrue(AssessmentPdfImageMapCoords.finiteNumber(overflow, "x1").isEmpty());
+    }
+
+    @Test
+    public void parseRectanglesAndCirclesSkipInvalidCoordinates() throws Exception {
+        AssessmentPdfImageMapCoords coords = new AssessmentPdfImageMapCoords(new ObjectMapper());
+        List<Rectangle> rectangles = coords.parseRectangles(List.of(
+                VALID_REGION,
+                "{\"x1\":null,\"y1\":19,\"x2\":181,\"y2\":283}",
+                "{\"x1\":\"17\",\"y1\":19,\"x2\":181,\"y2\":283}",
+                "{\"x1\":1e309,\"y1\":19,\"x2\":181,\"y2\":283}",
+                "{\"y1\":19,\"x2\":181,\"y2\":283}"));
+        assertEquals(1, rectangles.size());
+        assertEquals(17f, rectangles.get(0).getLeft(), 0.01f);
+        assertEquals(283f, rectangles.get(0).getTop(), 0.01f);
+
+        List<ImageMapCircle> circles = coords.parseCircles(List.of(
+                new AssessmentPdfItemGradingModel(STUDENT_CLICK, 1L),
+                new AssessmentPdfItemGradingModel("{\"x\":null,\"y\":666}", 2L),
+                new AssessmentPdfItemGradingModel("{\"x\":\"555\",\"y\":666}", 3L),
+                new AssessmentPdfItemGradingModel("{\"x\":1e309,\"y\":666}", 4L)));
+        assertEquals(1, circles.size());
+        assertEquals(555f, circles.get(0).getX(), 0.01f);
+        assertEquals(666f, circles.get(0).getY(), 0.01f);
+        assertEquals(1, circles.get(0).getSequence());
+    }
+
+    @Test
+    public void parseCirclesUsesItemTextSequenceNotPublishedId() {
+        AssessmentPdfImageMapCoords coords = new AssessmentPdfImageMapCoords(new ObjectMapper());
+        List<ImageMapCircle> circles = coords.parseCircles(List.of(
+                new AssessmentPdfItemGradingModel("{\"x\":30,\"y\":40}", 9002L, 2),
+                new AssessmentPdfItemGradingModel("{\"x\":10,\"y\":20}", 9001L, 1)));
+        assertEquals(2, circles.size());
+        assertEquals(2, circles.get(0).getSequence());
+        assertEquals(1, circles.get(1).getSequence());
+    }
+
+    @Test
+    public void studentMarkerHotspotShiftsStoredTopLeftTowardClick() {
+        assertEquals(555f + AssessmentPdfCellEvents.STUDENT_MARKER_OFFSET_X,
+                AssessmentPdfCellEvents.studentMarkerHotspotX(555f), 0.01f);
+        assertEquals(666f + AssessmentPdfCellEvents.STUDENT_MARKER_OFFSET_Y,
+                AssessmentPdfCellEvents.studentMarkerHotspotY(666f), 0.01f);
+    }
+
+    @Test
+    public void printableRenderUsesImageMapSrcAndPaintsRegionsWhenKeysAreShown() throws Exception {
+        ContentHostingService contentHostingService = contentHosting(MAP_RESOURCE);
+        AssessmentPdfQuestionModel question = imageMapQuestion(null, MAP_RESOURCE, List.of(VALID_REGION),
+                Collections.emptyList());
+
+        OverlayCapturingDocument withKeys = renderPrint(question, printSettings(true), contentHostingService);
+        assertEquals(1, withKeys.overlays.size());
+        assertEquals(1, withKeys.overlays.get(0).getAnswerRectangles().size());
+        assertEquals(17f, withKeys.overlays.get(0).getAnswerRectangles().get(0).getLeft(), 0.01f);
+        assertTrue(withKeys.overlays.get(0).getAnswerCircles().isEmpty());
+        verify(contentHostingService).getResource(MAP_RESOURCE);
+
+        OverlayCapturingDocument withoutKeys = renderPrint(question, printSettings(false), contentHosting(MAP_RESOURCE));
+        assertTrue(withoutKeys.overlays.isEmpty());
+    }
+
+    @Test
+    public void printableRenderSkipsOverlayForNullTextAndNonFiniteRegions() throws Exception {
+        ContentHostingService contentHostingService = contentHosting(MAP_RESOURCE);
+        AssessmentPdfQuestionModel question = imageMapQuestion(null, MAP_RESOURCE, List.of(
+                "{\"x1\":null,\"y1\":19,\"x2\":181,\"y2\":283}",
+                "{\"x1\":\"17\",\"y1\":19,\"x2\":181,\"y2\":283}",
+                "{\"x1\":1e309,\"y1\":19,\"x2\":181,\"y2\":283}"), Collections.emptyList());
+
+        OverlayCapturingDocument document = renderPrint(question, printSettings(true), contentHostingService);
+        assertTrue(document.overlays.isEmpty());
+        verify(contentHostingService).getResource(MAP_RESOURCE);
+    }
+
+    @Test
+    public void studentReportRenderPrefersImageSrcAndOverlaysStudentClick() throws Exception {
+        ContentHostingService contentHostingService = contentHosting(STUDENT_RESOURCE);
+        AssessmentPdfQuestionModel question = imageMapQuestion(STUDENT_RESOURCE, MAP_RESOURCE, List.of(VALID_REGION),
+                List.of(new AssessmentPdfItemGradingModel(STUDENT_CLICK, 9001L, 1)));
+
+        OverlayCapturingDocument document = renderReport(question, contentHostingService);
+        assertEquals(1, document.overlays.size());
+        ImageMapQuestionCellEvent overlay = document.overlays.get(0);
+        assertEquals(1, overlay.getAnswerRectangles().size());
+        assertEquals(1, overlay.getAnswerCircles().size());
+        ImageMapCircle click = overlay.getAnswerCircles().get(0);
+        assertEquals(555f, click.getX(), 0.01f);
+        assertEquals(666f, click.getY(), 0.01f);
+        assertEquals(1, click.getSequence());
+        verify(contentHostingService).getResource(STUDENT_RESOURCE);
+        verify(contentHostingService, never()).getResource(MAP_RESOURCE);
+    }
+
+    private static AssessmentPdfQuestionModel imageMapQuestion(String imageSrc, String imageMapSrc, List<String> regions,
+            List<AssessmentPdfItemGradingModel> clicks) {
+        return AssessmentPdfQuestionModel.builder()
+                .typeId(TypeIfc.IMAGEMAP_QUESTION)
+                .itemHtmlText("Identify the organs")
+                .itemScore(Double.valueOf(1))
+                .sequence("1")
+                .text("Identify the organs")
+                .imageSrc(imageSrc)
+                .imageMapSrc(imageMapSrc)
+                .imageMapItemTexts(List.of("Heart"))
+                .imageMapRegionJsons(regions)
+                .imageMapRows(List.of(new AssessmentPdfImageMapRowModel("1. Heart", Boolean.TRUE)))
+                .itemGradingData(clicks)
+                .build();
+    }
+
+    private static AssessmentPdfPrintSettingsModel printSettings(boolean showKeys) {
+        return new AssessmentPdfPrintSettingsModel(showKeys, "3", Boolean.FALSE, Boolean.FALSE, Boolean.TRUE);
+    }
+
+    private static ContentHostingService contentHosting(String resourceId) throws Exception {
+        ContentHostingService contentHostingService = mock(ContentHostingService.class);
+        ContentResource contentResource = mock(ContentResource.class);
+        when(contentHostingService.getResource(resourceId)).thenReturn(contentResource);
+        when(contentResource.getContent()).thenReturn(TEST_PNG);
+        return contentHostingService;
+    }
+
+    private static OverlayCapturingDocument renderPrint(AssessmentPdfQuestionModel question,
+            AssessmentPdfPrintSettingsModel settings, ContentHostingService contentHostingService) throws Exception {
+        AssessmentPdfContentHelper helper = new AssessmentPdfContentHelper(contentHostingService);
+        AssessmentPrintPdfModel printModel = new AssessmentPrintPdfModel("Quiz", "", false, settings,
+                List.of(new AssessmentPdfPartModel("Part 1", "", Collections.emptyList(), List.of(question))));
+        return render(QuestionRenderContext.forPrint(question, 1, 1, printModel, helper), helper);
+    }
+
+    private static OverlayCapturingDocument renderReport(AssessmentPdfQuestionModel question,
+            ContentHostingService contentHostingService) throws Exception {
+        AssessmentPdfContentHelper helper = new AssessmentPdfContentHelper(contentHostingService);
+        AssessmentStudentReportPdfModel reportModel = new AssessmentStudentReportPdfModel(
+                "Student One", "Student", "student@example.com", null, "Quiz", "Site A", 1.0, 1.0, false,
+                List.of(new AssessmentPdfPartModel("Part 1", "", Collections.emptyList(), List.of(question), "1", 1, 0, 1.0, 1.0)));
+        return render(QuestionRenderContext.forReport(question, 1, 1, reportModel, helper), helper);
+    }
+
+    private static OverlayCapturingDocument render(QuestionRenderContext context, AssessmentPdfContentHelper helper)
+            throws Exception {
+        OverlayCapturingDocument document = new OverlayCapturingDocument();
+        PdfWriter.getInstance(document, new ByteArrayOutputStream());
+        document.open();
+        new AssessmentPdfQuestionRenderer(helper).render(document, context);
+        document.close();
+        return document;
+    }
+
+    private static class OverlayCapturingDocument extends Document {
+        private final List<ImageMapQuestionCellEvent> overlays = new ArrayList<>();
+
+        @Override
+        public boolean add(Element element) throws DocumentException {
+            collectOverlays(element);
+            return super.add(element);
+        }
+
+        private void collectOverlays(Element element) {
+            if (!(element instanceof PdfPTable)) {
+                return;
+            }
+            PdfPTable table = (PdfPTable) element;
+            for (int i = 0; i < table.size(); i++) {
+                PdfPRow row = table.getRow(i);
+                if (row == null || row.getCells() == null) {
+                    continue;
+                }
+                for (PdfPCell cell : row.getCells()) {
+                    if (cell != null && cell.getCellEvent() instanceof ImageMapQuestionCellEvent) {
+                        overlays.add((ImageMapQuestionCellEvent) cell.getCellEvent());
+                    }
+                }
+            }
+        }
+    }
+
+    private static byte[] createPng() {
+        try {
+            BufferedImage image = new BufferedImage(200, 150, BufferedImage.TYPE_INT_RGB);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            if (!ImageIO.write(image, "png", output)) {
+                throw new IllegalStateException("No PNG ImageIO writer is available");
+            }
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
     }
 }

--- a/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRendererTest.java
+++ b/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRendererTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.samigo.impl.pdf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+
+public class AssessmentPdfQuestionRendererTest {
+
+    @Test
+    public void extractJsonObjectStripsPrefixAndUndefined() {
+        assertEquals("{\"x1\":1,\"y1\":2,\"x2\":3,\"y2\":4}",
+                AssessmentPdfQuestionRenderer.extractJsonObject("prefix {\"x1\":1,\"y1\":2,\"x2\":3,\"y2\":4}"));
+        assertNull(AssessmentPdfQuestionRenderer.extractJsonObject("undefined"));
+        assertNull(AssessmentPdfQuestionRenderer.extractJsonObject("no-json"));
+        assertNull(AssessmentPdfQuestionRenderer.extractJsonObject(null));
+    }
+}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PDF rendering for image-map questions in printable assessments and student reports.
  * Image-map source images, item text, and marked regions are now captured and displayed.
  * Answer keys and highlighted regions are shown when enabled.
  * Student reports support image-map region shapes, fallback image sources, and accurate click markers.
  * Image-map responses preserve item order and associated text.

* **Bug Fixes**
  * Invalid, incomplete, or non-finite image-map region data no longer prevents PDF generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->