### PR TITLE
NOJIRA Gradebook stabilize category creation e2e test

### DIFF
--- a/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GradebookTest.java
+++ b/e2e-tests/src/test/java/org/sakaiproject/e2e/tests/GradebookTest.java
@@ -22,7 +22,9 @@ import com.deque.html.axecore.playwright.AxeBuilder;
 import com.deque.html.axecore.results.AxeResults;
 import com.deque.html.axecore.results.CheckedNode;
 import com.deque.html.axecore.results.Rule;
+import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -51,20 +53,25 @@ class GradebookTest extends SakaiUiTestBase {
         page.navigate(sakaiUrl);
         sakai.toolClick("Gradebook");
 
-        page.locator(".navIntraTool a").filter(new Locator.FilterOptions().setHasText("Settings")).first().click(new Locator.ClickOptions().setForce(true));
-        page.locator(".accordion button").filter(new Locator.FilterOptions().setHasText("Categories")).first().click(new Locator.ClickOptions().setForce(true));
+        page.locator(".navIntraTool a").filter(new Locator.FilterOptions().setHasText("Settings")).first().click();
+        ElementHandle categoriesPanel = page.locator("#settingsCategories").elementHandle();
+        page.locator(".accordion button").filter(new Locator.FilterOptions().setHasText("Categories")).first().click();
+        // Bootstrap reveals the old panel before Wicket replaces it via AJAX.
+        page.waitForFunction("panel => !panel.isConnected", categoriesPanel);
+        categoriesPanel.dispose();
 
         assertThat(page.locator("#settingsCategories input[type=\"radio\"]:visible")).hasCount(3);
 
-        Locator weightedCategoryOption = page.locator("#settingsCategories input[name=\"categoryPanel:settingsCategoriesPanel:categoryType\"][value=\"radio4\"]").first();
+        Locator weightedCategoryOption = page.getByLabel("Categories & weighting", new Page.GetByLabelOptions().setExact(true));
         assertThat(weightedCategoryOption).isVisible();
-        weightedCategoryOption.check(new Locator.CheckOptions().setForce(true));
+        weightedCategoryOption.check();
         assertThat(weightedCategoryOption).isChecked();
 
         page.locator(".gb-category-row input[name$=\"name\"]").first().fill("A");
         page.locator(".gb-category-weight input[name$=\"weight\"]").first().fill("100");
 
-        page.locator(".act button.active").first().click(new Locator.ClickOptions().setForce(true));
+        page.locator(".act button.active").first().click();
+        assertThat(page.getByText("The settings were successfully updated", new Page.GetByTextOptions().setExact(true))).isVisible();
     }
 
     @Test


### PR DESCRIPTION
Opening the Categories accordion reveals its controls through Bootstrap before Wicket's AJAX response replaces the panel. The test can select a radio in that old panel while the replacement is still pending.

Wait for the original panel to detach before interacting with its replacement, select “Categories & weighting” by its label instead of the generated `radio4` value, and use normal Playwright actionability checks. Assert the save confirmation so the browser remains open until the settings are saved. The change is confined to the category creation test and its imports.

Validation: the course setup and category creation tests passed in three consecutive Chromium runs against `https://sakai.example` (6 test executions, no failures), using:

```sh
mvn -f e2e-tests/pom.xml test '-Dtest=GradebookTest#canCreateNewCourse+canCreateGradebookCategories' -DPLAYWRIGHT_BASE_URL=https://sakai.example
```

`git diff --check` also passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Gradebook category setup test reliability by synchronizing category panel updates.
  * Updated weighting-option selection to use accessible labels.
  * Added verification for the successful settings update message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->