### PR TITLE
SAK-52794 Statistics return report previews to the editor

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SiteStatsTest.java
@@ -199,6 +199,17 @@ class SiteStatsTest extends SakaiUiTestBase {
         page.waitForFunction(siteStatsCanvasHasPixelsScript());
         assertTrue(Boolean.TRUE.equals(page.evaluate(siteStatsCanvasHasPixelsScript())));
         assertNoLegacyReportChartImages();
+
+        page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions().setName(Pattern.compile("^Back$", Pattern.CASE_INSENSITIVE))).click();
+        assertThat(page.locator("#report-editor")).isVisible();
+        assertThat(page.getByLabel("Title")).hasValue(REPORT_TITLE);
+        assertThat(page.getByLabel("Description")).hasValue(REPORT_DESC);
+        assertThat(page.getByLabel("Period:")).hasValue("when-last7days");
+        assertThat(page.getByLabel(Pattern.compile("Presentation", Pattern.CASE_INSENSITIVE)))
+            .hasValue("how-presentation-both");
+        page.reload();
+        assertThat(page.getByLabel("Title")).hasValue(REPORT_TITLE);
     }
 
     @Test

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsController.java
@@ -150,6 +150,14 @@ public class SiteStatsController {
         return "reports/view";
     }
 
+    @GetMapping("/reports/preview/{previewId}/edit")
+    public String editPreview(@PathVariable String previewId, @RequestParam(required = false) String siteId,
+            Model model) {
+        String authorizedSiteId = toolService.reportSite(siteId);
+        commonReportForm(model, authorizedSiteId, toolService.previewReportForm(authorizedSiteId, previewId));
+        return "reports/edit";
+    }
+
     @GetMapping("/reports/preview/{previewId}")
     public String preview(@PathVariable String previewId, @RequestParam(required = false) String siteId, Model model) {
         String authorizedSiteId = toolService.reportSite(siteId);

--- a/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
+++ b/sitestats/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsToolService.java
@@ -212,6 +212,12 @@ public class SiteStatsToolService {
         return SiteStatsReportForm.from(report, userTimeService.getLocalTimeZone().toZoneId());
     }
 
+    public SiteStatsReportForm previewReportForm(String requestedSiteId, String previewId) {
+        String siteId = reportSite(requestedSiteId);
+        ReportDef report = reportAccessService.previewReportDefinition(siteId, previewId);
+        return SiteStatsReportForm.from(report, userTimeService.getLocalTimeZone().toZoneId());
+    }
+
     public CopiedReport copyReport(String requestedSiteId, long reportId) {
         ReportDef report = reportDefinition(requestedSiteId, reportId);
         SiteStatsReportForm form = SiteStatsReportForm.from(report, userTimeService.getLocalTimeZone().toZoneId());

--- a/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/view.html
+++ b/sitestats/sitestats-tool/src/webapp/WEB-INF/templates/reports/view.html
@@ -13,7 +13,7 @@
   <sakai-sitestats-report-panel th:attr="endpoint=${reportEndpoint}">
   </sakai-sitestats-report-panel>
   <div class="d-flex flex-wrap gap-2 mt-3 noprint">
-    <a class="btn btn-link" th:href="@{/reports(siteId=${siteId})}"
+    <a class="btn btn-link" th:href="${preview} ? @{/reports/preview/{id}/edit(id=${previewId},siteId=${siteId})} : @{/reports(siteId=${siteId})}"
        th:text="#{report_back}">Back to reports</a>
     <th:block th:if="${preview}">
       <a class="btn btn-link"


### PR DESCRIPTION
After Reports → Add → Generate report, Back currently returns to the report list and leaves the unsaved editor behind. Return previews to the report editor using the existing preview definition, preserving the title, description, and report settings. Saved reports continue to return to the report list.

The editor lookup uses the existing site/user authorization and preview cache, including its existing expiration. No additional session state or persistence is introduced.

Validation:
- 37 Statistics API/tool tests passed using Java 17.
- Rendered the actual Thymeleaf navigation: the preview Back assertion fails on upstream/master and passes with the fix; the saved-report Back link also passes.
- Extended SiteStatsTest to check Back restores the editor fields and survives refresh; Playwright test compilation passed. Live browser execution was unavailable because https://sakai.example refused connections.

[SAK-52794](https://sakaiproject.atlassian.net/browse/SAK-52794)


[SAK-52794]: https://sakaiproject.atlassian.net/browse/SAK-52794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to return from a generated report to its report editor.
  - Report editor settings—including title, description, reporting period, and presentation options—are restored when returning from a preview.
  - Report titles remain preserved after reloading the editor.

- **Bug Fixes**
  - Updated report navigation so users return to the appropriate preview editor when applicable, or to the reports list otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->