### PR TITLE
SAK-52857 Lessons recognize deleted linked quizzes

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/SamigoTest.java
@@ -30,9 +30,11 @@ import org.sakaiproject.e2e.support.SakaiUiTestBase;
 
 import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.assertions.LocatorAssertions;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import com.microsoft.playwright.options.AriaRole;
 import com.microsoft.playwright.options.LoadState;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -50,7 +52,7 @@ class SamigoTest extends SakaiUiTestBase {
         }
 
         sakai.login("instructor1");
-        sakaiUrl = sakai.createCourse("instructor1", List.of("sakai\\.rubrics", "sakai\\.samigo"));
+        sakaiUrl = sakai.createCourse("instructor1", List.of("sakai\\.rubrics", "sakai\\.samigo", "sakai\\.lessonbuildertool"));
         return sakaiUrl;
     }
 
@@ -389,6 +391,60 @@ class SamigoTest extends SakaiUiTestBase {
 
             assertThat(previewIframe).isVisible();
         }
+    }
+
+    @Test
+    @Order(10)
+    void deletedQuizIsUnavailableInLessons() {
+        String courseUrl = ensureCourseUrl();
+        sakai.login("instructor1");
+        page.navigate(courseUrl);
+        sakai.toolClick("Lessons");
+        page.getByRole(AriaRole.BUTTON,
+            new Page.GetByRoleOptions().setName("Add Content")).first().click();
+        page.locator("#addContentDiv").getByRole(AriaRole.BUTTON,
+            new Locator.GetByRoleOptions().setName("Link to a Test or Quiz").setExact(true)).click();
+        page.getByRole(AriaRole.RADIO,
+            new Page.GetByRoleOptions().setName(SAMIGO_TITLE).setExact(true)).check();
+        page.getByRole(AriaRole.BUTTON,
+            new Page.GetByRoleOptions().setName("Use selected item").setExact(true)).click();
+        assertThat(page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions().setName(SAMIGO_TITLE).setExact(true))).isVisible();
+
+        // Visit before deletion to populate Lessons' assessment cache for both roles.
+        sakai.login("student0011");
+        page.navigate(courseUrl);
+        sakai.toolClick("Lessons");
+        assertThat(page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions().setName(SAMIGO_TITLE).setExact(true))).isVisible();
+
+        sakai.login("instructor1");
+        page.navigate(courseUrl);
+        sakai.toolClick("Tests");
+        Locator quizRows = page.locator("#authorIndexForm\\:coreAssessments > tbody > tr")
+            .filter(new Locator.FilterOptions().setHasText(SAMIGO_TITLE));
+        assertThat(quizRows).hasCount(2);
+        for (Locator checkbox : quizRows.locator("input.select-checkbox").all()) {
+            checkbox.check();
+        }
+        page.onceDialog(dialog -> dialog.accept());
+        page.locator("#authorIndexForm\\:remove-selected").click();
+        assertThat(quizRows).hasCount(0);
+
+        sakai.toolClick("Lessons");
+        assertThat(page.locator("#content")).containsText("*Deleted*");
+        assertThat(page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions().setName(SAMIGO_TITLE).setExact(true))).hasCount(0);
+
+        sakai.login("student0011");
+        page.navigate(courseUrl);
+        sakai.toolClick("Lessons");
+        Locator unavailableQuiz = page.locator(".fake-disabled")
+            .filter(new Locator.FilterOptions().setHasText(SAMIGO_TITLE));
+        assertThat(unavailableQuiz).isVisible();
+        assertThat(unavailableQuiz).hasAttribute("title", "Item is not yet available");
+        assertThat(page.getByRole(AriaRole.LINK,
+            new Page.GetByRoleOptions().setName(SAMIGO_TITLE).setExact(true))).hasCount(0);
     }
 
     private void addMultipleChoiceQuestion(String points, String questionText, List<String> choices, int correctIndex) {

--- a/lessonbuilder/tool/pom.xml
+++ b/lessonbuilder/tool/pom.xml
@@ -195,6 +195,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>OKI</groupId>
+            <artifactId>OkiOSID</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>lessonbuilder-components</artifactId>
             <version>${project.version}</version>

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/service/SamigoEntity.java
@@ -585,9 +585,9 @@ public class SamigoEntity implements LessonEntity, QuizEntity {
     }
 
     public boolean objectExists() {
-	if (assessment == null)
-	    assessment = getPublishedAssessment(id);
-	return assessment != null;
+	// The cached assessment may predate deletion in Tests & Quizzes.
+	return !PublishedAssessmentFacade.DEAD_STATUS.equals(
+	    publishedAssessmentFacadeQueries.getPublishedAssessmentStatus(id));
     }
 
     public boolean notPublished(String ref) {

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -3873,7 +3873,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 			    simplePageBean.checkItemPermissions(i, true);
 			}
 			LessonEntity lessonEntity = quizEntity.getEntity(i.getSakaiId(),simplePageBean);
-			if (usable && lessonEntity != null && (canEditPage || !quizEntity.notPublished(i.getSakaiId()))) {
+			if (usable && lessonEntity != null && lessonEntity.objectExists() && (canEditPage || !quizEntity.notPublished(i.getSakaiId()))) {
 				// we've hacked Samigo to look at a special lesson builder
 				// session
 				// attribute. otherwise at the end of the test, Samigo replaces

--- a/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/SamigoEntityTest.java
+++ b/lessonbuilder/tool/src/test/org/sakaiproject/lessonbuildertool/service/SamigoEntityTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.lessonbuildertool.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.sakaiproject.tool.assessment.data.dao.assessment.PublishedAssessmentData;
+import org.sakaiproject.tool.assessment.data.ifc.assessment.AssessmentBaseIfc;
+import org.sakaiproject.tool.assessment.facade.PublishedAssessmentFacadeQueriesAPI;
+
+public class SamigoEntityTest {
+
+    private PublishedAssessmentFacadeQueriesAPI originalQueries;
+    private PublishedAssessmentFacadeQueriesAPI queries;
+    private SamigoEntity entity;
+
+    @Before
+    public void setUp() {
+        originalQueries = SamigoEntity.publishedAssessmentFacadeQueries;
+        entity = new SamigoEntity(LessonEntity.TYPE_SAMIGO, 42L, 1);
+        queries = mock(PublishedAssessmentFacadeQueriesAPI.class);
+        entity.setPublishedAssessmentFacadeQueries(queries);
+        entity.assessment = new PublishedAssessmentData();
+        entity.assessment.setStatus(AssessmentBaseIfc.ACTIVE_STATUS);
+    }
+
+    @After
+    public void tearDown() {
+        entity.setPublishedAssessmentFacadeQueries(originalQueries);
+    }
+
+    @Test
+    public void detectsDeletionAfterTheAssessmentHasBeenLoaded() {
+        when(queries.getPublishedAssessmentStatus(42L))
+                .thenReturn(AssessmentBaseIfc.ACTIVE_STATUS, AssessmentBaseIfc.DEAD_STATUS);
+
+        assertTrue(entity.objectExists());
+        assertFalse(entity.objectExists());
+    }
+
+    @Test
+    public void inactiveAndRetractedAssessmentsStillExist() {
+        when(queries.getPublishedAssessmentStatus(42L))
+                .thenReturn(AssessmentBaseIfc.INACTIVE_STATUS, AssessmentBaseIfc.RETRACT_FOR_EDIT_STATUS);
+
+        assertTrue(entity.objectExists());
+        assertTrue(entity.objectExists());
+    }
+}


### PR DESCRIPTION
Deleting a published quiz in Tests & Quizzes can leave its Lessons item looking available because `SamigoEntity.objectExists()` trusts a cached assessment. The instructor never sees the Deleted label, and students can follow a stale link into an error.

Use Samigo's existing single-column status query for the existence check, and require the quiz to exist before rendering its launch link. Lessons then applies its existing deleted-item behavior: instructors see Deleted with no launch link, students see an unavailable item instead of an active launch link. Inactive and retracted quizzes still count as existing.

Production changes are limited to those two checks. Add a focused regression test for deletion after loading an assessment and preservation of inactive/retracted states, plus Playwright coverage that links a quiz, visits Lessons as both roles, deletes the published quiz and draft, and checks both views. The test-scoped OkiOSID dependency is needed to load types referenced by the Samigo query interface.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52857

Validation:
- `mvn -pl lessonbuilder/tool -Dtest=SamigoEntityTest test -B -ntp` — 2 tests pass. The deletion regression fails against the original code.
- `mvn -f e2e-tests/pom.xml '-Dtest=SamigoTest#canCreateQuizFromScratch+deletedQuizIsUnavailableInLessons' test -B -ntp` — 2 tests pass against the local Sakai server with the changed classes loaded. Before the fix, the browser regression failed at the missing Deleted label. The server's original classes were restored after verification.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted Tests & Quizzes assessments now correctly appear as unavailable in Lessons.
  * Instructors see deleted assessments marked as deleted without an active link.
  * Students see deleted assessments as disabled items indicating they are not yet available.
  * Lessons now checks the current assessment status, preventing outdated cached information from showing broken links.

* **Tests**
  * Added automated coverage for deleted, active, inactive, and retracted assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->