### PR TITLE
SAK-52842 Statistics retain presence duration when users return to a site

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -125,7 +125,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 	private Map<String, LessonBuilderStat>			lessonBuilderStatMap	= Collections.synchronizedMap(new HashMap<>());
 	private Map<String, SiteActivity>				activityMap				= Collections.synchronizedMap(new HashMap<>());
 	private Map<String, SiteVisits>					visitsMap				= Collections.synchronizedMap(new HashMap<>());
-	private Map<SitePresenceKey, SitePresenceRecord>presencesMap			= Collections.synchronizedMap(new HashMap<>());
+	private Map<SitePresenceKey, List<SitePresenceRecord>> presencesMap			= Collections.synchronizedMap(new HashMap<>());
 	private Map<UniqueVisitsKey, Integer>			uniqueVisitsMap			= Collections.synchronizedMap(new HashMap<>());
 	private Map<String, ServerStat>					serverStatMap			= Collections.synchronizedMap(new HashMap<>());
 	private Map<String, UserStat>					userStatMap				= Collections.synchronizedMap(new HashMap<>());
@@ -748,7 +748,12 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 							.userId(userId)
 							.begin(dateTime.toInstant())
 							.build();
-					presencesMap.put(sitePresenceKey, beginningPresence);
+					List<SitePresenceRecord> sessionPresences = presencesMap.computeIfAbsent(sitePresenceKey, key -> new ArrayList<>());
+					// Preserve completed visits when the same session returns before the batch is saved.
+					if (!sessionPresences.isEmpty() && sessionPresences.get(sessionPresences.size() - 1).isBeginning()) {
+						sessionPresences.remove(sessionPresences.size() - 1);
+					}
+					sessionPresences.add(beginningPresence);
 				}
 			}finally{
 				lock.unlock();
@@ -759,7 +764,8 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 			lock.lock();
 			try{
 				// Populate presence map with end events
-				SitePresenceRecord existingPresence = presencesMap.get(sitePresenceKey);
+				List<SitePresenceRecord> sessionPresences = presencesMap.get(sitePresenceKey);
+				SitePresenceRecord existingPresence = sessionPresences == null ? null : sessionPresences.get(sessionPresences.size() - 1);
 				if(existingPresence != null) {
 					existingPresence.setEnd(dateTime.toInstant());
 				} else {
@@ -768,7 +774,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 							.userId(userId)
 							.end(dateTime.toInstant())
 							.build();
-					presencesMap.put(sitePresenceKey, endingPresence);
+					presencesMap.computeIfAbsent(sitePresenceKey, key -> new ArrayList<>()).add(endingPresence);
 				}
 			}finally{
 				lock.unlock();
@@ -928,8 +934,8 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
                     if(presencesMap.size() > 0) {
                         Collection<SitePresenceRecord> tmp6 = null;
                         synchronized(presencesMap){
-                            tmp6 = presencesMap.values();
-                            presencesMap = Collections.synchronizedMap(new HashMap<SitePresenceKey, SitePresenceRecord>());
+                            tmp6 = presencesMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+                            presencesMap = Collections.synchronizedMap(new HashMap<SitePresenceKey, List<SitePresenceRecord>>());
                         }
                         doUpdateSitePresencesObjects(session, tmp6);
                     }

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -931,14 +931,15 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
                     }
 
                     // do: SitePresences
-                    if(presencesMap.size() > 0) {
-                        Collection<SitePresenceRecord> tmp6 = null;
-                        synchronized(presencesMap){
-                            tmp6 = presencesMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
-                            presencesMap = Collections.synchronizedMap(new HashMap<SitePresenceKey, List<SitePresenceRecord>>());
-                        }
-                        doUpdateSitePresencesObjects(session, tmp6);
+                    Collection<SitePresenceRecord> tmp6;
+                    lock.lock();
+                    try {
+                        tmp6 = presencesMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+                        presencesMap = Collections.synchronizedMap(new HashMap<SitePresenceKey, List<SitePresenceRecord>>());
+                    } finally {
+                        lock.unlock();
                     }
+                    doUpdateSitePresencesObjects(session, tmp6);
 
                     // do: ServerStats
                     if(serverStatMap.size() > 0) {

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
@@ -1569,6 +1569,33 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
 	}
 
+	@Test
+	public void testSitePresencesRetainCompletedVisitWhenSessionReentersSite() {
+		Instant start = Instant.parse("2026-08-20T12:00:00Z");
+		String reference = "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX;
+		Event begin = statsUpdateManager.buildEvent(Date.from(start), StatsManager.SITEVISIT_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		Event end = statsUpdateManager.buildEvent(Date.from(start.plusSeconds(600)), StatsManager.SITEVISITEND_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		Event returnToSite = statsUpdateManager.buildEvent(Date.from(start.plusSeconds(900)), StatsManager.SITEVISIT_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		assertTrue(statsUpdateManager.collectEvents(List.of(begin, end, returnToSite)));
+
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		assertEquals(Duration.ofMinutes(10).toMillis(), results.get(0).getDuration());
+		assertEquals(Integer.valueOf(1), results.get(0).getCurrentOpenSessions());
+
+		Event leaveAgain = statsUpdateManager.buildEvent(Date.from(start.plusSeconds(1200)), StatsManager.SITEVISITEND_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		assertTrue(statsUpdateManager.collectEvents(List.of(leaveAgain)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		assertEquals(Duration.ofMinutes(15).toMillis(), results.get(0).getDuration());
+		assertEquals(Integer.valueOf(0), results.get(0).getCurrentOpenSessions());
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testSitePresencesExistingPresence() throws InterruptedException {

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -38,6 +39,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -72,6 +79,9 @@ import org.sakaiproject.util.ResourceLoader;
 import org.springframework.aop.framework.Advised;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 
 import lombok.extern.slf4j.Slf4j;
@@ -84,6 +94,7 @@ import java.time.ZoneId;
 public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringContextTests {
 
 	@Autowired private DB db;
+	@Autowired private PlatformTransactionManager transactionManager;
 	@Autowired private MemoryService memoryService;
 	@Autowired private ReportManager reportManager;
 	@Autowired private ResourceLoader resourceLoader;
@@ -1567,6 +1578,66 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
 		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
 		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testPresenceDrainWaitsForConcurrentAppend() throws Exception {
+		TestTransaction.flagForCommit();
+		TestTransaction.end();
+		TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+		CountDownLatch collecting = new CountDownLatch(1);
+		CountDownLatch releaseCollection = new CountDownLatch(1);
+		CountDownLatch flushing = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		Instant start = Instant.parse("2026-08-20T12:00:00Z");
+		String reference = "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX;
+		// Pause the incoming event's date conversion while collection owns the presence lock.
+		Date returnDate = new Date(start.plusSeconds(900).toEpochMilli()) {
+			@Override
+			public Instant toInstant() {
+				collecting.countDown();
+				try {
+					if (!releaseCollection.await(10, TimeUnit.SECONDS)) {
+						throw new AssertionError("Timed out waiting to append the returning visit");
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new AssertionError(e);
+				}
+				return super.toInstant();
+			}
+		};
+		Event begin = statsUpdateManager.buildEvent(Date.from(start), StatsManager.SITEVISIT_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		Event end = statsUpdateManager.buildEvent(Date.from(start.plusSeconds(600)), StatsManager.SITEVISITEND_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		Event returnToSite = statsUpdateManager.buildEvent(returnDate, StatsManager.SITEVISIT_EVENTID,
+				reference, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		try {
+			Future<Boolean> collector = executor.submit(() -> transaction.execute(status ->
+					statsUpdateManager.collectEvents(List.of(begin, end, returnToSite))));
+			assertTrue(collecting.await(10, TimeUnit.SECONDS));
+			Future<Boolean> flush = executor.submit(() -> transaction.execute(status -> {
+				flushing.countDown();
+				return statsUpdateManager.collectEvents(new Event[] {null});
+			}));
+			assertTrue(flushing.await(10, TimeUnit.SECONDS));
+			assertThrows(TimeoutException.class, () -> flush.get(1, TimeUnit.SECONDS));
+			releaseCollection.countDown();
+			assertTrue(flush.get(10, TimeUnit.SECONDS));
+			assertTrue(collector.get(10, TimeUnit.SECONDS));
+			transaction.executeWithoutResult(status -> {
+				List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+				assertEquals(1, results.size());
+				assertEquals(Duration.ofMinutes(10).toMillis(), results.get(0).getDuration());
+				assertEquals(Integer.valueOf(1), results.get(0).getCurrentOpenSessions());
+			});
+		} finally {
+			releaseCollection.countDown();
+			executor.shutdown();
+			assertTrue(executor.awaitTermination(15, TimeUnit.SECONDS));
+			transaction.executeWithoutResult(status -> db.deleteAll());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
When a user leaves and returns to the same site in one session before Statistics saves its event batch, the new `pres.begin` overwrites the completed visit. A ten-minute visit followed by a return is therefore persisted with zero duration.

Retain the session's presence records for the batch and match an end event to the latest record. Drain and replace the presence map under the same lock used by collection, then pass every retained record to the existing consolidation logic outside the lock. Preserve the existing handling of consecutive begin events without an intervening end.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52842

Validation:
- Added a regression test using the existing Spring/Hibernate wiring and public `StatsUpdateManager` API. Before the fix it failed with `expected: 600000 but was: 0`.
- The regression verifies the completed ten-minute visit survives re-entry, then verifies that ending the return visit in a later batch produces fifteen minutes total and zero open sessions.
- Java 17: `mvn -pl sitestats/sitestats-api,sitestats/sitestats-bundle,sitestats/sitestats-impl-hib,sitestats/sitestats-impl test -Dtest=StatsUpdateManagerTest,PresenceConsolidationTest,PresenceRecordTest -Dsurefire.failIfNoSpecifiedTests=false -q` passed: 54 tests passed, one existing test skipped. Includes overlapping sessions and multi-day presence cases.
- Added a concurrent regression through the real wired service: pause collection before appending a returning visit and start a concurrent flush. The old drain completes despite collection holding its lock; the fixed drain waits, and both visits survive. Verified the test fails before the locking fix and passes afterward.
- `git diff --check` passed.

This addresses a reproduced cause of missing duration; the specific Jira site's event history was unavailable to confirm whether it accounts for every reported zero. It does not reconstruct previously discarded durations. No UI flow changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved site presence tracking when a session leaves and later returns to a site.
  - Completed visit durations are now preserved while new visits are tracked separately.
  - Visit durations accumulate correctly across repeated visits, ensuring session counts and recorded time remain accurate.
  - Improved reliability when visit updates are received while presence data is being processed, preventing records from being lost or overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
