### PR TITLE
SAK-52837 SiteInfo preserve existing participant warnings across redirects

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteInfoTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteInfoTest.java
@@ -83,9 +83,12 @@ class SiteInfoTest extends SakaiUiTestBase {
                 .filter(new Locator.FilterOptions().setHasText("instructor1"));
         assertThat(existingParticipantMessage).containsText("instructor1");
         assertThat(existingParticipantMessage).not().containsText("[Ljava.lang.Object;");
-        page.locator("#officialAccountParticipant").fill("student0011\nstudent0011");
+        page.locator("#officialAccountParticipant").fill("instructor1\nstudent0011\nstudent0011");
         page.locator("#participant-helper form").first().locator("button[type=\"submit\"]").first().click();
         page.waitForLoadState();
+
+        assertThat(existingParticipantMessage).isVisible();
+        assertThat(existingParticipantMessage).containsText("instructor1");
 
         page.locator("#different-role").check(new Locator.CheckOptions().setForce(true));
         page.locator("#participant-helper form").first().locator("button[type=\"submit\"]").first().click();

--- a/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/ParticipantAddController.java
+++ b/site-manage/site-manage-participant-helper/src/java/org/sakaiproject/site/tool/helper/participant/ParticipantAddController.java
@@ -6,8 +6,10 @@
  */
 package org.sakaiproject.site.tool.helper.participant;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.sakaiproject.site.tool.helper.participant.impl.ParticipantDisplayResolver;
 import org.sakaiproject.site.tool.helper.participant.impl.ParticipantMessage;
@@ -23,6 +25,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.RedirectView;
 
 import lombok.Getter;
@@ -62,9 +65,10 @@ public class ParticipantAddController {
     }
 
     @PostMapping("/add")
-    public String submitAdd(@ModelAttribute AddForm form, Model model) {
+    public String submitAdd(@ModelAttribute AddForm form, Model model, RedirectAttributes redirectAttributes) {
         if (handler.submitAdd(form.getCsrfToken(), form.getOfficialAccountParticipant(),
                 form.getNonOfficialAccountParticipant(), ParticipantStatus.fromFormValue(form.getStatusChoice()))) {
+            redirectAttributes.addFlashAttribute("messages", messageViews());
             return "redirect:/roles";
         }
         model.addAttribute("addForm", createAddForm(handler.snapshot()));
@@ -173,13 +177,16 @@ public class ParticipantAddController {
     private String render(Model model, String view, int step) {
         model.addAttribute("siteTitle", handler.getSiteTitle());
         model.addAttribute("step", step);
-        List<ParticipantMessageView> messages = handler.getMessages().stream()
+        model.mergeAttributes(Map.of("messages", messageViews()));
+        return view;
+    }
+
+    private List<ParticipantMessageView> messageViews() {
+        return handler.getMessages().stream()
                 .map(message -> new ParticipantMessageView(
                         messageSource.getMessage(message.getCode(), message.getArgs(), LocaleContextHolder.getLocale()),
                         message.getSeverity()))
                 .toList();
-        model.addAttribute("messages", messages);
-        return view;
     }
 
     private RedirectView doneRedirect(String doneUrl) {
@@ -188,7 +195,7 @@ public class ParticipantAddController {
         return redirectView;
     }
 
-    public record ParticipantMessageView(String text, ParticipantMessage.Severity severity) {
+    public record ParticipantMessageView(String text, ParticipantMessage.Severity severity) implements Serializable {
 
         public String bannerClass() {
             return switch (severity) {

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/ParticipantAddControllerTest.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/ParticipantAddControllerTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ * Licensed under the Educational Community License, Version 2.0.
+ */
+package org.sakaiproject.site.tool.helper.participant;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.sakaiproject.entity.api.ResourceProperties;
+import org.sakaiproject.thread_local.api.ThreadLocalManager;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.sakaiproject.component.api.ServerConfigurationService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sakaiproject.authz.api.AuthzGroup;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.Role;
+import org.sakaiproject.event.api.UsageSessionService;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.sakaiproject.site.tool.helper.participant.impl.ParticipantConstants;
+import org.sakaiproject.site.tool.helper.participant.impl.ParticipantHelperTestConfiguration;
+import org.sakaiproject.tool.api.Session;
+import org.sakaiproject.tool.api.SessionManager;
+import org.sakaiproject.tool.api.ToolSession;
+import org.sakaiproject.user.api.User;
+import org.sakaiproject.user.api.UserDirectoryService;
+import org.sakaiproject.util.api.LocaleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration("src/webapp")
+@ContextConfiguration(classes = {ParticipantHelperWebMvcConfiguration.class, ParticipantHelperTestConfiguration.class})
+public class ParticipantAddControllerTest {
+    @Autowired private WebApplicationContext context;
+    @Autowired private SessionManager sessionManager;
+    @Autowired private SiteService siteService;
+    @Autowired private AuthzGroupService authzGroupService;
+    @Autowired private UserDirectoryService userDirectoryService;
+    @Autowired private LocaleService localeService;
+    private MockMvc mvc;
+    @BeforeClass
+    public static void initializeKernelBoundary() {
+        ComponentManager.testingMode = true;
+    }
+
+    @AfterClass
+    public static void closeKernelBoundary() {
+        ComponentManager.shutdown();
+        ComponentManager.testingMode = false;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        ComponentManager.loadComponent(ServerConfigurationService.class, context.getBean(ServerConfigurationService.class));
+        ComponentManager.loadComponent(SessionManager.class, sessionManager);
+        ComponentManager.loadComponent(ThreadLocalManager.class,
+                context.getBean(ThreadLocalManager.class));
+        mvc = MockMvcBuilders.webAppContextSetup(context).build();
+        when(localeService.getLocaleForCurrentSiteAndUser()).thenReturn(Locale.ENGLISH);
+        Session session = mock(Session.class);
+        ToolSession toolSession = mock(ToolSession.class);
+        Map<String, Object> state = new HashMap<>();
+        state.put(ParticipantConstants.HELPER_SITE_ID_ATTRIBUTE, "test-site");
+        when(toolSession.getAttribute(anyString())).thenAnswer(call -> state.get(call.getArgument(0)));
+        doAnswer(call -> { state.put(call.getArgument(0), call.getArgument(1)); return null; })
+                .when(toolSession).setAttribute(anyString(), any());
+        when(sessionManager.getCurrentSession()).thenReturn(session);
+        when(sessionManager.getCurrentToolSession()).thenReturn(toolSession);
+        Map<String, Object> sessionState = new HashMap<>();
+        sessionState.put(UsageSessionService.SAKAI_CSRF_SESSION_ATTRIBUTE, "token");
+        when(session.getAttribute(anyString())).thenAnswer(call -> sessionState.get(call.getArgument(0)));
+        doAnswer(call -> { sessionState.put(call.getArgument(0), call.getArgument(1)); return null; })
+                .when(session).setAttribute(anyString(), any());
+        Site site = mock(Site.class);
+        when(site.getProperties()).thenReturn(mock(ResourceProperties.class));
+        when(site.getId()).thenReturn("test-site");
+        when(site.getTitle()).thenReturn("Test site");
+        when(site.getType()).thenReturn("project");
+        when(siteService.getSite("test-site")).thenReturn(site);
+        when(siteService.siteReference("test-site")).thenReturn("/site/test-site");
+        when(siteService.allowUpdateSiteMembership("test-site")).thenReturn(true);
+        AuthzGroup realm = mock(AuthzGroup.class);
+        when(realm.getRoles()).thenReturn(Set.of());
+        when(authzGroupService.getAuthzGroup("/site/test-site")).thenReturn(realm);
+        for (String eid : new String[] {"existing", "new-user"}) {
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(eid);
+            when(user.getEid()).thenReturn(eid);
+            when(user.getDisplayId()).thenReturn(eid);
+            when(user.getSortName()).thenReturn(eid);
+            when(userDirectoryService.getUserByEid(eid)).thenReturn(user);
+        }
+        when(site.getUserRole("existing")).thenReturn(mock(Role.class));
+    }
+
+    @Test
+    public void keepsExistingMemberWarningAcrossRoleRedirect() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        mvc.perform(post("/add").header("Sec-Fetch-Site", "same-origin").session(session).param("csrfToken", "token")
+                .param("officialAccountParticipant", "existing\r\nnew-user").param("statusChoice", "active"))
+                .andExpect(status().is3xxRedirection()).andExpect(redirectedUrl("/roles"));
+        MvcResult roles = mvc.perform(get("/roles").session(session)).andExpect(status().isOk()).andReturn();
+        String html = roles.getResponse().getContentAsString();
+        assertTrue(html, html.contains("sak-banner-warn"));
+        assertTrue(html, html.contains("existing"));
+        assertTrue(html, html.contains("new-user"));
+        String refreshed = mvc.perform(get("/roles").session(session))
+                .andExpect(status().isOk()).andReturn().getResponse().getContentAsString();
+        assertFalse(refreshed, refreshed.contains("sak-banner-warn"));
+    }
+}

--- a/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/ParticipantHelperTestConfiguration.java
+++ b/site-manage/site-manage-participant-helper/src/test/java/org/sakaiproject/site/tool/helper/participant/impl/ParticipantHelperTestConfiguration.java
@@ -7,6 +7,10 @@
 package org.sakaiproject.site.tool.helper.participant.impl;
 
 import org.mockito.Mockito;
+import org.sakaiproject.coursemanagement.api.CourseManagementService;
+import org.sakaiproject.tool.api.ToolManager;
+import org.sakaiproject.util.api.LocaleService;
+import org.sakaiproject.thread_local.api.ThreadLocalManager;
 import org.sakaiproject.accountvalidator.api.service.AccountValidationService;
 import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.component.api.ServerConfigurationService;
@@ -40,6 +44,26 @@ public class ParticipantHelperTestConfiguration {
     @Bean(name = "org.sakaiproject.user.api.UserDirectoryService")
     public UserDirectoryService userDirectoryService() {
         return Mockito.mock(UserDirectoryService.class);
+    }
+
+    @Bean(name = "org.sakaiproject.coursemanagement.api.CourseManagementService")
+    public CourseManagementService courseManagementService() {
+        return Mockito.mock(CourseManagementService.class);
+    }
+
+    @Bean
+    public ThreadLocalManager threadLocalManager() {
+        return Mockito.mock(ThreadLocalManager.class);
+    }
+
+    @Bean
+    public ToolManager toolManager() {
+        return Mockito.mock(ToolManager.class);
+    }
+
+    @Bean
+    public LocaleService localeService() {
+        return Mockito.mock(LocaleService.class);
     }
 
     @Bean


### PR DESCRIPTION
When Add Participants contains both an existing site member and a new participant, the parser creates the existing-member warning, but the redirect to Choose Roles discards the request-scoped messages. The existing member silently disappears from the pending additions.

Carry the localized messages through Spring flash attributes and preserve them when rendering the destination page. Make the flashed message records serializable. The warning is consumed on the first GET, so it does not reappear on refresh. Existing membership and participant selection logic are unchanged.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52837

Validation:
- Added a Spring MVC regression test loading the production MVC configuration, real request-scoped handler, internal services, message source, and Thymeleaf templates. It submits an existing member together with a new participant and follows the redirect using the same HTTP session. The warning assertion failed before the fix and passes afterward; refresh also confirms the warning is consumed.
- All 21 participant-helper tests pass with Java 17: `mvn -pl site-manage/site-manage-participant-helper test -q`.
- Updated the existing Site Info Playwright flow to assert the warning after submitting mixed existing/new participants; `mvn -f e2e-tests/pom.xml test-compile -q` passed.
- `git diff --check` passed.
- Live Playwright execution was unavailable because `https://sakai.example` refused connections. The server-side regression renders the actual templates but does not replace a live browser run.

Current master already handles the existing-member-only case; this change closes the mixed-input redirect gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing-participant warnings now remain visible after adding participants and redirecting to the roles page.
  * Warnings clearly identify each participant who is already a member.
  * Participant warnings are cleared when the page is refreshed, preventing stale messages from reappearing.

* **Tests**
  * Added coverage for mixed submissions containing both existing and new participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->