### PR TITLE
SAK-52884 Sitestats Fix presence consolidation issues across multiple sessions and day boundaries

### DIFF
--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/PresenceConsolidation.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/PresenceConsolidation.java
@@ -155,6 +155,7 @@ public class PresenceConsolidation {
     public Duration getDuration() {
         return records.stream()
                 .map(Presence::getDuration)
+                .filter(duration -> !duration.isNegative())
                 .reduce(Duration.ZERO, (subtotalDuration, duration) -> subtotalDuration.plus(duration));
     }
 

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -424,17 +424,13 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 				// do update job
 				isIdle = false;
 				long startTime = System.currentTimeMillis();
-				int eventCount = collectThreadQueue.size();
-				if(eventCount > 0) {
-					//long startTime2 = System.currentTimeMillis();
-					while(collectThreadQueue.size() > 0){
+				TransactionTemplate tx = new TransactionTemplate(transactionManager);
+				tx.execute(status -> {
+					while (collectThreadQueue.size() > 0) {
 						preProcessEvent(collectThreadQueue.remove(0));
 					}
-					//long endTime2 = System.currentTimeMillis();
-					//log.debug("Time spent pre-processing " + eventCount + " event(s): " + (endTime2-startTime2) + " ms");
-				}
-				TransactionTemplate tx = new TransactionTemplate(transactionManager);
-				tx.execute(status -> doUpdateConsolidatedEvents());
+					return doUpdateConsolidatedEvents();
+				});
 				isIdle = true;
 				totalTimeInEventProcessing += (System.currentTimeMillis() - startTime);
 

--- a/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
+++ b/sitestats/sitestats-impl/src/java/org/sakaiproject/sitestats/impl/StatsUpdateManagerImpl.java
@@ -515,7 +515,8 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 			}
 			if(!isCollectAdminEvents() && ("admin").equals(userId)){
 				return;
-			}if(!statsManager.isShowAnonymousAccessEvents() && EventTrackingService.UNKNOWN_USER.equals(userId)){
+			}
+			if(!statsManager.isShowAnonymousAccessEvents() && EventTrackingService.UNKNOWN_USER.equals(userId)){
 				return;
 			}
 			
@@ -590,7 +591,7 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 			return;
 
 		Date date = getTruncatedDate(dateTime);
-		// update		
+		// update
 		if(isRegisteredEvent(eventId) && !StatsManager.SITEVISITEND_EVENTID.equals(eventId)){
 
 			// add to eventStatMap
@@ -721,9 +722,13 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 					addToLessonBuilderStatMap(key, userId, siteId, resourceRef, pageId, lessonBuilderAction, date);
 				}
 			}
