### PR TITLE
SAK-52815 Discussions fix pending message navigation

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumsTest.java
@@ -22,32 +22,19 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import java.util.List;
 import java.util.regex.Pattern;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.sakaiproject.e2e.support.SakaiUiTestBase;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ForumsTest extends SakaiUiTestBase {
 
-    private static String sakaiUrl;
     private static final String PENDING_TITLE = "Pending student conversation";
     private static final String FORUM_TITLE = "Playwright Forum " + System.currentTimeMillis();
     private static final String TOPIC_TITLE = "Playwright Topic " + System.currentTimeMillis();
 
-    @Test
-    @Order(1)
-    void createsSiteWithForums() {
+    private String createSiteWithForumAndTopic() {
         sakai.login("instructor1");
-        sakaiUrl = sakai.createCourse("instructor1", List.of("sakai\\.forums"));
-    }
-
-    @Test
-    @Order(2)
-    void canCreateForumAndTopic() {
-        sakai.login("instructor1");
-        page.navigate(sakaiUrl);
+        String siteUrl = sakai.createCourse("instructor1", List.of("sakai\\.forums"));
+        page.navigate(siteUrl);
         sakai.toolClick("Discussion");
 
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions()
@@ -83,7 +70,7 @@ class ForumsTest extends SakaiUiTestBase {
         }
 
         if (!topicVisible) {
-            page.navigate(sakaiUrl);
+            page.navigate(siteUrl);
             sakai.toolClick("Discussion");
             Locator forumLink = page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(FORUM_TITLE)).first();
             if (forumLink.count() > 0) {
@@ -92,11 +79,13 @@ class ForumsTest extends SakaiUiTestBase {
         }
 
         assertThat(page.getByText(TOPIC_TITLE).first()).isVisible();
+        return siteUrl;
     }
+
     @Test
-    @Order(3)
-    void studentSeesPendingPostWithoutModeratorNavigation() {
-        openTopic("student0011");
+    void pendingNavigationRespectsModeratorPermissions() {
+        String siteUrl = createSiteWithForumAndTopic();
+        openTopic(siteUrl, "student0011");
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions()
                 .setName("Start a New Conversation").setExact(true)).click();
         page.locator("input[id$=df_compose_title]").fill(PENDING_TITLE);
@@ -106,12 +95,8 @@ class ForumsTest extends SakaiUiTestBase {
         assertThat(page.locator(".messagePending").first()).isVisible();
         assertThat(page.getByText("Go to first pending message", new Page.GetByTextOptions().setExact(true))
                 .filter(new Locator.FilterOptions().setVisible(true))).hasCount(0);
-    }
 
-    @Test
-    @Order(4)
-    void moderatorKeepsPendingNavigationAfterMessageIsRead() {
-        openTopic("instructor1");
+        openTopic(siteUrl, "instructor1");
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(PENDING_TITLE).setExact(true)).first().click();
         Locator pendingNavigation = page.getByRole(AriaRole.BUTTON,
                 new Page.GetByRoleOptions().setName("Go to first pending message").setExact(true));
@@ -122,9 +107,9 @@ class ForumsTest extends SakaiUiTestBase {
         assertThat(page.locator(".messagePending").first()).isInViewport();
     }
 
-    private void openTopic(String user) {
+    private void openTopic(String siteUrl, String user) {
         sakai.login(user);
-        page.navigate(sakaiUrl);
+        page.navigate(siteUrl);
         sakai.toolClick("Discussion");
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(FORUM_TITLE).setExact(true)).first().click();
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(TOPIC_TITLE).setExact(true)).first().click();

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumsTest.java
@@ -100,7 +100,7 @@ class ForumsTest extends SakaiUiTestBase {
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions()
                 .setName("Start a New Conversation").setExact(true)).click();
         page.locator("input[id$=df_compose_title]").fill(PENDING_TITLE);
-        sakai.typeCkEditor("dfCompose:df_compose_body", "<p>Please review this pending message.</p>");
+        sakai.typeCkEditor("dfCompose:df_compose_body_inputRichText", "<p>Please review this pending message.</p>");
         page.locator("input[id$=post]").click();
         page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(PENDING_TITLE).setExact(true)).first().click();
         assertThat(page.locator(".messagePending").first()).isVisible();

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumsTest.java
@@ -32,6 +32,7 @@ import org.sakaiproject.e2e.support.SakaiUiTestBase;
 class ForumsTest extends SakaiUiTestBase {
 
     private static String sakaiUrl;
+    private static final String PENDING_TITLE = "Pending student conversation";
     private static final String FORUM_TITLE = "Playwright Forum " + System.currentTimeMillis();
     private static final String TOPIC_TITLE = "Playwright Topic " + System.currentTimeMillis();
 
@@ -55,6 +56,7 @@ class ForumsTest extends SakaiUiTestBase {
             .click();
 
         page.locator("form input[type=\"text\"]:visible").first().fill(FORUM_TITLE);
+        page.locator("input[type=checkbox][id$=moderated]").check();
         page.locator("button[type=\"submit\"]:has-text(\"Save\"), button[type=\"submit\"]:has-text(\"Create\"), input[type=\"submit\"][value*=\"Save\"], input[type=\"submit\"][value*=\"Create\"], .act button:has-text(\"Save\"), .act button:has-text(\"Create\"), .act input[value*=\"Save\"], .act input[value*=\"Create\"]")
             .first()
             .click(new Locator.ClickOptions().setForce(true));
@@ -91,4 +93,41 @@ class ForumsTest extends SakaiUiTestBase {
 
         assertThat(page.getByText(TOPIC_TITLE).first()).isVisible();
     }
+    @Test
+    @Order(3)
+    void studentSeesPendingPostWithoutModeratorNavigation() {
+        openTopic("student0011");
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions()
+                .setName("Start a New Conversation").setExact(true)).click();
+        page.locator("input[id$=df_compose_title]").fill(PENDING_TITLE);
+        sakai.typeCkEditor("dfCompose:df_compose_body", "<p>Please review this pending message.</p>");
+        page.locator("input[id$=post]").click();
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(PENDING_TITLE).setExact(true)).first().click();
+        assertThat(page.locator(".messagePending").first()).isVisible();
+        assertThat(page.getByText("Go to first pending message", new Page.GetByTextOptions().setExact(true))
+                .filter(new Locator.FilterOptions().setVisible(true))).hasCount(0);
+    }
+
+    @Test
+    @Order(4)
+    void moderatorKeepsPendingNavigationAfterMessageIsRead() {
+        openTopic("instructor1");
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(PENDING_TITLE).setExact(true)).first().click();
+        Locator pendingNavigation = page.getByRole(AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Go to first pending message").setExact(true));
+        assertThat(pendingNavigation).isVisible();
+        assertThat(page.locator(".messageNew")).hasCount(0);
+        assertThat(pendingNavigation).isVisible();
+        pendingNavigation.click();
+        assertThat(page.locator(".messagePending").first()).isInViewport();
+    }
+
+    private void openTopic(String user) {
+        sakai.login(user);
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Discussion");
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(FORUM_TITLE).setExact(true)).first().click();
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName(TOPIC_TITLE).setExact(true)).first().click();
+    }
+
 }

