### PR TITLE
SAK-52825 Lessons preserve MIME type when resizing embedded content

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
@@ -154,6 +154,9 @@ class LessonsTest extends SakaiUiTestBase {
         assertThat(embeddedImage).hasAttribute("alt", "Resized logo");
         page.reload();
         assertThat(embeddedImage).isVisible();
+        assertThat(embeddedImage).hasAttribute("width", "120");
+        assertThat(embeddedImage).hasAttribute("height", "80");
+        assertThat(embeddedImage).hasAttribute("alt", "Resized logo");
         assertThat(page.locator(".image-col .mm-type")).hasText("image/png");
     }
 

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/LessonsTest.java
@@ -115,6 +115,48 @@ class LessonsTest extends SakaiUiTestBase {
             new Locator.GetByRoleOptions().setName("Add More Pages").setExact(true))).isVisible();
     }
 
+    @Test
+    @Order(4)
+    void resizingEmbeddedImagePreservesItsMediaType() {
+        if (sakaiUrl == null) {
+            canCreateNewCourse();
+        }
+        sakai.login("instructor1");
+        page.navigate(sakaiUrl);
+        sakai.toolClick("Lessons");
+
+        // The query string prevents extension fallback from masking a lost MIME type.
+        String imageUrl = "https://www.google.com/images/branding/googlelogo/2x/"
+            + "googlelogo_color_272x92dp.png?regression=SAK-52825";
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Content")).first().click();
+        page.locator("#addContentDiv .add-multimedia").click();
+        Locator addDialog = page.locator("#add-multimedia-dialog");
+        assertThat(addDialog).isVisible();
+        addDialog.locator("#new-url-section-collapse").click();
+        addDialog.locator("#mm-url").fill(imageUrl);
+        addDialog.locator("#mm-add-item").click();
+
+        Locator embeddedImage = page.locator("img.multimedia");
+        assertThat(embeddedImage).hasAttribute("src", imageUrl);
+        assertThat(embeddedImage).isVisible();
+        embeddedImage.hover();
+        page.locator(".image-col .multimedia-edit").click();
+        Locator editDialog = page.locator("#edit-multimedia-dialog");
+        assertThat(editDialog).isVisible();
+        editDialog.locator("#width").fill("120");
+        editDialog.locator("#height").fill("80");
+        editDialog.locator("#alt").fill("Resized logo");
+        editDialog.locator("#edit-multimedia-item").click();
+
+        assertThat(embeddedImage).isVisible();
+        assertThat(embeddedImage).hasAttribute("width", "120");
+        assertThat(embeddedImage).hasAttribute("height", "80");
+        assertThat(embeddedImage).hasAttribute("alt", "Resized logo");
+        page.reload();
+        assertThat(embeddedImage).isVisible();
+        assertThat(page.locator(".image-col .mm-type")).hasText("image/png");
+    }
+
     private void addSubpage(String title) {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Content")).first().click();
 

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -4575,7 +4575,6 @@ public class SimplePageBean {
 			i.setWidth(width);
 			i.setAlt(alt);
 			i.setDescription(description);
-			i.setHtml(mimetype);
 			i.setPrerequisite(this.prerequisite);
 			setItemGroups(i, selectedGroups);
 			update(i);

--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -4921,8 +4921,6 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 		UIOutput.make(form, "alt-label", messageLocator.getMessage("simplepage.alt_label"));
 		UIInput.make(form, "alt", "#{simplePageBean.alt}");
 
-		UIInput.make(form, "mimetype", "#{simplePageBean.mimetype}");
-
 		UICommand.make(form, "edit-multimedia-item", messageLocator.getMessage("simplepage.save_message"), "#{simplePageBean.editMultimedia}");
 
 		UIInput.make(form, "multimedia-item-id", "#{simplePageBean.itemId}");


### PR DESCRIPTION
Saving width/height changes in Lessons' Edit Multimedia dialog overwrites the item's stored MIME type with an absent form value. URL embeds can then render as a generic object instead of their original media type.

Stop writing the MIME type in `editMultimedia()` and remove the unused RSF field binding. This dialog has no MIME-type input; changing display settings should preserve the stored type. The separate movie dialog's MIME-type editor is unchanged.

The production fix removes three lines. Add a Playwright regression that embeds a public HTTPS PNG URL, edits its dimensions and alt text, saves, and reloads. The URL includes a query string so extension-based detection cannot hide the loss of its stored MIME type.

Jira: https://sakaiproject.atlassian.net/browse/SAK-52825

Validation:
- `mvn -pl lessonbuilder/tool -DskipTests package -B -ntp` passes.
- `mvn -f e2e-tests/pom.xml '-Dtest=LessonsTest#resizingEmbeddedImagePreservesItsMediaType' test -B -ntp` passes against the local Sakai server with the changed classes loaded. The same regression fails on the original server immediately after saving, when the image element disappears.
- The browser test checks persisted width, height, alt text, image rendering, and the PNG MIME type after a reload. It uses a public Google PNG URL, so both the browser and Sakai server need outbound HTTPS access; no endpoint is mocked.
- `git diff --check` passes.
- Original local server files were restored after verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resizing embedded images in Lessons now preserves their media type.
  - Resized images remain visible after saving and reloading the page.
  - Updated image dimensions and alternative text are retained after resizing.
  - Editing multimedia content no longer replaces existing content information with an entered media type.
  - Images continue to display correctly even when their source URLs include query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->