### PR TITLE
SAK-52886 Fix Discussions and Gradebook table sorting regressions

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumThreadsSorterTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumThreadsSorterTest.java
@@ -55,7 +55,7 @@ class ForumThreadsSorterTest {
             page.evaluate("sakaiForumThreadsSorter.init(document.getElementById('threads'), 'en_US')");
 
             page.locator("[data-sakai-forum-sort=author]").click();
-            assertOrder(page, "A", "B", "A second reply", "B reply", "A reply", "A nested");
+            assertOrder(page, "A", "A reply", "A nested", "A second reply", "B", "B reply");
             page.locator("[data-sakai-forum-sort=date]").click();
             assertOrder(page, "A", "A reply", "A second reply", "A nested", "B", "B reply");
             page.locator("[data-sakai-forum-sort=date]").click();
@@ -64,7 +64,7 @@ class ForumThreadsSorterTest {
             page.locator("[data-sakai-forum-sort=thread]").click();
             assertOrder(page, "A", "A reply", "A nested", "A second reply", "B", "B reply");
             page.locator("[data-sakai-forum-sort=author]").click();
-            assertOrder(page, "A nested", "A reply", "B reply", "A second reply", "B", "A");
+            assertOrder(page, "B", "B reply", "A", "A reply", "A nested", "A second reply");
             page.locator("[data-sakai-forum-sort=thread]").click();
             assertOrder(page, "B", "B reply", "A", "A second reply", "A reply", "A nested");
             page.locator("[data-sakai-forum-sort=date]").click();

--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumThreadsSorterTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/ForumThreadsSorterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2003-2026 The Apereo Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *             http://opensource.org/licenses/ecl2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sakaiproject.e2e.tests;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ForumThreadsSorterTest {
+
+    @Test
+    void restoresThreadHierarchyAfterAuthorAndDateSorts() {
+        try (Playwright playwright = Playwright.create();
+                Browser browser = playwright.chromium().launch()) {
+            Page page = browser.newPage();
+            // Match the hierarchy markers and indentation emitted by HierDataTableRender.
+            page.setContent("""
+                <style>body { font-size: 16px; } td { padding-left: 0; }</style>
+                <table id="threads">
+                  <thead><tr>
+                    <th>Expand all</th>
+                    <th><a href="#" data-sakai-forum-sort="thread">Thread</a></th>
+                    <th><a href="#" data-sakai-forum-sort="author">Authored by</a></th>
+                    <th><a href="#" data-sakai-forum-sort="date">Date</a></th>
+                  </tr></thead>
+                  <tbody>
+                    <tr class="hierItemBlock"><td></td><td>A</td><td>Amy</td><td>2026-09-01</td></tr>
+                    <tr id="_id_11__hide_division_"><td></td><td style="padding-left:1em">A reply</td><td>Yan</td><td>2026-09-02</td></tr>
+                    <tr id="_id_12__hide_division_"><td></td><td style="padding-left:2em">A nested</td><td>Zoe</td><td>2026-09-04</td></tr>
+                    <tr id="_id_13__hide_division_"><td></td><td style="padding-left:1em">A second reply</td><td>Cara</td><td>2026-09-03</td></tr>
+                    <tr class="hierItemBlock"><td></td><td>B</td><td>Bob</td><td>2026-09-02</td></tr>
+                    <tr id="_id_21__hide_division_"><td></td><td style="padding-left:1em">B reply</td><td>Dan</td><td>2026-09-05</td></tr>
+                  </tbody>
+                </table>
+                """);
+            page.addScriptTag(new Page.AddScriptTagOptions().setPath(Path.of(
+                    "../msgcntr/messageforums-app/src/webapp/js/forumTopicThreadsSorter.js")));
+            page.evaluate("sakaiForumThreadsSorter.init(document.getElementById('threads'), 'en_US')");
+
+            page.locator("[data-sakai-forum-sort=author]").click();
+            assertOrder(page, "A", "B", "A second reply", "B reply", "A reply", "A nested");
+            page.locator("[data-sakai-forum-sort=date]").click();
+            assertOrder(page, "A", "A reply", "A second reply", "A nested", "B", "B reply");
+            page.locator("[data-sakai-forum-sort=date]").click();
+            assertOrder(page, "B", "B reply", "A", "A nested", "A second reply", "A reply");
+
+            page.locator("[data-sakai-forum-sort=thread]").click();
+            assertOrder(page, "A", "A reply", "A nested", "A second reply", "B", "B reply");
+            page.locator("[data-sakai-forum-sort=author]").click();
+            assertOrder(page, "A nested", "A reply", "B reply", "A second reply", "B", "A");
+            page.locator("[data-sakai-forum-sort=thread]").click();
+            assertOrder(page, "B", "B reply", "A", "A second reply", "A reply", "A nested");
+            page.locator("[data-sakai-forum-sort=date]").click();
+            assertOrder(page, "A", "A reply", "A second reply", "A nested", "B", "B reply");
+        }
+    }
+
+    private void assertOrder(Page page, String... subjects) {
+        assertThat(page.locator("#threads tbody tr td:nth-child(2)")).hasText(subjects);
+    }
+}

--- a/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentCompareGradesPanel.html
+++ b/gradebookng/tool/src/java/org/sakaiproject/gradebookng/tool/panels/StudentCompareGradesPanel.html
@@ -32,6 +32,7 @@
         </div>
 
         <script>
+          (() => {
             function generateTable(data){
               let tableHeaders = document.querySelector(".studentGradesComparison-TableContainer > table thead");
               let tableBody = document.querySelector(".studentGradesComparison-TableContainer > table tbody");
@@ -77,6 +78,7 @@
                 { targets: "_all", type: "html" }
               ]
             });
+          })();
         </script>
 
 	</wicket:panel>