-		} else if(StatsManager.SITEVISIT_EVENTID.equals(eventId)){
+		} else if (StatsManager.SITEVISIT_EVENTID.equals(eventId)) {
 			String visitsKey = siteId + date;
-			SitePresenceKey sitePresenceKey = SitePresenceKey.builder().siteId(siteId).userId(userId).sessionId(sessionId).build();
+			SitePresenceKey sitePresenceKey = SitePresenceKey.builder()
+					.siteId(siteId)
+					.userId(userId)
+					.sessionId(sessionId)
+					.build();
 			lock.lock();
 			try{
 				// Populate visits map
@@ -741,46 +746,67 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 				UniqueVisitsKey keyUniqueVisits = new UniqueVisitsKey(siteId, date);
 				uniqueVisitsMap.put(keyUniqueVisits, Integer.valueOf(1));
 
-				// Populate presence map with begin events
-				if(statsManager.getEnableSitePresences()) {
+				// populate presence map with begin events
+				if (statsManager.getEnableSitePresences()) {
+					// get the saved begin date if there is an open session
+					Session session = getHibernateTemplate().getSessionFactory().getCurrentSession();
+					Integer savedOpenSessions = doGetOpenSessions(session, siteId, userId);
+					Optional<Instant> savedBegin = doGetSavedBegin(session, siteId, userId);
+
+					Instant beginInstant = dateTime.toInstant();
+					if (savedOpenSessions > 0 && savedBegin.isPresent()
+						&& presencesMap.values().stream()
+							.flatMap(Collection::stream)
+							.noneMatch(p -> p.getSiteId().equals(siteId)
+								&& p.getUserId().equals(userId)
+								&& p.getEnd() != null
+								&& !p.getEnd().isBefore(savedBegin.get()))) {
+						beginInstant = savedBegin.get();
+					}
+
 					SitePresenceRecord beginningPresence = SitePresenceRecord.builder()
 							.siteId(siteId)
 							.userId(userId)
-							.begin(dateTime.toInstant())
+							.begin(beginInstant)
 							.build();
-					List<SitePresenceRecord> sessionPresences = presencesMap.computeIfAbsent(sitePresenceKey, key -> new ArrayList<>());
 					// Preserve completed visits when the same session returns before the batch is saved.
-					if (!sessionPresences.isEmpty() && sessionPresences.get(sessionPresences.size() - 1).isBeginning()) {
-						sessionPresences.remove(sessionPresences.size() - 1);
-					}
-					sessionPresences.add(beginningPresence);
+					presencesMap.computeIfAbsent(sitePresenceKey, key -> new ArrayList<>()).add(beginningPresence);
 				}
 			}finally{
 				lock.unlock();
 			}
-		}else if(StatsManager.SITEVISITEND_EVENTID.equals(eventId) && statsManager.getEnableSitePresences()){
+		} else if(StatsManager.SITEVISITEND_EVENTID.equals(eventId) && statsManager.getEnableSitePresences()) {
 			// site presence ended
-			SitePresenceKey sitePresenceKey = SitePresenceKey.builder().siteId(siteId).userId(userId).sessionId(sessionId).build();
+			SitePresenceKey sitePresenceKey = SitePresenceKey.builder()
+					.siteId(siteId)
+					.userId(userId)
+					.sessionId(sessionId)
+					.build();
 			lock.lock();
 			try{
-				// Populate presence map with end events
-				List<SitePresenceRecord> sessionPresences = presencesMap.get(sitePresenceKey);
-				SitePresenceRecord existingPresence = sessionPresences == null ? null : sessionPresences.get(sessionPresences.size() - 1);
-				if(existingPresence != null) {
+				List<SitePresenceRecord> sessionPresences = presencesMap.computeIfAbsent(sitePresenceKey, key -> new ArrayList<>());
+				Optional<SitePresenceRecord> openPresence = sessionPresences.stream()
+						.filter(presence -> presence.getEnd() == null)
+						.findFirst();
+				if (openPresence.isPresent()) {
+					SitePresenceRecord existingPresence = openPresence.get();
 					existingPresence.setEnd(dateTime.toInstant());
+					log.debug("Updated existing presence with 'end': {}", existingPresence);
 				} else {
+					// no open begin found: create an independent end (previous open session)
 					SitePresenceRecord endingPresence = SitePresenceRecord.builder()
 							.siteId(siteId)
 							.userId(userId)
 							.end(dateTime.toInstant())
 							.build();
-					presencesMap.computeIfAbsent(sitePresenceKey, key -> new ArrayList<>()).add(endingPresence);
+					sessionPresences.add(endingPresence);
+					log.debug("Registered independent 'end' presence with key {}: {}", sitePresenceKey, endingPresence);
 				}
 			}finally{
 				lock.unlock();
 			}
 		}
-		
+
 	}
 
 	private void addToLessonBuilderStatMap(String key, String userId, String siteId, String pageRef, long pageId, String action, Date date) {
@@ -1477,24 +1503,32 @@ public class StatsUpdateManagerImpl extends HibernateDaoSupport implements Runna
 			presenceConsolidation.addAll(completeUserSitePresences);
 
 			Map<Instant, PresenceConsolidation> consolidationByDay = presenceConsolidation.mapByDay();
-			consolidationByDay.forEach((day, consodation) -> {
-				Long durationMillis = consodation.getDuration().toMillis();
-				// TODO: log the duration we are saving here
-				log.debug("k{} saving duration for day {}: {}", key, day, durationMillis);
-				log.debug("consolidation: {}", consodation);
+			consolidationByDay.keySet().stream()
+    			.sorted()
+				.forEach(day -> {
+        			PresenceConsolidation consodation = consolidationByDay.get(day);
+					Long durationMillis = consodation.getDuration().toMillis();
+					// TODO: log the duration we are saving here
+					log.debug("k{} saving duration for day {}: {}", key, day, durationMillis);
+					log.debug("consolidation: {}", consodation);
 
-				SitePresence sitePresence = SitePresenceImpl.builder()
-						.siteId(siteId)
-						.userId(userId)
-						.duration(durationMillis)
-						.date(Date.from(day))
-						.lastVisitStartTime(lastStart.map(Date::from).orElse(null))
-						.currentOpenSessions(currentOpenSessions < 0 ? 0 : currentOpenSessions)
-						.build();
+					// If there are multiple days, only the most recent day has currentOpenSessions calculated, previous days are set to 0
+					int currentOpenSessionsForDay = day.equals(Collections.max(consolidationByDay.keySet()))
+							? (currentOpenSessions < 0 ? 0 : currentOpenSessions)
+							: 0;
 
-				doUpdateSitePresence(session, sitePresence);
-				doUpdateSitePresenceTotal(session, sitePresence);
-			});
+					SitePresence sitePresence = SitePresenceImpl.builder()
+							.siteId(siteId)
+							.userId(userId)
+							.duration(durationMillis)
+							.date(Date.from(day))
+							.lastVisitStartTime(lastStart.map(Date::from).orElse(null))
+							.currentOpenSessions(currentOpenSessionsForDay)
+							.build();
+
+					doUpdateSitePresence(session, sitePresence);
+					doUpdateSitePresenceTotal(session, sitePresence);
+				});
 
 			// There might be beginning presences on a date that was not saved above, so save them separately
 			List<SitePresenceRecord> unsavedBeginningPresences = validUserSitePresences.stream()

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/StatsUpdateManagerTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -79,10 +79,10 @@ import org.sakaiproject.util.ResourceLoader;
 import org.springframework.aop.framework.Advised;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.test.context.junit4.AbstractTransactionalJUnit4SpringContextTests;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -94,13 +94,13 @@ import java.time.ZoneId;
 public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringContextTests {
 
 	@Autowired private DB db;
-	@Autowired private PlatformTransactionManager transactionManager;
 	@Autowired private MemoryService memoryService;
 	@Autowired private ReportManager reportManager;
 	@Autowired private ResourceLoader resourceLoader;
 	@Autowired private SiteService siteService;
 	@Autowired private StatsManager statsManager;
 	@Autowired private StatsUpdateManager statsUpdateManager;
+	@Autowired private PlatformTransactionManager transactionManager;
 
 	@Before
 	public void onSetUp() throws Exception {
@@ -549,7 +549,7 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		//     0    20    40    60
 		//                    eval
 		// p1: b----------e
-		// p2:                       
+		// p2:
 		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
@@ -574,7 +574,7 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		//     0    20    40    60
 		//        eval        eval
 		// p1: b----------e
-		// p2:                       
+		// p2:
 		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
@@ -629,6 +629,35 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testSuccessiveSitePresencesSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for successive presences
+		//     0    20    40    60    80    100   120    140
+		//                                              eval
+		// p1: b----------e
+		// p2:                        b-------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testSuccessiveSitePresencesInterEvaluationCaseA() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -646,6 +675,53 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
 		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
 				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(40, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(40, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testSuccessiveSitePresencesInterEvaluationCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for successive presences
+		//     0    20    40    60    80    100   120    140
+		//                    eval         eval         eval
+		// p1: b----------e
+		// p2:                        b-------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 
 		// Evaluate at 60 seconds
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End)));
@@ -723,6 +799,129 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testSuccessiveSitePresencesInterEvaluationCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for successive presences
+		//     0    20    40    60    80    100   120    140
+		//        eval        eval                      eval
+		// p1: b----------e
+		// p2:                        b-------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(40, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testSuccessiveSitePresencesInterEvaluationCaseC() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for successive presences
+		//     0    20    40    60    80    100   120    140
+		//        eval                                  eval
+		// p1: b----------e
+		// p2:                        b-------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2Begin, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testSuccessiveSitePresencesInterEvaluationCaseCSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for successive presences
+		//     0    20    40    60    80    100   120    140
+		//        eval                                  eval
+		// p1: b----------e
+		// p2:                        b-------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2Begin, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testOverlappingSitePresences() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -752,6 +951,35 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testOverlappingSitePresencesSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60   80
+		//                         eval
+		// p1: b-----------e
+		// p2:       b-----------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(20, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(60, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 80 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin, presence1End, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(1, ChronoUnit.MINUTES).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testOverlappingSitePresencesInterEvaluationCaseA() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -769,6 +997,62 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
 		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
 				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(2), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresencesInterEvaluationCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100   120   140
+		//        eval        eval        eval        eval
+		// p1: b-----------------------e
+		// p2:             b-----------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 
 		// Evaluate at 20 seconds
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
@@ -855,6 +1139,53 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testOverlappingSitePresencesInterEvaluationCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100   120   140
+		//        eval                    eval        eval
+		// p1: b-----------------------e
+		// p2:             b-----------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testOverlappingSitePresencesInterEvaluationCaseC() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -893,6 +1224,129 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 
 		// Evaluate at 140 seconds
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresencesInterEvaluationCaseCSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100   120   140
+		//        eval        eval                    eval
+		// p1: b-----------------------e
+		// p2:             b-----------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(2), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresencesInterEvaluationCaseD() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100   120   140
+		//        eval                                eval
+		// p1: b-----------------------e
+		// p2:             b-----------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresencesInterEvaluationCaseDSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100   120   140
+		//        eval                                eval
+		// p1: b-----------------------e
+		// p2:             b-----------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence1End, presence2End)));
 		results = db.getResultsForClass(SitePresenceImpl.class);
 		assertEquals(1, results.size());
 		result = results.get(0);
@@ -941,7 +1395,46 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
-	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseAInterEvaluation() throws InterruptedException {
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//                                                                                            eval
+		// p1: b-----------------------e
+		// p2:            b------------------------e
+		// p3:                                                b------------e
+		// p4:                                                                        b------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin, presence1End, presence2End, presence3Begin, presence3End, presence4Begin, presence4End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseAInterEvaluationCaseA() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
 
@@ -968,6 +1461,108 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_D_ID);
 		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
 				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_D_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(2), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+
+		// Evaluate at 180 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence3Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(120, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 220 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence3End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(160, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+
+		// Evaluate at 160 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence4Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(160, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence4End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseAInterEvaluationCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//        eval        eval        eval        eval        eval        eval        eval        eval
+		// p1: b-----------------------e
+		// p2:            b------------------------e
+		// p3:                                                b------------e
+		// p4:                                                                        b------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 
 		// Evaluate at 20 seconds
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
@@ -1043,6 +1638,102 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseAInterEvaluationCaseB() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//        eval                                                                                eval
+		// p1: b-----------------------e
+		// p2:            b------------------------e
+		// p3:                                                b------------e
+		// p4:                                                                        b------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_C_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_C_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_D_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_D_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence1End, presence2End, presence3Begin, presence3End, presence4Begin, presence4End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseAInterEvaluationCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//        eval                                                                                eval
+		// p1: b-----------------------e
+		// p2:            b------------------------e
+		// p3:                                                b------------e
+		// p4:                                                                        b------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence1End, presence2End, presence3Begin, presence3End, presence4Begin, presence4End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseB() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -1082,7 +1773,46 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
-	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseBInterEvaluation() throws InterruptedException {
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//                                                                                            eval
+		// p1: b-----------e
+		// p2:                        b------------e
+		// p2:                                               b-------------------------e
+		// p3:                                                           b-------------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin, presence1End, presence2End, presence3Begin, presence3End, presence4Begin, presence4End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseBInterEvaluationCaseA() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
 
@@ -1184,6 +1914,204 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseBInterEvaluationCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//        eval        eval        eval        eval        eval        eval        eval        eval
+		// p1: b-----------e
+		// p2:                        b------------e
+		// p2:                                               b-------------------------e
+		// p3:                                                           b-------------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(40, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(40, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 140 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+
+		// Evaluate at 180 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence3Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 220 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence4Begin)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(2), result.getCurrentOpenSessions());
+
+		// Evaluate at 260 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence3End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(160, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence4End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseBInterEvaluationCaseB() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//        eval                                                                                eval
+		// p1: b-----------e
+		// p2:                        b------------e
+		// p2:                                               b-------------------------e
+		// p3:                                                           b-------------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_C_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_C_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_D_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_D_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2Begin, presence2End, presence3Begin, presence4Begin, presence3End, presence4End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testCombinedOverlappingAndSuccessiveSitePresencesCaseBInterEvaluationCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping and successive presences
+		//     0    20    40    60    80   100   120   140   160   180   200   220   240   260   280   300
+		//        eval                                                                                eval
+		// p1: b-----------e
+		// p2:                        b------------e
+		// p2:                                               b-------------------------e
+		// p3:                                                           b-------------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(120, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3Begin = statsUpdateManager.buildEvent(Date.from(base.plus(160, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence3End = statsUpdateManager.buildEvent(Date.from(base.plus(240, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4Begin = statsUpdateManager.buildEvent(Date.from(base.plus(200, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence4End = statsUpdateManager.buildEvent(Date.from(base.plus(280, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 300 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2Begin, presence2End, presence3Begin, presence3End, presence4Begin, presence4End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(200, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testTrickyOverlappingSitePresences() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -1213,6 +2141,35 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testTrickyOverlappingSitePresencesSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100
+		//                                eval
+		// p1: b-----------------------e
+		// p2:       b-----e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(20, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testTrickyOverlappingSitePresencesInterEvaluationCaseA() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -1230,6 +2187,44 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
 		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(60, ChronoUnit.SECONDS)),
 				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 20 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2Begin, presence2End, presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testTrickyOverlappingSitePresencesInterEvaluationCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100
+		//        eval                    eval
+		// p1: b-----------------------e
+		// p2:            b------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(60, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 
 		// Evaluate at 20 seconds
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin)));
@@ -1289,6 +2284,44 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testTrickyOverlappingSitePresencesInterEvaluationCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100
+		//              eval              eval
+		// p1: b-----------------------e
+		// p2:       b----------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(20, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(60, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 40 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(2), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End, presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testTrickyOverlappingSitePresencesInterEvaluationCaseC() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -1327,15 +2360,52 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testTrickyOverlappingSitePresencesInterEvaluationCaseCSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for overlapping presences
+		//     0    20    40    60    80   100
+		//                    eval        eval
+		// p1: b-----------------------e
+		// p2:       b-----e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(80, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(20, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(40, ChronoUnit.SECONDS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 60 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(40, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(1), result.getCurrentOpenSessions());
+
+		// Evaluate at 100 seconds
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		result = results.get(0);
+		assertEquals(FakeData.USER_A_ID, result.getUserId());
+		assertEquals(Duration.of(80, ChronoUnit.SECONDS).toMillis(), result.getDuration());
+		assertEquals(Integer.valueOf(0), result.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testSitePresenceTwoDays() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
 
 		// Create events for one presences
-		//     0    24    48	72    
+		//     0    24    48    72
 		//                    eval
 		// p1: b----------e
-		// p2:                       
 		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(48, ChronoUnit.HOURS)),
