### PR TITLE
SAK-52885 Sitestats fix locale-dependent test and CI locale setup

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,9 +36,11 @@ jobs:
           fi
       - name: Run tests with US locale
         env:
+          JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -Dmaven.wagon.http.retryHandler.count=2 -Dmaven.wagon.http.pool=true
         run: mvn -V -B -ntp -PskipBrokenTests test
       - name: Run tests with ES locale
         env:
+          JAVA_TOOL_OPTIONS: -Duser.language=es -Duser.country=ES
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -Dmaven.wagon.http.retryHandler.count=2 -Dmaven.wagon.http.pool=true
-        run: mvn -Duser.language=es -Duser.country=ES -V -B -ntp -PskipBrokenTests test
+        run: mvn -V -B -ntp -PskipBrokenTests test

--- a/sitestats/sitestats-tool/src/test/java/org/sakaiproject/sitestats/tool/config/SiteStatsMessagesTest.java
+++ b/sitestats/sitestats-tool/src/test/java/org/sakaiproject/sitestats/tool/config/SiteStatsMessagesTest.java
@@ -32,6 +32,7 @@ public class SiteStatsMessagesTest {
     public void setUp() {
         ResourceBundleMessageSource source = new ResourceBundleMessageSource();
         source.setBasename("Messages");
+        source.setFallbackToSystemLocale(false);
         messageSource = source;
     }
 


### PR DESCRIPTION
On a Spanish JVM, `SiteStatsMessagesTest` requests English but falls back to the system's Spanish bundle before the base English bundle, failing the exact message assertion. Disable system-locale fallback in the test message source so the requested translations and base English message are checked consistently.

The CI Spanish run previously passed locale properties as Maven arguments, which left `Locale.getDefault()` at `en_US` in the test JVM despite `user.language=es`. Set `JAVA_TOOL_OPTIONS` for both US and ES runs so each JVM starts with the intended locale.

Validation:
- Reproduced the exact reported failure with a Spanish JVM before the test fix.
- Confirmed actual JVM default locales of `en_US` and `es_ES` with temporary diagnostics, removed after verification.
- All 37 SiteStats API/tool tests pass under each locale using `-PskipBrokenTests`.
- `git diff --check` passes. Full repository suite not run locally.

https://sakaiproject.atlassian.net/browse/SAK-52885