--- a/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
+++ b/gradebookng/tool/src/webapp/scripts/gradebook-grade-summary.js
@@ -309,7 +309,7 @@ GradebookGradeSummary.prototype._print = function(headerHTML, contentHTML) {
 GradebookGradeSummary.prototype.setupTableSorting = function() {
   const table = this.$content[0]?.querySelector(".gb-summary-grade-panel table");
 
-  if (!table || table.tBodies.length > 1 || !table.querySelector("tbody td:not(:empty)") || DataTable.isDataTable(table)) return;
+  if (!table || table.dataset.groupedSorting || !table.querySelector("tbody td:not(:empty)") || DataTable.isDataTable(table)) return;
 
   table.querySelectorAll("td, th").forEach(node => {
     let sortValue = node.textContent.trim();
@@ -324,11 +324,67 @@ GradebookGradeSummary.prototype.setupTableSorting = function() {
     node.setAttribute("data-order", sortValue);
   });
 
+  if (table.tBodies.length > 1) {
+    this.setupGroupedTableSorting(table);
+    return;
+  }
+
   new DataTable(table, {
     paging: false,
     info: false,
     searching: false,
     order: []
+  });
+};
+
+
+GradebookGradeSummary.prototype.setupGroupedTableSorting = function(table) {
+  // Category headings and assignment bodies must stay in place for category toggles.
+  const groups = Array.from(table.tBodies)
+    .filter(body => body.classList.contains("gb-summary-assignments-tbody"))
+    .map(body => ({ body, rows: Array.from(body.rows) }));
+  const collator = new Intl.Collator(sakai.locale.userLanguage, { numeric: true, sensitivity: "base" });
+  const headers = Array.from(table.tHead.rows[0].cells);
+  table.dataset.groupedSorting = "true";
+
+  headers.forEach((header, columnIndex) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "btn btn-link p-0 text-reset text-start fw-bold";
+    button.append(...header.childNodes);
+    const icon = document.createElement("span");
+    icon.className = "bi bi-arrow-down-up ms-1";
+    icon.setAttribute("aria-hidden", "true");
+    button.append(icon);
+    header.append(button);
+
+    button.addEventListener("click", () => {
+      const previous = header.getAttribute("aria-sort");
+      const direction = previous === "ascending" ? "descending" : previous === "descending" ? null : "ascending";
+      headers.forEach(other => {
+        other.removeAttribute("aria-sort");
+        other.querySelector("button > .bi").className = "bi bi-arrow-down-up ms-1";
+      });
+      if (direction) {
+        header.setAttribute("aria-sort", direction);
+        icon.className = `bi bi-caret-${direction === "ascending" ? "up" : "down"}-fill ms-1`;
+      }
+
+      groups.forEach(({ body, rows }) => {
+        const sorted = rows.slice();
+        if (direction) {
+          sorted.sort((left, right) => {
+            const a = left.cells[columnIndex].dataset.order;
+            const b = right.cells[columnIndex].dataset.order;
+            const comparison = a !== "" && b !== "" && Number.isFinite(Number(a)) && Number.isFinite(Number(b))
+              ? Number(a) - Number(b)
+              : collator.compare(a, b);
+            return direction === "ascending" ? comparison : -comparison;
+          });
+        }
+        sorted.forEach(row => body.append(row));
+      });
+    });
   });
 };
 

--- a/msgcntr/messageforums-app/src/webapp/js/forumTopicThreadsSorter.js
+++ b/msgcntr/messageforums-app/src/webapp/js/forumTopicThreadsSorter.js
@@ -99,25 +99,21 @@
 
 		const rows = originalRows.slice();
 		const sortMode = table.tHead.rows[0].cells[columnIndex]?.querySelector("[data-sakai-forum-sort]")?.dataset.sakaiForumSort;
-		const sortFlat = sortMode === "author";
-		const sortByThread = sortMode === "thread";
 		const sortedRows = [];
+		const groups = buildGroups(rows).sort((left, right) =>
+			compareRows(columnIndex, ascending, locale)(left.parent, right.parent));
 
-		if (sortFlat) {
-			sortedRows.push(...rows.sort(compareRows(columnIndex, ascending, locale)));
-		} else {
-			const groups = buildGroups(rows).sort((left, right) =>
-				compareRows(columnIndex, ascending, locale)(left.parent, right.parent));
-
-			groups.forEach(group => {
-				sortedRows.push(group.parent);
-				if (sortByThread) {
-					sortedRows.push(...descendantsByThread(group.descendants, columnIndex, ascending, locale));
-				} else {
-					sortedRows.push(...group.descendants.sort(compareRows(columnIndex, ascending, locale)));
-				}
-			});
-		}
+		groups.forEach(group => {
+			sortedRows.push(group.parent);
+			if (sortMode === "author") {
+				// Sort conversations by their opening author without rearranging replies.
+				sortedRows.push(...group.descendants);
+			} else if (sortMode === "thread") {
+				sortedRows.push(...descendantsByThread(group.descendants, columnIndex, ascending, locale));
+			} else {
+				sortedRows.push(...group.descendants.sort(compareRows(columnIndex, ascending, locale)));
+			}
+		});
 
 		sortedRows.forEach(row => tbody.appendChild(row));
 	}
