### PR TITLE
SAK-52880 Sitestats cover missing report dates in editor

### DIFF
--- a/sitestats/sitestats-tool/src/test/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsReportFormTest.java
+++ b/sitestats/sitestats-tool/src/test/java/org/sakaiproject/sitestats/tool/mvc/SiteStatsReportFormTest.java
@@ -11,10 +11,38 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Date;
 
 import org.junit.Test;
+import org.sakaiproject.sitestats.api.report.ReportDef;
+import org.sakaiproject.sitestats.api.report.ReportManager;
+import org.sakaiproject.sitestats.api.report.ReportParams;
 
 public class SiteStatsReportFormTest {
+
+    @Test
+    public void loadsReportsWithNullableDatesInTheEffectiveUserTimeZone() {
+        ZoneId zoneId = ZoneId.of("Pacific/Kiritimati");
+        Date savedDate = Date.from(Instant.parse("2026-07-16T12:00:00Z"));
+        LocalDate expectedDate = LocalDate.of(2026, 7, 17);
+
+        for (Date from : new Date[] {null, savedDate}) {
+            for (Date to : new Date[] {null, savedDate}) {
+                ReportParams params = new ReportParams("site-id");
+                params.setWhen(ReportManager.WHEN_ALL);
+                params.setWhenFrom(from);
+                params.setWhenTo(to);
+                ReportDef report = new ReportDef();
+                report.setReportParams(params);
+
+                SiteStatsReportForm form = SiteStatsReportForm.from(report, zoneId);
+
+                assertEquals(ReportManager.WHEN_ALL, form.getWhen());
+                assertEquals(from == null ? null : expectedDate, form.getWhenFrom());
+                assertEquals(to == null ? null : expectedDate, form.getWhenTo());
+            }
+        }
+    }
 
     @Test
     public void createsDefaultDatesInTheEffectiveUserTimeZone() {


### PR DESCRIPTION
SAK-52880 reports an NPE when the Sakai 25 Statistics report editor converts a missing `whenFrom` date to an instant. On master, SAK-52731 (#14767) replaced `ReportsEditPage` with the Thymeleaf editor, whose `SiteStatsReportForm.from` already handles null start and end dates.

Add regression coverage to the existing form test for all four combinations of null and populated dates. Verify that the selected period is preserved and populated dates use the supplied user timezone. No production changes are needed on master.

This test-only PR does not fix Sakai 25: branches retaining the Wicket editor need a separate null-handling patch and should not cherry-pick this test as the runtime fix.

Validation: `mvn -pl sitestats/sitestats-api,sitestats/sitestats-tool -Dtest=SiteStatsReportFormTest -Dsurefire.failIfNoSpecifiedTests=false test -B -ntp` passed (2 tests); `git diff --check` passed. The API is included to compile against current master rather than an outdated locally installed snapshot. No UI flow changes or Playwright test are included; the regression exercises the public form conversion used by the current editor directly, without mocks.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52880


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming report date values are converted correctly for the effective user time zone.
  - Verified that nullable start and end dates remain blank when no value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->