### PR TITLE
SAK-52793 Gradebook persist excused status without a score

### DIFF
--- a/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
+++ b/gradebookng/impl/src/main/java/org/sakaiproject/grading/impl/GradingServiceImpl.java
@@ -2293,8 +2293,8 @@ public class GradingServiceImpl implements GradingService {
                     eventsToAdd.add(event);
                 }
             } else {
-                // if the grade is something other than null, add a new AGR
-                if (StringUtils.isNotBlank(newGrade) && (StringUtils.isNotBlank(gradeDef.getGrade()) || excuse != currentExcuse)) {
+                // A score or an excused status requires a grade record.
+                if (StringUtils.isNotBlank(newGrade) || excuse) {
                     gradeRec = new AssignmentGradeRecord(assignment, studentId, convertedGrade);
                     gradeRec.setGraderId(graderUid);
                     gradeRec.setDateRecorded(gradedDate);

--- a/gradebookng/impl/src/test/java/org/sakaiproject/grading/impl/test/GradingServiceTests.java
+++ b/gradebookng/impl/src/test/java/org/sakaiproject/grading/impl/test/GradingServiceTests.java
@@ -462,6 +462,40 @@ public class GradingServiceTests extends AbstractTransactionalJUnit4SpringContex
     }
 
     @Test
+    public void excuseStudentsWithoutScores() {
+        Gradebook gradebook = createGradebook();
+        Long assignmentId = createAssignment1(gradebook);
+
+        gradingService.saveGradeAndExcuseForStudent(gradebook.getUid(), siteId, assignmentId, user1, null, true);
+        gradingService.saveGradeAndExcuseForStudent(gradebook.getUid(), siteId, assignmentId, user2, "", true);
+
+        for (String studentId : List.of(user1, user2)) {
+            GradeDefinition grade = gradingService.getGradeDefinitionForStudentForItem(
+                    gradebook.getUid(), siteId, assignmentId, studentId);
+            assertTrue(grade.isExcused());
+            assertNull(grade.getGrade());
+            assertEquals(1, gradingService.getGradingEvents(studentId, assignmentId).size());
+        }
+
+        gradingService.saveGradeAndExcuseForStudent(gradebook.getUid(), siteId, assignmentId, user1, null, false);
+        GradeDefinition included = gradingService.getGradeDefinitionForStudentForItem(
+                gradebook.getUid(), siteId, assignmentId, user1);
+        assertFalse(included.isExcused());
+        assertNull(included.getGrade());
+    }
+
+    @Test
+    public void blankUnexcusedScoreDoesNotCreateGradingEvent() {
+        Gradebook gradebook = createGradebook();
+        Long assignmentId = createAssignment1(gradebook);
+
+        gradingService.saveGradeAndExcuseForStudent(gradebook.getUid(), siteId, assignmentId, user1, "", false);
+
+        assertTrue(gradingService.getGradingEvents(user1, assignmentId).isEmpty());
+        assertFalse(gradingService.getIsAssignmentExcused(gradebook.getUid(), assignmentId, user1));
+    }
+
+    @Test
     public void getAverageCourseGrade() {
 
         Gradebook gradebook = createGradebook();


### PR DESCRIPTION
Quick Entry discarded the Excused checkbox for students without an existing grade record unless a score was also entered. Create the record when the student is excused, preserving a blank score and the existing grading event behavior.

Adds regression coverage through the real Spring-wired grading service for null and empty scores, clearing an excuse without adding a score, and leaving blank unexcused entries untouched.

Validation:
- The new regression test fails on upstream/master at the excused-state assertion.
- `mvn -pl gradebookng/impl test -B -ntp` passes (33 tests).
- `git diff --check` passes.

No browser test was run. This changes service persistence without changing the Quick Entry UI flow; the regression exercises the public service API used by Quick Entry with real Spring/Hibernate collaborators. A browser test against the local installation would require deploying the updated shared grading service.

https://sakaiproject.atlassian.net/browse/SAK-52793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Students can now be excused even when no grade or a blank score is entered.
  * Clearing an excuse while retaining a blank score now works correctly.
  * Blank, unexcused scores no longer create unnecessary grading events.

* **Tests**
  * Added coverage for excused students without scores and blank unexcused scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->