### PR TITLE
SAK-52836 Polls count eligible voters for group results

### DIFF
--- a/polls/api/src/main/java/org/sakaiproject/poll/api/service/PollsService.java
+++ b/polls/api/src/main/java/org/sakaiproject/poll/api/service/PollsService.java
@@ -400,6 +400,14 @@ public interface PollsService {
     int getNumberUsersCanVote(String siteId);
 
     /**
+     * Count site users with vote permission who can access this poll.
+     * Applies group restrictions and the same access exceptions as voting.
+     * @param poll the poll
+     * @return number of eligible voters
+     */
+    int getNumberUsersCanVote(Poll poll);
+
+    /**
      * Return a map of group id -> group title for the given site. Returns an empty map if site not found.
      */
     Map<String, String> getGroupTitlesForSite(String siteId);

--- a/polls/impl/src/main/java/org/sakaiproject/poll/impl/service/PollsServiceImpl.java
+++ b/polls/impl/src/main/java/org/sakaiproject/poll/impl/service/PollsServiceImpl.java
@@ -1485,6 +1485,16 @@ public class PollsServiceImpl implements PollsService, EntityProducer, EntityTra
 
     @Override
     @Transactional(readOnly = true)
+    public int getNumberUsersCanVote(Poll poll) {
+        Objects.requireNonNull(poll, "poll cannot be null");
+        List<String> siteRefs = List.of(siteService.siteReference(poll.getSiteId()));
+        return (int) authzGroupService.getUsersIsAllowed(PERMISSION_VOTE, siteRefs).stream()
+                .filter(userId -> userCanViewPoll(poll, userId))
+                .count();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public boolean userCanViewPoll(Poll poll, String userId) {
 
         if (poll == null) {

--- a/polls/impl/src/test/java/org/sakaiproject/poll/test/service/PollsServiceTest.java
+++ b/polls/impl/src/test/java/org/sakaiproject/poll/test/service/PollsServiceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.poll.test.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.sakaiproject.poll.api.PollConstants.PERMISSION_ADD;
+import static org.sakaiproject.poll.api.PollConstants.PERMISSION_VOTE;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sakaiproject.authz.api.AuthzGroupService;
+import org.sakaiproject.authz.api.SecurityService;
+import org.sakaiproject.poll.api.model.Poll;
+import org.sakaiproject.poll.api.service.PollsService;
+import org.sakaiproject.site.api.Group;
+import org.sakaiproject.site.api.Site;
+import org.sakaiproject.site.api.SiteService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = PollsServiceTestConfiguration.class)
+public class PollsServiceTest {
+
+    @Autowired private PollsService pollsService;
+    @Autowired private SiteService siteService;
+    @Autowired private AuthzGroupService authzGroupService;
+    @Autowired private SecurityService securityService;
+
+    private Poll poll;
+
+    @Before
+    public void setUp() throws Exception {
+        poll = new Poll();
+        poll.setSiteId("voter-count-site");
+        poll.setTypeOfAccess(Poll.Access.GROUP);
+        poll.setGroupIds(Set.of("group-1"));
+        when(siteService.siteReference(poll.getSiteId())).thenReturn("/site/voter-count-site");
+        when(authzGroupService.getUsersIsAllowed(PERMISSION_VOTE, List.of("/site/voter-count-site")))
+                .thenReturn(Set.of("instructor", "student-1", "student-2", "overlapping", "outside"));
+        when(securityService.unlock("instructor", PERMISSION_ADD, "/site/voter-count-site"))
+                .thenReturn(true);
+
+        Site site = mock(Site.class);
+        Group first = mock(Group.class);
+        Group second = mock(Group.class);
+        when(first.getId()).thenReturn("group-1");
+        when(second.getId()).thenReturn("group-2");
+        when(siteService.getSite(poll.getSiteId())).thenReturn(site);
+        when(site.getGroupsWithMember("student-1")).thenReturn(List.of(first));
+        when(site.getGroupsWithMember("student-2")).thenReturn(List.of(second));
+        when(site.getGroupsWithMember("overlapping")).thenReturn(List.of(first, second));
+        when(site.getGroupsWithMember("outside")).thenReturn(List.of());
+        when(site.getGroupsWithMember("cannot-vote")).thenReturn(List.of(first));
+    }
+
+    @Test
+    public void groupPollCountsOnlyEligibleMembersAndInstructors() {
+        assertEquals(3, pollsService.getNumberUsersCanVote(poll));
+    }
+
+    @Test
+    public void overlappingGroupsDoNotCountVotersTwice() {
+        poll.setGroupIds(Set.of("group-1", "group-2"));
+        assertEquals(4, pollsService.getNumberUsersCanVote(poll));
+    }
+
+    @Test
+    public void deletedGroupDoesNotGrantAccessToOtherStudents() {
+        poll.setGroupIds(Set.of("deleted-group"));
+        assertEquals(1, pollsService.getNumberUsersCanVote(poll));
+    }
+
+    @Test
+    public void sitePollPreservesSiteWideCount() {
+        poll.setTypeOfAccess(Poll.Access.SITE);
+        assertEquals(5, pollsService.getNumberUsersCanVote(poll));
+        assertEquals(5, pollsService.getNumberUsersCanVote(poll.getSiteId()));
+    }
+
+    @Test
+    public void publicPollPreservesPublicAccessException() {
+        poll.setPublic(true);
+        assertEquals(5, pollsService.getNumberUsersCanVote(poll));
+    }
+}

--- a/polls/tool/src/main/java/org/sakaiproject/poll/tool/service/PollResultsService.java
+++ b/polls/tool/src/main/java/org/sakaiproject/poll/tool/service/PollResultsService.java
@@ -46,7 +46,7 @@ public class PollResultsService {
     public PollResults buildResults(Poll poll, String siteId, Locale locale) {
         List<Vote> votes = pollsService.getAllVotesForPoll(poll.getId());
         int distinctVoters = pollsService.getDistinctVotersForPoll(poll);
-        int potentialVoters = pollsService.getNumberUsersCanVote(siteId);
+        int potentialVoters = pollsService.getNumberUsersCanVote(poll);
         return new PollResults(
                 buildResultRows(poll, votes, distinctVoters, potentialVoters, locale),
                 votes.size(),

--- a/polls/tool/src/test/java/org/sakaiproject/poll/tool/service/PollResultsServiceTest.java
+++ b/polls/tool/src/test/java/org/sakaiproject/poll/tool/service/PollResultsServiceTest.java
@@ -147,7 +147,7 @@ public class PollResultsServiceTest {
     private PollResultsService.PollResults buildResults(Poll poll, List<Vote> votes, int distinctVoters, int potentialVoters) {
         when(pollsService.getAllVotesForPoll(poll.getId())).thenReturn(votes);
         when(pollsService.getDistinctVotersForPoll(poll)).thenReturn(distinctVoters);
-        when(pollsService.getNumberUsersCanVote("site-1")).thenReturn(potentialVoters);
+        when(pollsService.getNumberUsersCanVote(poll)).thenReturn(potentialVoters);
         return pollResultsService.buildResults(poll, "site-1", Locale.US);
     }
 


### PR DESCRIPTION
Group poll results currently use the number of voters in the whole site as their denominator. This inflates the eligible-voter total and the No vote count, and understates participation for a poll restricted to selected groups.

Add a poll-specific overload of `getNumberUsersCanVote` that filters the site's vote-permission holders through the existing `userCanViewPoll` rule, then use it in `PollResultsService`. Users in overlapping groups count once. The existing instructor (`poll.add`) and public-poll access exceptions are preserved, so the denominator matches voting eligibility rather than just group size. For example, 10 selected students plus 2 instructors who can vote count as 12, not the site's 52.

The production change is one service method, its API declaration, and one results-service call. Voting permissions and recorded votes are unchanged.

Validation:
- `mvn -pl polls/api,polls/impl,polls/tool -am -Dtest=PollsServiceTest,PollResultsServiceTest -Dsurefire.failIfNoSpecifiedTests=false test -B -ntp` passes: 5 service tests and 4 results tests.
- New service tests load the production Spring configuration and real Polls service, with kernel boundary mocks. They cover a single group, overlapping groups, a deleted group, site-wide polls, and public polls.
- Existing results tests cover vote percentages and No vote calculations using the new poll-specific count.
- `git diff --check` passes.
- No browser run or Playwright test was added. This changes service-side aggregation, not an interactive flow; the browser suite has no controlled group/permission fixture for these cases, which are exercised through the wired service instead.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added poll-specific voter eligibility counting, including group restrictions and voting access exceptions.

- **Bug Fixes**
  - Poll results now calculate potential voters based on the selected poll’s actual eligibility rules.
  - Improved handling for overlapping groups, missing groups, site-wide polls, and public polls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->