### PR TITLE
SAK-52770 Resources preserve public and authenticated access on import

### DIFF
--- a/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -7727,6 +7727,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 							// add collection
 							try {
 								ContentCollectionEdit edit = addCollection(nId);
+								copyImportedRoleAccess(oResource, edit);
 								// import properties
 								ResourcePropertiesEdit p = edit.getPropertiesEdit();
 								p.clear();
@@ -7747,6 +7748,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 							try {
 								// add resource
 								ContentResourceEdit edit = addResource(nId);
+								copyImportedRoleAccess(oResource, edit);
 								edit.setContentType(((ContentResource) oResource).getContentType());
 								edit.setContentSha256(((ContentResource) oResource).getContentSha256());
 								edit.setResourceType(((ContentResource) oResource).getResourceType());
@@ -7792,6 +7794,19 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, HardDeleteAware
 		return traversalMap;
 	} // importResources
  
+    private void copyImportedRoleAccess(GroupAwareEntity source, GroupAwareEdit target)
+            throws PermissionException, InconsistentException {
+        Set<String> sourceRoles = new LinkedHashSet<>(source.getRoleAccessIds());
+        sourceRoles.addAll(source.getInheritedRoleAccessIds());
+        Set<String> inheritedRoles = target.getInheritedRoleAccessIds();
+        // Preserve site-independent visibility without copying source-site group permissions.
+        for (String role : List.of(AuthzGroupService.ANON_ROLE, AuthzGroupService.AUTH_ROLE)) {
+            if (sourceRoles.contains(role) && !inheritedRoles.contains(role)) {
+                target.addRoleAccess(role);
+            }
+        }
+    }
+
 	@Override
 	public List<Map<String, String>> getEntityMap(String siteId) {
 

--- a/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/test/ContentHostingServiceTest.java
+++ b/kernel/kernel-impl/src/test/java/org/sakaiproject/content/impl/test/ContentHostingServiceTest.java
@@ -33,12 +33,14 @@ import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 
+import org.sakaiproject.authz.api.AuthzGroupService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentCollection;
 import org.sakaiproject.content.api.ContentCollectionEdit;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.content.api.ContentResourceEdit;
+import org.sakaiproject.entity.api.EntityTransferrer;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.exception.IdInvalidException;
@@ -106,6 +108,53 @@ public class ContentHostingServiceTest extends SakaiKernelTestBase {
 		
 	}
 	
+    @Test
+    public void testImportPreservesPublicAndAuthenticatedAccess() throws Exception {
+        ContentHostingService content = getService(ContentHostingService.class);
+        Session session = getService(SessionManager.class).getCurrentSession();
+        session.setUserEid("admin");
+        session.setUserId("admin");
+
+        for (String role : List.of(AuthzGroupService.ANON_ROLE, AuthzGroupService.AUTH_ROLE)) {
+            String source = "/import-access-" + role + "/";
+            String target = "/import-access-copy-" + role + "/";
+            content.commitCollection(content.addCollection(source));
+            content.commitCollection(content.addCollection(target));
+            ContentCollectionEdit folder = content.addCollection(source + "folder/");
+            folder.addRoleAccess(role);
+            content.commitCollection(folder);
+            ContentResourceEdit child = content.addResource(source + "folder/child.txt");
+            child.setContent(new byte[0]);
+            content.commitResource(child);
+            ContentResourceEdit file = content.addResource(source + "file.txt");
+            file.setContent(new byte[0]);
+            file.addRoleAccess(role);
+            content.commitResource(file);
+            ContentResourceEdit restricted = content.addResource(source + "restricted.txt");
+            restricted.setContent(new byte[0]);
+            content.commitResource(restricted);
+
+            ((EntityTransferrer) content).transferCopyEntities(source, target, null, null);
+
+            Assert.assertTrue(content.getCollection(target + "folder/").getRoleAccessIds().contains(role));
+            Assert.assertTrue(content.getResource(target + "folder/child.txt").getInheritedRoleAccessIds().contains(role));
+            Assert.assertTrue(content.getResource(target + "file.txt").getRoleAccessIds().contains(role));
+            Assert.assertTrue(content.getResource(target + "restricted.txt").getRoleAccessIds().isEmpty());
+
+            ContentCollectionEdit root = content.editCollection(source);
+            root.addRoleAccess(role);
+            content.commitCollection(root);
+            ContentResourceEdit inherited = content.addResource(source + "inherited.txt");
+            inherited.setContent(new byte[0]);
+            content.commitResource(inherited);
+            ((EntityTransferrer) content).transferCopyEntities(source, target, List.of(inherited.getId()), null);
+
+            Assert.assertTrue(content.getResource(target + "inherited.txt").getRoleAccessIds().contains(role));
+            Assert.assertTrue(content.getCollection(target).getRoleAccessIds().isEmpty());
+            Assert.assertTrue(content.getResource(target + "restricted.txt").getInheritedRoleAccessIds().isEmpty());
+        }
+    }
+
 	@Test
 	public void testSaveRetriveFolder() {
 		ContentHostingService ch = getService(ContentHostingService.class);


### PR DESCRIPTION
Resources imports copied properties and availability but lost the separate role permissions that make files and folders public or visible to all logged-in users.

Copy the anonymous and authenticated role access through the existing content-service API when creating imported items. Include inherited source access so selectively importing a child preserves its visibility. Avoid redundant inherited grants and keep the destination root's permissions unchanged, so existing destination content is not made public. Source-site group permissions are not copied.

Validation:
- Added regression coverage using the real kernel content and authorization services, with persisted files and folders.
- The regression fails before the fix at the imported folder's role-access assertion.
- `mvn -pl kernel/kernel-impl -Dtest=ContentHostingServiceTest test -B -ntp` passes: 11 tests.
- Covers both public and authenticated roles, folder descendants, direct file permissions, inherited source-root access on selective import, and unrelated destination content remaining restricted.
- `git diff --check` passes.

No browser test was run: this is a kernel import-service change with no UI flow changes, tested through the public EntityTransferrer API used by site import.

https://sakaiproject.atlassian.net/browse/SAK-52770
