### PR TITLE
SAK-52877 T&Q Hot Spot scoring uses the marker's top-left instead of the student's click

### DIFF
--- a/samigo/samigo-app/src/webapp/js/jquery.dynamiclist.student.js
+++ b/samigo/samigo-app/src/webapp/js/jquery.dynamiclist.student.js
@@ -54,8 +54,9 @@ function DynamicList(baseId_, templateId_, className_, anchor_)
 			if(this_.selectionList['sel_'+id] != undefined)
 			{
 				var coords = this_.selectionList['sel_'+id].getCoords();	
-				coords_str += '{"x":'+coords.x;
-				coords_str += ',"y":'+coords.y+'}';
+				if (coords != null && coords.x != null && coords.y != null) {
+					coords_str = JSON.stringify({click: true, x: coords.x, y: coords.y});
+				}
 			}
 			value += $(this).find('input[name=id_]').val()+"#:#"+coords_str;
 		});

--- a/samigo/samigo-app/src/webapp/js/selection.student.js
+++ b/samigo/samigo-app/src/webapp/js/selection.student.js
@@ -22,8 +22,8 @@ function selectionStudent(id_, className, anchor){
 	img.mousedown(function(e) {
 		if(isActive) 
 		{
-			x = parseInt(e.pageX + anchorJObj.scrollLeft() - anchorJObj.offset().left - (divJObj.width()/2));
-			y = parseInt(e.pageY + anchorJObj.scrollTop() - anchorJObj.offset().top - (divJObj.height()/2));
+			x = parseInt(e.pageX + anchorJObj.scrollLeft() - anchorJObj.offset().left);
+			y = parseInt(e.pageY + anchorJObj.scrollTop() - anchorJObj.offset().top);
 
 			move();
 		}
@@ -45,7 +45,7 @@ function selectionStudent(id_, className, anchor){
 	}
 	
 	this.getCoords = function(){
-		return {x: x, y: y};
+		return {x: x, y: y, click: true};
 	}
 	
 	this.setCoords = function(coords){
@@ -53,7 +53,11 @@ function selectionStudent(id_, className, anchor){
 		{	
 			x = coords.x;		
 			y = coords.y;
-			
+			if (coords.click !== true) {
+				var half = markerHalfSize();
+				x = x + half.x;
+				y = y + half.y;
+			}
 			move();
 		}
 	}
@@ -65,13 +69,27 @@ function selectionStudent(id_, className, anchor){
 		y = null;
 	}
 	
+	function markerHalfSize()
+	{
+		var hidden = divJObj.css('display') === 'none';
+		if (hidden) {
+			divJObj.css({ visibility: 'hidden', display: 'block' });
+		}
+		var half = { x: divJObj.width() / 2, y: divJObj.height() / 2 };
+		if (hidden) {
+			divJObj.css({ visibility: '', display: 'none' });
+		}
+		return half;
+	}
+	
 	function move()
 	{
+		var half = markerHalfSize();
 		divJObj.css({
 			position: 'absolute',
 			zIndex: 5000,
-			left: x,
-			top: y
+			left: x - half.x,
+			top: y - half.y
 		});
 		divJObj.show();		
 	}

--- a/samigo/samigo-app/src/webapp/js/selection.student.preview.js
+++ b/samigo/samigo-app/src/webapp/js/selection.student.preview.js
@@ -24,7 +24,7 @@ function selectionStudent(className, anchor){
 	}
 	
 	this.getCoords = function(){
-		return {x: x, y: y};
+		return {x: x, y: y, click: true};
 	}
 	
 	this.setCoords = function(coords){
@@ -32,7 +32,11 @@ function selectionStudent(className, anchor){
 		{
 			x = coords.x;		
 			y = coords.y;
-			
+			if (coords.click !== true) {
+				var half = markerHalfSize();
+				x = x + half.x;
+				y = y + half.y;
+			}
 			move();
 		}
 	}
@@ -42,13 +46,27 @@ function selectionStudent(className, anchor){
 		divJObj.remove();
 	}
 	
+	function markerHalfSize()
+	{
+		var hidden = divJObj.css('display') === 'none';
+		if (hidden) {
+			divJObj.css({ visibility: 'hidden', display: 'block' });
+		}
+		var half = { x: divJObj.width() / 2, y: divJObj.height() / 2 };
+		if (hidden) {
+			divJObj.css({ visibility: '', display: 'none' });
+		}
+		return half;
+	}
+	
 	function move()
 	{
+		var half = markerHalfSize();
 		divJObj.css({
 			position: 'absolute',
 			zIndex: 5000,
-			left: x,
-			top: y
+			left: x - half.x,
+			top: y - half.y
 		});
 		divJObj.show();		
 	}

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfCellEvents.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfCellEvents.java
@@ -180,10 +180,8 @@ public final class AssessmentPdfCellEvents {
                 PdfGState transparentState = new PdfGState();
                 transparentState.setFillOpacity(0.3f);
                 transparentState.setStrokeOpacity(0.8f);
-                float imageX = studentMarkerHotspotX(answerCircle.getX());
-                float imageY = studentMarkerHotspotY(answerCircle.getY());
-                float transformedX = x + imageX * scaleX;
-                float transformedY = y + drawnHeight - imageY * scaleY;
+                float transformedX = x + answerCircle.getX() * scaleX;
+                float transformedY = y + drawnHeight - answerCircle.getY() * scaleY;
                 if (answerCircle.getX() != 0 && answerCircle.getY() != 0) {
                     canvas.circle(transformedX, transformedY, radius);
                     canvas.setGState(transparentState);
@@ -217,10 +215,8 @@ public final class AssessmentPdfCellEvents {
             }
 
             for (ImageMapCircle answerCircle : answerCircles) {
-                float imageX = studentMarkerHotspotX(answerCircle.getX());
-                float imageY = studentMarkerHotspotY(answerCircle.getY());
-                float transformedX = x + imageX * scaleX;
-                float transformedY = y + drawnHeight - imageY * scaleY;
+                float transformedX = x + answerCircle.getX() * scaleX;
+                float transformedY = y + drawnHeight - answerCircle.getY() * scaleY;
                 if (answerCircle.getX() != 0 && answerCircle.getY() != 0) {
                     try {
                         canvas.beginText();
@@ -302,29 +298,5 @@ public final class AssessmentPdfCellEvents {
             this.y = y;
             this.sequence = sequence;
         }
-    }
-
-    /**
-     * Compensates for delivery storing the marker top-left, not the click
-     * ({@code selection.student.js} uses {@code click - (width/2, height/2)}).
-     * These deltas match the current 18×16 crosshair box in imageQuestion.student.css;
-     * they are not a live CSS contract.
-     *
-     * TODO: Stored image-map JSON is the .pointerClass top-left, so this PDF (and grading)
-     * must guess the click. Changing height/padding-left in imageQuestion.student.css
-     * desyncs the yellow dots (small regions look missed even when the on-screen marker
-     * sits on the target). 9 and 8 are half of that 18×16 box, an approximation of the
-     * crosshair center, not the live div (width includes the item number). Drop this
-     * offset once item grading stores the image click; then draw and score {x,y} as-is.
-     */
-    static final float STUDENT_MARKER_OFFSET_X = 9f;
-    static final float STUDENT_MARKER_OFFSET_Y = 8f;
-
-    static float studentMarkerHotspotX(float storedX) {
-        return storedX + STUDENT_MARKER_OFFSET_X;
-    }
-
-    static float studentMarkerHotspotY(float storedY) {
-        return storedY + STUDENT_MARKER_OFFSET_Y;
     }
 }

--- a/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfImageMapCoords.java
+++ b/samigo/samigo-impl/src/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfImageMapCoords.java
@@ -17,12 +17,14 @@ package org.sakaiproject.samigo.impl.pdf;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalDouble;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.sakaiproject.samigo.api.pdf.model.AssessmentPdfValueTypes.AssessmentPdfItemGradingModel;
 import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapCircle;
+import org.sakaiproject.tool.assessment.util.ImageMapCoordinates;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -62,8 +64,7 @@ final class AssessmentPdfImageMapCoords {
                 if (x1.isEmpty() || y1.isEmpty() || x2.isEmpty() || y2.isEmpty()) {
                     continue;
                 }
-                answerRectangles.add(new Rectangle((float) x1.getAsDouble(), (float) y1.getAsDouble(),
-                        (float) x2.getAsDouble(), (float) y2.getAsDouble()));
+                answerRectangles.add(new Rectangle((float) x1.getAsDouble(), (float) y1.getAsDouble(), (float) x2.getAsDouble(), (float) y2.getAsDouble()));
             } catch (JsonProcessingException e) {
                 log.warn("Skipping unparseable image map answer rectangle [{}], {}", regionJson, e.toString());
             }
@@ -79,25 +80,17 @@ final class AssessmentPdfImageMapCoords {
         int fallbackSequence = 1;
         for (AssessmentPdfItemGradingModel itemGrading : itemsGrading) {
             Long publishedItemTextId = itemGrading.getPublishedItemTextId();
-            String json = extractJsonObject(itemGrading.getAnswerText());
-            if (publishedItemTextId == null || json == null) {
+            if (publishedItemTextId == null) {
                 continue;
             }
-            try {
-                JsonNode jsonNode = jsonMapper.readTree(json);
-                OptionalDouble x = finiteNumber(jsonNode, "x");
-                OptionalDouble y = finiteNumber(jsonNode, "y");
-                if (x.isEmpty() || y.isEmpty()) {
-                    continue;
-                }
-                Integer sequence = itemGrading.getSequence();
-                int markerSequence = sequence != null ? sequence.intValue() : fallbackSequence;
-                answerCircles.add(new ImageMapCircle((float) x.getAsDouble(), (float) y.getAsDouble(), markerSequence));
-                fallbackSequence++;
-            } catch (JsonProcessingException e) {
-                log.warn("Skipping unparseable image map response for published item text {} [{}], {}", publishedItemTextId,
-                        itemGrading.getAnswerText(), e.toString());
+            Optional<ImageMapCoordinates.Point> point = ImageMapCoordinates.parseStudentPoint(itemGrading.getAnswerText());
+            if (point.isEmpty()) {
+                continue;
             }
+            Integer sequence = itemGrading.getSequence();
+            int markerSequence = sequence != null ? sequence.intValue() : fallbackSequence;
+            answerCircles.add(new ImageMapCircle((float) point.get().getClickX(), (float) point.get().getClickY(), markerSequence));
+            fallbackSequence++;
         }
         return answerCircles;
     }

--- a/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRendererTest.java
+++ b/samigo/samigo-impl/src/test/java/org/sakaiproject/samigo/impl/pdf/AssessmentPdfQuestionRendererTest.java
@@ -44,6 +44,7 @@ import org.sakaiproject.samigo.api.pdf.model.AssessmentStudentReportPdfModel;
 import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapCircle;
 import org.sakaiproject.samigo.impl.pdf.AssessmentPdfCellEvents.ImageMapQuestionCellEvent;
 import org.sakaiproject.tool.assessment.data.ifc.shared.TypeIfc;
+import org.sakaiproject.tool.assessment.util.ImageMapCoordinates;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,7 +63,8 @@ public class AssessmentPdfQuestionRendererTest {
     private static final String MAP_RESOURCE = "/group/site/map.png";
     private static final String STUDENT_RESOURCE = "/group/site/student.png";
     private static final String VALID_REGION = "{\"x1\":17,\"y1\":19,\"x2\":181,\"y2\":283}";
-    private static final String STUDENT_CLICK = "{\"x\":555,\"y\":666}";
+    private static final String STUDENT_CLICK = "{\"click\":true,\"x\":555,\"y\":666}";
+    private static final String LEGACY_CLICK = "{\"x\":555,\"y\":666}";
 
     @Test
     public void extractJsonObjectStripsPrefixAndUndefined() {
@@ -109,6 +111,22 @@ public class AssessmentPdfQuestionRendererTest {
     }
 
     @Test
+    public void parseCirclesUsesStoredClickWhenFlagPresentAndOffsetsLegacyTopLeft() {
+        AssessmentPdfImageMapCoords coords = new AssessmentPdfImageMapCoords(new ObjectMapper());
+        List<ImageMapCircle> clickCircles = coords.parseCircles(List.of(
+                new AssessmentPdfItemGradingModel(STUDENT_CLICK, 1L)));
+        assertEquals(1, clickCircles.size());
+        assertEquals(555f, clickCircles.get(0).getX(), 0.01f);
+        assertEquals(666f, clickCircles.get(0).getY(), 0.01f);
+
+        List<ImageMapCircle> legacyCircles = coords.parseCircles(List.of(
+                new AssessmentPdfItemGradingModel(LEGACY_CLICK, 1L)));
+        assertEquals(1, legacyCircles.size());
+        assertEquals(555f + (float) ImageMapCoordinates.LEGACY_OFFSET_X, legacyCircles.get(0).getX(), 0.01f);
+        assertEquals(666f + (float) ImageMapCoordinates.LEGACY_OFFSET_Y, legacyCircles.get(0).getY(), 0.01f);
+    }
+
+    @Test
     public void parseCirclesUsesItemTextSequenceNotPublishedId() {
         AssessmentPdfImageMapCoords coords = new AssessmentPdfImageMapCoords(new ObjectMapper());
         List<ImageMapCircle> circles = coords.parseCircles(List.of(
@@ -117,14 +135,6 @@ public class AssessmentPdfQuestionRendererTest {
         assertEquals(2, circles.size());
         assertEquals(2, circles.get(0).getSequence());
         assertEquals(1, circles.get(1).getSequence());
-    }
-
-    @Test
-    public void studentMarkerHotspotShiftsStoredTopLeftTowardClick() {
-        assertEquals(555f + AssessmentPdfCellEvents.STUDENT_MARKER_OFFSET_X,
-                AssessmentPdfCellEvents.studentMarkerHotspotX(555f), 0.01f);
-        assertEquals(666f + AssessmentPdfCellEvents.STUDENT_MARKER_OFFSET_Y,
-                AssessmentPdfCellEvents.studentMarkerHotspotY(666f), 0.01f);
     }
 
     @Test

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/services/GradingService.java
@@ -97,6 +97,7 @@ import org.sakaiproject.tool.assessment.integration.helper.ifc.GradebookServiceH
 import org.sakaiproject.tool.assessment.services.assessment.EventLogService;
 import org.sakaiproject.tool.assessment.services.assessment.PublishedAssessmentService;
 import org.sakaiproject.tool.assessment.util.ExtendedTimeDeliveryService;
+import org.sakaiproject.tool.assessment.util.ImageMapCoordinates;
 import org.sakaiproject.tool.assessment.util.SamigoExpressionError;
 import org.sakaiproject.tool.assessment.util.SamigoExpressionParser;
 import org.sakaiproject.tool.assessment.util.comparator.ImageMapGradingItemComparator;
@@ -2133,36 +2134,25 @@ Here are the definition and 12 cases I came up with (lydia, 01/2006):
 	 }
 	 
 	 ItemTextIfc itemTextIfc = (ItemTextIfc) publishedItemTextHash.get(data.getPublishedItemTextId());
-	 
-	 List answerArray = (List) itemTextIfc.getAnswerArray();
-	 AnswerIfc answerIfc= (AnswerIfc) answerArray.get(0); 
-	 
-	 try{
-		 String area = answerIfc.getText();
-		 Integer areax1=Integer.valueOf(area.substring(area.indexOf("\"x1\":")+5,area.indexOf(",", area.indexOf("\"x1\":"))));
-		 Integer areay1=Integer.valueOf(area.substring(area.indexOf("\"y1\":")+5,area.indexOf(",", area.indexOf("\"y1\":"))));
-		 Integer areax2=Integer.valueOf(area.substring(area.indexOf("\"x2\":")+5,area.indexOf(",", area.indexOf("\"x2\":"))));
-		 Integer areay2=Integer.valueOf(area.substring(area.indexOf("\"y2\":")+5,area.indexOf("}", area.indexOf("\"y2\":"))));
-		 
-		 String point = data.getAnswerText();
-		 Integer pointx=Integer.valueOf(point.substring(point.indexOf("\"x\":")+4,point.indexOf(",", point.indexOf("\"x\":"))));
-		 Integer pointy=Integer.valueOf(point.substring(point.indexOf("\"y\":")+4,point.indexOf("}", point.indexOf("\"y\":"))));
-		
-				 
-		 if (((pointx>=areax1)&&(pointx<=areax2))&&((pointy>=areay1)&&(pointy<=areay2))) {
-			 totalScore=answerScore;
-			 data.setIsCorrect(Boolean.TRUE);
-		 }else{
-			 totalScore=0;
-		 }
-	}catch(Exception ex){
-		 totalScore=0;
+	 if (itemTextIfc == null || itemTextIfc.getAnswerArray() == null || itemTextIfc.getAnswerArray().isEmpty()) {
+		 return 0;
 	 }
-	 	  
-    
+	 AnswerIfc answerIfc = (AnswerIfc) itemTextIfc.getAnswerArray().get(0);
+	 if (answerIfc == null) {
+		 return 0;
+	 }
+
+	 Optional<ImageMapCoordinates.Region> region = ImageMapCoordinates.parseRegion(answerIfc.getText());
+	 Optional<ImageMapCoordinates.Point> point = ImageMapCoordinates.parseStudentPoint(data.getAnswerText());
+	 if (region.isPresent() && point.isPresent() && region.get().contains(point.get().getClickX(), point.get().getClickY())) {
+		 totalScore = answerScore;
+		 data.setIsCorrect(Boolean.TRUE);
+	 } else {
+		 totalScore = 0;
+	 }
+
     return totalScore;
   }
-  
 
   /**
    * Validate a students numeric answer 

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/ImageMapCoordinates.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/ImageMapCoordinates.java
@@ -118,7 +118,7 @@ public final class ImageMapCoordinates {
             return OptionalDouble.empty();
         }
         double value = node.asDouble();
-        if (!Double.isFinite(value)) {
+        if (!Double.isFinite(value) || value > Float.MAX_VALUE || value < -Float.MAX_VALUE) {
             return OptionalDouble.empty();
         }
         return OptionalDouble.of(value);

--- a/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/ImageMapCoordinates.java
+++ b/samigo/samigo-services/src/java/org/sakaiproject/tool/assessment/util/ImageMapCoordinates.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.util;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Parses authored Hot Spot regions and student markers from stored JSON.
+ *
+ * New student responses include {@code "click":true} and store the image pixel that was clicked.
+ * Older responses omit that flag and store the top-left of the on-screen marker; those are shifted
+ * to an approximate click before scoring or drawing.
+ */
+@Slf4j
+public final class ImageMapCoordinates {
+
+    /**
+     * JSON field set by delivery when {@code x}/{@code y} are the click, not the marker corner.
+     */
+    public static final String CLICK_FIELD = "click";
+
+    /**
+     * Half of the 18×16 crosshair box in {@code imageQuestion.student.css}. Used only for
+     * responses that stored the marker top-left. New responses do not use this.
+     */
+    public static final double LEGACY_OFFSET_X = 9d;
+
+    public static final double LEGACY_OFFSET_Y = 8d;
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private ImageMapCoordinates() {
+    }
+
+    public static Optional<Point> parseStudentPoint(String answerText) {
+        String json = extractJsonObject(answerText);
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode node = JSON_MAPPER.readTree(json);
+            OptionalDouble x = finiteNumber(node, "x");
+            OptionalDouble y = finiteNumber(node, "y");
+            if (x.isEmpty() || y.isEmpty()) {
+                return Optional.empty();
+            }
+            JsonNode clickNode = node.get(CLICK_FIELD);
+            boolean clickStored = clickNode != null && clickNode.isBoolean() && clickNode.booleanValue();
+            return Optional.of(new Point(x.getAsDouble(), y.getAsDouble(), clickStored));
+        } catch (JsonProcessingException e) {
+            log.warn("Skipping unparseable image map student point [{}], {}", answerText, e.toString());
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<Region> parseRegion(String answerText) {
+        String json = extractJsonObject(answerText);
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            JsonNode node = JSON_MAPPER.readTree(json);
+            OptionalDouble x1 = finiteNumber(node, "x1");
+            OptionalDouble y1 = finiteNumber(node, "y1");
+            OptionalDouble x2 = finiteNumber(node, "x2");
+            OptionalDouble y2 = finiteNumber(node, "y2");
+            if (x1.isEmpty() || y1.isEmpty() || x2.isEmpty() || y2.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(new Region(x1.getAsDouble(), y1.getAsDouble(), x2.getAsDouble(), y2.getAsDouble()));
+        } catch (JsonProcessingException e) {
+            log.warn("Skipping unparseable image map region [{}], {}", answerText, e.toString());
+            return Optional.empty();
+        }
+    }
+
+    static String extractJsonObject(String raw) {
+        if (StringUtils.isBlank(raw) || Strings.CI.equals(raw, "undefined")) {
+            return null;
+        }
+        int start = raw.indexOf('{');
+        int end = raw.lastIndexOf('}');
+        if (start < 0 || end <= start) {
+            return null;
+        }
+        return raw.substring(start, end + 1);
+    }
+
+    static OptionalDouble finiteNumber(JsonNode parent, String field) {
+        if (parent == null || StringUtils.isBlank(field)) {
+            return OptionalDouble.empty();
+        }
+        JsonNode node = parent.get(field);
+        if (node == null || node.isMissingNode() || node.isNull() || !node.isNumber()) {
+            return OptionalDouble.empty();
+        }
+        double value = node.asDouble();
+        if (!Double.isFinite(value)) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of(value);
+    }
+
+    /**
+     * A student marker in image pixels. {@link #getClickX()} / {@link #getClickY()} are the
+     * coordinates to score and draw.
+     */
+    public static final class Point {
+        private final double storedX;
+        private final double storedY;
+        private final boolean clickStored;
+
+        Point(double storedX, double storedY, boolean clickStored) {
+            this.storedX = storedX;
+            this.storedY = storedY;
+            this.clickStored = clickStored;
+        }
+
+        public boolean isClickStored() {
+            return clickStored;
+        }
+
+        public double getClickX() {
+            return clickStored ? storedX : storedX + LEGACY_OFFSET_X;
+        }
+
+        public double getClickY() {
+            return clickStored ? storedY : storedY + LEGACY_OFFSET_Y;
+        }
+    }
+
+    /**
+     * An authored rectangular Hot Spot region in image pixels.
+     */
+    public static final class Region {
+        private final double x1;
+        private final double y1;
+        private final double x2;
+        private final double y2;
+
+        Region(double x1, double y1, double x2, double y2) {
+            this.x1 = x1;
+            this.y1 = y1;
+            this.x2 = x2;
+            this.y2 = y2;
+        }
+
+        public boolean contains(double x, double y) {
+            return x >= x1 && x <= x2 && y >= y1 && y <= y2;
+        }
+    }
+}

--- a/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceImageMapTest.java
+++ b/samigo/samigo-services/src/test/org/sakaiproject/tool/assessment/services/GradingServiceImageMapTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.tool.assessment.services;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import org.junit.Before;
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAnswer;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemData;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedItemText;
+import org.sakaiproject.tool.assessment.data.dao.grading.ItemGradingData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AnswerIfc;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.ItemTextIfc;
+import org.sakaiproject.tool.assessment.util.ImageMapCoordinates;
+
+public class GradingServiceImageMapTest {
+
+    private static final String SMALL_REGION = "{\"x1\":100,\"y1\":100,\"x2\":110,\"y2\":110}";
+    private static final String CLICK_IN_REGION = "{\"click\":true,\"x\":105,\"y\":105}";
+    private static final String CLICK_OUTSIDE_REGION = "{\"click\":true,\"x\":50,\"y\":50}";
+    private static final String LEGACY_CORNER_OUTSIDE_CLICK_INSIDE = "{\"x\":96,\"y\":97}";
+
+    private GradingService gradingService;
+
+    @Before
+    public void setUp() {
+        gradingService = new GradingService();
+    }
+
+    @Test
+    public void clickInsideSmallRegionIsCorrect() {
+        HotSpotFixture fixture = hotspot(SMALL_REGION);
+        fixture.grading.setAnswerText(CLICK_IN_REGION);
+
+        double score = gradingService.getImageMapScore(fixture.grading, fixture.item, fixture.itemTexts, fixture.answers);
+
+        assertEquals(1.0, score, 0.001);
+        assertEquals(Boolean.TRUE, fixture.grading.getIsCorrect());
+    }
+
+    @Test
+    public void clickOutsideSmallRegionIsIncorrect() {
+        HotSpotFixture fixture = hotspot(SMALL_REGION);
+        fixture.grading.setAnswerText(CLICK_OUTSIDE_REGION);
+
+        double score = gradingService.getImageMapScore(fixture.grading, fixture.item, fixture.itemTexts, fixture.answers);
+
+        assertEquals(0.0, score, 0.001);
+        assertEquals(Boolean.FALSE, fixture.grading.getIsCorrect());
+    }
+
+    @Test
+    public void legacyMarkerCornerOutsideSmallRegionStillScoresWhenClickWouldBeInside() {
+        HotSpotFixture fixture = hotspot(SMALL_REGION);
+        fixture.grading.setAnswerText(LEGACY_CORNER_OUTSIDE_CLICK_INSIDE);
+
+        double score = gradingService.getImageMapScore(fixture.grading, fixture.item, fixture.itemTexts, fixture.answers);
+
+        assertEquals(1.0, score, 0.001);
+        assertEquals(Boolean.TRUE, fixture.grading.getIsCorrect());
+        ImageMapCoordinates.Point point = ImageMapCoordinates.parseStudentPoint(LEGACY_CORNER_OUTSIDE_CLICK_INSIDE).get();
+        assertFalse(point.isClickStored());
+        assertEquals(105.0, point.getClickX(), 0.001);
+        assertEquals(105.0, point.getClickY(), 0.001);
+    }
+
+    @Test
+    public void unparseableAnswerScoresZero() {
+        HotSpotFixture fixture = hotspot(SMALL_REGION);
+        fixture.grading.setAnswerText("undefined");
+
+        double score = gradingService.getImageMapScore(fixture.grading, fixture.item, fixture.itemTexts, fixture.answers);
+
+        assertEquals(0.0, score, 0.001);
+        assertEquals(Boolean.FALSE, fixture.grading.getIsCorrect());
+    }
+
+    private static HotSpotFixture hotspot(String regionJson) {
+        PublishedItemData item = new PublishedItemData();
+        item.setItemId(16L);
+        item.setScore(1.0);
+
+        PublishedItemText itemText = new PublishedItemText();
+        itemText.setId(9001L);
+        itemText.setItem(item);
+        itemText.setSequence(1L);
+        itemText.setText("Right eye");
+
+        PublishedAnswer answer = new PublishedAnswer();
+        answer.setId(1L);
+        answer.setItem(item);
+        answer.setItemText(itemText);
+        answer.setText(regionJson);
+        answer.setIsCorrect(Boolean.TRUE);
+
+        Set<AnswerIfc> answers = new HashSet<>();
+        answers.add(answer);
+        itemText.setAnswerSet(answers);
+
+        ItemGradingData grading = new ItemGradingData();
+        grading.setPublishedItemId(16L);
+        grading.setPublishedItemTextId(9001L);
+
+        Map<Long, ItemTextIfc> itemTexts = new HashMap<>();
+        itemTexts.put(9001L, itemText);
+        Map<Long, AnswerIfc> publishedAnswers = new HashMap<>();
+        publishedAnswers.put(1L, answer);
+
+        return new HotSpotFixture(item, grading, itemTexts, publishedAnswers);
+    }
+
+    private static final class HotSpotFixture {
+        private final PublishedItemData item;
+        private final ItemGradingData grading;
+        private final Map<Long, ItemTextIfc> itemTexts;
+        private final Map<Long, AnswerIfc> answers;
+
+        private HotSpotFixture(PublishedItemData item, ItemGradingData grading, Map<Long, ItemTextIfc> itemTexts,
+                Map<Long, AnswerIfc> answers) {
+            this.item = item;
+            this.grading = grading;
+            this.itemTexts = itemTexts;
+            this.answers = answers;
+        }
+    }
+}


### PR DESCRIPTION
https://sakaiproject.atlassian.net/browse/SAK-52877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-map marker positioning and centering for student clicks.
  * Corrected image-map scoring and PDF answer rendering to use accurate click coordinates.
  * Preserved compatibility with previously stored marker coordinates.
  * Added safer handling for missing, invalid, or incomplete coordinate data.

* **Tests**
  * Expanded coverage for clicks inside and outside regions, legacy coordinates, and invalid responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->