@@ -1373,6 +2443,39 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
 		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
 				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 42 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(18, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testSuccessiveSitePresencesTwoDaysSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42
+		//                                            eval
+		// p1: b-----------e
+		// p2:                  b------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(12, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(18, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 
 		// Evaluate at 42 hours
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
@@ -1431,6 +2534,48 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testSuccessiveSitePresencesTwoDaysInterEvaluationSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42
+		//                    eval                    eval
+		// p1: b-----e
+		// p2:             b------------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(6, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(12, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 18 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(6, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(1), resultFirstDay.getCurrentOpenSessions());
+
+		// Evaluate at 42 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(18, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testOverlappingSitePresenceTwoDays() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -1464,7 +2609,40 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
-	public void testOverlappingSitePresenceTwoDaysInterEvaluation() throws InterruptedException {
+	public void testOverlappingSitePresenceTwoDaysSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42
+		//                                            eval
+		// p1: b-----------------------------e
+		// p2:                  b------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(30, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(18, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 42 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresenceTwoDaysInterEvaluationCaseA() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
 
@@ -1506,6 +2684,140 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 	}
 
 	@Test
+	public void testOverlappingSitePresenceTwoDaysInterEvaluationCaseASameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42    48
+		//                    eval                          eval
+		// p1: b-----------------------------------e
+		// p2:            b------------------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(12, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(42, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 18 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(2), resultFirstDay.getCurrentOpenSessions());
+
+		// Evaluate at 48 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(18, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresenceTwoDaysInterEvaluationCaseB() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42    48    54
+		//                                      eval              eval
+		// p1: b-----------------------------------------e
+		// p2:                              b------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(42, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(30, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(48, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 36 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(2), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(2), resultSecondDay.getCurrentOpenSessions());
+
+		// Evaluate at 54 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testOverlappingSitePresenceTwoDaysInterEvaluationCaseBSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42    48    54
+		//                                      eval              eval
+		// p1: b-----------------------------------------e
+		// p2:                              b------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(42, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(30, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(48, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 36 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(2), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(2), resultSecondDay.getCurrentOpenSessions());
+
+		// Evaluate at 52 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
 	public void testTrickyOverlappingSitePresenceTwoDays() throws InterruptedException {
 		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
 		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
@@ -1523,6 +2835,39 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
 		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(30, ChronoUnit.HOURS)),
 				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_B_ID);
