### PR TITLE
SAK-52874 Assignments Bulk publish does not distribute peer assessment

### DIFF
--- a/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
+++ b/assignment/api/src/java/org/sakaiproject/assignment/api/AssignmentService.java
@@ -373,12 +373,20 @@ public interface AssignmentService extends EntityProducer {
     public void updateAssignment(Assignment assignment) throws PermissionException;
 
     /**
-     * Publishes a draft assignment and performs first-publish integrations.
+     * Publishes an assignment, synchronizes its peer review schedule, and performs first-publish integrations.
      *
      * @param assignment the Assignment to publish.
      * @throws PermissionException if current User does not have permission to update the assignment.
      */
     public void publishAssignment(Assignment assignment) throws PermissionException;
+
+    /**
+     * Returns an assignment to draft and removes its scheduled peer review.
+     *
+     * @param assignment the Assignment to unpublish.
+     * @throws PermissionException if the current user cannot update the assignment.
+     */
+    public void unpublishAssignment(Assignment assignment) throws PermissionException;
 
     /**
      * Integrates assignment availability and due dates with Announcement and Calendar tools.

--- a/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
+++ b/assignment/impl/src/java/org/sakaiproject/assignment/impl/AssignmentServiceImpl.java
@@ -82,6 +82,7 @@ import org.sakaiproject.announcement.api.AnnouncementService;
 import org.sakaiproject.assignment.api.AssignmentConstants;
 import org.sakaiproject.assignment.api.AssignmentConstants.SubmissionStatus;
 import org.sakaiproject.assignment.api.AssignmentEntity;
+import org.sakaiproject.assignment.api.AssignmentPeerAssessmentService;
 import org.sakaiproject.assignment.api.AssignmentReferenceReckoner;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.AssignmentService.OpenDateNotification;
@@ -230,6 +231,7 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
     @Setter private ApplicationContext applicationContext;
     @Setter private AssignmentActivityProducer assignmentActivityProducer;
     @Setter private AssignmentDueReminderService assignmentDueReminderService;
+    @Setter private AssignmentPeerAssessmentService assignmentPeerAssessmentService;
     @Setter private ObjectFactory<AssignmentEntity> assignmentEntityFactory;
     @Setter private AssignmentRepository assignmentRepository;
     @Setter private AssignmentSupplementItemService assignmentSupplementItemService;
@@ -1707,10 +1709,21 @@ public class AssignmentServiceImpl implements AssignmentService, EntityTransferr
         boolean wasDraft = BooleanUtils.toBoolean(assignment.getDraft());
         assignment.setDraft(Boolean.FALSE);
         updateAssignmentInTransaction(assignment);
+        assignmentPeerAssessmentService.schedulePeerReview(assignment.getId());
 
         if (wasDraft) {
             integrateOnFirstPublish(assignment);
         }
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void unpublishAssignment(Assignment assignment) throws PermissionException {
+        Assert.notNull(assignment, "Assignment cannot be null");
+
+        assignment.setDraft(Boolean.TRUE);
+        updateAssignmentInTransaction(assignment);
+        assignmentPeerAssessmentService.removeScheduledPeerReview(assignment.getId());
     }
 
     private void updateAssignmentInTransaction(Assignment assignment) throws PermissionException {

--- a/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
+++ b/assignment/impl/src/test/org/sakaiproject/assignment/impl/AssignmentServiceTest.java
@@ -71,6 +71,7 @@ import org.sakaiproject.announcement.api.AnnouncementMessageEdit;
 import org.sakaiproject.announcement.api.AnnouncementMessageHeader;
 import org.sakaiproject.announcement.api.AnnouncementMessageHeaderEdit;
 import org.sakaiproject.announcement.api.AnnouncementService;
+import org.sakaiproject.api.app.scheduler.ScheduledInvocationManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -131,6 +132,8 @@ import org.springframework.test.context.junit4.AbstractTransactionalJUnit4Spring
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -147,6 +150,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringContextTests {
 
     private static final Faker faker = new Faker();
+    private static final String PEER_REVIEW_INVOKEE = "org.sakaiproject.assignment.api.AssignmentPeerAssessmentService";
 
     @Resource(name = "org.sakaiproject.announcement.api.AnnouncementService")
     private AnnouncementService announcementService;
@@ -160,6 +164,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
     private EventTrackingService eventTrackingService;
     @Autowired private FormattedText formattedText;
     @Autowired private GradingService gradingService;
+    @Autowired private ScheduledInvocationManager scheduledInvocationManager;
     @Autowired private SecurityService securityService;
     @Autowired private SessionManager sessionManager;
     @Autowired private ServerConfigurationService serverConfigurationService;
@@ -266,8 +271,11 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
     }
 
     @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void testPublishAssignmentIntegratesCalendarAndAnnouncement() throws Exception {
-        AssignmentServiceImpl service = integrationService();
+        Assignment assignment = createPublishableAssignment(false);
+        String siteId = assignment.getContext();
+        String assignmentId = assignment.getId();
         Calendar calendar = mock(Calendar.class);
         CalendarEvent calendarEvent = mock(CalendarEvent.class);
         CalendarEventEdit calendarEventEdit = mock(CalendarEventEdit.class);
@@ -277,8 +285,7 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         ResourcePropertiesEdit messageProperties = mock(ResourcePropertiesEdit.class);
         Event updateEvent = mock(Event.class);
         Event availableEvent = mock(Event.class);
-        Assignment assignment = mock(Assignment.class);
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = assignment.getProperties();
         Instant openTime = Instant.parse("2099-04-14T16:00:00Z");
         Instant dueTime = Instant.parse("2099-04-21T16:00:00Z");
 
@@ -287,22 +294,17 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         properties.put(AssignmentConstants.ASSIGNMENT_OPENDATE_NOTIFICATION,
                 AssignmentConstants.ASSIGNMENT_OPENDATE_NOTIFICATION_NONE);
 
-        when(assignment.getProperties()).thenReturn(properties);
-        when(assignment.getDraft()).thenReturn(Boolean.TRUE);
-        when(assignment.getTitle()).thenReturn("Bulk Publish Assignment");
-        when(assignment.getDueDate()).thenReturn(dueTime);
-        when(assignment.getOpenDate()).thenReturn(openTime);
-        when(assignment.getTypeOfAccess()).thenReturn(Assignment.Access.SITE);
-        when(assignment.getId()).thenReturn("assignment-id");
-        when(assignment.getContext()).thenReturn("site-id");
-        when(calendarService.calendarReference("site-id", SiteService.MAIN_CONTAINER)).thenReturn("calendar-ref");
+        assignment.setTitle("Bulk Publish Assignment");
+        assignment.setDueDate(dueTime);
+        assignment.setOpenDate(openTime);
+        when(calendarService.calendarReference(siteId, SiteService.MAIN_CONTAINER)).thenReturn("calendar-ref");
         when(calendarService.getCalendar("calendar-ref")).thenReturn(calendar);
         when(calendar.addEvent(Mockito.any(), Mockito.anyString(), Mockito.anyString(),
                 Mockito.eq("Deadline"), Mockito.eq(""), Mockito.eq(CalendarEvent.EventAccess.SITE),
                 Mockito.anyList(), Mockito.isNull())).thenReturn(calendarEvent);
         when(calendarEvent.getId()).thenReturn("calendar-event-id");
         when(calendar.getEditEvent("calendar-event-id", CalendarService.EVENT_ADD_CALENDAR)).thenReturn(calendarEventEdit);
-        when(announcementService.channelReference("site-id", SiteService.MAIN_CONTAINER)).thenReturn("announcement-ref");
+        when(announcementService.channelReference(siteId, SiteService.MAIN_CONTAINER)).thenReturn("announcement-ref");
         when(announcementService.getAnnouncementChannel("announcement-ref")).thenReturn(channel);
         when(channel.addAnnouncementMessage()).thenReturn(message);
         when(message.getAnnouncementHeaderEdit()).thenReturn(header);
@@ -320,13 +322,13 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         when(userTimeService.dateTimeFormat(openTime, null, null)).thenReturn("Apr 14, 2026 12:00 PM EDT");
         when(userTimeService.dateTimeFormat(dueTime, FormatStyle.MEDIUM, FormatStyle.LONG)).thenReturn("Apr 21, 2026 12:00 PM EDT");
         when(eventTrackingService.newEvent(AssignmentConstants.EVENT_UPDATE_ASSIGNMENT,
-                "/assignment/a/site-id/assignment-id", true)).thenReturn(updateEvent);
+                "/assignment/a/" + siteId + "/" + assignmentId, true)).thenReturn(updateEvent);
         when(eventTrackingService.newEvent(AssignmentConstants.EVENT_AVAILABLE_ASSIGNMENT,
-                "/assignment/a/site-id/assignment-id", true)).thenReturn(availableEvent);
+                "/assignment/a/" + siteId + "/" + assignmentId, true)).thenReturn(availableEvent);
 
-        service.publishAssignment(assignment);
+        assignmentService.publishAssignment(assignment);
 
-        verify(assignment).setDraft(Boolean.FALSE);
+        Assert.assertFalse(assignmentService.getAssignment(assignmentId).getDraft());
         verify(calendar).addEvent(Mockito.any(), Mockito.anyString(), Mockito.anyString(),
                 Mockito.eq("Deadline"), Mockito.eq(""), Mockito.eq(CalendarEvent.EventAccess.SITE),
                 Mockito.anyList(), Mockito.isNull());
@@ -341,7 +343,120 @@ public class AssignmentServiceTest extends AbstractTransactionalJUnit4SpringCont
         Assert.assertEquals("announcement-id", properties.get(ResourceProperties.PROP_ASSIGNMENT_OPENDATE_ANNOUNCEMENT_MESSAGE_ID));
         verify(eventTrackingService).post(updateEvent);
         verify(eventTrackingService).delay(availableEvent, openTime);
-        verify(service, Mockito.atLeast(3)).updateAssignment(assignment);
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void publishAssignmentSchedulesPeerReview() throws Exception {
+        Assignment assignment = createPublishableAssignment(true);
+
+        assignmentService.publishAssignment(assignment);
+
+        Assert.assertFalse(assignmentService.getAssignment(assignment.getId()).getDraft());
+        org.mockito.InOrder order = Mockito.inOrder(scheduledInvocationManager);
+        order.verify(scheduledInvocationManager).deleteDelayedInvocation(
+                PEER_REVIEW_INVOKEE, assignment.getId());
+        order.verify(scheduledInvocationManager).createDelayedInvocation(
+                assignment.getCloseDate(), PEER_REVIEW_INVOKEE, assignment.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void republishAssignmentReplacesPeerReviewSchedule() throws Exception {
+        Assignment assignment = createPublishableAssignment(true);
+        assignmentService.publishAssignment(assignment);
+        Instant newCloseDate = assignment.getCloseDate().plusSeconds(3600);
+        assignment.setCloseDate(newCloseDate);
+
+        assignmentService.publishAssignment(assignment);
+
+        verify(scheduledInvocationManager, Mockito.times(2)).deleteDelayedInvocation(
+                PEER_REVIEW_INVOKEE, assignment.getId());
+        verify(scheduledInvocationManager).createDelayedInvocation(
+                newCloseDate, PEER_REVIEW_INVOKEE, assignment.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void publishAssignmentWithoutPeerAssessmentRemovesStaleSchedule() throws Exception {
+        Assignment assignment = createPublishableAssignment(false);
+
+        assignmentService.publishAssignment(assignment);
+
+        verify(scheduledInvocationManager).deleteDelayedInvocation(PEER_REVIEW_INVOKEE, assignment.getId());
+        verify(scheduledInvocationManager, Mockito.never()).createDelayedInvocation(
+                Mockito.any(Instant.class), eq(PEER_REVIEW_INVOKEE), eq(assignment.getId()));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void unpublishAssignmentRemovesPeerReviewSchedule() throws Exception {
+        Assignment assignment = createPublishableAssignment(true);
+        assignmentService.publishAssignment(assignment);
+
+        assignmentService.unpublishAssignment(assignment);
+
+        Assert.assertTrue(assignmentService.getAssignment(assignment.getId()).getDraft());
+        verify(scheduledInvocationManager, Mockito.times(2)).deleteDelayedInvocation(
+                PEER_REVIEW_INVOKEE, assignment.getId());
+        verify(scheduledInvocationManager, Mockito.times(1)).createDelayedInvocation(
+                assignment.getCloseDate(), PEER_REVIEW_INVOKEE, assignment.getId());
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void deniedPublishDoesNotSchedulePeerReview() throws Exception {
+        Assignment assignment = createPublishableAssignment(true);
+        denyUpdate(assignment);
+
+        Assert.assertThrows(PermissionException.class, () -> assignmentService.publishAssignment(assignment));
+
+        Assert.assertTrue(assignmentService.getAssignment(assignment.getId()).getDraft());
+        verify(scheduledInvocationManager, Mockito.never()).deleteDelayedInvocation(
+                PEER_REVIEW_INVOKEE, assignment.getId());
+        verify(scheduledInvocationManager, Mockito.never()).createDelayedInvocation(
+                Mockito.any(Instant.class), eq(PEER_REVIEW_INVOKEE), eq(assignment.getId()));
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void deniedUnpublishPreservesPeerReviewSchedule() throws Exception {
+        Assignment assignment = createPublishableAssignment(true);
+        assignmentService.publishAssignment(assignment);
+        denyUpdate(assignment);
+
+        Assert.assertThrows(PermissionException.class, () -> assignmentService.unpublishAssignment(assignment));
+
+        Assert.assertFalse(assignmentService.getAssignment(assignment.getId()).getDraft());
+        verify(scheduledInvocationManager, Mockito.times(1)).deleteDelayedInvocation(
+                PEER_REVIEW_INVOKEE, assignment.getId());
+    }
+
+    private Assignment createPublishableAssignment(boolean peerAssessment) throws Exception {
+        String context = UUID.randomUUID().toString();
+        Assignment assignment = createNewAssignment(context);
+        when(securityService.unlock(eq(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT),
+                eq(AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference())))
+                .thenReturn(true);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT,
+                AssignmentReferenceReckoner.reckoner().context(context).reckon().getReference())).thenReturn(true);
+        Site site = mock(Site.class);
+        when(site.getId()).thenReturn(context);
+        when(siteService.getSite(context)).thenReturn(site);
+        assignment.setDraft(true);
+        assignment.setAllowPeerAssessment(peerAssessment);
+        assignment.setOpenDate(Instant.parse("2099-04-14T16:00:00Z"));
+        assignment.setDueDate(Instant.parse("2099-04-21T16:00:00Z"));
+        assignment.setCloseDate(Instant.parse("2099-04-22T16:00:00Z"));
+        assignmentService.updateAssignment(assignment);
+        return assignment;
+    }
+
+    private void denyUpdate(Assignment assignment) {
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT,
+                AssignmentReferenceReckoner.reckoner().assignment(assignment).reckon().getReference())).thenReturn(false);
+        when(securityService.unlock(AssignmentServiceConstants.SECURE_UPDATE_ASSIGNMENT,
+                AssignmentReferenceReckoner.reckoner().context(assignment.getContext()).reckon().getReference())).thenReturn(false);
     }
 
     private AssignmentServiceImpl integrationService() throws PermissionException {

--- a/assignment/impl/src/webapp/WEB-INF/components.xml
+++ b/assignment/impl/src/webapp/WEB-INF/components.xml
@@ -18,6 +18,7 @@
         <property name="announcementService" ref="org.sakaiproject.announcement.api.AnnouncementService"/>
         <property name="assignmentActivityProducer" ref="org.sakaiproject.assignment.taggable.api.AssignmentActivityProducer"/>
         <property name="assignmentDueReminderService" ref="org.sakaiproject.assignment.api.reminder.AssignmentDueReminderService"/>
+        <property name="assignmentPeerAssessmentService" ref="org.sakaiproject.assignment.api.AssignmentPeerAssessmentService"/>
         <property name="assignmentEntityFactory" ref="org.sakaiproject.assignment.api.AssignmentEntity.factory"/>
         <property name="assignmentRepository" ref="org.sakaiproject.assignment.api.persistence.AssignmentRepository"/>
         <property name="assignmentSupplementItemService" ref="org.sakaiproject.assignment.api.model.AssignmentSupplementItemService"/>

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11307,8 +11307,6 @@ public class AssignmentAction extends PagedResourceActionII {
 
         assignmentService.publishAssignment(assignment);
 
-        assignmentPeerAssessmentService.schedulePeerReview(assignment.getId());
-
         if (addToResolvedGradebookOnPublish) {
             integrateAssignmentWithGradebook(state, assignment.getTitle(), oAssociateGradebookAssignment, assignment,
                     assignment.getTitle(), assignment.getDueDate(), assignment.getTypeOfGrade(), assignment.getMaxGradePoint().toString(),
@@ -11414,9 +11412,7 @@ public class AssignmentAction extends PagedResourceActionII {
             try {
                 String id = AssignmentReferenceReckoner.reckoner().reference(ref).reckon().getId();
                 Assignment assignment = assignmentService.getAssignment(id);
-                assignment.setDraft(Boolean.TRUE);
-                assignmentService.updateAssignment(assignment);
-                assignmentPeerAssessmentService.removeScheduledPeerReview(assignment.getId());
+                assignmentService.unpublishAssignment(assignment);
             } catch (IdUnusedException e) {
                 log.warn("Cannot find assignment with ref: {}", ref);
                 addAlert(state, rb.getFormattedMessage("options_cannotFindAssignment", ref));

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11307,11 +11307,7 @@ public class AssignmentAction extends PagedResourceActionII {
 
         assignmentService.publishAssignment(assignment);
 
-        if (assignment.getAllowPeerAssessment()) {
-            assignmentPeerAssessmentService.schedulePeerReview(assignment.getId());
-        } else {
-            assignmentPeerAssessmentService.removeScheduledPeerReview(assignment.getId());
-        }
+        assignmentPeerAssessmentService.schedulePeerReview(assignment.getId());
 
         if (addToResolvedGradebookOnPublish) {
             integrateAssignmentWithGradebook(state, assignment.getTitle(), oAssociateGradebookAssignment, assignment,

--- a/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -11307,6 +11307,12 @@ public class AssignmentAction extends PagedResourceActionII {
 
         assignmentService.publishAssignment(assignment);
 
+        if (assignment.getAllowPeerAssessment()) {
+            assignmentPeerAssessmentService.schedulePeerReview(assignment.getId());
+        } else {
+            assignmentPeerAssessmentService.removeScheduledPeerReview(assignment.getId());
+        }
+
         if (addToResolvedGradebookOnPublish) {
             integrateAssignmentWithGradebook(state, assignment.getTitle(), oAssociateGradebookAssignment, assignment,
                     assignment.getTitle(), assignment.getDueDate(), assignment.getTypeOfGrade(), assignment.getMaxGradePoint().toString(),
@@ -11414,6 +11420,7 @@ public class AssignmentAction extends PagedResourceActionII {
                 Assignment assignment = assignmentService.getAssignment(id);
                 assignment.setDraft(Boolean.TRUE);
                 assignmentService.updateAssignment(assignment);
+                assignmentPeerAssessmentService.removeScheduledPeerReview(assignment.getId());
             } catch (IdUnusedException e) {
                 log.warn("Cannot find assignment with ref: {}", ref);
                 addAlert(state, rb.getFormattedMessage("options_cannotFindAssignment", ref));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing an assignment now synchronizes its peer-review schedule.
  * Republishing an assignment replaces its previous peer-review schedule.

* **Bug Fixes**
  * Returning an assignment to draft now removes its scheduled peer review.
  * Assignments without peer assessment no longer retain outdated peer-review schedules.
  * Permission-denied publish and unpublish actions no longer alter peer-review schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->