--- a/msgcntr/messageforums-app/src/webapp/js/forum.js
+++ b/msgcntr/messageforums-app/src/webapp/js/forum.js
@@ -291,71 +291,43 @@ var instrumentThreads = function(target){
     });
 }
 
-function setupMessageNav(messageType){
-	$('.messagesThreaded tr').each(function(rowIndex){
-		$(this).prop('rowCount',rowIndex)
-		});
-    if ($("." + messageType).size() >= 1) {
-        if (messageType == "messageNew") {
-            tofirst = $("#firstNewItemTitleHolder").text();
-            tonext = $("#nextNewItemTitleHolder").text();
-            last = $("#lastNewItemTitleHolder").text();
-        }
-        else {
-            tofirst = $("#firstPendingItemTitleHolder").text();
-            tonext = $("#nextPendingItemTitleHolder").text();
-            last = $("#lastPendingItemTitleHolder").text();
-        }
-		//go to first new or pending message
-		if ($('#messNavHolder').find('.jumpToNew[rel="setupMessageNav"]').length === 0) {
-			$('#messNavHolder').append("<span class='jumpToNew specialLink' rel='setupMessageNav'><a class='button' href='#" + messageType + "newMess0'>" + tofirst + "</a></span>");
-		}
-        //instrument link targets (clicking on "New" goes to next one, same with "Pending")
-		$("." + messageType).each(function(intIndex){
-            var parentRow = $(this).parents('tr');
-			var parentTable = $(this).parents('table');
-			var totalTableRows =$(parentTable).find('tr').size()
-            $(parentRow).addClass(messageType + 'Next');
-            $(this).after("<a class=\"messageNewAnchor\" name='" + messageType + "newMess" + intIndex + "'> </a>");
-            if (intIndex !== ($("." + messageType).size() - 1)) {
-                $(this).css({
-                    cursor: "pointer"
-                });
-                $(this).prop("title", tonext);
-                $(this).click(function(){
-                    //in message type is "New" find next new by crawling the DOM
-                    // (real next one may have been marked as read, so no longer news)
-                    if (messageType === 'messageNew') {
-                        const thisIndex = parseInt($(parentRow).prop('rowCount')) + 1;
-                        const targetElement = $(parentTable).find('tr').slice(thisIndex, totalTableRows).filter('.messageNewNext').eq(0);
-                        if (targetElement.length) {
-                            targetElement[0].scrollIntoView({ behavior: 'smooth' });$
-                        }
-                    }
-                    // if "Pending" just link directly to next one
-                    else {
-                        // Scroll the target into view using jquery
-                        const targetElement = $("a[name='" +  messageType + "newMess" + (intIndex + 1) + "']");
-                        if (targetElement.length) {
-                            targetElement[0].scrollIntoView({ behavior: 'smooth' });$
-                        }
-                    }
-                });
-                // Scroll the new message into view
-                $('#messNavHolder a').click(function(e) {$
-                    e.preventDefault();$
-                    const targetPosPrep = $(this).attr('href').replace('#','');$
-                    const targetElement = $("a[name='" + targetPosPrep + "']");$
-                    if (targetElement.length) {$
-                        targetElement[0].scrollIntoView({ behavior: 'smooth' });$
-                    }$
-                });$
-            }
-            else {
-                $(this).prop("title", last);
-            }
-        });
-    }
+function setupMessageNav(messageType) {
+    const holder = document.getElementById('messNavHolder');
+    if (!holder) return;
+    const selector = `.${messageType}`;
+    const messages = [...document.querySelectorAll(selector)];
+    const navSelector = `[data-message-type="${messageType}"]`;
+    holder.querySelector(navSelector)?.remove();
+    if (messages.length === 0) return;
+
+    const labelType = messageType === 'messageNew' ? 'New' : 'Pending';
+    const firstLabel = document.getElementById(`first${labelType}ItemTitleHolder`).textContent;
+    const nextLabel = document.getElementById(`next${labelType}ItemTitleHolder`).textContent;
+    const lastLabel = document.getElementById(`last${labelType}ItemTitleHolder`).textContent;
+    const scrollToMessage = message => message?.scrollIntoView({
+        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth'
+    });
+
+    messages.forEach((message, index) => {
+        const isLast = index === messages.length - 1;
+        message.title = isLast ? lastLabel : nextLabel;
+        message.style.cursor = isLast ? '' : 'pointer';
+        message.onclick = isLast ? null : () => {
+            const remaining = [...document.querySelectorAll(selector)];
+            scrollToMessage(remaining[remaining.indexOf(message) + 1]);
+        };
+    });
+
+    const nav = document.createElement('span');
+    nav.className = 'jumpToNew specialLink';
+    nav.dataset.messageType = messageType;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'button';
+    button.textContent = firstLabel;
+    button.onclick = () => scrollToMessage(document.querySelector(selector));
+    nav.append(button);
+    holder.append(nav);
 }
 
 function doAjax(messageId, topicId, self){
@@ -434,14 +406,8 @@ function doAjaxRead(messageId, topicId, self){
         success: function(msg){
             if (msg.match(/SUCCESS/)) {
                 setTimeout(function(){
-					$(self).parents('tr').removeClass('messageNewNext');
 					$(self).parents("div").children("span.messageNew").remove();
 					$(self).parents("div").children("div.messageMetadata").find("span.unreadMsg").removeClass('unreadMsg');
-					$(self).parents("div").parents("div").children('a.messageNewAnchor').remove();
-					// remove "Go to first new message" link if all messages have been marked as "read"
-					if ($('.messagesThreaded').find('a.messageNewAnchor').size() === 0) {
-					    $('.jumpToNew').remove();
-					}
 					//add button
 					if (isMarkAsNotReadValue === "true") {
 						$(self).prepend(

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfFlatView.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfFlatView.jsp
@@ -31,7 +31,9 @@
                 menuLinkSpan.html(menuLink.text());
 
                 setupMessageNav('messageNew');
-                setupMessageNav('messagePending');
+                if (<h:outputText value="#{ForumTool.selectedTopic.isModeratePostings}" />) {
+                    setupMessageNav('messagePending');
+                }
 
             });
 			var markAsNotReadText = "<h:outputText value="#{msgs.cdfm_mark_as_not_read}"/>";

--- a/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThread.jsp
+++ b/msgcntr/messageforums-app/src/webapp/jsp/discussionForum/message/dfViewThread.jsp
@@ -35,7 +35,9 @@
 				menuLinkSpan.addClass('current');
 				menuLinkSpan.html(menuLink.text());
 
-				setupMessageNav('messagePending');
+				if (<h:outputText value="#{ForumTool.selectedTopic.isModeratePostings}" />) {
+					setupMessageNav('messagePending');
+				}
 				setupMessageNav('messageNew');
 				if ($('div.hierItemBlock').length >= 1){
 					$('.itemNav').clone().addClass('specialLink').appendTo('form')


### PR DESCRIPTION
In moderated Discussions, students see an ineffective pending-message navigation control, while a moderator's control can disappear when unread messages are marked read. Pending and unread navigation shared the same control and anchor bookkeeping; unread cleanup could remove both.

Gate pending navigation on the selected topic's moderation permission in thread and flat views. Give pending and unread navigation independent controls and scroll directly to the current message markers. Use native buttons and DOM APIs, support a single pending message, avoid duplicate handlers on repeated setup, and respect reduced motion.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52815

Validation:
- Reproduced the old control disappearing in a Chromium fixture using the actual `forum.js` and Sakai's jQuery version, with only the mark-read HTTP response stubbed.
- Verified independent pending/unread controls, single-pending-message scrolling, pending navigation surviving mark-read cleanup, next-pending scrolling, repeated initialization without duplication, and empty-state cleanup with the changed script.
- Added student/moderator coverage to `ForumsTest`: students retain their Pending label without the moderator control; moderators retain the control after the message is read and can navigate to it.
- Java 17 `mvn -f e2e-tests/pom.xml test-compile -q` passed.
- `node --check` and `git diff --check` passed.
- Live Sakai/Playwright execution was unavailable because `https://sakai.example` refused connections. The isolated browser checks do not validate JSF permission rendering or the full student/instructor workflow; the added E2E flow still needs a run against a deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending-message navigation now appears only in moderated forums.
  * Moderators can continue navigating to the first pending message after opening it.
  * Pending-post navigation is no longer shown when moderation is disabled.
  * Message navigation provides smoother scrolling and respects reduced-motion accessibility preferences.
  * Navigation remains available after messages are marked as read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->