### PR TITLE
SAK-52866 Statistics preserve user activity search when returning from details

### DIFF
--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
@@ -208,7 +208,8 @@ public class SiteStatsController {
 
     @GetMapping("/useractivity/events/{eventId}")
     public String userActivityDetails(@PathVariable long eventId,
-            @RequestParam(required = false) String siteId, Model model) {
+            @RequestParam(required = false) String siteId,
+            @ModelAttribute UserActivityForm userActivityForm, Model model) {
         SiteStatsToolService.EventDetailsResult result = toolService.eventDetails(siteId, eventId);
         commonModel(model, result.getSiteId(), "useractivity");
         model.addAttribute("eventDetails", result);

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/user-activity-details.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/user-activity-details.html
@@ -15,7 +15,7 @@
       </dd>
     </th:block>
   </dl>
-  <a class="btn btn-link" th:href="@{/useractivity(siteId=${siteId})}"
+  <a class="btn btn-link" th:href="@{/useractivity(siteId=${siteId},userId=${userActivityForm.userId},toolId=${userActivityForm.toolId},startDate=${userActivityForm.startDate},endDate=${userActivityForm.endDate},page=${userActivityForm.page})}"
      th:text="#{back}">Back</a>
 </main>
 </body>

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/user-activity.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/user-activity.html
@@ -67,7 +67,7 @@
           <td class="text-break" th:text="${event.reference}"></td>
           <td>
             <a th:if="${event.resolvable}"
-               th:href="@{/useractivity/events/{id}(id=${event.id},siteId=${siteId})}"
+               th:href="@{/useractivity/events/{id}(id=${event.id},siteId=${siteId},userId=${userActivityForm.userId},toolId=${userActivityForm.toolId},startDate=${userActivityForm.startDate},endDate=${userActivityForm.endDate},page=${userActivityForm.page})}"
                th:text="#{de_resultsTable_detailsLink}">View details</a>
           </td>
         </tr>


### PR DESCRIPTION
In Statistics → User Activity, opening **Show more** and clicking **Back** resets the selected user and search results. Carry the user, tool, date range, and page through the details link and bind the existing `UserActivityForm` on the details endpoint so Back returns to the same search.

This is a three-file navigation fix based on `upstream/master`.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52866

Validation:
- Passed all 33 Statistics tool tests with Java 17: `mvn -pl sitestats/sitestats-api,sitestats/sitestats-bundle,sitestats/sitestats-tool test -DskipTests=false -DfailIfNoTests=false -q`.
- `git diff --check` passed.
- Browser validation was unavailable: `https://sakai.example` refused connections. No Playwright test was added because this flow needs a running instance with detailed event tracking and recorded, resolvable user events; the existing Statistics test has no such fixture. Adding an unverified fixture would expand this minimal navigation fix.

Manual regression: select a user with activity, choose a tool and date range, and search. Open Show more, then the page's Back link. Verify the same user, tool, dates, and results are displayed. Repeat from a later results page to verify pagination is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user activity filters and pagination when opening event details.
  * Preserved the current search and pagination state when returning from event details to the activity list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->