@@ -151,7 +147,7 @@
 	function init(table, userLocale) {
 		if (!table?.tHead?.rows.length) return;
 
-		// Keep the rendered hierarchy: author and date sorts can separate replies from their parents.
+		// Keep the rendered hierarchy so later sorts can restore reply nesting after date sorting.
 		const originalRows = Array.from(table.tBodies[0]?.rows || []);
 		const headers = Array.from(table.tHead.rows[0].cells);
 		const locale = userLocale.replaceAll("_", "-");

--- a/msgcntr/messageforums-app/src/webapp/js/forumTopicThreadsSorter.js
+++ b/msgcntr/messageforums-app/src/webapp/js/forumTopicThreadsSorter.js
@@ -93,11 +93,11 @@
 		return result;
 	}
 
-	function sortTable(table, columnIndex, ascending, locale) {
+	function sortTable(table, originalRows, columnIndex, ascending, locale) {
 		const tbody = table.tBodies[0];
 		if (!tbody) return;
 
-		const rows = Array.from(tbody.rows);
+		const rows = originalRows.slice();
 		const sortMode = table.tHead.rows[0].cells[columnIndex]?.querySelector("[data-sakai-forum-sort]")?.dataset.sakaiForumSort;
 		const sortFlat = sortMode === "author";
 		const sortByThread = sortMode === "thread";
@@ -151,6 +151,8 @@
 	function init(table, userLocale) {
 		if (!table?.tHead?.rows.length) return;
 
+		// Keep the rendered hierarchy: author and date sorts can separate replies from their parents.
+		const originalRows = Array.from(table.tBodies[0]?.rows || []);
 		const headers = Array.from(table.tHead.rows[0].cells);
 		const locale = userLocale.replaceAll("_", "-");
 		let expanded = true;
@@ -194,7 +196,7 @@
 				const ascending = header.dataset.sortDirection !== "asc";
 				header.dataset.sortDirection = ascending ? "asc" : "desc";
 				setSortClasses(header, ascending);
-				sortTable(table, columnIndex, ascending, locale);
+				sortTable(table, originalRows, columnIndex, ascending, locale);
 			});
 		});
 	}


### PR DESCRIPTION
Fix sorting regressions introduced by the DataTables 3 migration in Discussions and Gradebook.

- Discussions: keep conversations together when sorting by Authored By. Sort conversations by the opening post author and retain each conversation’s original reply order and nesting in both directions. Preserve the original rendered hierarchy so switching from date sorting back to author or conversation sorting restores reply relationships. This intentionally replaces the historical flat author sort.
- Gradebook summaries: category-grouped tables were skipped by the replacement sorter. Restore sorting within each category while retaining the existing category bodies, collapse state, raw grade values, and timestamp sort keys. Header buttons support keyboard operation, ascending/descending sorting, and restoring the original order.
- Gradebook comparison dialog: an illegal top-level `return` prevented its script from running. Scope the script inside an IIFE so rows render and sorting initializes, including when reopening the dialog.

[Jira: SAK-52886](https://sakaiproject.atlassian.net/browse/SAK-52886)

Validation:
- Updated `ForumThreadsSorterTest` verifies grouped ascending/descending author sorting, nested replies, and transitions among author/date/conversation sorting. `mvn -f e2e-tests/pom.xml test -Dtest=ForumThreadsSorterTest -q` passed. The original grouping regression was also confirmed to fail against the pre-fix sorter.
- Chromium checks using the production Gradebook scripts verified category membership, natural text sorting, numeric grades, timestamp ordering, keyboard sorting/reset, retained collapse state, expansion, and repeated initialization.
- Chromium checks verified comparison rows render and sort across two consecutive dialog fixtures.
- JavaScript syntax checks and `git diff --check` passed.

Browser validation used standalone rendered-table fixtures rather than a deployed Sakai server. No additional regression-test files were added for the Gradebook fixes, as requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved forum thread sorting while preserving parent-and-reply relationships across author, date, and thread sorting options.
  - Improved sorting for grouped grade tables while maintaining category structure.

- **New Features**
  - Added accessible sorting controls for assignments within grouped grade categories.

- **Tests**
  - Added end-to-end coverage to verify forum thread sorting and hierarchy restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->