### PR TITLE
SAK-52870 Lessons restore Pick a Page button styling

### DIFF
--- a/lessonbuilder/tool/src/webapp/templates/ShowPage.html
+++ b/lessonbuilder/tool/src/webapp/templates/ShowPage.html
@@ -492,7 +492,7 @@
             </div>
             <div class="modal-footer">
               <button class="btn-primary" type="submit" rsf:id="create-subpage" onclick="event.returnValue = checkSubpageForm(); return checkSubpageForm();"></button>
-              <a class="btn btn-secondary" id="subpage-choose" role="button" rsf:id="subpage-choose"><span rsf:id="msg=simplepage.page.chooser"></span></a>
+              <a class="button" id="subpage-choose" role="button" rsf:id="subpage-choose"><span rsf:id="msg=simplepage.page.chooser"></span></a>
               <button class="btn btn-secondary" type="submit" data-bs-dismiss="modal" rsf:id="cancel-subpage"></button>
             </div>
           </div>


### PR DESCRIPTION
Lessons → Add Content → Add Subpage displays **Pick a Page** as unformatted text after SAK-52812 replaced the native button with a link. Use Sakai's existing `button` class, whose secondary-button styles explicitly support anchors, to restore its background, border, padding, and interaction styling.

One template-line change, branched independently from `upstream/master`.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52870

Validation:
- Compiled the current default skin's `tool.scss` successfully.
- Compared before/after markup in Chromium using Playwright and the compiled skin. Before: transparent background and border. After: standard secondary-button background, border, and padding. Checked hover, keyboard focus, and Enter activation.
- `git diff --check` passed.
- The browser comparison was an isolated markup fixture, not a deployed Sakai instance: `https://sakai.example` refused connections. No E2E test was added for this styling-only change; navigation and form behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the subpage dialog’s choose button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->