+
+		// Evaluate at 42 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testTrickyOverlappingSitePresenceTwoDaysSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42
+		//                                            eval
+		// p1: b-----------------------------------e
+		// p2:            b------------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(12, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(30, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
 
 		// Evaluate at 42 hours
 		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence1End, presence2Begin, presence2End)));
@@ -1578,6 +2923,110 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
 		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
 		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@Test
+	public void testTrickyOverlappingSitePresenceTwoDaysInterEvaluationSameSessionId() throws InterruptedException {
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 3, 20, 0, 0, 0, 0);
+		Instant base = fixedDateTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		// Create events for one presences
+		//     0     6    12    18    24    30    36    42
+		//                    eval                    eval
+		// p1: b-----------------------------------e
+		// p2:            b------------e
+		final Event presence1Begin = statsUpdateManager.buildEvent(Date.from(base),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence1End = statsUpdateManager.buildEvent(Date.from(base.plus(36, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2Begin = statsUpdateManager.buildEvent(Date.from(base.plus(12, ChronoUnit.HOURS)),
+				StatsManager.SITEVISIT_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+		final Event presence2End = statsUpdateManager.buildEvent(Date.from(base.plus(24, ChronoUnit.HOURS)),
+				StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, FakeData.SESSION_A_ID);
+
+		// Evaluate at 18 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1Begin, presence2Begin)));
+		List<SitePresenceImpl> results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, results.size());
+		SitePresenceImpl resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(0, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(2), resultFirstDay.getCurrentOpenSessions());
+
+		// Evaluate at 42 hours
+		assertTrue(statsUpdateManager.collectEvents(List.of(presence1End, presence2End)));
+		results = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(2, results.size());
+		resultFirstDay = results.get(0);
+		assertEquals(FakeData.USER_A_ID, resultFirstDay.getUserId());
+		assertEquals(Duration.of(24, ChronoUnit.HOURS).toMillis(), resultFirstDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultFirstDay.getCurrentOpenSessions());
+		SitePresenceImpl resultSecondDay = results.get(1);
+		assertEquals(FakeData.USER_A_ID, resultSecondDay.getUserId());
+		assertEquals(Duration.of(12, ChronoUnit.HOURS).toMillis(), resultSecondDay.getDuration());
+		assertEquals(Integer.valueOf(0), resultSecondDay.getCurrentOpenSessions());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSitePresencesExistingPresence() throws InterruptedException {
+		// #3 Test: one pres.end (with one pres.begin already on db)
+		// insert related pres.begin directly on db
+		Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		long firstDuration = 10000;
+		SitePresence sp1 = new SitePresenceImpl();
+		sp1.setSiteId(FakeData.SITE_A_ID);
+		sp1.setDate(Date.from(now));
+		sp1.setUserId(FakeData.USER_A_ID);
+		sp1.setDuration(firstDuration);
+		sp1.setLastVisitStartTime(Date.from(now));
+		db.insertObject(sp1);
+		assertTrue(db.getResultsForClass(SitePresenceImpl.class).size() == 1);
+		// generate pres.end for processing in SST
+		// give it time before ending presence
+		Thread.sleep(1100);
+		Instant now2 = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		long secondDuration = now2.toEpochMilli() - now.toEpochMilli();
+		final Event eSV5e = statsUpdateManager.buildEvent(Date.from(now2), StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, "session-id-a");
+		assertTrue(statsUpdateManager.collectEvents(Arrays.asList(eSV5e)));
+		List<SitePresenceImpl> r1 = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, r1.size());
+		SitePresence es1 = r1.get(0);
+		assertEquals(FakeData.SITE_A_ID, es1.getSiteId());
+		assertEquals(eSV5e.getUserId(), es1.getUserId());
+		long totalDuration = es1.getDuration();
+		assertTrue(totalDuration == firstDuration + secondDuration);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSitePresencesExistingPresenceWithNoDuration() throws InterruptedException {
+		// #4 Test: one pres.end (with one pres.begin already on db, with duration = 0)
+		// insert related pres.begin directly on db
+		Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		long firstDuration = 0;
+		SitePresence sp1 = new SitePresenceImpl();
+		sp1.setSiteId(FakeData.SITE_A_ID);
+		sp1.setDate(Date.from(now));
+		sp1.setUserId(FakeData.USER_A_ID);
+		sp1.setDuration(firstDuration);
+		sp1.setLastVisitStartTime(Date.from(now));
+		db.insertObject(sp1);
+		assertTrue(db.getResultsForClass(SitePresenceImpl.class).size() == 1);
+		// generate pres.end for processing in SST
+		// give it time before ending presence
+		Thread.sleep(1100);
+		Instant now2 = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+		long secondDuration = now2.toEpochMilli() - now.toEpochMilli();
+		final Event eSV6e = statsUpdateManager.buildEvent(Date.from(now2), StatsManager.SITEVISITEND_EVENTID, "/presence/"+FakeData.SITE_A_ID+PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, "session-id-a");
+		assertTrue(statsUpdateManager.collectEvents(Arrays.asList(eSV6e)));
+		List<SitePresenceImpl> r1 = db.getResultsForClass(SitePresenceImpl.class);
+		assertEquals(1, r1.size());
+		SitePresence es1 = r1.get(0);
+		assertEquals(FakeData.SITE_A_ID, es1.getSiteId());
+		assertEquals(eSV6e.getUserId(), es1.getUserId());
+		long totalDuration = es1.getDuration();
+		assertTrue(totalDuration == firstDuration + secondDuration);
 	}
 
 	@Test
@@ -1667,68 +3116,6 @@ public class StatsUpdateManagerTest extends AbstractTransactionalJUnit4SpringCon
 		assertEquals(Integer.valueOf(0), results.get(0).getCurrentOpenSessions());
 	}
 
-	@SuppressWarnings("unchecked")
-	@Test
-	public void testSitePresencesExistingPresence() throws InterruptedException {
-		// #3 Test: one pres.end (with one pres.begin already on db)
-		// insert related pres.begin directly on db
-		Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-		long firstDuration = 10000;
-		SitePresence sp1 = new SitePresenceImpl();
-		sp1.setSiteId(FakeData.SITE_A_ID);
-		sp1.setDate(Date.from(now));
-		sp1.setUserId(FakeData.USER_A_ID);
-		sp1.setDuration(firstDuration);
-		sp1.setLastVisitStartTime(Date.from(now));
-		db.insertObject(sp1);
-		assertTrue(db.getResultsForClass(SitePresenceImpl.class).size() == 1);
-		// generate pres.end for processing in SST
-		// give it time before ending presence
-		Thread.sleep(1100);
-		Instant now2 = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-		long secondDuration = now2.toEpochMilli() - now.toEpochMilli();
-		final Event eSV5e = statsUpdateManager.buildEvent(Date.from(now2), StatsManager.SITEVISITEND_EVENTID, "/presence/" + FakeData.SITE_A_ID + PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, "session-id-a");
-		assertTrue(statsUpdateManager.collectEvents(Arrays.asList(eSV5e)));
-		List<SitePresenceImpl> r1 = db.getResultsForClass(SitePresenceImpl.class);
-		assertEquals(1, r1.size());
-		SitePresence es1 = r1.get(0);
-		assertEquals(FakeData.SITE_A_ID, es1.getSiteId());
-		assertEquals(eSV5e.getUserId(), es1.getUserId());
-		long totalDuration = es1.getDuration();
-		assertTrue(totalDuration == firstDuration + secondDuration);
-	}
-
-	@SuppressWarnings("unchecked")
-	@Test
-	public void testSitePresencesExistingPresenceWithNoDuration() throws InterruptedException {
-		// #4 Test: one pres.end (with one pres.begin already on db, with duration = 0)
-		// insert related pres.begin directly on db
-		Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-		long firstDuration = 0;
-		SitePresence sp1 = new SitePresenceImpl();
-		sp1.setSiteId(FakeData.SITE_A_ID);
-		sp1.setDate(Date.from(now));
-		sp1.setUserId(FakeData.USER_A_ID);
-		sp1.setDuration(firstDuration);
-		sp1.setLastVisitStartTime(Date.from(now));
-		db.insertObject(sp1);
-		assertTrue(db.getResultsForClass(SitePresenceImpl.class).size() == 1);
-		// generate pres.end for processing in SST
-		// give it time before ending presence
-		Thread.sleep(1100);
-		Instant now2 = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-		long secondDuration = now2.toEpochMilli() - now.toEpochMilli();
-		final Event eSV6e = statsUpdateManager.buildEvent(Date.from(now2), StatsManager.SITEVISITEND_EVENTID, "/presence/"+FakeData.SITE_A_ID+PresenceService.PRESENCE_SUFFIX, null, FakeData.USER_A_ID, "session-id-a");
-		assertTrue(statsUpdateManager.collectEvents(Arrays.asList(eSV6e)));
-		List<SitePresenceImpl> r1 = db.getResultsForClass(SitePresenceImpl.class);
-		assertEquals(1, r1.size());
-		SitePresence es1 = r1.get(0);
-		assertEquals(FakeData.SITE_A_ID, es1.getSiteId());
-		assertEquals(eSV6e.getUserId(), es1.getUserId());
-		long totalDuration = es1.getDuration();
-		assertTrue(totalDuration == firstDuration + secondDuration);
-	}
-	
 	// Test (remaining) CustomEventImpl fields
 	public void testCustomEventImpl() {
 		CustomEventImpl e1 = new CustomEventImpl(new Date(), FakeData.EVENT_CHATNEW, "/chat/msg/"+FakeData.SITE_A_ID, FakeData.SITE_A_ID, FakeData.USER_A_ID, "session-id-a", '-');

--- a/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/data/FakeData.java
+++ b/sitestats/sitestats-impl/src/test/org/sakaiproject/sitestats/test/data/FakeData.java
@@ -44,13 +44,13 @@ public class FakeData {
 	public final static int						SITE_C_USER_COUNT	= 2002;
 	
 	// USERs
-	public final static String					USER_A_ID			= "user-a";
-	public final static String					USER_B_ID			= "user-b";
 	public final static String					USER_ID_PREFIX		= "user-";
+	public final static String					USER_A_ID			= USER_ID_PREFIX  + "a";
+	public final static String					USER_B_ID			= USER_ID_PREFIX  + "b";
 
 	// SESSIONs
 	public final static String					SESSION_ID_PREFIX		= "session-id-";
-	public final static String					SESSION_A_ID			= SESSION_ID_PREFIX + "a";
+	public final static String					SESSION_A_ID			= SESSION_ID_PREFIX  + "a";
 	public final static String					SESSION_B_ID			= SESSION_ID_PREFIX  + "b";
 	public final static String					SESSION_C_ID			= SESSION_ID_PREFIX  + "c";
 	public final static String					SESSION_D_ID			= SESSION_ID_PREFIX  + "d";


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected presence duration totals by excluding invalid negative durations.
  - Preserved open presence sessions across batch saves for more accurate tracking.
  - Improved session closure handling when multiple open presence records exist.
  - Corrected daily presence consolidation so current open-session counts appear on the latest day and earlier days remain accurate.
  - Improved update reliability by processing presence events and consolidated statistics together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->